### PR TITLE
add solidity_parser api for testing

### DIFF
--- a/code-analysis/crates/codegen/parser/src/chumsky/generated_code.rs
+++ b/code-analysis/crates/codegen/parser/src/chumsky/generated_code.rs
@@ -156,7 +156,7 @@ impl GeneratedCode {
             .map(|version| {
                 let version = version.to_string();
                 let version_name = format_ident!("version_{}", version.replace(".", "_"));
-                quote!( let #version_name = Version::parse(#version).unwrap(); ).to_string()
+                quote!( let #version_name = &Version::parse(#version).unwrap(); ).to_string()
             })
             .collect::<Vec<String>>();
 
@@ -172,7 +172,7 @@ impl GeneratedCode {
                 }}
 
                 impl<'a> Parsers<'a> {{
-                    pub fn new(version: Version) -> Self {{
+                    pub fn new(version: &Version) -> Self {{
                         // Declare all versions -----------------------------
 
                         {}

--- a/code-analysis/crates/solidity/outputs/parser/src/bin/slang.rs
+++ b/code-analysis/crates/solidity/outputs/parser/src/bin/slang.rs
@@ -1,21 +1,8 @@
 use std::fs;
 
-use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
-use chumsky::prelude::*;
 use clap::Parser as ClapParser;
 use semver::Version;
-use solidity_parser::generated::parse::ErrorType;
-use strum::EnumString;
-
-use solidity_parser::generated::parse::Context;
-use solidity_parser::generated::parse::Parsers;
-use solidity_parser::generated::parse::SpanType;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, EnumString)]
-enum ParserType {
-    CST,
-    AST,
-}
+use solidity_parser::generated::parse::{Context, Parsers};
 
 #[derive(ClapParser, Debug)]
 struct ProgramArgs {
@@ -31,147 +18,49 @@ struct ProgramArgs {
     yaml_output: Option<String>,
 }
 
-struct Input<'a, Iter: Iterator<Item = char>> {
-    source: Iter,
-    position: usize,
-    context: &'a Context<'a>,
-}
-
-impl<'a> Input<'a, std::str::Chars<'a>> {
-    fn new(source: &'a str, context: &'a Context<'a>) -> Self {
-        Self {
-            source: source.chars(),
-            position: 0,
-            context,
-        }
-    }
-    fn eos(&self) -> (&'a Context<'a>, std::ops::Range<usize>) {
-        (self.context, 0..0)
-    }
-}
-
-impl<'a, Iter: Iterator<Item = char>> Iterator for Input<'a, Iter> {
-    type Item = (char, (&'a Context<'a>, std::ops::Range<usize>));
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let c = self.source.next();
-        match c {
-            Some(c) => {
-                self.position += 1;
-                Some((c, (self.context, self.position..(self.position + 1))))
-            }
-            None => None,
-        }
-    }
-}
-
-fn main() -> Result<(), usize> {
+fn main() -> std::io::Result<()> {
+    let context = Context::new();
     let args = ProgramArgs::parse();
 
-    let solidity_src = fs::read_to_string(args.solidity_input).expect("Failed to read file");
+    let solidity_src = fs::read_to_string(&args.solidity_input)
+        .expect(&format!("Failed to read file: {:?}", args.solidity_input));
 
-    let context = Context::new();
-    let input = Input::new(&solidity_src, &context);
-    let stream = chumsky::Stream::from_iter(input.eos(), input);
-    let (parse_tree, errs) = Parsers::new(args.version)
-        .source_unit
-        .parse_recovery(stream);
-    let number_of_errors = errs.len();
-    print_errors(errs, &solidity_src);
+    let parser = Parsers::new(&args.version).source_unit;
 
-    if let Some(source_unit) = parse_tree {
+    let output = solidity_parser::internal_api::parse(
+        &context,
+        &solidity_src,
+        parser,
+        /* with_color */ true,
+    );
+
+    for report in &output.error_reports {
+        eprintln!("{report}");
+    }
+
+    if let Some(source_unit) = output.root_node {
         if let Some(json_output) = args.json_output {
             let json = serde_json::to_string(&source_unit).expect("Failed to produce json");
             if json_output == "-" {
                 println!("{}", json);
             } else {
-                fs::write(json_output, json).expect("Failed to write json file");
+                fs::write(&json_output, json)
+                    .expect(&format!("Failed to write json file: {json_output}"));
             }
         }
+
         if let Some(yaml_output) = args.yaml_output {
             let yaml = serde_yaml::to_string(&source_unit).expect("Failed to produce yaml");
             if yaml_output == "-" {
                 println!("{}", yaml);
             } else {
-                fs::write(yaml_output, yaml).expect("Failed to write yaml file");
+                fs::write(&yaml_output, yaml)
+                    .expect(&format!("Failed to write yaml file: {yaml_output}"));
             }
         }
     }
 
-    if number_of_errors == 0 {
-        Ok(())
-    } else {
-        Err(number_of_errors)
-    }
-}
-
-// TODO: encapsulate the following in a support library
-
-fn print_errors<'a>(errs: Vec<ErrorType<'a>>, src: &'a str) {
-    errs.into_iter().for_each(|e| {
-        let context = e.span().context();
-        let report = generate_report(e);
-        let source = Source::from(src);
-        report.finish().print((context, source)).unwrap();
-    });
-}
-
-fn generate_report<'a>(e: ErrorType<'a>) -> ariadne::ReportBuilder<SpanType<'a>> {
-    let msg = if let chumsky::error::SimpleReason::Custom(msg) = e.reason() {
-        msg.clone()
-    } else {
-        format!(
-            "{}{}, expected {}",
-            if e.found().is_some() {
-                "Unexpected token"
-            } else {
-                "Unexpected end of input"
-            },
-            if let Some(label) = e.label() {
-                format!(" while parsing {}", label)
-            } else {
-                String::new()
-            },
-            if e.expected().len() == 0 {
-                "something else".to_string()
-            } else {
-                e.expected()
-                    .map(|expected| match expected {
-                        Some(expected) => expected.to_string(),
-                        None => "end of input".to_string(),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" or ")
-            },
-        )
-    };
-    let report = Report::build(ReportKind::Error, e.span().context(), e.span().start())
-        .with_code(3)
-        .with_message(msg)
-        .with_label(
-            Label::new(e.span())
-                .with_message(match e.reason() {
-                    chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
-                    _ => format!(
-                        "Unexpected {}",
-                        e.found()
-                            .map(|c| format!("token {}", c.fg(Color::Red)))
-                            .unwrap_or_else(|| "end of input".to_string())
-                    ),
-                })
-                .with_color(Color::Red),
-        );
-    let report = match e.reason() {
-        chumsky::error::SimpleReason::Unclosed { span, delimiter } => report.with_label(
-            Label::new(span.clone())
-                .with_message(format!(
-                    "Unclosed delimiter {}",
-                    delimiter.fg(Color::Yellow)
-                ))
-                .with_color(Color::Yellow),
-        ),
-        chumsky::error::SimpleReason::Unexpected => report,
-        chumsky::error::SimpleReason::Custom(_) => report,
-    };
-    report
+    let errors_count =
+        i32::try_from(output.error_reports.len()).expect("Failed to convert errors count to i32");
+    std::process::exit(errors_count);
 }

--- a/code-analysis/crates/solidity/outputs/parser/src/generated/parse.rs
+++ b/code-analysis/crates/solidity/outputs/parser/src/generated/parse.rs
@@ -568,10 +568,10 @@ pub struct Parsers<'a> {
 }
 
 impl<'a> Parsers<'a> {
-    pub fn new(version: Version) -> Self {
+    pub fn new(version: &Version) -> Self {
         // Declare all versions -----------------------------
 
-        let version_0_6_0 = Version::parse("0.6.0").unwrap();
+        let version_0_6_0 = &Version::parse("0.6.0").unwrap();
 
         // Declare all productions --------------------------
 

--- a/code-analysis/crates/solidity/outputs/parser/src/internal_api.rs
+++ b/code-analysis/crates/solidity/outputs/parser/src/internal_api.rs
@@ -1,0 +1,147 @@
+use ariadne::{Color, Config, Fmt, Label, Report, ReportKind, Source};
+use chumsky::{Parser, Span, Stream};
+
+use crate::generated::parse::{Context, ErrorType, ParserType, SpanType};
+
+pub struct ParserOutput<TNode> {
+    pub root_node: Option<TNode>,
+    pub error_reports: Vec<String>,
+}
+
+pub fn parse<'a, TNode>(
+    context: &'a Context<'a>,
+    source: &'a str,
+    parser: ParserType<'a, TNode>,
+    with_color: bool,
+) -> ParserOutput<TNode> {
+    let input = Input::new(source, context);
+    let stream = Stream::from_iter(input.eos(), input);
+
+    let (parse_tree, errors) = parser.parse_recovery(stream);
+
+    let mut error_reports = vec![];
+    for error in &errors {
+        let source = Source::from(source);
+        let context = error.span().context();
+        let report = render_error_report(&error, with_color);
+
+        let mut result = vec![];
+        report
+            .write((context, source), &mut result)
+            .expect("Failed to write report");
+
+        let result = String::from_utf8(result).expect("Failed to convert report to utf8");
+        error_reports.push(result);
+    }
+
+    return ParserOutput {
+        root_node: parse_tree,
+        error_reports,
+    };
+}
+
+struct Input<'a, Iter: Iterator<Item = char>> {
+    source: Iter,
+    position: usize,
+    context: &'a Context<'a>,
+}
+
+impl<'a> Input<'a, std::str::Chars<'a>> {
+    fn new(source: &'a str, context: &'a Context<'a>) -> Self {
+        Self {
+            source: source.chars(),
+            position: 0,
+            context,
+        }
+    }
+
+    fn eos(&self) -> (&'a Context<'a>, std::ops::Range<usize>) {
+        (self.context, 0..0)
+    }
+}
+
+impl<'a, Iter: Iterator<Item = char>> Iterator for Input<'a, Iter> {
+    type Item = (char, (&'a Context<'a>, std::ops::Range<usize>));
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.source.next() {
+            Some(c) => {
+                self.position += 1;
+                Some((c, (self.context, self.position..(self.position + 1))))
+            }
+            None => None,
+        }
+    }
+}
+
+fn render_error_report<'a>(error: &ErrorType<'a>, with_color: bool) -> Report<SpanType<'a>> {
+    let builder = Report::build(
+        ReportKind::Error,
+        error.span().context(),
+        error.span().start(),
+    );
+
+    let builder = builder.with_config(Config::default().with_color(with_color));
+
+    // TODO(OmarTawfik): also disable colors below if with_color is false
+
+    let msg = if let chumsky::error::SimpleReason::Custom(msg) = error.reason() {
+        msg.clone()
+    } else {
+        format!(
+            "{}{}, expected {}",
+            if error.found().is_some() {
+                "Unexpected token"
+            } else {
+                "Unexpected end of input"
+            },
+            if let Some(label) = error.label() {
+                format!(" while parsing {}", label)
+            } else {
+                String::new()
+            },
+            if error.expected().len() == 0 {
+                "something else".to_string()
+            } else {
+                error
+                    .expected()
+                    .map(|expected| match expected {
+                        Some(expected) => expected.to_string(),
+                        None => "end of input".to_string(),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" or ")
+            },
+        )
+    };
+
+    let builder = builder.with_code(3).with_message(msg).with_label(
+        Label::new(error.span())
+            .with_message(match error.reason() {
+                chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
+                _ => format!(
+                    "Unexpected {}",
+                    error
+                        .found()
+                        .map(|c| format!("token {}", c.fg(Color::Red)))
+                        .unwrap_or_else(|| "end of input".to_string())
+                ),
+            })
+            .with_color(Color::Red),
+    );
+
+    let builder = match error.reason() {
+        chumsky::error::SimpleReason::Unclosed { span, delimiter } => builder.with_label(
+            Label::new(span.clone())
+                .with_message(format!(
+                    "Unclosed delimiter {}",
+                    delimiter.fg(Color::Yellow)
+                ))
+                .with_color(Color::Yellow),
+        ),
+        chumsky::error::SimpleReason::Unexpected => builder,
+        chumsky::error::SimpleReason::Custom(_) => builder,
+    };
+
+    return builder.finish();
+}

--- a/code-analysis/crates/solidity/outputs/parser/src/lib.rs
+++ b/code-analysis/crates/solidity/outputs/parser/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod generated;
+pub mod internal_api;


### PR DESCRIPTION
Abstracts away the parser API from `slang.rs` binary into a common `lib` module, so that tests can reuse that API in the next PR.

Nit: makes the parsers accept the version by reference, since it is not needed for comparison checks.