### PR TITLE
rename rust vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     // Please keep this list in-sync with "${workspaceRoot}/.vscode/extensions.json"
     //
     // Language Support
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "NomicFoundation.hardhat-solidity",
     "tamasfe.even-better-toml",
     "yzhang.markdown-all-in-one",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
     //
     // Language Support
     "igochkov.vscode-ebnf",
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "NomicFoundation.hardhat-solidity",
     "redhat.vscode-yaml",
     "tamasfe.even-better-toml",


### PR DESCRIPTION
Extension was recently moved/migrated to the rust foundation, which produces VS Code warnings when you open the repo. Moving to the new name.