### PR TITLE
fix ariadne error on empty strings

### DIFF
--- a/crates/codegen/parser/src/chumsky/boilerplate.rs
+++ b/crates/codegen/parser/src/chumsky/boilerplate.rs
@@ -746,46 +746,19 @@ pub fn parse_macros() -> TokenStream {
 
 pub fn error_renderer() -> TokenStream {
     quote!(
-        fn render_error_report(error: &ErrorType, with_color: bool) -> Report<SpanType> {
-            let mut builder: ReportBuilder<SpanType> = Report::build(
-                ReportKind::Error,
-                error.span().context(),
-                error.span().start(),
-            )
-            .with_config(Config::default().with_color(with_color));
+        fn render_error_report(error: &ErrorType, source: &str, with_color: bool) -> String {
+            let kind = ReportKind::Error;
+            let color = if with_color { Color::Red } else { Color::Unset };
 
-            let error_color = if with_color { Color::Red } else { Color::Unset };
-
-            builder = match error.reason() {
+            let message = match error.reason() {
                 SimpleReason::Custom(message) => {
                     // use custom message as-is
-                    builder.with_message(message)
+                    message.to_string()
                 }
-                SimpleReason::Unclosed { span, delimiter } => {
-                    builder.add_label(
-                        Label::<SpanType>::new(span.to_owned())
-                            .with_color(error_color)
-                            .with_message("Unclosed delimiter"),
-                    );
-
-                    builder.with_message(format!(
-                        "Expected delimiter '{}' to be closed",
-                        delimiter.fg(error_color)
-                    ))
+                SimpleReason::Unclosed { delimiter, .. } => {
+                    format!("Expected delimiter '{}' to be closed", delimiter.fg(color))
                 }
                 SimpleReason::Unexpected => {
-                    let found = if let Some(found) = error.found() {
-                        format!("'{}'", found.fg(error_color))
-                    } else {
-                        "end of input".to_string()
-                    };
-
-                    builder.add_label(
-                        Label::<SpanType>::new(error.span())
-                            .with_color(error_color)
-                            .with_message(format!("Found {found}.")),
-                    );
-
                     let mut expected: Vec<&Option<char>> = error.expected().collect();
                     expected.sort();
 
@@ -802,11 +775,50 @@ pub fn error_renderer() -> TokenStream {
                             .join(" or ")
                     };
 
-                    builder.with_message(format!("Expected {expected}."))
+                    format!("Expected {expected}.")
                 }
             };
 
-            return builder.finish();
+            if source.is_empty() {
+                let start = error.span().start();
+                let end = error.span().end();
+                return format!("{kind}: {message}\n   ─[{start}:{end}]");
+            }
+
+            let label = match error.reason() {
+                SimpleReason::Custom(_) => "Error occurred here.".to_string(),
+                SimpleReason::Unclosed { delimiter, .. } => {
+                    format!("Unclosed delimiter '{}'.", delimiter.fg(color))
+                }
+                SimpleReason::Unexpected => {
+                    if let Some(found) = error.found() {
+                        format!("Found '{}'.", found.fg(color))
+                    } else {
+                        "Found end of input.".to_string()
+                    }
+                }
+            };
+
+            let mut builder = Report::build(kind, error.span().context(), error.span().start())
+                .with_config(Config::default().with_color(with_color))
+                .with_message(message);
+
+            builder.add_label(
+                Label::new(error.span())
+                    .with_color(color)
+                    .with_message(label),
+            );
+
+            let mut result = vec![];
+            builder
+                .finish()
+                .write(Source::from(&source), &mut result)
+                .expect("Failed to write report");
+
+            return String::from_utf8(result)
+                .expect("Failed to convert report to utf8")
+                .trim()
+                .to_string();
         }
     )
 }

--- a/crates/codegen/parser/src/chumsky/rust_lib_boilerplate.rs
+++ b/crates/codegen/parser/src/chumsky/rust_lib_boilerplate.rs
@@ -186,12 +186,12 @@ pub fn language_head() -> TokenStream {
         use std::rc::Rc;
 
         use chumsky::{error::SimpleReason, Parser, Span};
-        use ariadne::{Color, Config, Fmt, Label, Report, ReportBuilder, ReportKind, Source};
+        use ariadne::{Color, Config, Fmt, Label, Report, ReportKind, Source};
         use semver::Version;
 
         use super::{
             cst,
-            parse::{Parsers, BoxedParserType, ErrorType, SpanType},
+            parse::{BoxedParserType, ErrorType, Parsers},
         };
 
         pub struct Language {
@@ -232,20 +232,11 @@ pub fn language_head() -> TokenStream {
             }
 
             pub fn errors_as_strings(&self, source: &str, with_colour: bool) -> Vec<String> {
-                let mut results = vec![];
-                for error in &self.errors {
-                    let report = render_error_report(&error, with_colour);
-
-                    let mut result = vec![];
-                    report
-                        .write(Source::from(source), &mut result)
-                        .expect("Failed to write report");
-
-                    let result = String::from_utf8(result).expect("Failed to convert report to utf8");
-                    results.push(result);
-                }
-
-                results
+                return self
+                    .errors
+                    .iter()
+                    .map(|error| render_error_report(error, source, with_colour))
+                    .collect();
             }
 
             pub fn is_valid(&self) -> bool {

--- a/crates/codegen/parser/src/chumsky/typescript_lib_boilerplate.rs
+++ b/crates/codegen/parser/src/chumsky/typescript_lib_boilerplate.rs
@@ -275,13 +275,13 @@ pub fn language_head() -> TokenStream {
         use std::rc::Rc;
 
         use chumsky::{error::SimpleReason, Parser, Span};
-        use ariadne::{Color, Config, Fmt, Label, Report, ReportBuilder, ReportKind, Source};
+        use ariadne::{Color, Config, Fmt, Label, Report, ReportKind, Source};
         use semver::Version;
 
         use super::{
             cst,
             cst::RcNodeExtensions as CSTRcNodeExtensions,
-            parse::{Parsers, BoxedParserType, ErrorType, SpanType},
+            parse::{BoxedParserType, ErrorType, Parsers},
         };
         use napi::bindgen_prelude::*;
 
@@ -333,20 +333,11 @@ pub fn language_head() -> TokenStream {
 
             #[napi]
             pub fn errors_as_strings(&self, source: String, with_colour: bool) -> Vec<String> {
-                let mut results = vec![];
-                for error in &self.errors {
-                    let report = render_error_report(&error, with_colour);
-
-                    let mut result = vec![];
-                    report
-                        .write(Source::from(source.as_str()), &mut result)
-                        .expect("Failed to write report");
-
-                    let result = String::from_utf8(result).expect("Failed to convert report to utf8");
-                    results.push(result);
-                }
-
-                results
+                return self
+                    .errors
+                    .iter()
+                    .map(|error| render_error_report(error, &source, with_colour))
+                    .collect();
             }
 
             #[napi]

--- a/crates/solidity/outputs/rust/tests/src/cst_output/generated/ContractDefinition.rs
+++ b/crates/solidity/outputs/rust/tests/src/cst_output/generated/ContractDefinition.rs
@@ -17,3 +17,8 @@ fn missing_field_type() -> Result<()> {
 fn unterminated_body() -> Result<()> {
     return run("ContractDefinition", "unterminated_body");
 }
+
+#[test]
+fn zero_length_input() -> Result<()> {
+    return run("ContractDefinition", "zero_length_input");
+}

--- a/crates/solidity/outputs/typescript/lib/src/generated/language.rs
+++ b/crates/solidity/outputs/typescript/lib/src/generated/language.rs
@@ -3,9 +3,9 @@
 use super::{
     cst,
     cst::RcNodeExtensions as CSTRcNodeExtensions,
-    parse::{BoxedParserType, ErrorType, Parsers, SpanType},
+    parse::{BoxedParserType, ErrorType, Parsers},
 };
-use ariadne::{Color, Config, Fmt, Label, Report, ReportBuilder, ReportKind, Source};
+use ariadne::{Color, Config, Fmt, Label, Report, ReportKind, Source};
 use chumsky::{error::SimpleReason, Parser, Span};
 use napi::bindgen_prelude::*;
 use semver::Version;
@@ -51,55 +51,26 @@ impl ParserOutput {
     }
     #[napi]
     pub fn errors_as_strings(&self, source: String, with_colour: bool) -> Vec<String> {
-        let mut results = vec![];
-        for error in &self.errors {
-            let report = render_error_report(&error, with_colour);
-            let mut result = vec![];
-            report
-                .write(Source::from(source.as_str()), &mut result)
-                .expect("Failed to write report");
-            let result = String::from_utf8(result).expect("Failed to convert report to utf8");
-            results.push(result);
-        }
-        results
+        return self
+            .errors
+            .iter()
+            .map(|error| render_error_report(error, &source, with_colour))
+            .collect();
     }
     #[napi]
     pub fn is_valid(&self) -> bool {
         self.parse_tree.is_some() && self.errors.is_empty()
     }
 }
-fn render_error_report(error: &ErrorType, with_color: bool) -> Report<SpanType> {
-    let mut builder: ReportBuilder<SpanType> = Report::build(
-        ReportKind::Error,
-        error.span().context(),
-        error.span().start(),
-    )
-    .with_config(Config::default().with_color(with_color));
-    let error_color = if with_color { Color::Red } else { Color::Unset };
-    builder = match error.reason() {
-        SimpleReason::Custom(message) => builder.with_message(message),
-        SimpleReason::Unclosed { span, delimiter } => {
-            builder.add_label(
-                Label::<SpanType>::new(span.to_owned())
-                    .with_color(error_color)
-                    .with_message("Unclosed delimiter"),
-            );
-            builder.with_message(format!(
-                "Expected delimiter '{}' to be closed",
-                delimiter.fg(error_color)
-            ))
+fn render_error_report(error: &ErrorType, source: &str, with_color: bool) -> String {
+    let kind = ReportKind::Error;
+    let color = if with_color { Color::Red } else { Color::Unset };
+    let message = match error.reason() {
+        SimpleReason::Custom(message) => message.to_string(),
+        SimpleReason::Unclosed { delimiter, .. } => {
+            format!("Expected delimiter '{}' to be closed", delimiter.fg(color))
         }
         SimpleReason::Unexpected => {
-            let found = if let Some(found) = error.found() {
-                format!("'{}'", found.fg(error_color))
-            } else {
-                "end of input".to_string()
-            };
-            builder.add_label(
-                Label::<SpanType>::new(error.span())
-                    .with_color(error_color)
-                    .with_message(format!("Found {found}.")),
-            );
             let mut expected: Vec<&Option<char>> = error.expected().collect();
             expected.sort();
             let expected = if expected.len() == 0 {
@@ -114,10 +85,44 @@ fn render_error_report(error: &ErrorType, with_color: bool) -> Report<SpanType> 
                     .collect::<Vec<_>>()
                     .join(" or ")
             };
-            builder.with_message(format!("Expected {expected}."))
+            format!("Expected {expected}.")
         }
     };
-    return builder.finish();
+    if source.is_empty() {
+        let start = error.span().start();
+        let end = error.span().end();
+        return format!("{kind}: {message}\n   ─[{start}:{end}]");
+    }
+    let label = match error.reason() {
+        SimpleReason::Custom(_) => "Error occurred here.".to_string(),
+        SimpleReason::Unclosed { delimiter, .. } => {
+            format!("Unclosed delimiter '{}'.", delimiter.fg(color))
+        }
+        SimpleReason::Unexpected => {
+            if let Some(found) = error.found() {
+                format!("Found '{}'.", found.fg(color))
+            } else {
+                "Found end of input.".to_string()
+            }
+        }
+    };
+    let mut builder = Report::build(kind, error.span().context(), error.span().start())
+        .with_config(Config::default().with_color(with_color))
+        .with_message(message);
+    builder.add_label(
+        Label::new(error.span())
+            .with_color(color)
+            .with_message(label),
+    );
+    let mut result = vec![];
+    builder
+        .finish()
+        .write(Source::from(&source), &mut result)
+        .expect("Failed to write report");
+    return String::from_utf8(result)
+        .expect("Failed to convert report to utf8")
+        .trim()
+        .to_string();
 }
 
 #[napi]

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/zero_length_input/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/zero_length_input/generated/0.4.11.yml
@@ -1,0 +1,8 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+errors:
+  - |
+    Error: Expected '/' or 'a' or 'c'.
+       ─[0:0]
+
+root: null


### PR DESCRIPTION
It fails to report errors on empty strings with:

```
thread 'cst_output::generated::ContractDefinition::zero_length_input' panicked at 'index out of bounds: the len is 0 but the index is 0'.
```

This PR just returns the error message without the report in this case.
