### PR TITLE
add codegen file utils

### DIFF
--- a/code-analysis/crates/codegen/src/build_utils.rs
+++ b/code-analysis/crates/codegen/src/build_utils.rs
@@ -1,0 +1,68 @@
+use std::{path::PathBuf, process::Command};
+
+pub fn read_source_file(file_path: &PathBuf) -> String {
+    rerun_if_changed(file_path);
+
+    let contents = std::fs::read_to_string(file_path)
+        .expect(&format!("Cannot read source file: {file_path:?}"));
+
+    return contents;
+}
+
+pub fn write_generated_file(file_path: &PathBuf, contents: &str) {
+    rerun_if_changed(file_path);
+
+    let contents = format!("{}\n\n{}", generate_header(file_path), contents);
+
+    if file_path.exists() {
+        let existing_contents = std::fs::read_to_string(file_path)
+            .expect(&format!("Cannot read existing file: {file_path:?}"));
+
+        // To respect Cargo incrementability, don't touch the file if it is already up to date.
+        if contents == existing_contents {
+            return;
+        }
+    }
+
+    std::fs::create_dir_all(
+        file_path
+            .parent()
+            .expect(&format!("Cannot get parent directory of: {file_path:?}")),
+    )
+    .expect(&format!("Cannot create parent directory of: {file_path:?}"));
+
+    std::fs::write(file_path, contents)
+        .expect(&format!("Cannot write generated file: {file_path:?}"));
+}
+
+pub fn delete_generated_file(file_path: &PathBuf) {
+    rerun_if_changed(file_path);
+
+    if file_path.exists() {
+        std::fs::remove_file(file_path)
+            .expect(&format!("Cannot delete generated file: {file_path:?}"));
+    }
+}
+
+fn generate_header(file_path: &PathBuf) -> String {
+    let warning_line = "This file is generated via `cargo build`. Please don't edit by hand.";
+
+    let extension = file_path
+        .extension()
+        .expect(&format!("Cannot get extension of file: {file_path:?}"))
+        .to_str()
+        .expect(&format!("Cannot get extension of file: {file_path:?}"));
+
+    return match extension {
+        "ebnf" => format!("(* {warning_line} *)"),
+        "md" => format!("<!-- {warning_line} -->"),
+        "rs" => format!("// {warning_line}"),
+        "yml" => format!("# {warning_line}"),
+        _ => panic!("Unsupported extension: {extension}"),
+    };
+}
+
+fn rerun_if_changed(file_path: &PathBuf) {
+    let file_path = file_path.to_str().unwrap();
+    println!("cargo:rerun-if-changed={file_path}");
+}

--- a/code-analysis/crates/codegen/src/chumsky/generate.rs
+++ b/code-analysis/crates/codegen/src/chumsky/generate.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
     path::PathBuf,
 };
 
 use quote::quote;
 
+use crate::build_utils::write_generated_file;
 use crate::schema::*;
 
 use super::{combinator_tree::ProductionGeneratedCode, rustfmt::rustfmt};
@@ -47,14 +47,8 @@ impl Grammar {
     }
 
     fn format_and_write_source(path: &PathBuf, source: String) {
-        // Make it possible to debug the code even when rustfmt dies
-        // by writing the unformatted code to the file.
-        fs::write(path, source.as_str()).expect(format!("Unable to write to {:?}", path).as_str());
         let formatted_src = rustfmt(source);
-        if formatted_src != "" {
-            fs::write(path, formatted_src)
-                .expect(format!("Unable to write to {:?}", path).as_str());
-        };
+        write_generated_file(path, &formatted_src);
     }
 
     // Compute a topological ordering, with backlinks ignored

--- a/code-analysis/crates/codegen/src/ebnf/grammar.rs
+++ b/code-analysis/crates/codegen/src/ebnf/grammar.rs
@@ -1,10 +1,11 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 
+use crate::build_utils::write_generated_file;
 use crate::schema::*;
 
 impl Grammar {
     pub fn generate_ebnf(&self, output_path: &PathBuf) {
-        let mut w = File::create(output_path).expect("Unable to create file");
+        let mut w: Vec<u8> = Vec::new();
 
         writeln!(w, "(*").unwrap();
         writeln!(w, " * {}", self.manifest.title).unwrap();
@@ -28,5 +29,7 @@ impl Grammar {
                 }
             }
         }
+
+        write_generated_file(output_path, &String::from_utf8(w).unwrap());
     }
 }

--- a/code-analysis/crates/codegen/src/lib.rs
+++ b/code-analysis/crates/codegen/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build_utils;
 pub mod chumsky;
 pub mod ebnf;
 pub mod schema;

--- a/code-analysis/crates/codegen/src/schema/mod.rs
+++ b/code-analysis/crates/codegen/src/schema/mod.rs
@@ -15,7 +15,7 @@ use serde::{
 };
 use serde_yaml::Value;
 
-use crate::chumsky::combinator_tree::CombinatorTreeRoot;
+use crate::{build_utils::read_source_file, chumsky::combinator_tree::CombinatorTreeRoot};
 
 pub mod validation;
 
@@ -579,9 +579,9 @@ pub enum ExpressionAssociativity {
 
 impl Grammar {
     pub fn from_manifest(manifest_path: &PathBuf) -> Self {
-        let contents = std::fs::read(manifest_path).unwrap();
+        let contents = read_source_file(manifest_path);
         let manifest_path_str = &manifest_path.to_str().unwrap();
-        let manifest: Manifest = serde_yaml::from_slice(&contents).expect(manifest_path_str);
+        let manifest: Manifest = serde_yaml::from_str(&contents).expect(manifest_path_str);
 
         let productions: IndexMap<String, Vec<ProductionRef>> = manifest
             .sections
@@ -593,9 +593,9 @@ impl Grammar {
                     let topic_path = manifest_path.parent().unwrap().join(definition);
                     let topic_path_str = topic_path.to_str().unwrap();
 
-                    let contents = std::fs::read(&topic_path).expect(topic_path_str);
+                    let contents = read_source_file(&topic_path);
                     let rules: Vec<Production> =
-                        serde_yaml::from_slice(&contents).expect(topic_path_str);
+                        serde_yaml::from_str(&contents).expect(topic_path_str);
                     let rules: Vec<ProductionRef> = rules.into_iter().map(|p| Rc::new(p)).collect();
 
                     return Some((definition.clone(), rules));

--- a/code-analysis/crates/codegen/src/schema/validation.rs
+++ b/code-analysis/crates/codegen/src/schema/validation.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use semver::Version;
 
 use crate::{
+    build_utils::read_source_file,
     schema::{EBNFDelimitedBy, EBNFRepeat, EBNFSeparatedBy, Expression, Grammar, EBNF},
     spec::topics::generate_topic_slug,
 };
@@ -181,7 +182,7 @@ impl LoadedSchemas {
     }
 
     pub fn validate(&mut self, yaml_path: &PathBuf) {
-        let yaml_contents = std::fs::read_to_string(&yaml_path).unwrap();
+        let yaml_contents = read_source_file(&yaml_path);
 
         let schema_path_re = Regex::new(r"# yaml-language-server: \$schema=([\.\-/a-z]+)").unwrap();
         let mut schema_path_matches = schema_path_re.captures_iter(&yaml_contents);
@@ -194,7 +195,7 @@ impl LoadedSchemas {
         let schema_path = yaml_path.parent().unwrap().join(schema_path);
 
         if !self.schemas.contains_key(&schema_path) {
-            let schema_contents = std::fs::read_to_string(&schema_path).unwrap();
+            let schema_contents = read_source_file(&schema_path);
             let schema_json = &serde_json::from_str(&schema_contents).unwrap();
             let schema = JSONSchema::compile(schema_json).unwrap();
 

--- a/code-analysis/crates/codegen/src/spec/grammar.rs
+++ b/code-analysis/crates/codegen/src/spec/grammar.rs
@@ -1,6 +1,6 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 
-use crate::schema::Grammar;
+use crate::{build_utils::write_generated_file, schema::Grammar};
 
 use super::{
     productions::{write_production, SpecProductionContext},
@@ -15,15 +15,13 @@ pub fn generate_spec_grammar(
     let context = generate_context(grammar);
     let grammar_path = generated_folder.join("00-grammar").join("index.md");
 
-    std::fs::create_dir_all(grammar_path.parent().unwrap()).unwrap();
-
     entries.push(NavigationEntry {
         indentation_level: 1,
         title: grammar.manifest.title.clone(),
         file_path: Some(grammar_path.clone()),
     });
 
-    let mut w = File::create(grammar_path).expect("Unable to create file");
+    let mut w: Vec<u8> = Vec::new();
     writeln!(w, "# {}", grammar.manifest.title).unwrap();
     writeln!(w).unwrap();
     writeln!(w, "<!-- markdownlint-disable no-inline-html -->").unwrap();
@@ -58,6 +56,8 @@ pub fn generate_spec_grammar(
 
     writeln!(w).unwrap();
     writeln!(w, "--8<-- \"specification/notes/00-grammar/index.md\"").unwrap();
+
+    write_generated_file(&grammar_path, &String::from_utf8(w).unwrap());
 }
 
 fn generate_context(grammar: &Grammar) -> SpecProductionContext {

--- a/code-analysis/crates/codegen/src/spec/topics.rs
+++ b/code-analysis/crates/codegen/src/spec/topics.rs
@@ -1,6 +1,9 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 
-use crate::schema::Grammar;
+use crate::{
+    build_utils::{read_source_file, write_generated_file},
+    schema::Grammar,
+};
 
 use super::{
     productions::{write_production, SpecProductionContext},
@@ -58,8 +61,7 @@ pub fn generate_spec_sections(
                         file_path: Some(notes_file.clone()),
                     });
 
-                    std::fs::create_dir_all(topic_file.parent().unwrap()).unwrap();
-                    let mut w = File::create(topic_file).expect("Unable to create file");
+                    let mut w : Vec<u8> = Vec::new();
 
                     writeln!(w, "<!-- markdownlint-disable no-inline-html -->").unwrap();
                     writeln!(w, "<!-- markdownlint-disable no-space-in-emphasis -->").unwrap();
@@ -93,13 +95,15 @@ pub fn generate_spec_sections(
                     assert!(notes_file.exists(), "Notes file does not exist: {notes_file:?}");
 
                     assert_eq!(
-                        std::fs::read_to_string(&notes_file).unwrap().lines().nth(0),
+                        read_source_file(&notes_file).lines().nth(0),
                         Some("<!-- markdownlint-configure-file { \"first-line-heading\": { \"level\": 2 } } -->"),
                         "First line of notes file should be the markdownlint configuration: {:?}", &notes_file
                     );
 
                     writeln!(w).unwrap();
-                    writeln!(&w, "--8<-- \"specification/notes/{topic_slug}/index.md\"").unwrap();
+                    writeln!(w, "--8<-- \"specification/notes/{topic_slug}/index.md\"").unwrap();
+
+                    write_generated_file(&topic_file, &String::from_utf8(w).unwrap());
                 });
         });
 }

--- a/code-analysis/crates/parsers/ebnf/src/generated/derived.ebnf
+++ b/code-analysis/crates/parsers/ebnf/src/generated/derived.ebnf
@@ -1,3 +1,5 @@
+(* This file is generated via `cargo build`. Please don't edit by hand. *)
+
 (*
  * Nomic Foundation EBNF Grammar
  *)

--- a/code-analysis/crates/parsers/ebnf/src/generated/mod.rs
+++ b/code-analysis/crates/parsers/ebnf/src/generated/mod.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 pub mod parser_implementation;
 pub mod parser_interface;
 pub mod tree_implementation;

--- a/code-analysis/crates/parsers/ebnf/src/generated/parser_implementation.rs
+++ b/code-analysis/crates/parsers/ebnf/src/generated/parser_implementation.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use super::parser_interface::*;
 use super::tree_interface::*;
 use chumsky::prelude::*;

--- a/code-analysis/crates/parsers/ebnf/src/generated/parser_interface.rs
+++ b/code-analysis/crates/parsers/ebnf/src/generated/parser_interface.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use chumsky::prelude::{BoxedParser, Simple};
 pub type ErrorType = Simple<char>;
 pub type ParserType<T> = BoxedParser<'static, char, T, ErrorType>;

--- a/code-analysis/crates/parsers/ebnf/src/generated/tree_implementation.rs
+++ b/code-analysis/crates/parsers/ebnf/src/generated/tree_implementation.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use super::tree_interface::*;
 impl<T: DefaultTest> DefaultTest for Box<T> {
     fn is_default(&self) -> bool {

--- a/code-analysis/crates/parsers/ebnf/src/generated/tree_interface.rs
+++ b/code-analysis/crates/parsers/ebnf/src/generated/tree_interface.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 pub trait DefaultTest {

--- a/code-analysis/crates/parsers/solidity/src/generated/derived.ebnf
+++ b/code-analysis/crates/parsers/solidity/src/generated/derived.ebnf
@@ -1,3 +1,5 @@
+(* This file is generated via `cargo build`. Please don't edit by hand. *)
+
 (*
  * Solidity Grammar
  *)

--- a/code-analysis/crates/parsers/solidity/src/generated/mod.rs
+++ b/code-analysis/crates/parsers/solidity/src/generated/mod.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 pub mod parser_implementation;
 pub mod parser_interface;
 pub mod tree_implementation;

--- a/code-analysis/crates/parsers/solidity/src/generated/parser_implementation.rs
+++ b/code-analysis/crates/parsers/solidity/src/generated/parser_implementation.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use super::parser_interface::*;
 use super::tree_interface::*;
 use chumsky::prelude::*;

--- a/code-analysis/crates/parsers/solidity/src/generated/parser_interface.rs
+++ b/code-analysis/crates/parsers/solidity/src/generated/parser_interface.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use chumsky::prelude::{BoxedParser, Simple};
 pub type ErrorType = Simple<char>;
 pub type ParserType<T> = BoxedParser<'static, char, T, ErrorType>;

--- a/code-analysis/crates/parsers/solidity/src/generated/tree_implementation.rs
+++ b/code-analysis/crates/parsers/solidity/src/generated/tree_implementation.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 use super::tree_interface::*;
 impl<T: DefaultTest> DefaultTest for Box<T> {
     fn is_default(&self) -> bool {

--- a/code-analysis/crates/parsers/solidity/src/generated/tree_interface.rs
+++ b/code-analysis/crates/parsers/solidity/src/generated/tree_interface.rs
@@ -1,3 +1,5 @@
+// This file is generated via `cargo build`. Please don't edit by hand.
+
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 pub trait DefaultTest {

--- a/documentation/docs/specification/generated/00-grammar/index.md
+++ b/documentation/docs/specification/generated/00-grammar/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 # Solidity Grammar
 
 <!-- markdownlint-disable no-inline-html -->

--- a/documentation/docs/specification/generated/01-file-structure/01-license-specifier/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/01-license-specifier/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/01-file-structure/02-source-unit/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/02-source-unit/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/01-file-structure/03-pragmas/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/03-pragmas/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/01-file-structure/04-imports/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/04-imports/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/01-file-structure/05-trivia/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/05-trivia/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/01-file-structure/06-natspec-format/index.md
+++ b/documentation/docs/specification/generated/01-file-structure/06-natspec-format/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/01-contracts/index.md
+++ b/documentation/docs/specification/generated/02-definitions/01-contracts/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/02-interfaces/index.md
+++ b/documentation/docs/specification/generated/02-definitions/02-interfaces/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/03-libraries/index.md
+++ b/documentation/docs/specification/generated/02-definitions/03-libraries/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/04-structs/index.md
+++ b/documentation/docs/specification/generated/02-definitions/04-structs/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/05-enums/index.md
+++ b/documentation/docs/specification/generated/02-definitions/05-enums/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/06-constants/index.md
+++ b/documentation/docs/specification/generated/02-definitions/06-constants/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/07-state-variables/index.md
+++ b/documentation/docs/specification/generated/02-definitions/07-state-variables/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/08-functions/index.md
+++ b/documentation/docs/specification/generated/02-definitions/08-functions/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/09-modifiers/index.md
+++ b/documentation/docs/specification/generated/02-definitions/09-modifiers/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/10-events/index.md
+++ b/documentation/docs/specification/generated/02-definitions/10-events/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/11-user-defined-value-types/index.md
+++ b/documentation/docs/specification/generated/02-definitions/11-user-defined-value-types/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/02-definitions/12-errors/index.md
+++ b/documentation/docs/specification/generated/02-definitions/12-errors/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/03-types/01-advanced-types/index.md
+++ b/documentation/docs/specification/generated/03-types/01-advanced-types/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/03-types/02-function-types/index.md
+++ b/documentation/docs/specification/generated/03-types/02-function-types/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/03-types/03-mapping-types/index.md
+++ b/documentation/docs/specification/generated/03-types/03-mapping-types/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/03-types/04-elementary-types/index.md
+++ b/documentation/docs/specification/generated/03-types/04-elementary-types/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/03-types/05-addresses/index.md
+++ b/documentation/docs/specification/generated/03-types/05-addresses/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/04-statements/01-blocks/index.md
+++ b/documentation/docs/specification/generated/04-statements/01-blocks/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/04-statements/02-declaration-statements/index.md
+++ b/documentation/docs/specification/generated/04-statements/02-declaration-statements/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/04-statements/03-control-statements/index.md
+++ b/documentation/docs/specification/generated/04-statements/03-control-statements/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/04-statements/04-error-handling/index.md
+++ b/documentation/docs/specification/generated/04-statements/04-error-handling/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/01-base-expressions/index.md
+++ b/documentation/docs/specification/generated/05-expressions/01-base-expressions/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/02-binary-operators/index.md
+++ b/documentation/docs/specification/generated/05-expressions/02-binary-operators/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/03-unary-operators/index.md
+++ b/documentation/docs/specification/generated/05-expressions/03-unary-operators/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/04-primary-expressions/index.md
+++ b/documentation/docs/specification/generated/05-expressions/04-primary-expressions/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/05-numbers/index.md
+++ b/documentation/docs/specification/generated/05-expressions/05-numbers/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/06-strings/index.md
+++ b/documentation/docs/specification/generated/05-expressions/06-strings/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/05-expressions/07-identifiers/index.md
+++ b/documentation/docs/specification/generated/05-expressions/07-identifiers/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/06-yul/01-assembly-block/index.md
+++ b/documentation/docs/specification/generated/06-yul/01-assembly-block/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/06-yul/02-yul-statements/index.md
+++ b/documentation/docs/specification/generated/06-yul/02-yul-statements/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/06-yul/03-yul-expressions/index.md
+++ b/documentation/docs/specification/generated/06-yul/03-yul-expressions/index.md
@@ -1,3 +1,5 @@
+<!-- This file is generated via `cargo build`. Please don't edit by hand. -->
+
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable no-space-in-emphasis -->
 <!-- cSpell:disable -->

--- a/documentation/docs/specification/generated/mkdocs.navigation.yml
+++ b/documentation/docs/specification/generated/mkdocs.navigation.yml
@@ -1,3 +1,5 @@
+# This file is generated via `cargo build`. Please don't edit by hand.
+
 nav:
   - Specification:
       - Solidity Grammar: specification/generated/00-grammar/index.md

--- a/documentation/scripts/build.sh
+++ b/documentation/scripts/build.sh
@@ -18,8 +18,8 @@ source "$THIS_DIR/common.sh"
   # shellcheck disable=SC2016
   yq eval-all '. as $file ireduce ({}; . *+ $file )' \
     "$DOCUMENTATION_DIR/mkdocs.config.yml" \
-    "$DOCUMENTATION_DIR/mkdocs.specification.yml" \
     "$DOCUMENTATION_DIR/mkdocs.theme.yml" \
+    "$DOCUMENTATION_DIR/docs/specification/generated/mkdocs.navigation.yml" \
     > "$DOCUMENTATION_TARGET_DIR/mkdocs.yml"
 )
 


### PR DESCRIPTION
Adding a single utility to do all file-system operations for all codegen. All future codegen scripts should use that instead of `std::fs`:

* Notify Cargo to rerun if one of the sources/destinations change.
* Don't touch the file system if files are already up-to-date, in order not to mess with Cargo incrementability.
* Fail if files are not up-to-date in CI.