### PR TITLE
improvements to cargo run binaries

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,3 +1,4 @@
 env = {
+  "PATH": "${HERMIT_ENV}/code-analysis/scripts/bin:${PATH}",
   "REPO_ROOT": "${HERMIT_ENV}",
 }

--- a/code-analysis/Cargo.lock
+++ b/code-analysis/Cargo.lock
@@ -1228,6 +1228,7 @@ dependencies = [
 name = "solidity_rust_cli"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "clap",
  "semver",
  "serde_json",

--- a/code-analysis/crates/solidity/outputs/rust/cli/Cargo.toml
+++ b/code-analysis/crates/solidity/outputs/rust/cli/Cargo.toml
@@ -5,6 +5,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 clap = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }

--- a/code-analysis/crates/solidity/outputs/rust/cli/src/main.rs
+++ b/code-analysis/crates/solidity/outputs/rust/cli/src/main.rs
@@ -1,59 +1,69 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
+use anyhow::{Context, Result};
 use clap::Parser as ClapParser;
 use semver::Version;
 use solidity_rust_lib::{generated::parse::Parsers, internal_api::parser::parse};
 
 #[derive(ClapParser, Debug)]
 struct ProgramArgs {
-    solidity_input: String,
+    input_file: String,
 
     #[clap(long)]
     version: Version,
 
     #[clap(long)]
-    json_output: Option<String>,
+    json: Option<String>,
 
     #[clap(long)]
-    yaml_output: Option<String>,
+    yaml: Option<String>,
 }
 
-fn main() -> std::io::Result<()> {
+fn main() -> Result<()> {
     let args = ProgramArgs::parse();
 
-    let solidity_src = fs::read_to_string(&args.solidity_input)
-        .expect(&format!("Failed to read file: {:?}", args.solidity_input));
+    let input = {
+        let input_file = &PathBuf::from(args.input_file).canonicalize()?;
+        fs::read_to_string(input_file).context(format!("Failed to read file: {input_file:?}"))?
+    };
 
-    let parser = Parsers::new(&args.version).source_unit;
-    let output = parse(&solidity_src, parser, /* with_color */ true);
+    let output = {
+        let parser = Parsers::new(&args.version).source_unit;
+        parse(&input, parser, /* with_color */ true)
+    };
 
     for report in &output.error_reports {
         eprintln!("{report}");
     }
 
-    if let Some(source_unit) = output.root_node {
-        if let Some(json_output) = args.json_output {
-            let json = serde_json::to_string(&source_unit).expect("Failed to produce json");
-            if json_output == "-" {
+    if let Some(root_node) = output.root_node {
+        if let Some(json_path) = args.json {
+            let json = serde_json::to_string_pretty(&root_node).context("Failed to write json")?;
+
+            if json_path == "-" {
                 println!("{}", json);
             } else {
-                fs::write(&json_output, json)
-                    .expect(&format!("Failed to write json file: {json_output}"));
+                let json_path = &PathBuf::from(json_path).canonicalize()?;
+                fs::write(json_path, json)
+                    .context(format!("Failed to write json file: {json_path:?}"))?;
             }
         }
 
-        if let Some(yaml_output) = args.yaml_output {
-            let yaml = serde_yaml::to_string(&source_unit).expect("Failed to produce yaml");
-            if yaml_output == "-" {
+        if let Some(yaml_path) = args.yaml {
+            let yaml = serde_yaml::to_string(&root_node).context("Failed to write yaml")?;
+
+            if yaml_path == "-" {
                 println!("{}", yaml);
             } else {
-                fs::write(&yaml_output, yaml)
-                    .expect(&format!("Failed to write yaml file: {yaml_output}"));
+                let yaml_path = &PathBuf::from(yaml_path).canonicalize()?;
+                fs::write(&yaml_path, yaml)
+                    .context(format!("Failed to write yaml file: {yaml_path:?}"))?;
             }
         }
     }
 
-    let errors_count =
-        i32::try_from(output.error_reports.len()).expect("Failed to convert errors count to i32");
+    let errors_count = i32::try_from(output.error_reports.len())
+        .context("Failed to convert errors count to i32")?;
+
     std::process::exit(errors_count);
 }

--- a/code-analysis/scripts/bin/README.md
+++ b/code-analysis/scripts/bin/README.md
@@ -1,0 +1,17 @@
+# Cargo Run Scripts
+
+This folder contains scripts/shorthands for rust binaries we add to the Cargo workspace.
+These scripts read and reuse the same configs used by other build/test scripts.
+
+This folder is added to the hermit environment `$PATH`, it can be directly invoked from any folder. Example:
+
+```bash
+solidity_rust_cli --version 0.8.0 "./code-analysis/crates/solidity/samples/Bee_token.sol" --json "output.json"
+```
+
+Whenever we add new binaries (internal or external), we should add a new script to this folder:
+
+```bash
+cd "$REPO_ROOT/code-analysis/scripts/bin"
+ln -s _slang_cargo_bin_runner.sh THE_NEW_BINARY_NAME
+```

--- a/code-analysis/scripts/bin/_slang_cargo_bin_runner.sh
+++ b/code-analysis/scripts/bin/_slang_cargo_bin_runner.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../common.sh"
+
+(
+  # Run setup first
+  "$REPO_ROOT/code-analysis/scripts/setup.sh"
+)
+
+(
+  cargo run \
+    --manifest-path "$REPO_ROOT/code-analysis/Cargo.toml" \
+    --bin "$(basename "$0")" \
+    -- "$@"
+)

--- a/code-analysis/scripts/bin/solidity_rust_cli
+++ b/code-analysis/scripts/bin/solidity_rust_cli
@@ -1,0 +1,1 @@
+_slang_cargo_bin_runner.sh


### PR DESCRIPTION
Added a `code-analysis/scripts/bin` folder that contains scripts/shorthands for rust binaries we add to the Cargo workspace.
These scripts read and reuse the same configs used by other build/test scripts.

For now, it only has a single script: `solidity_rust_cli`.
And since I added this folder to the hermit environment `$PATH`, it can be directly invoked from any folder:

```bash
solidity_rust_cli --version 0.8.0 ./code-analysis/crates/solidity/samples/Bee_token.sol' --json -
```

Whenever we add new binaries (internal or external), we should add a new script to this folder:

```bash
cd "$REPO_ROOT/code-analysis/scripts/bin"
ln -s _slang_cargo_bin_runner.sh THE_NEW_BINARY_NAME
```

I also added a bunch of tiny improvements for issues I found while using this single binary:

- Fixed a bug where relative paths were not resolved correctly in error messages.
- use `serde_json::to_string_pretty()` instead of `serde_json::to_string()` for indented/formatted output.
- Removed a bunch of `expect()` and `unwrap()`, to propagate `anyhow::Context` correctly.
