### PR TITLE
upgrade to rust 1.65.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "0.2.1"
-rust-version = "1.64.0" # Keep this version in sync with "$RUST_VERSION" in "$REPO_ROOT/bin/hermit.hcl"
+rust-version = "1.65.0" # Keep this version in sync with "$RUST_VERSION" in "$REPO_ROOT/bin/hermit.hcl"
 edition = "2021"
 publish = false
 

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -7,7 +7,7 @@ env = {
 
   // Rust:
   "RUST_BACKTRACE": "FULL",
-  "RUST_VERSION": "1.64.0", // Keep this version in sync with "rust-version" in "$REPO_ROOT/Cargo.toml"
+  "RUST_VERSION": "1.65.0", // Keep this version in sync with "rust-version" in "$REPO_ROOT/Cargo.toml"
 
   // TypeScript:
   "TS_NODE_PROJECT": "${HERMIT_ENV}/tsconfig.json",


### PR DESCRIPTION
Needed to use `cargo-xwin` to compile NAPI binaries on windows.