### PR TITLE
fix test snapshot indices

### DIFF
--- a/crates/codegen/syntax_templates/src/shared/language.rs
+++ b/crates/codegen/syntax_templates/src/shared/language.rs
@@ -182,11 +182,7 @@ pub(crate) fn render_error_report(
     };
 
     if source.is_empty() {
-        return format!(
-            "{kind}: {message}\n   ─[{source_id}:{source_start}:{source_end}]",
-            source_start = source_start.char,
-            source_end = source_end.char
-        );
+        return format!("{kind}: {message}\n   ─[{source_id}:0:0]");
     }
 
     let mut builder = Report::build(kind, source_id, source_start.byte)

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -184,11 +184,7 @@ pub(crate) fn render_error_report(
     };
 
     if source.is_empty() {
-        return format!(
-            "{kind}: {message}\n   ─[{source_id}:{source_start}:{source_end}]",
-            source_start = source_start.char,
-            source_end = source_end.char
-        );
+        return format!("{kind}: {message}\n   ─[{source_id}:0:0]");
     }
 
     let mut builder = Report::build(kind, source_id, source_start.byte)

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -184,11 +184,7 @@ pub(crate) fn render_error_report(
     };
 
     if source.is_empty() {
-        return format!(
-            "{kind}: {message}\n   ─[{source_id}:{source_start}:{source_end}]",
-            source_start = source_start.char,
-            source_end = source_end.char
-        );
+        return format!("{kind}: {message}\n   ─[{source_id}:0:0]");
     }
 
     let mut builder = Report::build(kind, source_id, source_start.byte)

--- a/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.4.11.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"This Emoji: 😃"                                                        │ 0..25
+  1  │ unicode"This Emoji: 😃"                                                           │ 0..25
 
 Errors: # 1 total
   - >

--- a/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.7.0.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/unicode_string_literal/generated/0.7.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"This Emoji: 😃"                                                        │ 0..25
+  1  │ unicode"This Emoji: 😃"                                                           │ 0..25
 
 Errors: []
 

--- a/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_multiple/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_multiple/generated/0.4.11.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"happy 😃" unicode'sad 😔'                                            │ 0..37
+  1  │ unicode"happy 😃" unicode'sad 😔'                                                  │ 0..37
 
 Errors: # 1 total
   - >

--- a/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_multiple/generated/0.7.0.yml
+++ b/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_multiple/generated/0.7.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"happy 😃" unicode'sad 😔'                                            │ 0..37
+  1  │ unicode"happy 😃" unicode'sad 😔'                                                  │ 0..37
 
 Errors: []
 

--- a/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_single/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_single/generated/0.4.11.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"emoji 😃"                                                              │ 0..19
+  1  │ unicode"emoji 😃"                                                                 │ 0..19
 
 Errors: # 1 total
   - >

--- a/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_single/generated/0.7.0.yml
+++ b/crates/solidity/testing/snapshots/cst_output/StringExpression/unicode_single/generated/0.7.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 Source: >
-  1  │ unicode"emoji 😃"                                                              │ 0..19
+  1  │ unicode"emoji 😃"                                                                 │ 0..19
 
 Errors: []
 

--- a/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
+++ b/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
@@ -36,13 +36,13 @@ fn write_source<W: Write>(w: &mut W, source: &str) -> Result<()> {
     let line_data = source
         .lines()
         .enumerate()
-        .map(|(index, line)| (index, line, line.bytes().len()))
+        .map(|(index, line)| (index, line, line.bytes().len(), line.chars().count()))
         .collect::<Vec<_>>();
 
     let source_width = {
         let source_width = line_data
             .iter()
-            .map(|(_, _, length)| *length)
+            .map(|(_, _, _, chars)| *chars)
             .max()
             .unwrap_or(0);
 
@@ -52,13 +52,13 @@ fn write_source<W: Write>(w: &mut W, source: &str) -> Result<()> {
     writeln!(w, "Source: >")?;
 
     let mut offset = 0;
-    for (index, line, length) in line_data.iter() {
-        let range = offset..(offset + length);
+    for (index, line, bytes, chars) in line_data.iter() {
+        let range = offset..(offset + bytes);
         writeln!(
             w,
             "  {line_number: <2} │ {line}{padding} │ {range:?}",
             line_number = index + 1,
-            padding = " ".repeat(source_width - length),
+            padding = " ".repeat(source_width - chars),
         )?;
 
         offset = range.end + 1;


### PR DESCRIPTION
Follow up on #458

- make sure test snapshots padding uses chars instead of bytes
- fixed a minor bug with rendering error messages on empty source input, as it expects line/col, not start/end bytes.