### PR TITLE
add yamllint for grammar files

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,30 @@
+rules:
+  braces:
+    forbid: "non-empty"
+  brackets:
+    forbid: "non-empty"
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: true
+  document-end:
+    present: false
+  document-start:
+    present: false
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  float-values:
+    forbid-inf: true
+    forbid-nan: true
+    forbid-scientific-notation: true
+    require-numeral-before-decimal: true
+  key-duplicates: "enable"
+  new-lines: "enable"
+  octal-values:
+    forbid-explicit-octal: true
+    forbid-implicit-octal: true
+  quoted-strings:
+    allow-quoted-quotes: true
+    quote-type: "double"
+    required: true
+  truthy: "enable"

--- a/scripts/linting/Pipfile
+++ b/scripts/linting/Pipfile
@@ -1,0 +1,7 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+yamllint = "==1.28.0"

--- a/scripts/linting/Pipfile.lock
+++ b/scripts/linting/Pipfile.lock
@@ -1,0 +1,89 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2bd784f163419b71746e898c868c26814e38bdc7b4b96a94c19bd544eea6bf6a"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pathspec": {
+            "hashes": [
+                "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
+                "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.10.3"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf",
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.6.3"
+        },
+        "yamllint": {
+            "hashes": [
+                "sha256:89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
+                "sha256:9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b"
+            ],
+            "index": "pypi",
+            "version": "==1.28.0"
+        }
+    },
+    "develop": {}
+}

--- a/scripts/linting/linters/yamllint.sh
+++ b/scripts/linting/linters/yamllint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
+
+YAML_FILES=$(_list_source_files '**/*.yml')
+
+(
+  printf "\n\n🧪 yamllint 🧪\n\n\n"
+  cd "$REPO_ROOT/scripts/linting"
+
+  echo "$YAML_FILES" | xargs \
+    python3 -m pipenv run yamllint \
+    --strict \
+    --config-file "$REPO_ROOT/.yamllint.yml"
+)

--- a/scripts/linting/run.sh
+++ b/scripts/linting/run.sh
@@ -7,6 +7,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 (
   # Run setup first
   "$REPO_ROOT/scripts/setup/npm.sh"
+  "$REPO_ROOT/scripts/setup/pipenv.sh"
 )
 
 (
@@ -18,6 +19,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
   "$REPO_ROOT/scripts/linting/linters/markdownlint.sh"
   "$REPO_ROOT/scripts/linting/linters/prettier.sh"
   "$REPO_ROOT/scripts/linting/linters/shellcheck.sh"
+  "$REPO_ROOT/scripts/linting/linters/yamllint.sh"
 
   printf "\n\n✅ Linting Success ✅\n\n\n"
 )


### PR DESCRIPTION
Editing YAML repeatedly without clear diffrentiation between a boolean value `true` and a string value with the same contents. I also think the grammar terminals much harder to read (and grep across) without double quotes, so I'm adding `yamllint` to check for such errors, and already fixed the existing violations in a separate PR.

Please see the added `.yamllint.yml` for the list of enabled rules, and let me know if you have any feedback. I took the liberty to enable a few other ones I found helpful, but happy to be convinced otherwise: https://yamllint.readthedocs.io/en/stable/rules.html
