### PR TITLE
expose `ParseError` API

### DIFF
--- a/.changeset/itchy-bulldogs-roll.md
+++ b/.changeset/itchy-bulldogs-roll.md
@@ -1,0 +1,5 @@
+---
+"changelog": minor
+---
+
+expose `ParseError` API

--- a/crates/codegen/syntax_templates/src/rust/parser_output.rs
+++ b/crates/codegen/syntax_templates/src/rust/parser_output.rs
@@ -1,9 +1,6 @@
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 
-use super::{
-    cst,
-    language::{render_error_report, ParseError},
-};
+use super::{cst, language::render_error_report};
 
 #[derive(PartialEq)]
 pub struct ParseOutput {
@@ -13,27 +10,34 @@ pub struct ParseOutput {
 
 impl ParseOutput {
     pub fn parse_tree(&self) -> Option<Rc<cst::Node>> {
-        self.parse_tree.clone()
+        return self.parse_tree.clone();
     }
 
-    pub fn error_count(&self) -> usize {
-        self.errors.len()
-    }
-
-    pub fn errors_as_strings(
-        &self,
-        source_id: &str,
-        source: &str,
-        with_colour: bool,
-    ) -> Vec<String> {
-        return self
-            .errors
-            .iter()
-            .map(|error| render_error_report(error, source_id, source, with_colour))
-            .collect();
+    pub fn errors(&self) -> &Vec<ParseError> {
+        return &self.errors;
     }
 
     pub fn is_valid(&self) -> bool {
-        self.parse_tree.is_some() && self.errors.is_empty()
+        return self.parse_tree.is_some() && self.errors.is_empty();
+    }
+}
+
+#[derive(PartialEq)]
+pub struct ParseError {
+    pub(crate) position: usize,
+    pub(crate) expected: BTreeSet<String>,
+}
+
+impl ParseError {
+    pub fn position(&self) -> usize {
+        return self.position;
+    }
+
+    pub fn expected(&self) -> &BTreeSet<String> {
+        return &self.expected;
+    }
+
+    pub fn to_error_report(&self, source_id: &str, source: &str, with_colour: bool) -> String {
+        return render_error_report(self, source_id, source, with_colour);
     }
 }

--- a/crates/codegen/syntax_templates/src/shared/language.rs
+++ b/crates/codegen/syntax_templates/src/shared/language.rs
@@ -3,25 +3,23 @@ pub use std::{collections::BTreeSet, ops::Range, rc::Rc};
 #[allow(deprecated, unused_imports)]
 use semver::Version;
 
-pub use super::{cst, kinds::*, parser_output::ParseOutput};
+pub use super::{
+    cst,
+    kinds::*,
+    parser_output::{ParseError, ParseOutput},
+};
 
 const DEBUG_ERROR_MERGING: bool = false;
 
-#[derive(PartialEq)]
-pub struct ParseError {
-    position: usize,
-    expected: BTreeSet<String>,
-}
-
 impl ParseError {
-    pub fn new<T: Into<String>>(position: usize, expected: T) -> Self {
+    pub(crate) fn new<T: Into<String>>(position: usize, expected: T) -> Self {
         Self {
             position,
             expected: BTreeSet::from([expected.into()]),
         }
     }
 
-    pub fn merge_with(&mut self, other: Self) {
+    pub(crate) fn merge_with(&mut self, other: Self) {
         if DEBUG_ERROR_MERGING {
             if self.position < other.position {
                 self.expected = BTreeSet::from([format!(
@@ -54,7 +52,8 @@ impl ParseError {
         }
     }
 
-    pub fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
         if let Some(other) = other {
             self.merge_with(other)
         }

--- a/crates/codegen/syntax_templates/src/typescript/parser_output.rs
+++ b/crates/codegen/syntax_templates/src/typescript/parser_output.rs
@@ -1,9 +1,7 @@
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 
 use super::{
-    cst,
-    cst_types::RcNodeExtensions as CSTRcNodeExtensions,
-    language::{render_error_report, ParseError},
+    cst, cst_types::RcNodeExtensions as CSTRcNodeExtensions, language::render_error_report,
 };
 use napi::bindgen_prelude::*;
 
@@ -17,30 +15,41 @@ pub struct ParseOutput {
 impl ParseOutput {
     #[napi(ts_return_type = "RuleNode | TokenNode | null")]
     pub fn parse_tree(&self, env: Env) -> Option<napi::JsObject> {
-        self.parse_tree.clone().map(|n| n.to_js(&env))
+        return self.parse_tree.clone().map(|n| n.to_js(&env));
     }
 
     #[napi]
-    pub fn error_count(&self) -> usize {
-        self.errors.len()
-    }
-
-    #[napi]
-    pub fn errors_as_strings(
-        &self,
-        source_id: String,
-        source: String,
-        with_colour: bool,
-    ) -> Vec<String> {
-        return self
-            .errors
-            .iter()
-            .map(|error| render_error_report(error, &source_id, &source, with_colour))
-            .collect();
+    pub fn errors(&self) -> Vec<ParseError> {
+        return self.errors.clone();
     }
 
     #[napi]
     pub fn is_valid(&self) -> bool {
-        self.parse_tree.is_some() && self.errors.is_empty()
+        return self.parse_tree.is_some() && self.errors.is_empty();
+    }
+}
+
+#[napi]
+#[derive(PartialEq, Clone)]
+pub struct ParseError {
+    pub(crate) position: usize,
+    pub(crate) expected: BTreeSet<String>,
+}
+
+#[napi]
+impl ParseError {
+    #[napi(getter)]
+    pub fn position(&self) -> usize {
+        return self.position;
+    }
+
+    #[napi]
+    pub fn expected(&self) -> Vec<String> {
+        return self.expected.iter().cloned().collect();
+    }
+
+    #[napi]
+    pub fn to_error_report(&self, source_id: String, source: String, with_colour: bool) -> String {
+        return render_error_report(self, &source_id, &source, with_colour);
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -5,25 +5,23 @@ pub use std::{collections::BTreeSet, ops::Range, rc::Rc};
 #[allow(deprecated, unused_imports)]
 use semver::Version;
 
-pub use super::{cst, kinds::*, parser_output::ParseOutput};
+pub use super::{
+    cst,
+    kinds::*,
+    parser_output::{ParseError, ParseOutput},
+};
 
 const DEBUG_ERROR_MERGING: bool = false;
 
-#[derive(PartialEq)]
-pub struct ParseError {
-    position: usize,
-    expected: BTreeSet<String>,
-}
-
 impl ParseError {
-    pub fn new<T: Into<String>>(position: usize, expected: T) -> Self {
+    pub(crate) fn new<T: Into<String>>(position: usize, expected: T) -> Self {
         Self {
             position,
             expected: BTreeSet::from([expected.into()]),
         }
     }
 
-    pub fn merge_with(&mut self, other: Self) {
+    pub(crate) fn merge_with(&mut self, other: Self) {
         if DEBUG_ERROR_MERGING {
             if self.position < other.position {
                 self.expected = BTreeSet::from([format!(
@@ -56,7 +54,8 @@ impl ParseError {
         }
     }
 
-    pub fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
         if let Some(other) = other {
             self.merge_with(other)
         }

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser_output.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser_output.rs
@@ -1,11 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 
-use super::{
-    cst,
-    language::{render_error_report, ParseError},
-};
+use super::{cst, language::render_error_report};
 
 #[derive(PartialEq)]
 pub struct ParseOutput {
@@ -15,27 +12,34 @@ pub struct ParseOutput {
 
 impl ParseOutput {
     pub fn parse_tree(&self) -> Option<Rc<cst::Node>> {
-        self.parse_tree.clone()
+        return self.parse_tree.clone();
     }
 
-    pub fn error_count(&self) -> usize {
-        self.errors.len()
-    }
-
-    pub fn errors_as_strings(
-        &self,
-        source_id: &str,
-        source: &str,
-        with_colour: bool,
-    ) -> Vec<String> {
-        return self
-            .errors
-            .iter()
-            .map(|error| render_error_report(error, source_id, source, with_colour))
-            .collect();
+    pub fn errors(&self) -> &Vec<ParseError> {
+        return &self.errors;
     }
 
     pub fn is_valid(&self) -> bool {
-        self.parse_tree.is_some() && self.errors.is_empty()
+        return self.parse_tree.is_some() && self.errors.is_empty();
+    }
+}
+
+#[derive(PartialEq)]
+pub struct ParseError {
+    pub(crate) position: usize,
+    pub(crate) expected: BTreeSet<String>,
+}
+
+impl ParseError {
+    pub fn position(&self) -> usize {
+        return self.position;
+    }
+
+    pub fn expected(&self) -> &BTreeSet<String> {
+        return &self.expected;
+    }
+
+    pub fn to_error_report(&self, source_id: &str, source: &str, with_colour: bool) -> String {
+        return render_error_report(self, source_id, source, with_colour);
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/lib.rs
+++ b/crates/solidity/outputs/cargo/crate/src/lib.rs
@@ -25,7 +25,7 @@ mod public_api {
         }
 
         pub mod parser {
-            pub use crate::generated::language::{ParseOutput, ProductionKind};
+            pub use crate::generated::language::{ParseError, ParseOutput, ProductionKind};
         }
 
         pub mod visitors {

--- a/crates/solidity/outputs/cargo/crate/src/main.rs
+++ b/crates/solidity/outputs/cargo/crate/src/main.rs
@@ -61,12 +61,16 @@ fn execute_parse_command(file_path: String, version: Version, json: bool) -> Res
     let language = Language::new(version)?;
     let output = language.parse(ProductionKind::SourceUnit, &input);
 
-    for report in &output.errors_as_strings(
-        input_file.to_str().unwrap(),
-        &input,
-        /* with_colour */ true,
-    ) {
-        eprintln!("{report}");
+    let errors = output.errors();
+    for error in errors {
+        eprintln!(
+            "{report}",
+            report = error.to_error_report(
+                input_file.to_str().unwrap(),
+                &input,
+                /* with_colour */ true,
+            )
+        );
     }
 
     if json {
@@ -76,5 +80,5 @@ fn execute_parse_command(file_path: String, version: Version, json: bool) -> Res
         }
     }
 
-    std::process::exit(output.error_count() as i32);
+    std::process::exit(errors.len() as i32);
 }

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -5,25 +5,23 @@ pub use std::{collections::BTreeSet, ops::Range, rc::Rc};
 #[allow(deprecated, unused_imports)]
 use semver::Version;
 
-pub use super::{cst, kinds::*, parser_output::ParseOutput};
+pub use super::{
+    cst,
+    kinds::*,
+    parser_output::{ParseError, ParseOutput},
+};
 
 const DEBUG_ERROR_MERGING: bool = false;
 
-#[derive(PartialEq)]
-pub struct ParseError {
-    position: usize,
-    expected: BTreeSet<String>,
-}
-
 impl ParseError {
-    pub fn new<T: Into<String>>(position: usize, expected: T) -> Self {
+    pub(crate) fn new<T: Into<String>>(position: usize, expected: T) -> Self {
         Self {
             position,
             expected: BTreeSet::from([expected.into()]),
         }
     }
 
-    pub fn merge_with(&mut self, other: Self) {
+    pub(crate) fn merge_with(&mut self, other: Self) {
         if DEBUG_ERROR_MERGING {
             if self.position < other.position {
                 self.expected = BTreeSet::from([format!(
@@ -56,7 +54,8 @@ impl ParseError {
         }
     }
 
-    pub fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn maybe_merge_with(mut self, other: Option<Self>) -> Self {
         if let Some(other) = other {
             self.merge_with(other)
         }

--- a/crates/solidity/outputs/npm/crate/src/generated/parser_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/parser_output.rs
@@ -1,11 +1,9 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 
 use super::{
-    cst,
-    cst_types::RcNodeExtensions as CSTRcNodeExtensions,
-    language::{render_error_report, ParseError},
+    cst, cst_types::RcNodeExtensions as CSTRcNodeExtensions, language::render_error_report,
 };
 use napi::bindgen_prelude::*;
 
@@ -19,30 +17,41 @@ pub struct ParseOutput {
 impl ParseOutput {
     #[napi(ts_return_type = "RuleNode | TokenNode | null")]
     pub fn parse_tree(&self, env: Env) -> Option<napi::JsObject> {
-        self.parse_tree.clone().map(|n| n.to_js(&env))
+        return self.parse_tree.clone().map(|n| n.to_js(&env));
     }
 
     #[napi]
-    pub fn error_count(&self) -> usize {
-        self.errors.len()
-    }
-
-    #[napi]
-    pub fn errors_as_strings(
-        &self,
-        source_id: String,
-        source: String,
-        with_colour: bool,
-    ) -> Vec<String> {
-        return self
-            .errors
-            .iter()
-            .map(|error| render_error_report(error, &source_id, &source, with_colour))
-            .collect();
+    pub fn errors(&self) -> Vec<ParseError> {
+        return self.errors.clone();
     }
 
     #[napi]
     pub fn is_valid(&self) -> bool {
-        self.parse_tree.is_some() && self.errors.is_empty()
+        return self.parse_tree.is_some() && self.errors.is_empty();
+    }
+}
+
+#[napi]
+#[derive(PartialEq, Clone)]
+pub struct ParseError {
+    pub(crate) position: usize,
+    pub(crate) expected: BTreeSet<String>,
+}
+
+#[napi]
+impl ParseError {
+    #[napi(getter)]
+    pub fn position(&self) -> usize {
+        return self.position;
+    }
+
+    #[napi]
+    pub fn expected(&self) -> Vec<String> {
+        return self.expected.iter().cloned().collect();
+    }
+
+    #[napi]
+    pub fn to_error_report(&self, source_id: String, source: String, with_colour: bool) -> String {
+        return render_error_report(self, &source_id, &source, with_colour);
     }
 }

--- a/crates/solidity/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.d.ts
@@ -640,7 +640,11 @@ export class Language {
 }
 export class ParseOutput {
   parseTree(): RuleNode | TokenNode | null;
-  errorCount(): bigint;
-  errorsAsStrings(sourceId: string, source: string, withColour: boolean): Array<string>;
+  errors(): Array<ParseError>;
   isValid(): boolean;
+}
+export class ParseError {
+  get position(): bigint;
+  expected(): Array<string>;
+  toErrorReport(sourceId: string, source: string, withColour: boolean): string;
 }

--- a/crates/solidity/outputs/npm/package/src/generated/index.js
+++ b/crates/solidity/outputs/npm/package/src/generated/index.js
@@ -239,7 +239,8 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`);
 }
 
-const { NodeType, RuleNode, TokenNode, TokenKind, RuleKind, ProductionKind, Language, ParseOutput } = nativeBinding;
+const { NodeType, RuleNode, TokenNode, TokenKind, RuleKind, ProductionKind, Language, ParseOutput, ParseError } =
+  nativeBinding;
 
 module.exports.NodeType = NodeType;
 module.exports.RuleNode = RuleNode;
@@ -249,3 +250,4 @@ module.exports.RuleKind = RuleKind;
 module.exports.ProductionKind = ProductionKind;
 module.exports.Language = Language;
 module.exports.ParseOutput = ParseOutput;
+module.exports.ParseError = ParseError;

--- a/crates/solidity/outputs/npm/tests/src/index.spec.ts
+++ b/crates/solidity/outputs/npm/tests/src/index.spec.ts
@@ -24,3 +24,26 @@ test("parse some syntax", (t) => {
     t.fail("Expected RuleNode");
   }
 });
+
+test("render some error", (t) => {
+  const l = new Language("0.8.1");
+  const source = "int256 constant";
+  const errors = l.parse(ProductionKind.SourceUnit, source).errors();
+
+  t.is(errors.length, 1);
+
+  const report = errors[0]?.toErrorReport("test.sol", source, /* withColor */ false);
+
+  t.is(
+    report,
+    `
+Error: Expected end of input.
+   ╭─[test.sol:1:1]
+   │
+ 1 │ int256 constant
+   │ │ 
+   │ ╰─ Error occurred here.
+───╯
+`.trim(),
+  );
+});

--- a/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
+++ b/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
@@ -73,7 +73,7 @@ fn write_errors<W: Write>(
     source_id: &str,
     source: &str,
 ) -> Result<()> {
-    let errors = output.errors_as_strings(source_id, source, /* with_colour */ false);
+    let errors = output.errors();
 
     if errors.len() == 0 {
         writeln!(w, "Errors: []")?;
@@ -84,7 +84,8 @@ fn write_errors<W: Write>(
 
     for error in errors {
         writeln!(w, "  - >")?;
-        for line in error.lines() {
+        let report = error.to_error_report(source_id, source, /* with_colour */ false);
+        for line in report.lines() {
             writeln!(w, "    {line}")?;
         }
     }

--- a/crates/solidity/testing/utils/src/node_extensions/tests.rs
+++ b/crates/solidity/testing/utils/src/node_extensions/tests.rs
@@ -16,7 +16,7 @@ fn extract_non_trivia() -> Result<()> {
     let language = Language::new(Version::parse("0.8.0")?)?;
     let output = language.parse(ProductionKind::Expression, source);
 
-    assert_eq!(output.error_count(), 0);
+    assert_eq!(output.errors().len(), 0);
 
     let parse_tree = output.parse_tree().context("Expected a parse tree")?;
     let value = parse_tree.extract_non_trivia(source);


### PR DESCRIPTION
We should have a fully typed error tree, rich with any metadata that downstream consumers might need to provide a good experience to their users.
Until that API is finalized, let's just return the `ParseError` for now.