### PR TITLE
remove DX vscode extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,10 +23,6 @@
     "DavidAnson.vscode-markdownlint",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "timonwong.shellcheck",
-    // Developer Experience
-    "mhutchie.git-graph",
-    "ms-azuretools.vscode-docker",
-    "vscode-icons-team.vscode-icons"
+    "timonwong.shellcheck"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,10 +13,6 @@
     "DavidAnson.vscode-markdownlint",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "timonwong.shellcheck",
-    // Developer Experience
-    "mhutchie.git-graph",
-    "ms-azuretools.vscode-docker",
-    "vscode-icons-team.vscode-icons"
+    "timonwong.shellcheck"
   ]
 }


### PR DESCRIPTION
Responding to earlier feedback about leaving this to local preferences, instead of enforcing repo-wide standards
