### PR TITLE
sort rg output by path for deterministic linting

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,5 +17,5 @@ function _list_source_files() {
   pattern="$1"
 
   cd "$REPO_ROOT"
-  rg --files --hidden --glob '!.git/**' --glob "$pattern" | xargs realpath --canonicalize-existing
+  rg --files --hidden --sort "path" --glob '!.git/**' --glob "$pattern" | xargs realpath --canonicalize-existing
 }


### PR DESCRIPTION
Was producing inconsistent errors on the command line.
This sorts the files that get sent to different linters.
