### PR TITLE
fix spec pages deployment

### DIFF
--- a/documentation/scripts/deploy.sh
+++ b/documentation/scripts/deploy.sh
@@ -18,6 +18,7 @@ fi
 
 (
   printf "\n\n🚀 Deploy to GitHub Pages 🚀\n\n\n"
+  cd "$DOCUMENTATION_DIR"
   python3 -m pipenv run ghp-import --no-jekyll --no-history --push "$DOCUMENTATION_SITE_DIR"
 )
 


### PR DESCRIPTION
Unfortunately `pipenv` commands need to run from the same directory that contain the `Pipfile`.
Broken by the hermit move in #146