### PR TITLE
use separate tokens for each newline

### DIFF
--- a/crates/solidity/inputs/schema/grammar/01-file-structure/05-trivia/productions.yml
+++ b/crates/solidity/inputs/schema/grammar/01-file-structure/05-trivia/productions.yml
@@ -14,10 +14,10 @@
   kind: "TriviaParser"
   unversioned:
     sequence:
-      - zeroOrMore:
-          choice:
-            - reference: "Whitespace"
-            - reference: "SingleLineComment"
+      - optional:
+          reference: "Whitespace"
+      - optional:
+          reference: "SingleLineComment"
       - reference: "EndOfLine"
 
 - name: "EndOfFileTrivia"
@@ -41,10 +41,10 @@
 - name: "EndOfLine"
   kind: "Scanner"
   unversioned:
-    oneOrMore:
-      choice:
-        - terminal: "\r"
-        - terminal: "\n"
+    sequence:
+      - optional:
+          terminal: "\r"
+      - terminal: "\n"
 
 - name: "MultilineComment"
   kind: "Scanner"

--- a/crates/solidity/outputs/rust/lib/src/generated/scanners.rs
+++ b/crates/solidity/outputs/rust/lib/src/generated/scanners.rs
@@ -811,12 +811,15 @@ impl Language {
         }
     }
 
-    // «EndOfLine» = 1…{ '\u{d}' | '\u{a}' } ;
+    // «EndOfLine» = [ '\u{d}' ] '\u{a}' ;
 
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn scan_end_of_line(&self, stream: &mut Stream) -> bool {
         {
-            scan_one_or_more!(stream, scan_predicate!(stream, |c| c == '\n' || c == '\r'))
+            scan_sequence!(
+                scan_optional!(stream, scan_chars!(stream, '\r')),
+                scan_chars!(stream, '\n')
+            )
         }
     }
 

--- a/crates/solidity/outputs/rust/tests/src/cst_output/generated/SourceUnit.rs
+++ b/crates/solidity/outputs/rust/tests/src/cst_output/generated/SourceUnit.rs
@@ -12,3 +12,8 @@ fn empty_file() -> Result<()> {
 fn end_of_file_trivia() -> Result<()> {
     return run("SourceUnit", "end_of_file_trivia");
 }
+
+#[test]
+fn trailing_trivia() -> Result<()> {
+    return run("SourceUnit", "trailing_trivia");
+}

--- a/crates/solidity/outputs/spec/generated/ebnf/01-file-structure/05-trivia/end-of-line.html
+++ b/crates/solidity/outputs/spec/generated/ebnf/01-file-structure/05-trivia/end-of-line.html
@@ -4,13 +4,11 @@
   <code>
     <span style="color: var(--md-code-hl-keyword-color);"><span id="end-of-line-production">«EndOfLine»</span></span>
     <span style="color: var(--md-code-hl-operator-color);"> = </span>
-    <span style="color: var(--md-code-hl-constant-color);">1</span>
-    <span style="color: var(--md-code-hl-operator-color);">…</span>
-    <span style="color: var(--md-code-hl-operator-color);">{ </span>
+    <span style="color: var(--md-code-hl-operator-color);">[ </span>
     <span style="color: var(--md-code-hl-string-color);">'\u{d}'</span>
-    <span style="color: var(--md-code-hl-operator-color);"> | </span>
+    <span style="color: var(--md-code-hl-operator-color);"> ]</span>
+    <span style="color: var(--md-code-hl-operator-color);"> </span>
     <span style="color: var(--md-code-hl-string-color);">'\u{a}'</span>
-    <span style="color: var(--md-code-hl-operator-color);"> }</span>
     <span style="color: var(--md-code-hl-operator-color);"> ;</span>
     <br/>
   </code>

--- a/crates/solidity/outputs/spec/generated/ebnf/01-file-structure/05-trivia/trailing-trivia.html
+++ b/crates/solidity/outputs/spec/generated/ebnf/01-file-structure/05-trivia/trailing-trivia.html
@@ -4,11 +4,13 @@
   <code>
     <span style="color: var(--md-code-hl-keyword-color);"><span id="trailing-trivia-production">TrailingTrivia</span></span>
     <span style="color: var(--md-code-hl-operator-color);"> = </span>
-    <span style="color: var(--md-code-hl-operator-color);">{ </span>
+    <span style="color: var(--md-code-hl-operator-color);">[ </span>
     <span style="color: var(--md-code-hl-keyword-color);"><a class="slang-global-ebnf-link" href="../../01-file-structure/05-trivia/#whitespace-production">«Whitespace»</a></span>
-    <span style="color: var(--md-code-hl-operator-color);"> | </span>
+    <span style="color: var(--md-code-hl-operator-color);"> ]</span>
+    <span style="color: var(--md-code-hl-operator-color);"> </span>
+    <span style="color: var(--md-code-hl-operator-color);">[ </span>
     <span style="color: var(--md-code-hl-keyword-color);"><a class="slang-global-ebnf-link" href="../../01-file-structure/05-trivia/#single-line-comment-production">«SingleLineComment»</a></span>
-    <span style="color: var(--md-code-hl-operator-color);"> }</span>
+    <span style="color: var(--md-code-hl-operator-color);"> ]</span>
     <span style="color: var(--md-code-hl-operator-color);"> </span>
     <span style="color: var(--md-code-hl-keyword-color);"><a class="slang-global-ebnf-link" href="../../01-file-structure/05-trivia/#end-of-line-production">«EndOfLine»</a></span>
     <span style="color: var(--md-code-hl-operator-color);"> ;</span>

--- a/crates/solidity/outputs/typescript/lib/src/generated/scanners.rs
+++ b/crates/solidity/outputs/typescript/lib/src/generated/scanners.rs
@@ -811,12 +811,15 @@ impl Language {
         }
     }
 
-    // «EndOfLine» = 1…{ '\u{d}' | '\u{a}' } ;
+    // «EndOfLine» = [ '\u{d}' ] '\u{a}' ;
 
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn scan_end_of_line(&self, stream: &mut Stream) -> bool {
         {
-            scan_one_or_more!(stream, scan_predicate!(stream, |c| c == '\n' || c == '\r'))
+            scan_sequence!(
+                scan_optional!(stream, scan_chars!(stream, '\r')),
+                scan_chars!(stream, '\n')
+            )
         }
     }
 

--- a/crates/solidity/testing/snapshots/cst_output/InterfaceDefinition/sample_counter/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/InterfaceDefinition/sample_counter/generated/0.4.11.yml
@@ -17,8 +17,8 @@ Tree:
       - Identifier (Token): "ICounter" # 10..18
       - OpenBrace (Token): "{" # 19..20
       - _REPEATED (Rule): # 21..171 "    // returns the current count\n    function coun..."
-          - ContractBodyElement (Rule): # 21..106 "    // returns the current count\n    function coun..."
-              - FunctionDefinition (Rule): # 21..106 "    // returns the current count\n    function coun..."
+          - ContractBodyElement (Rule): # 21..105 "    // returns the current count\n    function coun..."
+              - FunctionDefinition (Rule): # 21..105 "    // returns the current count\n    function coun..."
                   - FunctionKeyword (Token): # 21..66 "    // returns the current count\n    function"
                       - SingleLineComment (Trivia): "// returns the current count" # 25..53
                       - Contents: "function" # 58..66
@@ -41,9 +41,9 @@ Tree:
                                       - UnsignedIntegerType (Token): "uint" # 98..102
                       - CloseParen (Token): ")" # 102..103
                   - Semicolon (Token): ";" # 103..104
-          - ContractBodyElement (Rule): # 106..171 "    // increments the counter\n    function increme..."
-              - FunctionDefinition (Rule): # 106..171 "    // increments the counter\n    function increme..."
-                  - FunctionKeyword (Token): # 106..148 "    // increments the counter\n    function"
+          - ContractBodyElement (Rule): # 105..171 "\n    // increments the counter\n    function increm..."
+              - FunctionDefinition (Rule): # 105..171 "\n    // increments the counter\n    function increm..."
+                  - FunctionKeyword (Token): # 105..148 "\n    // increments the counter\n    function"
                       - SingleLineComment (Trivia): "// increments the counter" # 110..135
                       - Contents: "function" # 140..148
                   - Identifier (Token): "increment" # 149..158

--- a/crates/solidity/testing/snapshots/cst_output/SourceUnit/trailing_trivia/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/SourceUnit/trailing_trivia/generated/0.4.11.yml
@@ -1,0 +1,32 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract First {}                                                                │ 0..17
+  2  │                                                                                  │ 18..18
+  3  │                                                                                  │ 19..19
+  4  │ // Newlines both before and after this comment should                            │ 20..73
+  5  │ // be included in the trivia of the second contract.                             │ 74..126
+  6  │                                                                                  │ 127..127
+  7  │                                                                                  │ 128..128
+  8  │ contract Second {}                                                               │ 129..147
+
+Errors: []
+
+Tree:
+  - SourceUnit (Rule): # 0..148 "contract First {}\n\n\n// Newlines both before and af..."
+      - _REPEATED (Rule): # 0..148 "contract First {}\n\n\n// Newlines both before and af..."
+          - Definition (Rule): # 0..18 "contract First {}\n"
+              - ContractDefinition (Rule): # 0..18 "contract First {}\n"
+                  - ContractKeyword (Token): "contract" # 0..8
+                  - Identifier (Token): "First" # 9..14
+                  - OpenBrace (Token): "{" # 15..16
+                  - CloseBrace (Token): "}" # 16..17
+          - Definition (Rule): # 18..148 "\n\n// Newlines both before and after this comment s..."
+              - ContractDefinition (Rule): # 18..148 "\n\n// Newlines both before and after this comment s..."
+                  - ContractKeyword (Token): # 18..137 "\n\n// Newlines both before and after this comment s..."
+                      - SingleLineComment (Trivia): "// Newlines both before and after this comment sho..." # 20..73
+                      - SingleLineComment (Trivia): "// be included in the trivia of the second contrac..." # 74..126
+                      - Contents: "contract" # 129..137
+                  - Identifier (Token): "Second" # 138..144
+                  - OpenBrace (Token): "{" # 145..146
+                  - CloseBrace (Token): "}" # 146..147

--- a/crates/solidity/testing/snapshots/cst_output/SourceUnit/trailing_trivia/input.sol
+++ b/crates/solidity/testing/snapshots/cst_output/SourceUnit/trailing_trivia/input.sol
@@ -1,0 +1,8 @@
+contract First {}
+
+
+// Newlines both before and after this comment should
+// be included in the trivia of the second contract.
+
+
+contract Second {}


### PR DESCRIPTION
- Using a separate tokens for each newline, to convey this information to users, instead of relying on them to reparse trivia to count lines.
- This also fixes the issue where `TrailingTrivia` scans all subsequent newlines. Now it will only scan a single newline character on the same line.