### PR TITLE
validate non-empty top-level expressions

### DIFF
--- a/crates/codegen/schema/src/validation/ast/productions.rs
+++ b/crates/codegen/schema/src/validation/ast/productions.rs
@@ -64,7 +64,7 @@ pub type ExpressionRef = std::rc::Rc<Expression>;
 
 pub struct Expression {
     pub config: ExpressionConfig,
-    pub ebnf: EBNF,
+    pub ebnf: Node<EBNF>,
 }
 
 impl Expression {
@@ -120,76 +120,112 @@ pub struct EBNFSeparatedBy {
 }
 
 impl EBNF {
-    pub fn new(syntax: &cst::NodeRef, value: types::productions::EBNF) -> Self {
-        return match value {
+    pub fn new(syntax: &cst::NodeRef, value: types::productions::EBNF) -> Node<Self> {
+        match value {
             types::productions::EBNF::Choice(value) => {
-                let syntax = &syntax.unwrap_field("choice").value;
-                Self::Choice(syntax.zip_array(value, Expression::new))
+                let syntax = syntax.unwrap_field("choice");
+                return Node::new(
+                    &syntax.key,
+                    Self::Choice(syntax.value.zip_array(value, Expression::new)),
+                );
             }
             types::productions::EBNF::DelimitedBy(value) => {
-                let syntax = &syntax.unwrap_field("delimitedBy").value;
-                Self::DelimitedBy(EBNFDelimitedBy {
-                    open: ast_value!(syntax, value, open),
-                    expression: ast_value!(syntax, value, expression, Expression),
-                    close: ast_value!(syntax, value, close),
-                })
+                let syntax = syntax.unwrap_field("delimitedBy");
+                return Node::new(
+                    &syntax.key,
+                    Self::DelimitedBy(EBNFDelimitedBy {
+                        open: ast_value!(syntax.value, value, open),
+                        expression: ast_value!(syntax.value, value, expression, Expression),
+                        close: ast_value!(syntax.value, value, close),
+                    }),
+                );
             }
             types::productions::EBNF::Difference(value) => {
-                let syntax = &syntax.unwrap_field("difference").value;
-                Self::Difference(EBNFDifference {
-                    minuend: ast_value!(syntax, value, minuend, Expression),
-                    subtrahend: ast_value!(syntax, value, subtrahend, Expression),
-                })
+                let syntax = syntax.unwrap_field("difference");
+                return Node::new(
+                    &syntax.key,
+                    Self::Difference(EBNFDifference {
+                        minuend: ast_value!(syntax.value, value, minuend, Expression),
+                        subtrahend: ast_value!(syntax.value, value, subtrahend, Expression),
+                    }),
+                );
             }
             types::productions::EBNF::Not(value) => {
-                let syntax = &syntax.unwrap_field("not").value;
-                Self::Not(Expression::new(syntax, value))
+                let syntax = syntax.unwrap_field("not");
+                return Node::new(
+                    &syntax.key,
+                    Self::Not(Expression::new(&syntax.value, value)),
+                );
             }
             types::productions::EBNF::OneOrMore(value) => {
-                let syntax = &syntax.unwrap_field("oneOrMore").value;
-                Self::OneOrMore(Expression::new(syntax, value))
+                let syntax = syntax.unwrap_field("oneOrMore");
+                return Node::new(
+                    &syntax.key,
+                    Self::OneOrMore(Expression::new(&syntax.value, value)),
+                );
             }
             types::productions::EBNF::Optional(value) => {
-                let syntax = &syntax.unwrap_field("optional").value;
-                Self::Optional(Expression::new(syntax, value))
+                let syntax = syntax.unwrap_field("optional");
+                return Node::new(
+                    &syntax.key,
+                    Self::Optional(Expression::new(&syntax.value, value)),
+                );
             }
             types::productions::EBNF::Range(value) => {
-                let syntax = &syntax.unwrap_field("range").value;
-                Self::Range(EBNFRange {
-                    from: ast_value!(syntax, value, from),
-                    to: ast_value!(syntax, value, to),
-                })
+                let syntax = syntax.unwrap_field("range");
+                return Node::new(
+                    &syntax.key,
+                    Self::Range(EBNFRange {
+                        from: ast_value!(syntax.value, value, from),
+                        to: ast_value!(syntax.value, value, to),
+                    }),
+                );
             }
             types::productions::EBNF::Reference(value) => {
-                let syntax = &syntax.unwrap_field("reference").value;
-                Self::Reference(Node::new(syntax, value))
+                let syntax = syntax.unwrap_field("reference");
+                return Node::new(
+                    &syntax.key,
+                    Self::Reference(Node::new(&syntax.value, value)),
+                );
             }
             types::productions::EBNF::Repeat(value) => {
-                let syntax = &syntax.unwrap_field("repeat").value;
-                Self::Repeat(EBNFRepeat {
-                    min: ast_value!(syntax, value, min),
-                    max: ast_value!(syntax, value, max),
-                    expression: ast_value!(syntax, value, expression, Expression),
-                })
+                let syntax = syntax.unwrap_field("repeat");
+                return Node::new(
+                    &syntax.key,
+                    Self::Repeat(EBNFRepeat {
+                        min: ast_value!(syntax.value, value, min),
+                        max: ast_value!(syntax.value, value, max),
+                        expression: ast_value!(syntax.value, value, expression, Expression),
+                    }),
+                );
             }
             types::productions::EBNF::SeparatedBy(value) => {
-                let syntax = &syntax.unwrap_field("separatedBy").value;
-                Self::SeparatedBy(EBNFSeparatedBy {
-                    separator: ast_value!(syntax, value, separator),
-                    expression: ast_value!(syntax, value, expression, Expression),
-                })
+                let syntax = syntax.unwrap_field("separatedBy");
+                return Node::new(
+                    &syntax.key,
+                    Self::SeparatedBy(EBNFSeparatedBy {
+                        separator: ast_value!(syntax.value, value, separator),
+                        expression: ast_value!(syntax.value, value, expression, Expression),
+                    }),
+                );
             }
             types::productions::EBNF::Sequence(value) => {
-                let syntax = &syntax.unwrap_field("sequence").value;
-                Self::Sequence(syntax.zip_array(value, Expression::new))
+                let syntax = syntax.unwrap_field("sequence");
+                return Node::new(
+                    &syntax.key,
+                    Self::Sequence(syntax.value.zip_array(value, Expression::new)),
+                );
             }
             types::productions::EBNF::Terminal(value) => {
-                let syntax = &syntax.unwrap_field("terminal").value;
-                Self::Terminal(Node::new(syntax, value))
+                let syntax = syntax.unwrap_field("terminal");
+                return Node::new(&syntax.key, Self::Terminal(Node::new(&syntax.value, value)));
             }
             types::productions::EBNF::ZeroOrMore(value) => {
-                let syntax = &syntax.unwrap_field("zeroOrMore").value;
-                Self::ZeroOrMore(Expression::new(syntax, value))
+                let syntax = syntax.unwrap_field("zeroOrMore");
+                return Node::new(
+                    &syntax.key,
+                    Self::ZeroOrMore(Expression::new(&syntax.value, value)),
+                );
             }
         };
     }

--- a/crates/codegen/schema/src/validation/ast/visitors.rs
+++ b/crates/codegen/schema/src/validation/ast/visitors.rs
@@ -137,7 +137,7 @@ impl Receiver for ExpressionRef {
             VisitorResponse::StepIn => { /* Continue */ }
         };
 
-        match &self.ebnf {
+        match &self.ebnf.value {
             EBNF::Choice(expressions) | EBNF::Sequence(expressions) => {
                 for expression in expressions {
                     expression.receive(visitor, reporter);

--- a/crates/codegen/schema/src/validation/mod.rs
+++ b/crates/codegen/schema/src/validation/mod.rs
@@ -33,6 +33,7 @@ impl Model {
 
         rules::versions::check(&self, &mut errors);
         rules::references::check(&self, &definitions, &mut errors);
+        rules::empty_productions::check(&self, &mut errors);
 
         return errors.err_or(());
     }

--- a/crates/codegen/schema/src/validation/rules/empty_productions.rs
+++ b/crates/codegen/schema/src/validation/rules/empty_productions.rs
@@ -1,0 +1,81 @@
+use codegen_utils::errors::CodegenErrors;
+
+use crate::validation::{
+    ast::{
+        productions::{EBNFRepeat, ExpressionRef, ProductionRef, EBNF},
+        visitors::{Reporter, Visitor, VisitorExtensions, VisitorResponse},
+    },
+    types::productions::ProductionKind,
+    Model,
+};
+
+pub fn check(model: &Model, errors: &mut CodegenErrors) {
+    let mut visitor = EmptyProductionsVisitor::new();
+
+    visitor.visit(model, errors);
+}
+
+struct EmptyProductionsVisitor {}
+
+impl EmptyProductionsVisitor {
+    fn new() -> Self {
+        return Self {};
+    }
+}
+
+impl Visitor for EmptyProductionsVisitor {
+    fn visit_production(
+        &mut self,
+        production: &ProductionRef,
+        _reporter: &mut Reporter,
+    ) -> VisitorResponse {
+        match production.kind.value {
+            ProductionKind::Trivia => {
+                // Skip. Allowed to be empty.
+                return VisitorResponse::StepOut;
+            }
+            ProductionKind::Token | ProductionKind::Rule => {
+                // Check the root expression.
+                return VisitorResponse::StepIn;
+            }
+        };
+    }
+
+    fn visit_expression(
+        &mut self,
+        expression: &ExpressionRef,
+        reporter: &mut Reporter,
+    ) -> VisitorResponse {
+        match &expression.ebnf.value {
+            EBNF::Choice(_)
+            | EBNF::DelimitedBy(_)
+            | EBNF::Difference(_)
+            | EBNF::Not(_)
+            | EBNF::OneOrMore(_)
+            | EBNF::Range(_)
+            | EBNF::Reference(_)
+            | EBNF::SeparatedBy(_)
+            | EBNF::Sequence(_)
+            | EBNF::Terminal(_) => {
+                // Cannot be optionally empty. Do nothing.
+            }
+            EBNF::Optional(_) | EBNF::ZeroOrMore(_) => {
+                reporter.report(&expression.ebnf.syntax, Errors::PossibleEmptyRoot);
+            }
+            EBNF::Repeat(EBNFRepeat { min, .. }) => {
+                if min.value == 0 {
+                    reporter.report(&min.syntax, Errors::PossibleEmptyRoot);
+                }
+            }
+        };
+
+        // Only check the top-most expression. Ignore nested ones.
+        return VisitorResponse::StepOut;
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Errors {
+    #[error("A production's root expression cannot be optionally empty. Refactor usages to specify the arity instead.")]
+    PossibleEmptyRoot,
+}

--- a/crates/codegen/schema/src/validation/rules/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/mod.rs
@@ -1,3 +1,4 @@
 pub mod definitions;
+pub mod empty_productions;
 pub mod references;
 pub mod versions;

--- a/crates/codegen/schema/src/validation/rules/references.rs
+++ b/crates/codegen/schema/src/validation/rules/references.rs
@@ -39,7 +39,7 @@ impl Visitor for ReferencesCollector<'_> {
         expression: &ExpressionRef,
         reporter: &mut Reporter,
     ) -> VisitorResponse {
-        if let EBNF::Reference(reference) = &expression.ebnf {
+        if let EBNF::Reference(reference) = &expression.ebnf.value {
             let Node { syntax, value } = reference;
             if self.definitions.expressions.contains_key(value) {
                 reporter.report(syntax, Errors::Illegal(value.to_owned()))


### PR DESCRIPTION
Making sure each token consumes at least one character.