### PR TITLE
fix published crate license field

### DIFF
--- a/crates/solidity/outputs/cargo/crate/Cargo.toml
+++ b/crates/solidity/outputs/cargo/crate/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 
 readme = "README.md"
-license-file = "LICENSE"
+license = "MIT"
 keywords = ["code-analysis", "parser", "sol", "solidity", "yul"]
 categories = [
   "compilers",


### PR DESCRIPTION
This should fix the `non-standard` license field shown on https://crates.io/crates/slang_solidity

![image](https://user-images.githubusercontent.com/15987992/234818500-67541ea4-d1ea-4364-81a1-b000d1d62e5e.png)
