### PR TITLE
allow solidity grammar checks to be invoked from command line

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,12 @@
        */
       "label": "Validate Solidity Grammar",
       "type": "shell",
-      "command": "scripts/solidity/problem-matcher.sh",
+      "command": "scripts/solidity/check-grammar.sh",
+      "options": {
+        "env": {
+          "VSCODE_PROBLEM_MATCHER": "true"
+        }
+      },
       "problemMatcher": {
         "owner": "solidity",
         "source": "codegen_utils",
@@ -26,7 +31,7 @@
         "fileLocation": "absolute",
         "pattern": [
           {
-            "regexp": "^\\s*([^:]+):([^:]+):([^-]+)-([^:]+):([^:]+): ([^:]+): (.+)$",
+            "regexp": "^\\s*slang-problem-matcher:([^:]+):([^:]+):([^-]+)-([^:]+):([^:]+): ([^:]+): (.+)$",
             "file": 1,
             "line": 2,
             "column": 3,

--- a/crates/codegen/utils/src/errors.rs
+++ b/crates/codegen/utils/src/errors.rs
@@ -75,13 +75,14 @@ struct ErrorDescriptor {
 
 impl std::fmt::Display for ErrorDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let display = if std::env::var("VSCODE_PROBLEM_MATCHER").is_ok() {
-            self.to_problem_matcher()
-        } else {
-            self.to_ariadne_report()
-        };
+        if std::env::var("VSCODE_PROBLEM_MATCHER").is_ok() {
+            writeln!(f, "{}", self.to_problem_matcher())?;
+            writeln!(f, "")?;
+        }
 
-        return writeln!(f, "{display}");
+        writeln!(f, "{}", self.to_ariadne_report())?;
+
+        return Ok(());
     }
 }
 
@@ -118,7 +119,7 @@ impl ErrorDescriptor {
 
     fn to_problem_matcher(&self) -> String {
         return format!(
-            "{file}:{line}:{column}-{end_line}:{end_column}: {severity}: {message}",
+            "slang-problem-matcher:{file}:{line}:{column}-{end_line}:{end_column}: {severity}: {message}",
             file = self.file_path.to_str().unwrap(),
             line = self.range.start.line,
             column = self.range.start.column,

--- a/scripts/solidity/check-grammar.sh
+++ b/scripts/solidity/check-grammar.sh
@@ -4,10 +4,8 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/../cargo/_common.sh"
 
-export VSCODE_PROBLEM_MATCHER="true"
-
 (
-  printf "\n\n🧪 Checking Project 🧪\n\n\n"
+  printf "\n\n🧪 Checking Solidity Grammar 🧪\n\n\n"
   cd "$REPO_ROOT"
 
   cargo check --offline --lib \


### PR DESCRIPTION
Enables calling `scripts/solidity/check-grammar.sh` to get ariadne reports of any issues.