### PR TITLE
unify RA and shell scripts env

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,11 @@
   "editor.formatOnSave": true,
   "editor.rulers": [120],
   "files.eol": "\n",
+  "rust-analyzer.server.extraEnv": {
+    "CARGO": "${workspaceFolder}/bin/cargo",
+    "RUSTC": "${workspaceFolder}/bin/rustc",
+    "RUSTFMT": "${workspaceFolder}/bin/rustfmt"
+  },
   "rust-analyzer.server.path": "${workspaceFolder}/bin/rust-analyzer",
   "search.exclude": {
     "**/.hermit/": true,

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,4 +1,11 @@
 env = {
-  "PATH": "${HERMIT_ENV}/scripts/cargo/run:${PATH}",
+  // Used by build scripts to locate source files:
   "REPO_ROOT": "${HERMIT_ENV}",
+
+  // Adds local script shortcuts to user PATH:
+  "PATH": "${HERMIT_ENV}/scripts/cargo/run:${PATH}",
+
+  // Used by any invocation of `cargo` within the repository:
+  "RUST_BACKTRACE": "FULL",
+  "RUSTFLAGS": "--warn unused_crate_dependencies",
 }

--- a/crates/codegen/utils/src/context.rs
+++ b/crates/codegen/utils/src/context.rs
@@ -6,10 +6,7 @@ use std::{
 use anyhow::{bail, Result};
 use walkdir::WalkDir;
 
-use crate::{
-    errors::CodegenErrors,
-    internal::files::{self, calculate_repo_root},
-};
+use crate::{errors::CodegenErrors, internal::files};
 
 pub struct CodegenContext {
     input_dirs: HashSet<PathBuf>,
@@ -28,7 +25,7 @@ impl CodegenContext {
             generated_files: HashSet::new(),
             check_only: std::env::var("CI").is_ok(),
 
-            repo_root: calculate_repo_root()?,
+            repo_root: PathBuf::from(std::env::var("REPO_ROOT")?),
         };
 
         if let Err(error) = operation(&mut context) {

--- a/crates/codegen/utils/src/internal/files.rs
+++ b/crates/codegen/utils/src/internal/files.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 
-use crate::{
-    commands::run_command, context::CodegenContext, internal::formatting::format_source_file,
-};
+use crate::{context::CodegenContext, internal::formatting::format_source_file};
 
 pub fn read_file(file_path: &PathBuf) -> Result<String> {
     return std::fs::read_to_string(file_path)
@@ -57,25 +55,4 @@ pub fn verify_file(codegen: &CodegenContext, file_path: &PathBuf, contents: &str
     );
 
     return Ok(());
-}
-
-pub fn calculate_repo_root() -> Result<PathBuf> {
-    if let Ok(repo_root) = std::env::var("REPO_ROOT") {
-        return Ok(PathBuf::from(repo_root));
-    }
-
-    // If this environment variable is not set, it means we are running outside the Hermit environment.
-    // Most likely, it is the rust-analyzer extension running inside VSCode.
-    // Try to locate the repository root by looking for the ".git" directory.
-
-    let git_dir = run_command(
-        &std::env::current_dir()?,
-        &["git", "rev-parse", "--git-dir"],
-        None,
-    )?;
-
-    let git_dir = PathBuf::from(git_dir);
-    let repo_root = git_dir.parent().unwrap().canonicalize()?;
-
-    return Ok(repo_root);
 }

--- a/scripts/_utils.sh
+++ b/scripts/_utils.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Prints necessary commands needed to activate the Hermit environment:
+#
+function _print_hermit_env() {
+  _repo_root="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
+
+  # Check if another environment is already active:
+  if [[ "${HERMIT_ENV:-}" ]]; then
+    if [[ "$HERMIT_ENV" == "$_repo_root" ]]; then
+      # Our repository. Do nothing.
+      return
+    fi
+
+    # Not our repository. Deactivate it first.
+    "$HERMIT_ENV/bin/hermit" env --deactivate
+  fi
+
+  # Activate this repository's environment.
+  "$_repo_root/bin/hermit" env --activate
+}
+
+#
+# Searches the repository for all files matching the passed globs:
+# - Globs should be relative to "$REPO_ROOT".
+# - Results are canonicalized (converted to full paths).
+# - It also excludes files hidden by ".gitignore".
+#
+function _list_source_files() {
+  pattern="$1"
+
+  cd "$REPO_ROOT"
+  rg \
+    --files --sort "path" \
+    --hidden --glob '!.git/**' --glob '!.hermit/**' \
+    --glob "$pattern" \
+    | xargs realpath --canonicalize-existing
+}

--- a/scripts/cargo/_common.sh
+++ b/scripts/cargo/_common.sh
@@ -4,18 +4,7 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
-# Enable stack traces for any errors
-export RUST_BACKTRACE="full"
-
-RUSTFLAGS="${RUSTFLAGS:-}"
-RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--warn unused_crate_dependencies")"
-
 if [[ "${CI:-}" ]]; then
   # Strict checks for CI
-  RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--deny warnings")"
-else
-  # Optimizations for local development
-  RUSTFLAGS="$(_try_append_arg "$RUSTFLAGS" "--codegen target-cpu=native")"
+  RUSTFLAGS="${RUSTFLAGS:-} --deny warnings"
 fi
-
-export RUSTFLAGS


### PR DESCRIPTION
To get diagnostics, `rust-analyzer` runs `cargo check` under the hood. But when we run local check/test scripts, we run `cargo check` again, adding custom flags.

This breaks incremental builds, and forces it to check all crates again. Now local REPL takes twice as long!

This PR makes sure that both invocations will have the same exact settings and environment variables.

Note: unfortunately, we cannot put default `RUSTFLAGS` in Cargo's config files, because any environment variable usage (e.g. CI builds) overwrites it. It needs to be additive.
