### PR TITLE
make sure all named sub-parsers can produce rule kinds

### DIFF
--- a/crates/codegen/syntax/src/combinator_node.rs
+++ b/crates/codegen/syntax/src/combinator_node.rs
@@ -253,10 +253,11 @@ impl<'context> CombinatorNode<'context> {
                     .iter()
                     .map(|expr| Self::from_parser(tree, expr))
                     .collect::<Vec<_>>();
-                if elements.len() == 1 {
-                    return elements.pop().unwrap();
-                } else {
+
+                if name.is_some() || elements.len() > 1 {
                     Self::Choice { name, elements }
+                } else {
+                    return elements.pop().unwrap();
                 }
             }
 


### PR DESCRIPTION
Context: https://github.com/NomicFoundation/slang/issues/339#issuecomment-1458114009

add support for naming `choice` parsers, as we can have two nodes of the same kind in succession, and we need to differentiate which is which.

Closes #339
