### PR TITLE
remove `PrecedenceParser.name`

### DIFF
--- a/crates/codegen/ebnf/src/precedence_parser.rs
+++ b/crates/codegen/ebnf/src/precedence_parser.rs
@@ -6,7 +6,7 @@ impl GenerateEbnf for PrecedenceParserRef {
     fn generate_ebnf(&self) -> EbnfNode {
         let mut choices = vec![];
 
-        for definition in &self.definition.definitions {
+        for definition in &self.operators {
             let mut comment = None;
 
             let operator = match definition.model {
@@ -43,12 +43,7 @@ impl GenerateEbnf for PrecedenceParserRef {
             ));
         }
 
-        choices.push(
-            self.definition
-                .primary_expression
-                .definition
-                .generate_ebnf(),
-        );
+        choices.push(self.primary_expression.definition.generate_ebnf());
 
         return EbnfNode::choices(choices);
     }

--- a/crates/codegen/schema/src/types/precedence_parser.rs
+++ b/crates/codegen/schema/src/types/precedence_parser.rs
@@ -6,19 +6,10 @@ use crate::types::ParserRef;
 pub type PrecedenceParserRef = std::rc::Rc<PrecedenceParser>;
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct PrecedenceParser {
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(flatten)]
-    pub definition: PrecedenceParserDefinition,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct PrecedenceParserDefinition {
+pub struct PrecedenceParser {
     #[schemars(title = "Operator Definitions")]
-    pub definitions: Vec<OperatorDefinition>,
+    pub operators: Vec<OperatorDefinition>,
 
     #[schemars(title = "Primary Expression")]
     pub primary_expression: ParserRef,

--- a/crates/codegen/schema/src/validation/rules/definitions/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/mod.rs
@@ -2,7 +2,7 @@ use codegen_utils::errors::CodegenResult;
 use indexmap::IndexSet;
 
 use crate::{
-    types::{LanguageDefinitionRef, ParserRef, PrecedenceParserRef, ProductionRef},
+    types::{LanguageDefinitionRef, ParserRef, ProductionRef},
     validation::visitors::{run_visitor, LocationRef, Reporter, Visitor},
 };
 
@@ -63,24 +63,6 @@ impl Visitor for Definitions {
         reporter: &mut Reporter,
     ) -> bool {
         if let Some(name) = &parser.name {
-            if self.language.productions.contains_key(name) {
-                reporter.report(
-                    location,
-                    Errors::ExpressionNamedAsProduction(name.to_owned()),
-                );
-            }
-        }
-
-        return true;
-    }
-
-    fn visit_precedence_parser(
-        &mut self,
-        precedence_parser: &PrecedenceParserRef,
-        location: &LocationRef,
-        reporter: &mut Reporter,
-    ) -> bool {
-        if let Some(name) = &precedence_parser.name {
             if self.language.productions.contains_key(name) {
                 reporter.report(
                     location,

--- a/crates/codegen/schema/src/validation/visitors/receivers.rs
+++ b/crates/codegen/schema/src/validation/visitors/receivers.rs
@@ -263,7 +263,7 @@ impl Receiver for PrecedenceParserRef {
 
         {
             let location = location.field("definitions");
-            for (i, definition) in self.definition.definitions.iter().enumerate() {
+            for (i, definition) in self.operators.iter().enumerate() {
                 let location = location.index(i).field("operator");
                 definition
                     .operator
@@ -273,8 +273,7 @@ impl Receiver for PrecedenceParserRef {
 
         {
             let location = location.field("primaryExpression");
-            self.definition
-                .primary_expression
+            self.primary_expression
                 .receive(visitor, language, location, reporter);
         }
     }

--- a/crates/codegen/syntax/src/combinator_node.rs
+++ b/crates/codegen/syntax/src/combinator_node.rs
@@ -221,10 +221,8 @@ impl<'context> CombinatorNode<'context> {
         tree: &'context CombinatorTree<'context>,
         parser: &PrecedenceParserRef,
     ) -> &'context CombinatorNode<'context> {
-        let primary_expression = Self::from_parser(tree, &parser.definition.primary_expression);
         let operators: Vec<PrecedenceRuleOperator> = parser
-            .definition
-            .definitions
+            .operators
             .iter()
             .map(|definition| -> PrecedenceRuleOperator {
                 PrecedenceRuleOperator {
@@ -234,6 +232,9 @@ impl<'context> CombinatorNode<'context> {
                 }
             })
             .collect();
+
+        let primary_expression = Self::from_parser(tree, &parser.primary_expression);
+
         return tree.context.alloc_node(Self::PrecedenceExpressionRule {
             tree,
             operators,

--- a/crates/solidity/inputs/language/definition/01-file-structure/03-pragmas/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/03-pragmas/productions.yml
@@ -25,7 +25,7 @@
 - name: "VersionPragmaExpression"
   kind: "PrecedenceParser"
   unversioned:
-    definitions:
+    operators:
       - name: "VersionPragmaAlternatives"
         model: "BinaryLeftAssociative"
         operator:

--- a/crates/solidity/inputs/language/definition/03-types/01-advanced-types/productions.yml
+++ b/crates/solidity/inputs/language/definition/03-types/01-advanced-types/productions.yml
@@ -3,7 +3,7 @@
 - name: "TypeName"
   kind: "PrecedenceParser"
   unversioned:
-    definitions:
+    operators:
       - name: "ArrayTypeName"
         model: "UnaryPostfix"
         operator:

--- a/crates/solidity/inputs/language/definition/05-expressions/01-base-expressions/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/01-base-expressions/productions.yml
@@ -4,7 +4,7 @@
   kind: "PrecedenceParser"
   versioned:
     0.4.11:
-      definitions:
+      operators:
         - name: "AssignmentExpression"
           model: "BinaryLeftAssociative"
           operator:
@@ -100,7 +100,7 @@
 
     0.6.0:
       # ExponentiationExpression is now BinaryRightAssociative
-      definitions:
+      operators:
         - name: "AssignmentExpression"
           model: "BinaryLeftAssociative"
           operator:

--- a/crates/solidity/inputs/language/definition/06-yul/03-yul-expressions/productions.yml
+++ b/crates/solidity/inputs/language/definition/06-yul/03-yul-expressions/productions.yml
@@ -3,7 +3,7 @@
 - name: "YulExpression"
   kind: "PrecedenceParser"
   unversioned:
-    definitions:
+    operators:
       - name: "YulFunctionCallExpression"
         model: "UnaryPostfix"
         operator:

--- a/crates/solidity/inputs/language/generated/productions.schema.json
+++ b/crates/solidity/inputs/language/generated/productions.schema.json
@@ -535,13 +535,9 @@
     },
     "PrecedenceParser": {
       "type": "object",
-      "required": ["definitions", "primaryExpression"],
+      "required": ["operators", "primaryExpression"],
       "properties": {
-        "name": {
-          "default": null,
-          "type": ["string", "null"]
-        },
-        "definitions": {
+        "operators": {
           "title": "Operator Definitions",
           "type": "array",
           "items": {


### PR DESCRIPTION
Part of tightening the grammar. This removes `PrecedenceParser.name` since it is idle/unused in codegen.