### PR TITLE
CST misses last character when parsing (erroneous) `arr[]` as an Expression

### DIFF
--- a/crates/codegen/syntax/src/to_parser_code.rs
+++ b/crates/codegen/syntax/src/to_parser_code.rs
@@ -343,6 +343,7 @@ fn precedence_expression_to_parser_code(
                                 {}
                         }
                     )*
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 }
             })

--- a/crates/solidity/outputs/cargo/crate/src/generated/parsers.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parsers.rs
@@ -2619,6 +2619,7 @@ impl Language {
                             ),
                             ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                         }
+                        stream.set_position(start_position);
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
@@ -2796,6 +2797,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
@@ -2957,6 +2959,7 @@ impl Language {
                             ),
                             ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                         }
+                        stream.set_position(start_position);
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
@@ -3134,6 +3137,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
@@ -8804,6 +8808,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {

--- a/crates/solidity/outputs/npm/crate/src/generated/parsers.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/parsers.rs
@@ -2619,6 +2619,7 @@ impl Language {
                             ),
                             ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                         }
+                        stream.set_position(start_position);
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
@@ -2796,6 +2797,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
@@ -2957,6 +2959,7 @@ impl Language {
                             ),
                             ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                         }
+                        stream.set_position(start_position);
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
@@ -3134,6 +3137,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
@@ -8804,6 +8808,7 @@ impl Language {
                         ),
                         ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_) => {}
                     }
+                    stream.set_position(start_position);
                     break ParserResult::no_match(vec![]);
                 };
                 match result {

--- a/crates/solidity/testing/snapshots/cst_output/Expression/index_missing/generated/0.4.11.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/index_missing/generated/0.4.11.yml
@@ -6,15 +6,15 @@ Source: >
 Errors: # 1 total
   - >
     Error: Expected end of file.
-       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/index_missing/input.sol:1:5]
+       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/index_missing/input.sol:1:4]
        │
      1 │ arr[]
-       │     ┬  
+       │    ─┬  
        │     ╰── Error occurred here.
     ───╯
 
 Tree:
-  - Expression (Rule): # 0..4 "arr["
+  - Expression (Rule): # 0..5 "arr[]"
       - PrimaryExpression (Rule): # 0..3 "arr"
           - Identifier (Token): "arr" # 0..3
-      - SKIPPED (Token): "[" # 3..4
+      - SKIPPED (Token): "[]" # 3..5


### PR DESCRIPTION
Fixes #511