### PR TITLE
use `number` and getters in npm public API

### DIFF
--- a/.changeset/hot-frogs-itch.md
+++ b/.changeset/hot-frogs-itch.md
@@ -1,0 +1,5 @@
+---
+"changelog": minor
+---
+
+use `number` and getters in npm public API

--- a/crates/codegen/syntax/src/typescript_lib_code_generator.rs
+++ b/crates/codegen/syntax/src/typescript_lib_code_generator.rs
@@ -77,7 +77,7 @@ impl CodeGenerator {
                         }}
                     }}
 
-                    #[napi]
+                    #[napi(getter)]
                     pub fn version(&self) -> String {{
                         self.version.to_string()
                     }}

--- a/crates/codegen/syntax_templates/src/typescript/cst_types.rs
+++ b/crates/codegen/syntax_templates/src/typescript/cst_types.rs
@@ -34,30 +34,30 @@ impl RuleNode {
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range(&self) -> [usize; 2] {
+    pub fn byte_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range(&self) -> [usize; 2] {
+    pub fn char_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range_including_trivia(&self) -> [usize; 2] {
+    pub fn byte_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range_including_trivia(&self) -> [usize; 2] {
+    pub fn char_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
-    #[napi(ts_return_type = "(RuleNode | TokenNode)[]")]
+    #[napi(getter, ts_return_type = "(RuleNode | TokenNode)[]")]
     pub fn children(&self, env: Env) -> Vec<JsObject> {
         match self.0.as_ref() {
             Node::Rule { children, .. } => children.iter().map(|child| child.to_js(&env)).collect(),
@@ -82,30 +82,30 @@ impl TokenNode {
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range(&self) -> [usize; 2] {
+    pub fn byte_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range(&self) -> [usize; 2] {
+    pub fn char_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range_including_trivia(&self) -> [usize; 2] {
+    pub fn byte_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range_including_trivia(&self) -> [usize; 2] {
+    pub fn char_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
-    #[napi(ts_return_type = "(RuleNode | TokenNode)[]")]
+    #[napi(getter, ts_return_type = "(RuleNode | TokenNode)[]")]
     pub fn trivia(&self, env: Env) -> Vec<JsObject> {
         match self.0.as_ref() {
             Node::Token { trivia, .. } => {

--- a/crates/codegen/syntax_templates/src/typescript/parser_output.rs
+++ b/crates/codegen/syntax_templates/src/typescript/parser_output.rs
@@ -15,17 +15,17 @@ pub struct ParseOutput {
 
 #[napi]
 impl ParseOutput {
-    #[napi(ts_return_type = "RuleNode | TokenNode | null")]
+    #[napi(getter, ts_return_type = "RuleNode | TokenNode | null")]
     pub fn parse_tree(&self, env: Env) -> Option<napi::JsObject> {
         return self.parse_tree.clone().map(|n| n.to_js(&env));
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn errors(&self) -> Vec<ParseError> {
         return self.errors.clone();
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn is_valid(&self) -> bool {
         return self.parse_tree.is_some() && self.errors.is_empty();
     }
@@ -41,16 +41,16 @@ pub struct ParseError {
 #[napi]
 impl ParseError {
     #[napi(getter)]
-    pub fn byte_position(&self) -> usize {
-        return self.position.byte;
+    pub fn byte_position(&self) -> u32 {
+        return self.position.byte as u32;
     }
 
     #[napi(getter)]
-    pub fn char_position(&self) -> usize {
-        return self.position.char;
+    pub fn char_position(&self) -> u32 {
+        return self.position.char as u32;
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn expected(&self) -> Vec<String> {
         return self.expected.iter().cloned().collect();
     }

--- a/crates/solidity/outputs/npm/crate/src/generated/cst_types.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/cst_types.rs
@@ -36,30 +36,30 @@ impl RuleNode {
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range(&self) -> [usize; 2] {
+    pub fn byte_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range(&self) -> [usize; 2] {
+    pub fn char_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range_including_trivia(&self) -> [usize; 2] {
+    pub fn byte_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range_including_trivia(&self) -> [usize; 2] {
+    pub fn char_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
-    #[napi(ts_return_type = "(RuleNode | TokenNode)[]")]
+    #[napi(getter, ts_return_type = "(RuleNode | TokenNode)[]")]
     pub fn children(&self, env: Env) -> Vec<JsObject> {
         match self.0.as_ref() {
             Node::Rule { children, .. } => children.iter().map(|child| child.to_js(&env)).collect(),
@@ -84,30 +84,30 @@ impl TokenNode {
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range(&self) -> [usize; 2] {
+    pub fn byte_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range(&self) -> [usize; 2] {
+    pub fn char_range(&self) -> [u32; 2] {
         let range = self.0.range();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn byte_range_including_trivia(&self) -> [usize; 2] {
+    pub fn byte_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.byte, range.end.byte]
+        [range.start.byte as u32, range.end.byte as u32]
     }
 
     #[napi(getter, ts_return_type = "[ start: number, end: number ]")]
-    pub fn char_range_including_trivia(&self) -> [usize; 2] {
+    pub fn char_range_including_trivia(&self) -> [u32; 2] {
         let range = self.0.range_including_trivia();
-        [range.start.char, range.end.char]
+        [range.start.char as u32, range.end.char as u32]
     }
 
-    #[napi(ts_return_type = "(RuleNode | TokenNode)[]")]
+    #[napi(getter, ts_return_type = "(RuleNode | TokenNode)[]")]
     pub fn trivia(&self, env: Env) -> Vec<JsObject> {
         match self.0.as_ref() {
             Node::Token { trivia, .. } => {

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -399,7 +399,7 @@ impl Language {
         }
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn version(&self) -> String {
         self.version.to_string()
     }

--- a/crates/solidity/outputs/npm/crate/src/generated/parser_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/parser_output.rs
@@ -17,17 +17,17 @@ pub struct ParseOutput {
 
 #[napi]
 impl ParseOutput {
-    #[napi(ts_return_type = "RuleNode | TokenNode | null")]
+    #[napi(getter, ts_return_type = "RuleNode | TokenNode | null")]
     pub fn parse_tree(&self, env: Env) -> Option<napi::JsObject> {
         return self.parse_tree.clone().map(|n| n.to_js(&env));
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn errors(&self) -> Vec<ParseError> {
         return self.errors.clone();
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn is_valid(&self) -> bool {
         return self.parse_tree.is_some() && self.errors.is_empty();
     }
@@ -43,16 +43,16 @@ pub struct ParseError {
 #[napi]
 impl ParseError {
     #[napi(getter)]
-    pub fn byte_position(&self) -> usize {
-        return self.position.byte;
+    pub fn byte_position(&self) -> u32 {
+        return self.position.byte as u32;
     }
 
     #[napi(getter)]
-    pub fn char_position(&self) -> usize {
-        return self.position.char;
+    pub fn char_position(&self) -> u32 {
+        return self.position.char as u32;
     }
 
-    #[napi]
+    #[napi(getter)]
     pub fn expected(&self) -> Vec<String> {
         return self.expected.iter().cloned().collect();
     }

--- a/crates/solidity/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.d.ts
@@ -626,7 +626,7 @@ export class RuleNode {
   get charRange(): [start: number, end: number];
   get byteRangeIncludingTrivia(): [start: number, end: number];
   get charRangeIncludingTrivia(): [start: number, end: number];
-  children(): (RuleNode | TokenNode)[];
+  get children(): (RuleNode | TokenNode)[];
 }
 export class TokenNode {
   get type(): NodeType.Token;
@@ -635,21 +635,21 @@ export class TokenNode {
   get charRange(): [start: number, end: number];
   get byteRangeIncludingTrivia(): [start: number, end: number];
   get charRangeIncludingTrivia(): [start: number, end: number];
-  trivia(): (RuleNode | TokenNode)[];
+  get trivia(): (RuleNode | TokenNode)[];
 }
 export class Language {
   constructor(version: string);
-  version(): string;
+  get version(): string;
   parse(productionKind: ProductionKind, input: string): ParseOutput;
 }
 export class ParseOutput {
-  parseTree(): RuleNode | TokenNode | null;
-  errors(): Array<ParseError>;
-  isValid(): boolean;
+  get parseTree(): RuleNode | TokenNode | null;
+  get errors(): Array<ParseError>;
+  get isValid(): boolean;
 }
 export class ParseError {
-  get bytePosition(): bigint;
-  get charPosition(): bigint;
-  expected(): Array<string>;
+  get bytePosition(): number;
+  get charPosition(): number;
+  get expected(): Array<string>;
   toErrorReport(sourceId: string, source: string, withColour: boolean): string;
 }

--- a/crates/solidity/outputs/npm/tests/src/index.spec.ts
+++ b/crates/solidity/outputs/npm/tests/src/index.spec.ts
@@ -3,33 +3,55 @@ import test from "ava";
 import { Language, RuleKind, TokenKind, NodeType, RuleNode, TokenNode, ProductionKind } from "@nomicfoundation/slang";
 
 test("parse some token", (t) => {
-  const l = new Language("0.8.1");
-  const cst = l.parse(ProductionKind.DecimalNumber, "5_286_981").parseTree();
-  if (cst instanceof TokenNode) {
-    t.is(cst.type, NodeType.Token);
-    t.is(cst.kind, TokenKind.DecimalNumber);
+  const source = "5_286_981";
+  const language = new Language("0.8.1");
+
+  const { parseTree } = language.parse(ProductionKind.DecimalNumber, source);
+
+  if (parseTree instanceof TokenNode) {
+    t.is(parseTree.type, NodeType.Token);
+    t.is(parseTree.kind, TokenKind.DecimalNumber);
+    t.is(parseTree.trivia.length, 0);
   } else {
     t.fail("Expected TokenNode");
   }
 });
 
 test("parse some syntax", (t) => {
-  const l = new Language("0.8.1");
-  const cst = l.parse(ProductionKind.SourceUnit, "int256 constant z = 1**2**3;").parseTree();
-  if (cst instanceof RuleNode) {
-    t.is(cst.type, NodeType.Rule);
-    t.is(cst.kind, RuleKind.SourceUnit);
-    t.is(cst.children().length, 1);
+  const source = "int256 constant z = 1**2**3;";
+  const language = new Language("0.8.1");
+
+  const { parseTree } = language.parse(ProductionKind.SourceUnit, source);
+
+  if (parseTree instanceof RuleNode) {
+    t.is(parseTree.type, NodeType.Rule);
+    t.is(parseTree.kind, RuleKind.SourceUnit);
+    t.is(parseTree.children.length, 1);
   } else {
     t.fail("Expected RuleNode");
   }
 });
 
-test("render some error", (t) => {
-  const l = new Language("0.8.1");
-  const source = "int256 constant";
-  const errors = l.parse(ProductionKind.SourceUnit, source).errors();
+test("calculate both byte and char ranges", (t) => {
+  const source = `unicode"some 😁 emoji"`;
+  const language = new Language("0.8.1");
 
+  const { parseTree } = language.parse(ProductionKind.UnicodeStringLiteral, source);
+
+  if (parseTree instanceof TokenNode) {
+    t.is(parseTree.kind, TokenKind.UnicodeStringLiteral);
+    t.deepEqual(parseTree.charRange, [0, 21]);
+    t.deepEqual(parseTree.byteRange, [0, 24]);
+  } else {
+    t.fail("Expected TokenNode");
+  }
+});
+
+test("render some error", (t) => {
+  const source = "int256 constant";
+  const language = new Language("0.8.1");
+
+  const { errors } = language.parse(ProductionKind.SourceUnit, source);
   t.is(errors.length, 1);
 
   const report = errors[0]?.toErrorReport("test.sol", source, /* withColor */ false);


### PR DESCRIPTION
Turns out that using `#[napi(ts_return_type = "number")]` only affects the return type in the generated `index.d.ts` file, but not the actual return type at runtime. Currently we are using `usize`, which maps to JavaScript's `BigInt` by default, which means our types are incorrect.

This PR uses `u32` instead which maps to JavaScript's `number` type. Also adds a few missing `getter` attributes, and adds a test to check the new types.

Follow up on #458 