### PR TITLE
use (* *) for EBNF comments instead of /* */

### DIFF
--- a/tools/solidity-parser/src/generated/derived.ebnf
+++ b/tools/solidity-parser/src/generated/derived.ebnf
@@ -1,3 +1,11 @@
+(*
+ * Solidity Grammar
+ *)
+
+(*
+ * First Section: Trivia
+ *)
+
 «IGNORE» = { «Whitespace» | «Comment» | «LineComment» } ;
 
 «Whitespace» = 1…*{ '\u{20}' | '\u{9}' | '\u{d}' | '\u{a}' } ;
@@ -5,6 +13,10 @@
 «Comment» = '/*' { ¬'*' | 1…*{ '*' } ¬( '*' | '/' ) } { '*' } '*/' ;
 
 «LineComment» = '//' { ¬( '\u{a}' | '\u{d}' ) } ;
+
+(*
+ * First Section: Solidity File
+ *)
 
 SourceUnit = «IGNORE» { Directive | Definition } $ ;
 
@@ -25,6 +37,10 @@ SelectedImport = «Identifier» [ 'as' «Identifier» ] ;
 ImportPath = «AsciiStringLiteral» ;
 
 UsingDirective = 'using' ( IdentifierPath | '{' 1…*{ IdentifierPath / ',' } '}' ) 'for' ( '*' | TypeName ) [ 'global' ] ';' ;
+
+(*
+ * Todo Section: Todo Topic
+ *)
 
 ContractDefinition = [ 'abstract' ] 'contract' «Identifier» [ InheritanceSpecifierList ] '{' { ContractBodyElement } '}' ;
 

--- a/tools/syntax-schema/src/ebnf/generated/derived.ebnf
+++ b/tools/syntax-schema/src/ebnf/generated/derived.ebnf
@@ -1,3 +1,11 @@
+(*
+ * Nomic Foundation EBNF Grammar
+ *)
+
+(*
+ * Productions: Productions
+ *)
+
 grammar = «IGNORE» { production } $ ;
 
 production = «Identifier» '=' expression ';' ;
@@ -48,6 +56,6 @@ charRange = «SingleCharString» '…' «SingleCharString» ;
 
 «IGNORE» = { «Whitespace» | «Comment» } ;
 
-«Comment» = '/*' { ¬'*' | 1…*{ '*' } ¬( '*' | '/' ) } { '*' } '*/' ;
+«Comment» = '(*' { ¬'*' | 1…*{ '*' } ¬( '*' | ')' ) } { '*' } '*)' ;
 
 «Whitespace» = 1…*{ '\u{9}' | '\u{a}' | '\u{d}' | '\u{20}' } ;

--- a/tools/syntax-schema/src/ebnf/generated/parser_implementation.rs
+++ b/tools/syntax-schema/src/ebnf/generated/parser_implementation.rs
@@ -45,8 +45,8 @@ impl Parsers {
 
         let mut expression_parser = Recursive::declare();
 
-        // «Comment» = '/*' { ¬'*' | 1…*{ '*' } ¬( '*' | '/' ) } { '*' } '*/' ;
-        let comment_parser = terminal("/*")
+        // «Comment» = '(*' { ¬'*' | 1…*{ '*' } ¬( '*' | ')' ) } { '*' } '*)' ;
+        let comment_parser = terminal("(*")
             .ignored()
             .map(|_| FixedTerminal::<2usize>())
             .then(
@@ -60,7 +60,7 @@ impl Parsers {
                         .at_least(1usize)
                         .map(|v| v.len())
                         .then(
-                            filter(|&c: &char| c != '*' && c != '/').map(|_| FixedTerminal::<1>()),
+                            filter(|&c: &char| c != '*' && c != ')').map(|_| FixedTerminal::<1>()),
                         )
                         .map(|v| Box::new(comment::_S3::new(v)))
                         .map(|v| Box::new(comment::_C2::_S3(v))),
@@ -74,7 +74,7 @@ impl Parsers {
                 )
                 .map(|v| Box::new(comment::Content::new(v))),
             )
-            .then(terminal("*/").ignored().map(|_| FixedTerminal::<2usize>()))
+            .then(terminal("*)").ignored().map(|_| FixedTerminal::<2usize>()))
             .map(|v| Box::new(comment::_S0::new(v)))
             .boxed();
 

--- a/tools/syntax-schema/src/ebnf/generated/tree_implementation.rs
+++ b/tools/syntax-schema/src/ebnf/generated/tree_implementation.rs
@@ -32,22 +32,24 @@ impl<const N: usize> DefaultTest for FixedTerminal<N> {
 
 impl comment::_S0 {
     pub fn new(
-        ((slash_star, content), star_slash): (
+        ((open_paren_star, content), star_close_paren): (
             (FixedTerminal<2usize>, Box<comment::Content>),
             FixedTerminal<2usize>,
         ),
     ) -> Self {
         Self {
-            slash_star,
+            open_paren_star,
             content,
-            star_slash,
+            star_close_paren,
         }
     }
 }
 
 impl DefaultTest for comment::_S0 {
     fn is_default(&self) -> bool {
-        self.slash_star.is_default() && self.content.is_default() && self.star_slash.is_default()
+        self.open_paren_star.is_default()
+            && self.content.is_default()
+            && self.star_close_paren.is_default()
     }
 }
 

--- a/tools/syntax-schema/src/ebnf/generated/tree_interface.rs
+++ b/tools/syntax-schema/src/ebnf/generated/tree_interface.rs
@@ -8,7 +8,7 @@ pub trait DefaultTest {
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct FixedTerminal<const N: usize>();
 
-/// «Comment» = '/*' { ¬'*' | 1…*{ '*' } ¬( '*' | '/' ) } { '*' } '*/' ;
+/// «Comment» = '(*' { ¬'*' | 1…*{ '*' } ¬( '*' | ')' ) } { '*' } '*)' ;
 pub mod comment {
     #[allow(unused_imports)]
     use super::*;
@@ -16,11 +16,11 @@ pub mod comment {
     #[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
     pub struct _S0 {
         #[serde(default, skip_serializing_if = "DefaultTest::is_default")]
-        pub slash_star: FixedTerminal<2usize>,
+        pub open_paren_star: FixedTerminal<2usize>,
         #[serde(default, skip_serializing_if = "DefaultTest::is_default")]
         pub content: Box<comment::Content>,
         #[serde(default, skip_serializing_if = "DefaultTest::is_default")]
-        pub star_slash: FixedTerminal<2usize>,
+        pub star_close_paren: FixedTerminal<2usize>,
     }
     #[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
     pub struct Content {

--- a/tools/syntax-schema/src/ebnf/grammar.rs
+++ b/tools/syntax-schema/src/ebnf/grammar.rs
@@ -6,14 +6,27 @@ impl Grammar {
     pub fn generate_ebnf(&self, output_path: &PathBuf) {
         let mut w = File::create(output_path).expect("Unable to create file");
 
-        let mut first = true;
-        for p in self.productions.iter().flat_map(|(_, p)| p) {
-            if first {
-                first = false;
-            } else {
-                writeln!(w).unwrap();
+        writeln!(w, "(*").unwrap();
+        writeln!(w, " * {}", self.manifest.title).unwrap();
+        writeln!(w, " *)").unwrap();
+
+        for section in &self.manifest.sections {
+            for topic in &section.topics {
+                match &topic.definition {
+                    None => {}
+                    Some(definition) => {
+                        writeln!(w).unwrap();
+                        writeln!(w, "(*").unwrap();
+                        writeln!(w, " * {}: {}", section.title, topic.title).unwrap();
+                        writeln!(w, " *)").unwrap();
+
+                        for production in self.productions.get(definition).unwrap() {
+                            writeln!(w).unwrap();
+                            writeln!(w, "{}", production.generate_ebnf(self).join("\n")).unwrap();
+                        }
+                    }
+                }
             }
-            writeln!(w, "{}", p.generate_ebnf(self).join("\n")).unwrap();
         }
     }
 }

--- a/tools/syntax-schema/src/ebnf/production.rs
+++ b/tools/syntax-schema/src/ebnf/production.rs
@@ -27,7 +27,7 @@ impl Production {
                 .iter()
                 .map(|(version, expr)| {
                     let mut w = String::new();
-                    write!(w, "/* {} */ {} = ", version, self.ebnf_display_name()).unwrap();
+                    write!(w, "(* {} *) {} = ", version, self.ebnf_display_name()).unwrap();
                     expr.generate_ebnf(grammar, &mut w);
                     write!(w, ";").unwrap();
                     w

--- a/tools/syntax-schema/syntax/ebnf/derived.yml
+++ b/tools/syntax-schema/syntax/ebnf/derived.yml
@@ -177,7 +177,7 @@
 - name: Comment
   isToken: true
   sequence:
-    - terminal: /*
+    - terminal: (*
     - zeroOrMore:
         choice:
           - not:
@@ -188,10 +188,10 @@
               - not:
                   choice:
                     - terminal: "*"
-                    - terminal: /
+                    - terminal: )
     - oneOrMore:
         terminal: "*"
-    - terminal: /
+    - terminal: )
 - name: Whitespace
   isToken: true
   choice:

--- a/tools/syntax-schema/syntax/ebnf/topics/01-productions/01-productions.yml
+++ b/tools/syntax-schema/syntax/ebnf/topics/01-productions/01-productions.yml
@@ -206,7 +206,7 @@
 - name: Comment
   isToken: true
   sequence:
-    - terminal: /*
+    - terminal: (*
     - sequence:
         - zeroOrMore:
             choice:
@@ -218,11 +218,11 @@
                   - not:
                       choice:
                         - terminal: "*"
-                        - terminal: /
+                        - terminal: )
         - zeroOrMore:
             terminal: "*"
       config: { name: Content }
-    - terminal: "*/"
+    - terminal: "*)"
 
 - name: Whitespace
   isToken: true


### PR DESCRIPTION
This is the valid syntax for EBNF, as exists in:

1. The [official wiki page](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form).
2. VS Code syntax highlighting.
3. GitHub syntax highlighting (issues/PRs).

```ebnf
Example that (* works *) and one that /* does not */
```

![image](https://user-images.githubusercontent.com/15987992/174784736-d7470393-2fe1-40e0-b6d7-34c916f132c3.png)
