### PR TITLE
Float apt-get versions in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,21 +25,18 @@ RUN apt-get update
 
 # Shell
 
-ENV HOME="${HOME:-"/root"}"
-ENV PATH="$HOME/bin:$PATH"
-COPY "./scripts" "$HOME"
-
 RUN apt-get install --assume-yes \
-  "bash=5.1-3ubuntu2" \
-  "curl=7.74.0-1.3ubuntu2.1" \
-  "git=1:2.32.0-1ubuntu1" \
-  "zsh=5.8-6ubuntu0.1"
+  "bash=5.*" \
+  "curl=7.*" \
+  "git=1:2.*" \
+  "zsh=5.*"
 
+COPY "./scripts" "$HOME"
 RUN curl -fsSL "https://github.com/cashapp/hermit/releases/download/v0.18.3/install.sh" | bash
 
 # Rust
 
 RUN apt-get install --assume-yes \
-  "build-essential=12.9ubuntu2" \
-  "pkg-config=0.29.2-1ubuntu1" \
-  "libssl-dev=1.1.1l-1ubuntu1.2"
+  "build-essential=12.*" \
+  "pkg-config=0.*" \
+  "libssl-dev=1.*"

--- a/.devcontainer/scripts/.entrypoint.sh
+++ b/.devcontainer/scripts/.entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# See https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+"$SLANG_BUILD_SCRIPT"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.devcontainer
         with:
-          entrypoint: ${{ matrix.script }}
+          entrypoint: ./.devcontainer/scripts/.entrypoint.sh
+        env:
+          SLANG_BUILD_SCRIPT: ${{ matrix.script }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,4 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: ./documentation/scripts/deploy.sh
+      - run: ./.devcontainer/scripts/.entrypoint.sh
+        env:
+          SLANG_BUILD_SCRIPT: ./documentation/scripts/deploy.sh


### PR DESCRIPTION
I originally pinned them to make sure we have reproducible builds, but unfortunately this is not possible, since their repositories often expire old versions, and they are no longer downloadable. Now our CI is failing.

To unblock our CI, let's use the major version for now, until we have a better fix.

These packages are not part of the product we build anyways. They are only used for the dev environment, so reproducibility is less impactful here.

Also fixes the following issue by trusting the repository inside the container, since we are now getting the latest `git`:
https://github.blog/2022-04-12-git-security-vulnerability-announced/