### PR TITLE
Enable search in generated files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
   "rust-analyzer.server.path": "${workspaceFolder}/bin/rust-analyzer",
   "search.exclude": {
     "**/.hermit/": true,
-    "**/generated/": true,
     "**/node_modules/": true,
     "**/target/": true
   },


### PR DESCRIPTION
Searching in generated files was previously disabled to remove noise, but since the addition of the "View as Tree" feature, this is not much of a concern:

![image](https://user-images.githubusercontent.com/15987992/226901352-55c5bd57-a7a4-4093-9edd-50645482805f.png)

This also enables quick open, so I can now go to the generated parser by just typing `cmd+q` then `gen/lang`.