### PR TITLE
set rustflags from cargo toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[profile.release]
+incremental = true
+lto = true
+
+[build]
+rustflags = ["--warn", "unused_crate_dependencies"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,11 @@
   "rust-analyzer.check.allTargets": true,
   "rust-analyzer.check.features": "all",
   "rust-analyzer.server.extraEnv": {
+    // Keep in sync with the CLI environment in "$REPO_ROOT/scripts/cargo/check.sh"
     "CARGO": "${workspaceFolder}/bin/cargo",
     "RUSTC": "${workspaceFolder}/bin/rustc",
-    "RUSTFMT": "${workspaceFolder}/bin/rustfmt"
+    "RUSTFMT": "${workspaceFolder}/bin/rustfmt",
+    "RUSTUP": "${workspaceFolder}/bin/rustup"
   },
   "rust-analyzer.server.path": "${workspaceFolder}/bin/rust-analyzer",
   "search.exclude": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace.package]
+version = "0.1.1"
+rust-version = "1.64.0" # Keep this version in sync with "$RUST_VERSION" in "$REPO_ROOT/bin/hermit.hcl"
+edition = "2021"
+publish = false
+
 [workspace]
 members = [
     "crates/codegen/ebnf",
@@ -17,12 +23,6 @@ members = [
     "crates/solidity/testing/smoke",
     "crates/solidity/testing/utils",
 ]
-
-[workspace.package]
-version = "0.1.1"
-rust-version = "1.64.0" # Keep this version in sync with "$RUST_VERSION" in "$REPO_ROOT/bin/hermit.hcl"
-edition = "2021"
-publish = false
 
 [workspace.dependencies]
 anyhow = { version = "1.0.70", features = ["backtrace", "std"] }
@@ -63,7 +63,3 @@ typed-arena = { version = "2.0.2" }
 url = { version = "2.3.1" }
 walkdir = { version = "2.3.3" }
 yaml-rust = { version = "0.4.5" }
-
-[profile.release]
-incremental = true
-lto = true

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -7,9 +7,8 @@ env = {
 
   // Rust:
   "RUST_BACKTRACE": "FULL",
-  "RUST_VERSION": "1.64.0",
-  "RUSTFLAGS": "${RUSTFLAGS} --warn unused_crate_dependencies",
+  "RUST_VERSION": "1.64.0", // Keep this version in sync with "rust-version" in "$REPO_ROOT/Cargo.toml"
 
   // TypeScript:
-  "TS_NODE_PROJECT": "${REPO_ROOT}/tsconfig.json",
+  "TS_NODE_PROJECT": "${HERMIT_ENV}/tsconfig.json",
 }

--- a/crates/codegen/utils/src/context.rs
+++ b/crates/codegen/utils/src/context.rs
@@ -156,7 +156,7 @@ impl CodegenContext {
     }
 
     fn print_cargo_markers(&self) {
-        if std::env::var("RUSTC").is_err() {
+        if std::env::var("OUT_DIR").is_err() {
             // This environment variable is only set for Cargo build tasks.
             // When it is missing, it means we are running from tests, and we shouldn't print these markers.
             return;

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,8 +6,3 @@ source "$(dirname "${BASH_SOURCE[0]}")/_utils.sh"
 
 # Activate the Hermit environment:
 eval "$(_print_hermit_env)"
-
-# Strict checks for CI
-if [[ "${CI:-}" ]]; then
-  RUSTFLAGS="${RUSTFLAGS:-} --deny warnings"
-fi

--- a/scripts/cargo/check.sh
+++ b/scripts/cargo/check.sh
@@ -5,9 +5,31 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
 (
   printf "\n\n🧪 Checking Project 🧪\n\n\n"
-
   cd "$REPO_ROOT"
-  cargo check --offline --all --all-targets --all-features
+
+  # Keep in sync with the Rust Analyzer environment in "$REPO_ROOT/.vscode/settings.json"
+  export CARGO="${REPO_ROOT}/bin/cargo"
+  export RUSTC="${REPO_ROOT}/bin/rustc"
+  export RUSTFMT="${REPO_ROOT}/bin/rustfmt"
+  export RUSTUP="${REPO_ROOT}/bin/rustup"
+
+  command=(
+    cargo check
+    --offline
+    --all
+    --all-targets
+    --all-features
+  )
+
+  # Strict checks for CI
+  if [[ "${CI:-}" ]]; then
+    command+=(
+      --config
+      'build.rustflags = ["--deny", "warnings"]'
+    )
+  fi
+
+  "${command[@]}"
 
   printf "\n\n✅ Check Success ✅\n\n\n"
 )

--- a/scripts/npm/napi/build.sh
+++ b/scripts/npm/napi/build.sh
@@ -32,13 +32,6 @@ function _napi_build() {
     _group_output cargo install "cargo-xwin" --version "0.14.2"
   fi
 
-  if [[ "$target" == *"-unknown-linux-musl" ]]; then
-    # https://github.com/rust-lang/rust/pull/40113#issuecomment-323193341
-    RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=-crt-static"
-  fi
-
-  export RUSTFLAGS
-
   # Navigate to where files should be generated:
   cd "$PACKAGE_DIR/src/generated"
 


### PR DESCRIPTION
Unfortunately we cannot edit `$RUSTFLAGS` env var as it breaks rust compilation incrementability. Let's move to using `build.rustflags` config variable instead.