### PR TITLE
rename EBNF to ExpressionParser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,6 @@ dependencies = [
 name = "codegen_schema"
 version = "0.0.0"
 dependencies = [
- "Inflector",
  "anyhow",
  "codegen_utils",
  "indexmap",

--- a/crates/codegen/parser/src/chumsky/combinator_node.rs
+++ b/crates/codegen/parser/src/chumsky/combinator_node.rs
@@ -1,6 +1,5 @@
 use codegen_schema::types::productions::{
-    EBNFDelimitedBy, EBNFDifference, EBNFRepeat, EBNFSeparatedBy, ExpressionRef, ParserType,
-    ProductionKind, EBNF,
+    ExpressionParser, ExpressionRef, ParserType, ProductionKind,
 };
 use itertools::Itertools;
 
@@ -92,11 +91,11 @@ impl<'context> CombinatorNode<'context> {
     ) -> &'context CombinatorNode<'context> {
         if let Some(ParserType::Precedence) = expression.config.parser_type {
             if tree.production.kind == ProductionKind::Rule {
-                if let EBNF::Choice(exprs) = &expression.ebnf {
+                if let ExpressionParser::Choice(exprs) = &expression.parser {
                     let mut trailing_rules = Vec::new();
                     let mut operators = Vec::new();
                     for expr in exprs {
-                        if let EBNF::Reference(prod_name) = &expr.ebnf {
+                        if let ExpressionParser::Reference(prod_name) = &expr.parser {
                             let operator_tree = tree.context.get_tree_by_name(prod_name);
                             if let Some(operator) = operator_tree.to_precedence_rule_operator(tree)
                             {
@@ -135,8 +134,8 @@ impl<'context> CombinatorNode<'context> {
             return tree.context.alloc_node(Self::TerminalTrie { trie });
         }
 
-        tree.context.alloc_node(match &expression.ebnf {
-            EBNF::Choice(exprs) => {
+        tree.context.alloc_node(match &expression.parser {
+            ExpressionParser::Choice(exprs) => {
                 // Terminals in choices are merged, and represented as a trie
 
                 enum TN<'c> {
@@ -161,26 +160,26 @@ impl<'context> CombinatorNode<'context> {
                 Self::Choice { name, elements }
             }
 
-            EBNF::DelimitedBy(EBNFDelimitedBy {
+            ExpressionParser::DelimitedBy {
                 open,
                 expression,
                 close,
-            }) => Self::DelimitedBy {
+            } => Self::DelimitedBy {
                 name,
                 open: open.clone(),
                 expr: Self::new(tree, expression),
                 close: close.clone(),
             },
 
-            EBNF::Difference(EBNFDifference {
+            ExpressionParser::Difference {
                 minuend,
                 subtrahend,
-            }) => Self::Difference {
+            } => Self::Difference {
                 minuend: Self::new(tree, minuend),
                 subtrahend: Self::new(tree, subtrahend),
             },
 
-            EBNF::Not(_) => {
+            ExpressionParser::Not(_) => {
                 if let Some(filter) = CharacterFilter::new(tree, expression, true) {
                     Self::CharacterFilter { name, filter }
                 } else {
@@ -188,21 +187,21 @@ impl<'context> CombinatorNode<'context> {
                 }
             }
 
-            EBNF::OneOrMore(expr) => Self::OneOrMore {
+            ExpressionParser::OneOrMore(expr) => Self::OneOrMore {
                 name,
                 expr: Self::new(tree, expr),
             },
 
-            EBNF::Optional(expr) => Self::Optional {
+            ExpressionParser::Optional(expr) => Self::Optional {
                 expr: Self::new(tree, expr),
             },
 
-            EBNF::Range(_) => Self::CharacterFilter {
+            ExpressionParser::Range { .. } => Self::CharacterFilter {
                 name,
                 filter: CharacterFilter::new(tree, expression, true).unwrap(),
             },
 
-            EBNF::Reference(name) => Self::Reference {
+            ExpressionParser::Reference(name) => Self::Reference {
                 tree: tree
                     .context
                     .trees_by_name
@@ -211,36 +210,36 @@ impl<'context> CombinatorNode<'context> {
                     .expect("Production not found"),
             },
 
-            EBNF::Repeat(EBNFRepeat {
+            ExpressionParser::Repeat {
                 expression,
                 min,
                 max,
-            }) => Self::Repeated {
+            } => Self::Repeated {
                 name,
                 expr: Self::new(tree, expression),
                 min: *min,
                 max: *max,
             },
 
-            EBNF::SeparatedBy(EBNFSeparatedBy {
+            ExpressionParser::SeparatedBy {
                 expression,
                 separator,
-            }) => Self::SeparatedBy {
+            } => Self::SeparatedBy {
                 name,
                 expr: Self::new(tree, expression),
                 separator: separator.clone(),
             },
 
-            EBNF::Sequence(exprs) => Self::Sequence {
+            ExpressionParser::Sequence(exprs) => Self::Sequence {
                 name,
                 elements: exprs.iter().map(|e| Self::new(tree, e)).collect(),
             },
 
-            EBNF::Terminal(_) => Self::TerminalTrie {
+            ExpressionParser::Terminal(_) => Self::TerminalTrie {
                 trie: TerminalTrie::new(tree, expression).unwrap(),
             },
 
-            EBNF::ZeroOrMore(expr) => Self::ZeroOrMore {
+            ExpressionParser::ZeroOrMore(expr) => Self::ZeroOrMore {
                 name,
                 expr: Self::new(tree, expr),
             },

--- a/crates/codegen/parser/src/chumsky/terminal_trie.rs
+++ b/crates/codegen/parser/src/chumsky/terminal_trie.rs
@@ -1,4 +1,4 @@
-use codegen_schema::types::productions::{ExpressionRef, ProductionKind, EBNF};
+use codegen_schema::types::productions::{ExpressionParser, ExpressionRef, ProductionKind};
 use patricia_tree::{node::Node, PatriciaMap};
 use proc_macro2::TokenStream;
 
@@ -39,12 +39,12 @@ impl TerminalTrie {
         expression: &ExpressionRef,
         force_all_entries_to_be_named: bool,
     ) -> bool {
-        match &expression.ebnf {
-            EBNF::Choice(exprs) => exprs.iter().fold(true, |accum, e| {
+        match &expression.parser {
+            ExpressionParser::Choice(exprs) => exprs.iter().fold(true, |accum, e| {
                 accum && self.collect_terminals(tree, e, force_all_entries_to_be_named)
             }),
 
-            EBNF::Terminal(string) => {
+            ExpressionParser::Terminal(string) => {
                 self.0.insert(
                     string.clone(),
                     TreeEntry {
@@ -62,7 +62,7 @@ impl TerminalTrie {
                 true
             }
 
-            EBNF::Reference(name) => {
+            ExpressionParser::Reference(name) => {
                 tree.production.kind == ProductionKind::Token
                     && self.collect_terminals(
                         tree,

--- a/crates/codegen/schema/Cargo.toml
+++ b/crates/codegen/schema/Cargo.toml
@@ -16,7 +16,6 @@ serde_json = { workspace = true }
 [dependencies]
 codegen_utils = { workspace = true }
 indexmap = { workspace = true }
-Inflector = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/codegen/schema/generated/topic.schema.json
+++ b/crates/codegen/schema/generated/topic.schema.json
@@ -67,7 +67,19 @@
           "required": ["delimitedBy"],
           "properties": {
             "delimitedBy": {
-              "$ref": "#/definitions/EBNFDelimitedBy"
+              "type": "object",
+              "required": ["close", "expression", "open"],
+              "properties": {
+                "open": {
+                  "type": "string"
+                },
+                "expression": {
+                  "$ref": "#/definitions/Expression"
+                },
+                "close": {
+                  "type": "string"
+                }
+              }
             }
           }
         },
@@ -77,7 +89,16 @@
           "required": ["difference"],
           "properties": {
             "difference": {
-              "$ref": "#/definitions/EBNFDifference"
+              "type": "object",
+              "required": ["minuend", "subtrahend"],
+              "properties": {
+                "minuend": {
+                  "$ref": "#/definitions/Expression"
+                },
+                "subtrahend": {
+                  "$ref": "#/definitions/Expression"
+                }
+              }
             }
           }
         },
@@ -117,7 +138,20 @@
           "required": ["range"],
           "properties": {
             "range": {
-              "$ref": "#/definitions/EBNFRange"
+              "type": "object",
+              "required": ["from", "to"],
+              "properties": {
+                "from": {
+                  "type": "string",
+                  "maxLength": 1,
+                  "minLength": 1
+                },
+                "to": {
+                  "type": "string",
+                  "maxLength": 1,
+                  "minLength": 1
+                }
+              }
             }
           }
         },
@@ -137,7 +171,23 @@
           "required": ["repeat"],
           "properties": {
             "repeat": {
-              "$ref": "#/definitions/EBNFRepeat"
+              "type": "object",
+              "required": ["expression", "max", "min"],
+              "properties": {
+                "min": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "max": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "expression": {
+                  "$ref": "#/definitions/Expression"
+                }
+              }
             }
           }
         },
@@ -147,7 +197,16 @@
           "required": ["separatedBy"],
           "properties": {
             "separatedBy": {
-              "$ref": "#/definitions/EBNFSeparatedBy"
+              "type": "object",
+              "required": ["expression", "separator"],
+              "properties": {
+                "separator": {
+                  "type": "string"
+                },
+                "expression": {
+                  "$ref": "#/definitions/Expression"
+                }
+              }
             }
           }
         },
@@ -232,80 +291,6 @@
     "ExpressionAssociativity": {
       "type": "string",
       "enum": ["Left", "Right"]
-    },
-    "EBNFDelimitedBy": {
-      "type": "object",
-      "required": ["close", "expression", "open"],
-      "properties": {
-        "open": {
-          "type": "string"
-        },
-        "expression": {
-          "$ref": "#/definitions/Expression"
-        },
-        "close": {
-          "type": "string"
-        }
-      }
-    },
-    "EBNFDifference": {
-      "type": "object",
-      "required": ["minuend", "subtrahend"],
-      "properties": {
-        "minuend": {
-          "$ref": "#/definitions/Expression"
-        },
-        "subtrahend": {
-          "$ref": "#/definitions/Expression"
-        }
-      }
-    },
-    "EBNFRange": {
-      "type": "object",
-      "required": ["from", "to"],
-      "properties": {
-        "from": {
-          "type": "string",
-          "maxLength": 1,
-          "minLength": 1
-        },
-        "to": {
-          "type": "string",
-          "maxLength": 1,
-          "minLength": 1
-        }
-      }
-    },
-    "EBNFRepeat": {
-      "type": "object",
-      "required": ["expression", "max", "min"],
-      "properties": {
-        "min": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "max": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "expression": {
-          "$ref": "#/definitions/Expression"
-        }
-      }
-    },
-    "EBNFSeparatedBy": {
-      "type": "object",
-      "required": ["expression", "separator"],
-      "properties": {
-        "separator": {
-          "type": "string"
-        },
-        "expression": {
-          "$ref": "#/definitions/Expression"
-        }
-      }
     }
   }
 }

--- a/crates/codegen/schema/src/types/productions.rs
+++ b/crates/codegen/schema/src/types/productions.rs
@@ -39,7 +39,7 @@ pub struct Expression {
     #[serde(default, flatten)]
     pub config: ExpressionConfig,
     #[serde(flatten)]
-    pub ebnf: EBNF,
+    pub parser: ExpressionParser,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
@@ -70,15 +70,22 @@ pub enum ExpressionAssociativity {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub enum EBNF {
+pub enum ExpressionParser {
     #[schemars(title = "Choice Expression")]
     Choice(Vec<ExpressionRef>),
 
     #[schemars(title = "DelimitedBy Expression")]
-    DelimitedBy(EBNFDelimitedBy),
+    DelimitedBy {
+        open: String,
+        expression: ExpressionRef,
+        close: String,
+    },
 
     #[schemars(title = "Difference Expression")]
-    Difference(EBNFDifference),
+    Difference {
+        minuend: ExpressionRef,
+        subtrahend: ExpressionRef,
+    },
 
     #[schemars(title = "Not Expression")]
     Not(ExpressionRef),
@@ -90,17 +97,23 @@ pub enum EBNF {
     Optional(ExpressionRef),
 
     #[schemars(title = "Range Expression")]
-    Range(EBNFRange),
+    Range { from: char, to: char },
 
     #[schemars(title = "Reference Expression")]
     Reference(String),
 
     #[schemars(title = "Repeat Expression")]
-    Repeat(EBNFRepeat),
+    Repeat {
+        min: usize,
+        max: usize,
+        expression: ExpressionRef,
+    },
 
     #[schemars(title = "SeparatedBy Expression")]
-    SeparatedBy(EBNFSeparatedBy),
-
+    SeparatedBy {
+        separator: String,
+        expression: ExpressionRef,
+    },
     #[schemars(title = "Sequence Expression")]
     Sequence(Vec<ExpressionRef>),
 
@@ -109,41 +122,4 @@ pub enum EBNF {
 
     #[schemars(title = "ZeroOrMore Expression")]
     ZeroOrMore(ExpressionRef),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct EBNFDelimitedBy {
-    pub open: String,
-    pub expression: ExpressionRef,
-    pub close: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct EBNFDifference {
-    pub minuend: ExpressionRef,
-    pub subtrahend: ExpressionRef,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct EBNFRange {
-    pub from: char,
-    pub to: char,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct EBNFRepeat {
-    pub min: usize,
-    pub max: usize,
-    pub expression: ExpressionRef,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct EBNFSeparatedBy {
-    pub separator: String,
-    pub expression: ExpressionRef,
 }

--- a/crates/codegen/schema/src/validation/ast/files.rs
+++ b/crates/codegen/schema/src/validation/ast/files.rs
@@ -44,7 +44,7 @@ impl TopicFile {
             value,
         } = syntax_file;
 
-        let value = syntax.zip_array(value.to_owned(), Production::new);
+        let value = syntax.zip(value.to_owned(), Production::new);
 
         return Self {
             path: FilePathRef::new(path.to_owned()),

--- a/crates/codegen/schema/src/validation/ast/utils.rs
+++ b/crates/codegen/schema/src/validation/ast/utils.rs
@@ -1,67 +1,23 @@
 use crate::yaml::cst;
 
-// These macros ensure field names are strongly typed, so that refactoring doesn't break them.
-mod macros {
-    #[macro_export]
-    macro_rules! ast_value {
-        ($syntax:expr, $value:expr, $key:ident, $type:ty) => {{
-            let key = inflector::Inflector::to_camel_case(stringify!($key));
-            let syntax = &$syntax.unwrap_field(&key).value;
-            let value = $value.$key.to_owned();
-
-            <$type>::new(syntax, value)
-        }};
-
-        ($syntax:expr, $value:expr, $key:ident) => {{
-            crate::ast_value!($syntax, $value, $key, crate::validation::ast::Node<_>)
-        }};
-    }
-
-    #[macro_export]
-    macro_rules! ast_array {
-        ($syntax:expr, $value:expr, $key:ident, $type:ty) => {{
-            let key = inflector::Inflector::to_camel_case(stringify!($key));
-            let syntax = &$syntax.unwrap_field(&key).value;
-            let value = $value.$key;
-
-            syntax.zip_array(value, |syntax, value| <$type>::new(syntax, value))
-        }};
-
-        ($syntax:expr, $value:expr, $key:ident) => {{
-            crate::ast_array!($syntax, $value, $key, crate::validation::ast::Node<_>)
-        }};
-    }
-
-    #[macro_export]
-    macro_rules! ast_optional {
-        ($syntax:expr, $value:expr, $key:ident, $type:ty) => {{
-            $value.$key.and_then(|value| {
-                let key = inflector::Inflector::to_camel_case(stringify!($key));
-                let syntax = &$syntax.unwrap_field(&key).value;
-
-                Some(<$type>::new(syntax, value))
-            })
-        }};
-
-        ($syntax:expr, $value:expr, $key:ident) => {{
-            crate::ast_optional!($syntax, $value, $key, crate::validation::ast::Node<_>)
-        }};
-    }
-}
-
 impl cst::Node {
-    pub fn unwrap_field<'a>(&'a self, key: &str) -> &'a cst::NodeFieldRef {
+    pub fn field<'a>(&'a self, key: &str) -> &'a cst::NodeFieldRef {
         match self {
             Self::Object { fields, .. } => {
-                return fields
-                    .get(key)
-                    .expect(&format!("Key '{key}' not found in object: {self:?}"));
+                return fields.get(key).expect(&format!(
+                    "Key '{key}' not found in object at {:?}",
+                    self.range()
+                ));
             }
             _ => panic!("Unexpected node: {self:?}"),
         };
     }
 
-    pub fn zip_array<TData, TResult, TMapper: Fn(&cst::NodeRef, TData) -> TResult>(
+    pub fn get<'a>(&'a self, key: &str) -> &'a cst::NodeRef {
+        return &self.field(key).value;
+    }
+
+    pub fn zip<TData, TResult, TMapper: Fn(&cst::NodeRef, TData) -> TResult>(
         &self,
         value: Vec<TData>,
         mapper: TMapper,
@@ -80,7 +36,7 @@ impl cst::Node {
                 assert_eq!(value.len(), 0);
                 return vec![];
             }
-            _ => panic!("Unexpected node: {self:?}"),
+            _ => panic!("Unexpected node at {:?}", self.range()),
         };
     }
 }

--- a/crates/codegen/schema/src/validation/rules/references.rs
+++ b/crates/codegen/schema/src/validation/rules/references.rs
@@ -4,7 +4,7 @@ use codegen_utils::errors::CodegenErrors;
 
 use crate::validation::{
     ast::{
-        productions::{ExpressionRef, EBNF},
+        productions::{ExpressionParser, ExpressionRef},
         visitors::{Reporter, Visitor, VisitorExtensions, VisitorResponse},
         Node,
     },
@@ -39,7 +39,7 @@ impl Visitor for ReferencesCollector<'_> {
         expression: &ExpressionRef,
         reporter: &mut Reporter,
     ) -> VisitorResponse {
-        if let EBNF::Reference(reference) = &expression.ebnf.value {
+        if let ExpressionParser::Reference(reference) = &expression.parser.value {
             let Node { syntax, value } = reference;
             if self.definitions.expressions.contains_key(value) {
                 reporter.report(syntax, Errors::Illegal(value.to_owned()))


### PR DESCRIPTION
It is a remnant of the old days when we parsed EBNF grammar. `EBNF` is not really representative of what it does, since we added many non-standard variants, like `range` and `difference` and removing it will make things clearer for new comers/readers.

Also using struct enum variants, instead of separate structs, to make the callsites more readable. This matches users in `codegen_schema::validation::ast` and `codegen_parser::chumsky`.

Also refactored validation code to match. One day, I would like to automatically generate the AST from rust types via a separate `[Derive]` macro, but the current code works and is a good first step.
