### PR TITLE
add scaffolding for "internals" documentation section

### DIFF
--- a/documentation/docs/internals/01-code-generation/01-syntax-schema/index.md
+++ b/documentation/docs/internals/01-code-generation/01-syntax-schema/index.md
@@ -1,0 +1,3 @@
+# Syntax Schema
+
+TODO amazing stuff!

--- a/documentation/docs/internals/01-code-generation/02-parser/index.md
+++ b/documentation/docs/internals/01-code-generation/02-parser/index.md
@@ -1,0 +1,3 @@
+# Parser
+
+TODO amazing stuff!

--- a/documentation/docs/internals/01-code-generation/03-syntax-tree/index.md
+++ b/documentation/docs/internals/01-code-generation/03-syntax-tree/index.md
@@ -1,0 +1,3 @@
+# Syntax Tree
+
+TODO amazing stuff!

--- a/documentation/mkdocs.config.yml
+++ b/documentation/mkdocs.config.yml
@@ -8,5 +8,9 @@ docs_dir: !ENV DOCUMENTATION_SOURCE_FILES
 site_dir: !ENV DOCUMENTATION_SITE_DIR
 
 nav:
-  - Home: index.md
-  - "": snippets/under-construction.md
+  - index.md
+  - Internals:
+      - Code Generation:
+          - internals/01-code-generation/01-syntax-schema/index.md
+          - internals/01-code-generation/02-parser/index.md
+          - internals/01-code-generation/03-syntax-tree/index.md


### PR DESCRIPTION
We should be adding more documentation to it over time.

... also cleaned up a runaway `snippets/under-construction.md` entry that was left from earlier PRs.