### PR TITLE
rename `VisitorExitResponse::StepIn` to `VisitorExitResponse::Continue`

### DIFF
--- a/.changeset/silver-geese-clap.md
+++ b/.changeset/silver-geese-clap.md
@@ -1,0 +1,5 @@
+---
+"changelog": minor
+---
+
+rename `VisitorExitResponse::StepIn` to `VisitorExitResponse::Continue`

--- a/crates/codegen/syntax_templates/src/rust/cst_visitor.rs
+++ b/crates/codegen/syntax_templates/src/rust/cst_visitor.rs
@@ -24,7 +24,7 @@ pub trait Visitor<E> {
         node: &Rc<Node>,
         path: &Vec<Rc<Node>>,
     ) -> Result<VisitorExitResponse, E> {
-        Ok(VisitorExitResponse::StepIn)
+        Ok(VisitorExitResponse::Continue)
     }
 
     fn enter_token(
@@ -46,7 +46,7 @@ pub trait Visitor<E> {
         node: &Rc<Node>,
         path: &Vec<Rc<Node>>,
     ) -> Result<VisitorExitResponse, E> {
-        Ok(VisitorExitResponse::StepIn)
+        Ok(VisitorExitResponse::Continue)
     }
 }
 
@@ -58,7 +58,7 @@ pub enum VisitorEntryResponse {
 
 pub enum VisitorExitResponse {
     Quit,
-    StepIn,
+    Continue,
 }
 
 pub trait Visitable<T: Visitor<E>, E> {
@@ -93,8 +93,10 @@ fn accept_visitor_with_path<T: Visitor<E>, E>(
                                 path.pop();
                                 return Ok(VisitorExitResponse::Quit);
                             }
-                            VisitorExitResponse::StepIn => {}
-                        }
+                            VisitorExitResponse::Continue => {
+                                continue;
+                            }
+                        };
                     }
                     path.pop();
                 }
@@ -117,8 +119,10 @@ fn accept_visitor_with_path<T: Visitor<E>, E>(
                                 path.pop();
                                 return Ok(VisitorExitResponse::Quit);
                             }
-                            VisitorExitResponse::StepIn => {}
-                        }
+                            VisitorExitResponse::Continue => {
+                                continue;
+                            }
+                        };
                     }
                     path.pop();
                 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst_visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst_visitor.rs
@@ -26,7 +26,7 @@ pub trait Visitor<E> {
         node: &Rc<Node>,
         path: &Vec<Rc<Node>>,
     ) -> Result<VisitorExitResponse, E> {
-        Ok(VisitorExitResponse::StepIn)
+        Ok(VisitorExitResponse::Continue)
     }
 
     fn enter_token(
@@ -48,7 +48,7 @@ pub trait Visitor<E> {
         node: &Rc<Node>,
         path: &Vec<Rc<Node>>,
     ) -> Result<VisitorExitResponse, E> {
-        Ok(VisitorExitResponse::StepIn)
+        Ok(VisitorExitResponse::Continue)
     }
 }
 
@@ -60,7 +60,7 @@ pub enum VisitorEntryResponse {
 
 pub enum VisitorExitResponse {
     Quit,
-    StepIn,
+    Continue,
 }
 
 pub trait Visitable<T: Visitor<E>, E> {
@@ -95,8 +95,10 @@ fn accept_visitor_with_path<T: Visitor<E>, E>(
                                 path.pop();
                                 return Ok(VisitorExitResponse::Quit);
                             }
-                            VisitorExitResponse::StepIn => {}
-                        }
+                            VisitorExitResponse::Continue => {
+                                continue;
+                            }
+                        };
                     }
                     path.pop();
                 }
@@ -119,8 +121,10 @@ fn accept_visitor_with_path<T: Visitor<E>, E>(
                                 path.pop();
                                 return Ok(VisitorExitResponse::Quit);
                             }
-                            VisitorExitResponse::StepIn => {}
-                        }
+                            VisitorExitResponse::Continue => {
+                                continue;
+                            }
+                        };
                     }
                     path.pop();
                 }


### PR DESCRIPTION
Since it is not actually stepping into anything, but it is just about to step out of the current node.