### PR TITLE
remove rustup from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,11 +28,13 @@ RUN apt-get update
 ENV HOME="${HOME:-"/root"}"
 ENV PATH="$HOME/bin:$PATH"
 COPY "./scripts" "$HOME"
+
 RUN apt-get install --assume-yes \
   "bash=5.1-3ubuntu2" \
   "curl=7.74.0-1.3ubuntu2.1" \
   "git=1:2.32.0-1ubuntu1" \
   "zsh=5.8-6ubuntu0.1"
+
 RUN curl -fsSL "https://github.com/cashapp/hermit/releases/download/v0.18.3/install.sh" | bash
 
 # Rust
@@ -41,8 +43,3 @@ RUN apt-get install --assume-yes \
   "build-essential=12.9ubuntu2" \
   "pkg-config=0.29.2-1ubuntu1" \
   "libssl-dev=1.1.1l-1ubuntu1.2"
-RUN curl -sSf https://sh.rustup.rs | sh -s -- -y \
-  --default-toolchain stable \
-  --profile minimal \
-  --no-modify-path \
-  --component rust-src


### PR DESCRIPTION
Since it is not required for CI. Should reduce the time it takes to build/run tests.