### PR TITLE
Add arm64 rust support to hermit

### DIFF
--- a/tools/syntax-schema/bin/hermit.hcl
+++ b/tools/syntax-schema/bin/hermit.hcl
@@ -1,0 +1,1 @@
+sources = ["env:///hermit", "https://github.com/cashapp/hermit-packages.git"]

--- a/tools/syntax-schema/hermit/rust.hcl
+++ b/tools/syntax-schema/hermit/rust.hcl
@@ -1,0 +1,34 @@
+description = "A language empowering everyone to build reliable and efficient software."
+binaries = ["bin/*"]
+strip = 2
+env = {
+  "CARGO_HOME": "${HERMIT_ENV}/.hermit/rust",
+  "PATH": "${HERMIT_ENV}/.hermit/rust/bin:${PATH}",
+}
+
+darwin {
+  source = "https://static.rust-lang.org/dist/rust-${version}-${xarch}-apple-darwin.tar.xz"
+}
+
+linux {
+  source = "https://static.rust-lang.org/dist/rust-${version}-${xarch}-unknown-linux-gnu.tar.xz"
+}
+
+channel "nightly" {
+  update = "24h"
+
+  darwin {
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarch}-apple-darwin.tar.xz"
+  }
+
+  linux {
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarch}-unknown-linux-gnu.tar.xz"
+  }
+}
+
+version "1.51.0" "1.52.1" "1.53.0" "1.54.0" "1.55.0" "1.56.0" "1.57.0" "1.58.0"
+        "1.58.1" "1.59.0" "1.60.0" {
+  auto-version {
+    github-release = "rust-lang/rust"
+  }
+}

--- a/tools/version-breaks/bin/hermit.hcl
+++ b/tools/version-breaks/bin/hermit.hcl
@@ -1,0 +1,1 @@
+sources = ["env:///hermit", "https://github.com/cashapp/hermit-packages.git"]

--- a/tools/version-breaks/hermit/rust.hcl
+++ b/tools/version-breaks/hermit/rust.hcl
@@ -1,0 +1,34 @@
+description = "A language empowering everyone to build reliable and efficient software."
+binaries = ["bin/*"]
+strip = 2
+env = {
+  "CARGO_HOME": "${HERMIT_ENV}/.hermit/rust",
+  "PATH": "${HERMIT_ENV}/.hermit/rust/bin:${PATH}",
+}
+
+darwin {
+  source = "https://static.rust-lang.org/dist/rust-${version}-${xarch}-apple-darwin.tar.xz"
+}
+
+linux {
+  source = "https://static.rust-lang.org/dist/rust-${version}-${xarch}-unknown-linux-gnu.tar.xz"
+}
+
+channel "nightly" {
+  update = "24h"
+
+  darwin {
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarch}-apple-darwin.tar.xz"
+  }
+
+  linux {
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarch}-unknown-linux-gnu.tar.xz"
+  }
+}
+
+version "1.51.0" "1.52.1" "1.53.0" "1.54.0" "1.55.0" "1.56.0" "1.57.0" "1.58.0"
+        "1.58.1" "1.59.0" "1.60.0" {
+  auto-version {
+    github-release = "rust-lang/rust"
+  }
+}


### PR DESCRIPTION
This adds the modified rust.hcl file to the two rust tools, and modifies the sources in hermit.hcl to load those rust.hcl files.

Termporary until I get it upstreamed.