### PR TITLE
build infra fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,5 @@
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
     "timonwong.shellcheck"
-  ],
-  "settings": {
-    "rust-analyzer.server.path": "/workspaces/slang/bin/rust-analyzer"
-  }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "editor.rulers": [120],
   "files.eol": "\n",
+  "rust-analyzer.server.path": "${workspaceFolder}/bin/rust-analyzer",
   "search.exclude": {
     "**/.hermit/": true,
     "**/generated/": true,

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,5 +17,23 @@ function _list_source_files() {
   pattern="$1"
 
   cd "$REPO_ROOT"
-  rg --files --hidden --sort "path" --glob '!.git/**' --glob "$pattern" | xargs realpath --canonicalize-existing
+  rg \
+    --files --sort "path" \
+    --hidden --glob '!.git/**' --glob '!.hermit/**' \
+    --glob "$pattern" \
+    | xargs realpath --canonicalize-existing
+}
+
+#
+# Optionally appends an argument to a string if it doesn't already contain it.
+#
+function _try_append_arg() {
+  original="$1"
+  arg="$2"
+
+  if [[ "$original" == *"$arg"* ]]; then
+    echo "$original"
+  else
+    echo "$original $arg"
+  fi
 }

--- a/scripts/cargo/_common.sh
+++ b/scripts/cargo/_common.sh
@@ -7,19 +7,15 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 # Enable stack traces for any errors
 export RUST_BACKTRACE="full"
 
+RUSTFLAGS="${RUSTFLAGS:-}"
+RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--warn unused_crate_dependencies")"
+
 if [[ "${CI:-}" ]]; then
   # Strict checks for CI
-  declare -a rust_flags=(
-    "${RUSTFLAGS:-}"
-    "--warn unused_crate_dependencies"
-    "--deny warnings"
-  )
+  RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--deny warnings")"
 else
   # Optimizations for local development
-  declare -a rust_flags=(
-    "${RUSTFLAGS:-}"
-    "--codegen target-cpu=native"
-  )
+  RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--codegen target-cpu=native")"
 fi
 
-export RUSTFLAGS="${rust_flags[*]}"
+export RUSTFLAGS


### PR DESCRIPTION
- remove hermit files from rg linter file search, as it was including files in `$REPO_ROOT/.hermit` in linting.
- use local rust-analyzer binary: https://github.com/rust-lang/rust-analyzer/pull/13993
- showing the `unused_crate_dependencies` cargo warning locally, not just CI.
