### PR TITLE
fast cargo run for adjacent crate binaries

### DIFF
--- a/tools/solidity-parser/scripts/generate.sh
+++ b/tools/solidity-parser/scripts/generate.sh
@@ -7,13 +7,11 @@ PROJECT_DIR=$(dirname "$THIS_DIR")
 # shellcheck source=/dev/null
 [[ "${HERMIT_ENV:-}" == "$PROJECT_DIR" ]] || source "$PROJECT_DIR/bin/activate-hermit"
 
-cargo install --path ../syntax-schema
-
 ###################################################
 # Solidity from the original antlr grammar
 ###################################################
 
-manifest_to_chumsky \
+cargo run --manifest-path "../syntax-schema/Cargo.toml" --bin "manifest_to_chumsky" -- \
   --manifest-input "$PROJECT_DIR/syntax/solidity/original/manifest.yml" \
   --no-default-map --box-non-tokens \
   --chumsky-output "$PROJECT_DIR/src/parser.rs"

--- a/tools/solidity-parser/scripts/run.sh
+++ b/tools/solidity-parser/scripts/run.sh
@@ -7,16 +7,14 @@ PROJECT_DIR=$(dirname "$THIS_DIR")
 # shellcheck source=/dev/null
 [[ "${HERMIT_ENV:-}" == "$PROJECT_DIR" ]] || source "$PROJECT_DIR/bin/activate-hermit"
 
-cargo install --path ../syntax-schema
-
 ###################################################
 # Solidity from the intended source manifest
 ###################################################
 
-manifest_to_ebnf \
+cargo run --manifest-path "../syntax-schema/Cargo.toml" --bin "manifest_to_ebnf" -- \
   --manifest-input "$PROJECT_DIR/syntax/solidity/manifest.yml" \
   --ebnf-output "$PROJECT_DIR/syntax/solidity/derived.ebnf"
 
-manifest_to_chumsky \
+cargo run --manifest-path "../syntax-schema/Cargo.toml" --bin "manifest_to_chumsky" -- \
   --manifest-input "$PROJECT_DIR/syntax/solidity/manifest.yml" \
   --chumsky-output "$PROJECT_DIR/syntax/solidity/derived.rs"

--- a/tools/syntax-schema/scripts/run.sh
+++ b/tools/syntax-schema/scripts/run.sh
@@ -18,10 +18,6 @@ cargo run --bin manifest_to_chumsky -- \
   --manifest-input "$PROJECT_DIR/syntax/ebnf/manifest.yml" \
   --chumsky-output "$PROJECT_DIR/src/ebnf/parser.rs"
 
-cargo run --bin manifest_to_chumsky -- \
-  --manifest-input "$PROJECT_DIR/syntax/ebnf/manifest.yml" \
-  --chumsky-output "$PROJECT_DIR/src/ebnf/parser.rs"
-
 cargo run --bin manifest_to_ebnf -- \
   --manifest-input "$PROJECT_DIR/syntax/ebnf/manifest.yml" \
   --ebnf-output "$PROJECT_DIR/syntax/ebnf/derived.ebnf"


### PR DESCRIPTION
`cargo install` unfortunately requires updating Cargo's manifest every time the command is run, which is slow + blocks working offline. I found this to be a much faster way to run binaries from an adjacent crate. Please let me know if you have concerns on switching.

Also removes one duplicate command from the schema crate.