### PR TITLE
fix cargo publish scripts

### DIFF
--- a/scripts/cargo/publish.sh
+++ b/scripts/cargo/publish.sh
@@ -23,7 +23,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
   if [[ "$repo_version" == "$published_version" ]]; then
     echo "Skipping publish, since the repository version is already published."
-    return 0
+    exit 0
   fi
 
   command=(


### PR DESCRIPTION
typo from earlier pr:

```log
scripts/cargo/publish.sh: line 26: return: can only `return' from a function or sourced script
```
