### PR TITLE
turn on debugging information

### DIFF
--- a/code-analysis/Cargo.toml
+++ b/code-analysis/Cargo.toml
@@ -51,7 +51,7 @@ unicode_names2 = { version = "0.6.0" }
 walkdir = { version = "2.3.2" }
 
 [profile.dev]
-debug = 0
+debug = 2
 incremental = true
 
 [profile.release]


### PR DESCRIPTION
Found it really hard to debug failures/errors without it enabled.
I ran a few tests by changing `boilerplate.rs` (to regenerate the parser code) and running `time cargo build`, and difference was ignorable.

Before:

- cargo build  24.38s user 4.05s system 196% cpu 14.494 total
- cargo build  24.42s user 3.57s system 195% cpu 14.304 total
- cargo build  24.86s user 3.63s system 190% cpu 14.965 total

After:

- cargo build  25.93s user 3.87s system 188% cpu 15.799 total
- cargo build  25.51s user 3.76s system 181% cpu 16.090 total
- cargo build  25.36s user 3.67s system 190% cpu 15.232 total
