### PR TITLE
hide generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
+# Use LF instead of CRLF everywhere
 * text eol=lf
+
+# Generated files
+**/generated/** linguist-generated=true
+**/generated/** merge=slang-generated-files-merge-driver

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,11 @@
+# To include this in your local git config, add the following two lines to your ".git/config" file:
+# --------------------- .git/config ---------------------
+# [include]
+# path = ../.gitconfig
+# -------------------------------------------------------
+
+# Always choose existing (ours) version of any conflict
+# Our CI will ensure each individual PR has the corrrect changes if any were missed
+[merge "slang-generated-files-merge-driver"]
+name = slang-generated-files-merge-driver
+driver = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,12 @@
   "editor.formatOnSave": true,
   "editor.rulers": [120],
   "files.eol": "\n",
+  "search.exclude": {
+    "**/.hermit/": true,
+    "**/generated/": true,
+    "**/node_modules/": true,
+    "**/target/": true
+  },
   // Terminal
   "terminal.integrated.defaultProfile.linux": "devcontainer-zsh",
   "terminal.integrated.profiles.linux": {


### PR DESCRIPTION
This PR adopts a `**/generated/**` file pattern where:

1. Automatically collapse them during GitHub PR Review.
2. It will be excluded from VS Code global file search (unless file is loaded/opened).
3. Optionally, assumes an "ours" merge strategy when rebasing branches, where the existing version of the generated file wins.

Number 3 proved very useful rebasing some work this week. I don't have to keep accepting the same changes over and over when rebasing a stack, and the CI will already warn me if commit is out of date. Thoughts on this? Happy to remove if you feel it won't be useful to you/others.

This is done using a git merge driver, where each developer has to explicitly enable (via `.git/config`, instructions included in the PR). Unfortunately, there is no way to persist this config to the repo directly.