### PR TITLE
verify outdated generated files locally

### DIFF
--- a/code-analysis/crates/codegen/ebnf/src/grammar.rs
+++ b/code-analysis/crates/codegen/ebnf/src/grammar.rs
@@ -6,11 +6,11 @@ use codegen_utils::context::CodegenContext;
 use super::production::ProductionEBNFExtensions;
 
 pub trait GrammarEBNFExtensions {
-    fn generate_ebnf(&self, codegen: &CodegenContext, path: &PathBuf);
+    fn generate_ebnf(&self, codegen: &mut CodegenContext, output_dir: &PathBuf);
 }
 
 impl GrammarEBNFExtensions for Grammar {
-    fn generate_ebnf(&self, codegen: &CodegenContext, output_dir: &PathBuf) {
+    fn generate_ebnf(&self, codegen: &mut CodegenContext, output_dir: &PathBuf) {
         let mut w: Vec<u8> = Vec::new();
 
         writeln!(w, "(*").unwrap();

--- a/code-analysis/crates/codegen/parser/src/chumsky/generated_code.rs
+++ b/code-analysis/crates/codegen/parser/src/chumsky/generated_code.rs
@@ -73,7 +73,7 @@ impl GeneratedCode {
         &self.errors
     }
 
-    pub fn write_to_source_files(&self, codegen: &CodegenContext, output_dir: &PathBuf) {
+    pub fn write_to_source_files(&self, codegen: &mut CodegenContext, output_dir: &PathBuf) {
         codegen
             .write_file(
                 &output_dir.join("mod.rs"),

--- a/code-analysis/crates/codegen/parser/src/chumsky/grammar.rs
+++ b/code-analysis/crates/codegen/parser/src/chumsky/grammar.rs
@@ -8,11 +8,11 @@ use super::combinator_tree::CombinatorTree;
 use super::generated_code::GeneratedCode;
 
 pub trait GrammarChumskyExtensions {
-    fn generate_chumsky(&self, codegen: &CodegenContext, output_dir: &std::path::PathBuf);
+    fn generate_chumsky(&self, codegen: &mut CodegenContext, output_dir: &std::path::PathBuf);
 }
 
 impl GrammarChumskyExtensions for Grammar {
-    fn generate_chumsky(&self, codegen: &CodegenContext, output_dir: &std::path::PathBuf) {
+    fn generate_chumsky(&self, codegen: &mut CodegenContext, output_dir: &std::path::PathBuf) {
         let mut version_breaks = BTreeSet::new();
         for production in self.productions.values().flatten() {
             for version in production.versions.keys() {

--- a/code-analysis/crates/codegen/spec/src/grammar.rs
+++ b/code-analysis/crates/codegen/spec/src/grammar.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 pub fn generate_spec_grammar(
-    codegen: &CodegenContext,
+    codegen: &mut CodegenContext,
     grammar: &Grammar,
     generated_folder: &PathBuf,
     entries: &mut Vec<NavigationEntry>,

--- a/code-analysis/crates/codegen/spec/src/lib.rs
+++ b/code-analysis/crates/codegen/spec/src/lib.rs
@@ -2,7 +2,7 @@ use codegen_schema::Grammar;
 use codegen_utils::context::CodegenContext;
 
 use self::{grammar::generate_spec_grammar, topics::generate_spec_sections};
-use std::{collections::HashSet, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 
 mod grammar;
 mod productions;
@@ -15,34 +15,26 @@ pub struct NavigationEntry {
 }
 
 pub trait GrammarSpecExtensions {
-    fn generate_spec(&self, codegen: &CodegenContext, documentation_folder: &PathBuf);
+    fn generate_spec(&self, codegen: &mut CodegenContext, documentation_folder: &PathBuf);
 }
 
 impl GrammarSpecExtensions for Grammar {
-    fn generate_spec(&self, codegen: &CodegenContext, documentation_folder: &PathBuf) {
+    fn generate_spec(&self, codegen: &mut CodegenContext, documentation_folder: &PathBuf) {
         let generated_folder = documentation_folder.join("docs/specification/generated");
 
         let mut entries: Vec<NavigationEntry> = Vec::new();
         generate_spec_grammar(codegen, self, &generated_folder, &mut entries);
         generate_spec_sections(codegen, self, &generated_folder, &mut entries);
 
-        let mut generated_files: HashSet<&PathBuf> = entries
-            .iter()
-            .filter_map(|entry| entry.file_path.as_ref())
-            .collect();
-
-        let navigation_file = generate_spec_navigation(codegen, &documentation_folder, &entries);
-        generated_files.insert(&navigation_file);
-
-        delete_orphaned_files(codegen, &generated_folder, &generated_files)
+        generate_spec_navigation(codegen, &documentation_folder, &entries);
     }
 }
 
 fn generate_spec_navigation(
-    codegen: &CodegenContext,
+    codegen: &mut CodegenContext,
     documentation_folder: &PathBuf,
     entries: &Vec<NavigationEntry>,
-) -> PathBuf {
+) {
     let docs_folder = documentation_folder.join("docs");
 
     let mut w: Vec<u8> = Vec::new();
@@ -80,24 +72,4 @@ fn generate_spec_navigation(
     codegen
         .write_file(&navigation_file, &String::from_utf8(w).unwrap())
         .unwrap();
-
-    return navigation_file;
-}
-
-fn delete_orphaned_files(
-    codegen: &CodegenContext,
-    root_folder: &PathBuf,
-    generated_files: &HashSet<&PathBuf>,
-) {
-    root_folder.read_dir().unwrap().for_each(|child| {
-        let child_path = child.unwrap().path();
-
-        if child_path.is_dir() {
-            delete_orphaned_files(codegen, &child_path, generated_files);
-        } else if generated_files.contains(&child_path) {
-            // Keep file
-        } else {
-            codegen.delete_file(&child_path).unwrap();
-        }
-    })
 }

--- a/code-analysis/crates/codegen/spec/src/topics.rs
+++ b/code-analysis/crates/codegen/spec/src/topics.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 pub fn generate_spec_sections(
-    codegen: &CodegenContext,
+    codegen: &mut CodegenContext,
     grammar: &Grammar,
     generated_folder: &PathBuf,
     entries: &mut Vec<NavigationEntry>,

--- a/code-analysis/crates/codegen/utils/src/commands.rs
+++ b/code-analysis/crates/codegen/utils/src/commands.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::context::CodegenContext;
 
-pub(crate) fn run_command(
+pub fn run_command(
     codegen: &CodegenContext,
     parts: &Vec<&str>,
     stdin: Option<&str>,

--- a/code-analysis/crates/codegen/utils/src/files.rs
+++ b/code-analysis/crates/codegen/utils/src/files.rs
@@ -1,71 +1,85 @@
-use std;
-use std::path::PathBuf;
-
-use crate::{
-    context::CodegenContext,
-    formatting::{format_source_file, generate_header},
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{bail, Context, Result};
 
-impl CodegenContext {
-    pub fn read_file(&self, file_path: &PathBuf) -> Result<String> {
-        rerun_if_changed(file_path)?;
+use crate::{context::CodegenContext, formatting::format_source_file};
 
-        return std::fs::read_to_string(file_path)
-            .context(format!("Cannot read source file: {file_path:?}"));
-    }
-
-    pub fn write_file(&self, file_path: &PathBuf, contents: &str) -> Result<()> {
-        rerun_if_changed(file_path)?;
-
-        let parent_dir = file_path
-            .parent()
-            .context(format!("Cannot get parent directory of: {file_path:?}"))?;
-
-        std::fs::create_dir_all(parent_dir)
-            .context(format!("Cannot create parent directory of: {file_path:?}"))?;
-
-        let header = generate_header(file_path)?;
-        let contents = format!("{header}\n\n{contents}");
-
-        let formatted = match format_source_file(self, file_path, &contents) {
-            Ok(formatted) => formatted,
-            Err(error) => {
-                std::fs::write(file_path, contents)
-                    .context(format!("Cannot write generated file: {file_path:?}"))?;
-
-                bail!(error);
-            }
-        };
-
-        if file_path.exists() {
-            let existing_contents = std::fs::read_to_string(file_path)
-                .context(format!("Cannot read existing file: {file_path:?}"))?;
-
-            // To respect Cargo incrementability, don't touch the file if it is already up to date.
-            if formatted == existing_contents {
-                return Ok(());
-            }
-        }
-
-        return std::fs::write(file_path, formatted)
-            .context(format!("Cannot write generated file: {file_path:?}"));
-    }
-
-    pub fn delete_file(&self, file_path: &PathBuf) -> Result<()> {
-        rerun_if_changed(file_path)?;
-
-        return match file_path.exists() {
-            false => Ok(()),
-            true => std::fs::remove_file(file_path)
-                .context(format!("Cannot delete generated file: {file_path:?}")),
-        };
-    }
+pub fn read_file(file_path: &PathBuf) -> Result<String> {
+    return std::fs::read_to_string(file_path)
+        .context(format!("Cannot read source file: {file_path:?}"));
 }
 
-fn rerun_if_changed(file_path: &PathBuf) -> Result<()> {
-    let file_path = file_path.to_str().context("Failed to get file path")?;
-    println!("cargo:rerun-if-changed={file_path}");
+pub fn write_file(codegen: &CodegenContext, file_path: &PathBuf, contents: &str) -> Result<()> {
+    let parent_dir = file_path
+        .parent()
+        .context(format!("Cannot get parent directory of: {file_path:?}"))?;
+
+    std::fs::create_dir_all(parent_dir)
+        .context(format!("Cannot create parent directory of: {file_path:?}"))?;
+
+    let formatted = format_source_file(codegen, file_path, &contents)?;
+
+    // To respect Cargo incrementability, don't touch the file if it is already up to date.
+    if file_path.exists() {
+        let existing_contents = std::fs::read_to_string(file_path)
+            .context(format!("Cannot read existing file: {file_path:?}"))?;
+
+        if formatted == existing_contents {
+            return Ok(());
+        }
+    }
+
+    return std::fs::write(file_path, formatted)
+        .context(format!("Cannot write generated file: {file_path:?}"));
+}
+
+pub fn verify_file(codegen: &CodegenContext, file_path: &PathBuf, contents: &str) -> Result<()> {
+    let formatted = format_source_file(codegen, file_path, &contents)?;
+
+    if !file_path.exists() {
+        bail!("Generated file does not exist: {file_path:?}");
+    }
+
+    let existing_contents = std::fs::read_to_string(file_path)
+        .context(format!("Cannot read existing file: {file_path:?}"))?;
+
+    if formatted != existing_contents {
+        bail!("Generated file is out of date: {file_path:?}");
+    }
+
     return Ok(());
+}
+
+pub fn check_for_extra_files(current_dir: &Path, generated_files: &HashSet<PathBuf>) -> Result<()> {
+    if !current_dir.metadata()?.is_dir() {
+        bail!("Path is not a directory: {current_dir:?}");
+    }
+
+    for child in current_dir.read_dir()? {
+        let child = child?;
+        let child_path = child.path();
+
+        if child.metadata()?.is_file() {
+            if !generated_files.contains(&child.path()) {
+                bail!("Extra file in generated dir: {child_path:?}");
+            }
+        } else {
+            check_for_extra_files(&child_path, generated_files)?;
+        }
+    }
+
+    return Ok(());
+}
+
+pub fn get_generated_dir<'a>(path: &'a Path) -> Result<&'a Path> {
+    return if path.is_dir() && path.ends_with("generated") {
+        Ok(path)
+    } else {
+        path.parent()
+            .context(format!("Failed to find generated parent dir of: {path:?}"))
+            .and_then(get_generated_dir)
+    };
 }

--- a/code-analysis/crates/codegen/utils/src/formatting.rs
+++ b/code-analysis/crates/codegen/utils/src/formatting.rs
@@ -4,7 +4,33 @@ use crate::{commands::run_command, context::CodegenContext};
 
 use anyhow::{bail, Context, Result};
 
-pub(crate) fn generate_header(file_path: &PathBuf) -> Result<String> {
+pub fn format_source_file(
+    codegen: &CodegenContext,
+    file_path: &PathBuf,
+    contents: &str,
+) -> Result<String> {
+    let header = generate_header(file_path)?;
+    let unformatted = format!("{header}\n\n{contents}");
+
+    return formatters::run(codegen, file_path, &unformatted)
+        .context(format!("Failed to format {file_path:?}"))
+        .or_else(|formatter_error| {
+            // Try to write the unformatted version to disk, to be able to debug what went wrong.
+            let debug_file = PathBuf::from(std::env::var("OUT_DIR")?).join(format!(
+                "codegen/formatter/failure.{ext}",
+                ext = get_extension(file_path)?
+            ));
+
+            return match std::fs::write(&debug_file, &unformatted) {
+                Err(_) => Err(formatter_error), // propagate the original one.
+                Ok(()) => Err(formatter_error).context(format!(
+                    "The unformatted version was written to {debug_file:?}"
+                )),
+            };
+        });
+}
+
+fn generate_header(file_path: &PathBuf) -> Result<String> {
     let warning_line = "This file is generated via `cargo build`. Please don't edit by hand.";
 
     return match get_extension(file_path)? {
@@ -16,19 +42,6 @@ pub(crate) fn generate_header(file_path: &PathBuf) -> Result<String> {
     };
 }
 
-pub(crate) fn format_source_file(
-    codegen: &CodegenContext,
-    file_path: &PathBuf,
-    contents: &str,
-) -> Result<String> {
-    return match get_extension(file_path)? {
-        "rs" => run_rustfmt_binary(codegen, file_path, contents),
-        "md" | "yml" => run_prettier_binary(codegen, file_path, contents),
-        "ebnf" => Ok(contents.to_owned()), // we don't format these files (yet)
-        ext => bail!("Unsupported extension to format: {ext}"),
-    };
-}
-
 fn get_extension<'a>(file_path: &'a PathBuf) -> Result<&'a str> {
     return file_path
         .extension()
@@ -37,44 +50,63 @@ fn get_extension<'a>(file_path: &'a PathBuf) -> Result<&'a str> {
         .context(format!("Cannot read extension of file: {file_path:?}"));
 }
 
-fn run_rustfmt_binary(
-    codegen: &CodegenContext,
-    file_path: &PathBuf,
-    contents: &str,
-) -> Result<String> {
-    return run_command(
-        codegen,
-        &vec!["rustfmt", "--emit", "stdout"],
-        Some(contents),
-    )
-    .context(format!("Failed to run rustfmt on file: {file_path:?}"));
-}
+mod formatters {
+    use super::*;
 
-fn run_prettier_binary(
-    codegen: &CodegenContext,
-    file_path: &PathBuf,
-    contents: &str,
-) -> Result<String> {
-    let node_path = codegen.repo_dir.join("bin/node");
-
-    let prettier_path = codegen
-        .repo_dir
-        .join("infrastructure/node_modules/.bin/prettier");
-
-    if !prettier_path.exists() {
-        let setup_path = codegen.repo_dir.join("infrastructure/scripts/setup.sh");
-        bail!("Failed to find prettier binary at: {prettier_path:?}. Please run {setup_path:?} to install it.");
+    pub fn run(codegen: &CodegenContext, file_path: &PathBuf, contents: &str) -> Result<String> {
+        return match get_extension(file_path)? {
+            "rs" => run_rustfmt(codegen, file_path, contents),
+            "md" | "yml" => run_prettier(codegen, file_path, contents),
+            "ebnf" => Ok(contents.to_owned()), // we don't format these files (yet)
+            ext => bail!("Unsupported extension to format: {ext}"),
+        };
     }
 
-    return run_command(
-        codegen,
-        &vec![
-            node_path.to_str().context("Failed to get path")?,
-            prettier_path.to_str().context("Failed to get path")?,
-            "--stdin-filepath", // used to infer the language, and detect `.prettierrc` options
-            file_path.to_str().context("Failed to read file path")?,
-        ],
-        Some(contents),
-    )
-    .context(format!("Failed to run prettier on file: {file_path:?}"));
+    fn run_rustfmt(
+        codegen: &CodegenContext,
+        file_path: &PathBuf,
+        contents: &str,
+    ) -> Result<String> {
+        let rustfmt_path = codegen.repo_dir.join("bin/rustfmt");
+
+        return run_command(
+            codegen,
+            &vec![
+                rustfmt_path.to_str().context("Failed to get path")?,
+                "--emit",
+                "stdout",
+            ],
+            Some(contents),
+        )
+        .context(format!("Failed to run rustfmt on file: {file_path:?}"));
+    }
+
+    fn run_prettier(
+        codegen: &CodegenContext,
+        file_path: &PathBuf,
+        contents: &str,
+    ) -> Result<String> {
+        let node_path = codegen.repo_dir.join("bin/node");
+
+        let prettier_path = codegen
+            .repo_dir
+            .join("infrastructure/node_modules/.bin/prettier");
+
+        if !prettier_path.exists() {
+            let setup_path = codegen.repo_dir.join("infrastructure/scripts/setup.sh");
+            bail!("Failed to find prettier binary at: {prettier_path:?}. Please run {setup_path:?} to install it.");
+        }
+
+        return run_command(
+            codegen,
+            &vec![
+                node_path.to_str().context("Failed to get path")?,
+                prettier_path.to_str().context("Failed to get path")?,
+                "--stdin-filepath", // used to infer the language, and detect `.prettierrc` options
+                file_path.to_str().context("Failed to read file path")?,
+            ],
+            Some(contents),
+        )
+        .context(format!("Failed to run prettier on file: {file_path:?}"));
+    }
 }

--- a/code-analysis/crates/codegen/utils/src/lib.rs
+++ b/code-analysis/crates/codegen/utils/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod commands;
+mod commands;
+mod files;
+mod formatting;
+
 pub mod context;
-pub mod files;
-pub mod formatting;

--- a/code-analysis/scripts/check.sh
+++ b/code-analysis/scripts/check.sh
@@ -16,7 +16,7 @@ source "$THIS_DIR/common.sh"
   cd "$PROJECT_DIR"
 
   export RUST_BACKTRACE="full"
-  export SLANG_CODEGEN_VALIDATE="true"
+  export SLANG_VALIDATE_GENERATED_FILES="true"
 
   cargo check --locked
   cargo fmt --check --all


### PR DESCRIPTION
A necessity for snapshot tests, added in subsequent PRs:

1. Moves "outdated file checks" to run during build atomically, instead of verifying them before/after the build. This means we can just run `check.sh` locally as well.
2. Makes sure each `generated/**` folder is fully created during every build, so that the build will fail if there are any lingering files there, and that each file is generated only once.