### PR TITLE
update smoking tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,6 @@ url = { version = "2.3.1" }
 walkdir = { version = "2.3.2" }
 yaml-rust = { version = "0.4.5" }
 
-[profile.dev]
-debug = 2
-incremental = true
-
 [profile.release]
+incremental = true
 lto = true

--- a/scripts/cargo/_common.sh
+++ b/scripts/cargo/_common.sh
@@ -8,12 +8,18 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 export RUST_BACKTRACE="full"
 
 if [[ "${CI:-}" ]]; then
-  # Strict checks for rustc
+  # Strict checks for CI
   declare -a rust_flags=(
     "${RUSTFLAGS:-}"
     "--warn unused_crate_dependencies"
     "--deny warnings"
   )
-
-  export RUSTFLAGS="${rust_flags[*]}"
+else
+  # Optimizations for local development
+  declare -a rust_flags=(
+    "${RUSTFLAGS:-}"
+    "--codegen target-cpu=native"
+  )
 fi
+
+export RUSTFLAGS="${rust_flags[*]}"


### PR DESCRIPTION
- fix parsing/extracting versions from files with unicode characters
- display accurate progress/failure percent so far
- removed some defaults from `Cargo.toml`
- using `--codegen target-cpu=native` for local scripts for faster execution.
