### PR TITLE
fix unicode string parsing

### DIFF
--- a/.changeset/early-turtles-rest.md
+++ b/.changeset/early-turtles-rest.md
@@ -1,0 +1,5 @@
+---
+"changelog": patch
+---
+
+fix primary expressions parser order

--- a/crates/solidity/inputs/schema/grammar/05-expressions/02-primary-expressions/productions.yml
+++ b/crates/solidity/inputs/schema/grammar/05-expressions/02-primary-expressions/productions.yml
@@ -5,26 +5,26 @@
   versioned:
     0.4.11:
       choice:
-        - reference: "Identifier"
+        - reference: "NewExpression"
         - reference: "TupleExpression"
         - reference: "ArrayLiteral"
-        - reference: "StringExpression"
-        - reference: "NumericLiteral"
         - reference: "BooleanLiteral"
-        - reference: "NewExpression"
+        - reference: "NumericLiteral"
+        - reference: "StringExpression"
         - reference: "ElementaryType"
+        - reference: "Identifier"
     0.5.3:
       # added: TypeExpression
       choice:
-        - reference: "Identifier"
-        - reference: "TupleExpression"
-        - reference: "ArrayLiteral"
-        - reference: "StringExpression"
-        - reference: "NumericLiteral"
-        - reference: "BooleanLiteral"
         - reference: "NewExpression"
+        - reference: "TupleExpression"
         - reference: "TypeExpression"
+        - reference: "ArrayLiteral"
+        - reference: "BooleanLiteral"
+        - reference: "NumericLiteral"
+        - reference: "StringExpression"
         - reference: "ElementaryType"
+        - reference: "Identifier"
 
 - name: "TypeExpression"
   kind: "Parser"

--- a/crates/solidity/outputs/cargo/crate/src/syntax/generated/parsers.rs
+++ b/crates/solidity/outputs/cargo/crate/src/syntax/generated/parsers.rs
@@ -17884,20 +17884,55 @@ impl Language {
     }
 
     // (* v0.4.11 *)
-    // PrimaryExpression = «Identifier»
+    // PrimaryExpression = NewExpression
     //                   | TupleExpression
     //                   | ArrayLiteral
-    //                   | StringExpression
-    //                   | NumericLiteral
     //                   | BooleanLiteral
-    //                   | NewExpression
-    //                   | ElementaryType;
+    //                   | NumericLiteral
+    //                   | StringExpression
+    //                   | ElementaryType
+    //                   | «Identifier»;
 
     #[allow(unused_assignments, unused_parens)]
     fn parse_primary_expression_0_4_11(&self, stream: &mut Stream) -> ParserResult {
         loop {
             let start_position = stream.position();
             let mut furthest_error;
+            match self.parse_new_expression(stream) {
+                Fail { error } => furthest_error = error,
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_tuple_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_array_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_boolean_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_numeric_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_string_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_elementary_type(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
             match {
                 let leading_trivia = self.optional_leading_trivia(stream);
                 let start = stream.position();
@@ -17919,41 +17954,6 @@ impl Language {
                     }
                 }
             } {
-                Fail { error } => furthest_error = error,
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_tuple_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_array_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_string_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_numeric_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_boolean_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_new_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_elementary_type(stream) {
                 Fail { error } => furthest_error.merge_with(error),
                 pass => break pass,
             }
@@ -17964,21 +17964,61 @@ impl Language {
     }
 
     // (* v0.5.3 *)
-    // PrimaryExpression = «Identifier»
+    // PrimaryExpression = NewExpression
     //                   | TupleExpression
-    //                   | ArrayLiteral
-    //                   | StringExpression
-    //                   | NumericLiteral
-    //                   | BooleanLiteral
-    //                   | NewExpression
     //                   | TypeExpression
-    //                   | ElementaryType;
+    //                   | ArrayLiteral
+    //                   | BooleanLiteral
+    //                   | NumericLiteral
+    //                   | StringExpression
+    //                   | ElementaryType
+    //                   | «Identifier»;
 
     #[allow(unused_assignments, unused_parens)]
     fn parse_primary_expression_0_5_3(&self, stream: &mut Stream) -> ParserResult {
         loop {
             let start_position = stream.position();
             let mut furthest_error;
+            match self.parse_new_expression(stream) {
+                Fail { error } => furthest_error = error,
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_tuple_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_type_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_array_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_boolean_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_numeric_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_string_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_elementary_type(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
             match {
                 let leading_trivia = self.optional_leading_trivia(stream);
                 let start = stream.position();
@@ -18000,46 +18040,6 @@ impl Language {
                     }
                 }
             } {
-                Fail { error } => furthest_error = error,
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_tuple_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_array_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_string_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_numeric_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_boolean_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_new_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_type_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_elementary_type(stream) {
                 Fail { error } => furthest_error.merge_with(error),
                 pass => break pass,
             }

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Expression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Expression.rs
@@ -165,3 +165,8 @@ fn prefix_minus() -> Result<()> {
 fn prefix_plus() -> Result<()> {
     return run("Expression", "prefix_plus");
 }
+
+#[test]
+fn unicode_string_literal() -> Result<()> {
+    return run("Expression", "unicode_string_literal");
+}

--- a/crates/solidity/outputs/npm/crate/src/syntax/generated/parsers.rs
+++ b/crates/solidity/outputs/npm/crate/src/syntax/generated/parsers.rs
@@ -17884,20 +17884,55 @@ impl Language {
     }
 
     // (* v0.4.11 *)
-    // PrimaryExpression = «Identifier»
+    // PrimaryExpression = NewExpression
     //                   | TupleExpression
     //                   | ArrayLiteral
-    //                   | StringExpression
-    //                   | NumericLiteral
     //                   | BooleanLiteral
-    //                   | NewExpression
-    //                   | ElementaryType;
+    //                   | NumericLiteral
+    //                   | StringExpression
+    //                   | ElementaryType
+    //                   | «Identifier»;
 
     #[allow(unused_assignments, unused_parens)]
     fn parse_primary_expression_0_4_11(&self, stream: &mut Stream) -> ParserResult {
         loop {
             let start_position = stream.position();
             let mut furthest_error;
+            match self.parse_new_expression(stream) {
+                Fail { error } => furthest_error = error,
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_tuple_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_array_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_boolean_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_numeric_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_string_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_elementary_type(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
             match {
                 let leading_trivia = self.optional_leading_trivia(stream);
                 let start = stream.position();
@@ -17919,41 +17954,6 @@ impl Language {
                     }
                 }
             } {
-                Fail { error } => furthest_error = error,
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_tuple_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_array_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_string_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_numeric_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_boolean_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_new_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_elementary_type(stream) {
                 Fail { error } => furthest_error.merge_with(error),
                 pass => break pass,
             }
@@ -17964,21 +17964,61 @@ impl Language {
     }
 
     // (* v0.5.3 *)
-    // PrimaryExpression = «Identifier»
+    // PrimaryExpression = NewExpression
     //                   | TupleExpression
-    //                   | ArrayLiteral
-    //                   | StringExpression
-    //                   | NumericLiteral
-    //                   | BooleanLiteral
-    //                   | NewExpression
     //                   | TypeExpression
-    //                   | ElementaryType;
+    //                   | ArrayLiteral
+    //                   | BooleanLiteral
+    //                   | NumericLiteral
+    //                   | StringExpression
+    //                   | ElementaryType
+    //                   | «Identifier»;
 
     #[allow(unused_assignments, unused_parens)]
     fn parse_primary_expression_0_5_3(&self, stream: &mut Stream) -> ParserResult {
         loop {
             let start_position = stream.position();
             let mut furthest_error;
+            match self.parse_new_expression(stream) {
+                Fail { error } => furthest_error = error,
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_tuple_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_type_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_array_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_boolean_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_numeric_literal(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_string_expression(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
+            match self.parse_elementary_type(stream) {
+                Fail { error } => furthest_error.merge_with(error),
+                pass => break pass,
+            }
+            stream.set_position(start_position);
             match {
                 let leading_trivia = self.optional_leading_trivia(stream);
                 let start = stream.position();
@@ -18000,46 +18040,6 @@ impl Language {
                     }
                 }
             } {
-                Fail { error } => furthest_error = error,
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_tuple_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_array_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_string_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_numeric_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_boolean_literal(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_new_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_type_expression(stream) {
-                Fail { error } => furthest_error.merge_with(error),
-                pass => break pass,
-            }
-            stream.set_position(start_position);
-            match self.parse_elementary_type(stream) {
                 Fail { error } => furthest_error.merge_with(error),
                 pass => break pass,
             }

--- a/crates/solidity/outputs/spec/generated/ebnf/05-expressions/02-primary-expressions/primary-expression/0.4.11.md
+++ b/crates/solidity/outputs/spec/generated/ebnf/05-expressions/02-primary-expressions/primary-expression/0.4.11.md
@@ -1,12 +1,12 @@
 <!-- This file is generated automatically by infrastructure scripts. Please don't edit by hand. -->
 
 ```{ .ebnf .slang-ebnf #PrimaryExpression }
-PrimaryExpression = «Identifier»
+PrimaryExpression = NewExpression
                   | TupleExpression
                   | ArrayLiteral
-                  | StringExpression
-                  | NumericLiteral
                   | BooleanLiteral
-                  | NewExpression
-                  | ElementaryType;
+                  | NumericLiteral
+                  | StringExpression
+                  | ElementaryType
+                  | «Identifier»;
 ```

--- a/crates/solidity/outputs/spec/generated/ebnf/05-expressions/02-primary-expressions/primary-expression/0.5.3.md
+++ b/crates/solidity/outputs/spec/generated/ebnf/05-expressions/02-primary-expressions/primary-expression/0.5.3.md
@@ -1,13 +1,13 @@
 <!-- This file is generated automatically by infrastructure scripts. Please don't edit by hand. -->
 
 ```{ .ebnf .slang-ebnf #PrimaryExpression }
-PrimaryExpression = «Identifier»
+PrimaryExpression = NewExpression
                   | TupleExpression
-                  | ArrayLiteral
-                  | StringExpression
-                  | NumericLiteral
-                  | BooleanLiteral
-                  | NewExpression
                   | TypeExpression
-                  | ElementaryType;
+                  | ArrayLiteral
+                  | BooleanLiteral
+                  | NumericLiteral
+                  | StringExpression
+                  | ElementaryType
+                  | «Identifier»;
 ```

--- a/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.4.11.yml
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ unicode"This Emoji: 😃"                                                        │ 0..25
+
+Errors: []
+
+Tree:
+  - Expression (Rule): # 0..25 'unicode"This Emoji: 😃"'
+      - PrimaryExpression (Rule): # 0..25 'unicode"This Emoji: 😃"'
+          - StringExpression (Rule): # 0..25 'unicode"This Emoji: 😃"'
+              - _REPEATED (Rule): # 0..25 'unicode"This Emoji: 😃"'
+                  - UnicodeStringLiteral (Token): 'unicode"This Emoji: 😃"' # 0..25

--- a/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/input.sol
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/input.sol
@@ -1,0 +1,1 @@
+unicode"This Emoji: 😃"


### PR DESCRIPTION
sorted primary expressions to attempt sub-expressions with unique prefixes first, then literals, then identifiers at last. This prevents cases where parser recognizes an identifier at the start of `unicode""` literals.
