### PR TITLE
update public API surface

### DIFF
--- a/crates/codegen/syntax_templates/src/typescript/cst_types.rs
+++ b/crates/codegen/syntax_templates/src/typescript/cst_types.rs
@@ -36,6 +36,7 @@ impl RuleNode {
 
     #[napi(
         getter,
+        js_name = "textLength",
         ts_return_type = "[ utf8: number, utf16: number, char: number]"
     )]
     pub fn text_len(&self) -> [u32; 3] {
@@ -70,6 +71,7 @@ impl TokenNode {
 
     #[napi(
         getter,
+        js_name = "textLength",
         ts_return_type = "[ utf8: number, utf16: number, char: number]"
     )]
     pub fn text_len(&self) -> [u32; 3] {

--- a/crates/codegen/syntax_templates/src/typescript/parse_output.rs
+++ b/crates/codegen/syntax_templates/src/typescript/parse_output.rs
@@ -55,7 +55,6 @@ impl ParseError {
         ];
     }
 
-    #[napi(getter)]
     pub fn tokens_that_would_have_allowed_more_progress(&self) -> Vec<String> {
         let tokens_that_would_have_allowed_more_progress = self
             .tokens_that_would_have_allowed_more_progress

--- a/crates/solidity/outputs/npm/crate/src/generated/cst_types.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/cst_types.rs
@@ -38,6 +38,7 @@ impl RuleNode {
 
     #[napi(
         getter,
+        js_name = "textLength",
         ts_return_type = "[ utf8: number, utf16: number, char: number]"
     )]
     pub fn text_len(&self) -> [u32; 3] {
@@ -72,6 +73,7 @@ impl TokenNode {
 
     #[napi(
         getter,
+        js_name = "textLength",
         ts_return_type = "[ utf8: number, utf16: number, char: number]"
     )]
     pub fn text_len(&self) -> [u32; 3] {

--- a/crates/solidity/outputs/npm/crate/src/generated/parse_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/parse_output.rs
@@ -57,7 +57,6 @@ impl ParseError {
         ];
     }
 
-    #[napi(getter)]
     pub fn tokens_that_would_have_allowed_more_progress(&self) -> Vec<String> {
         let tokens_that_would_have_allowed_more_progress = self
             .tokens_that_would_have_allowed_more_progress

--- a/crates/solidity/outputs/npm/package/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/generated/index.d.ts
@@ -649,13 +649,13 @@ export enum ProductionKind {
 export class RuleNode {
   get type(): NodeType.Rule;
   get kind(): RuleKind;
-  get textLen(): [utf8: number, utf16: number, char: number];
+  get textLength(): [utf8: number, utf16: number, char: number];
   get children(): (RuleNode | TokenNode)[];
 }
 export class TokenNode {
   get type(): NodeType.Token;
   get kind(): TokenKind;
-  get textLen(): [utf8: number, utf16: number, char: number];
+  get textLength(): [utf8: number, utf16: number, char: number];
 }
 export class Language {
   constructor(version: string);
@@ -670,6 +670,5 @@ export class ParseOutput {
 }
 export class ParseError {
   get range(): [start: [utf8: number, utf16: number, char: number], end: [utf8: number, utf16: number, char: number]];
-  get tokensThatWouldHaveAllowedMoreProgress(): Array<string>;
   toErrorReport(sourceId: string, source: string, withColour: boolean): string;
 }

--- a/crates/solidity/outputs/npm/tests/src/cst-output.ts
+++ b/crates/solidity/outputs/npm/tests/src/cst-output.ts
@@ -40,8 +40,8 @@ test("calculate both byte and char ranges", (t) => {
 
   if (parseTree instanceof TokenNode) {
     t.is(parseTree.kind, TokenKind.UnicodeStringLiteral);
-    t.deepEqual(parseTree.textLen[2], 21);
-    t.deepEqual(parseTree.textLen[0], 24);
+    t.deepEqual(parseTree.textLength[2], 21);
+    t.deepEqual(parseTree.textLength[0], 24);
   } else {
     t.fail("Expected TokenNode");
   }

--- a/documentation/public/user-guide/cargo-crate/index.md
+++ b/documentation/public/user-guide/cargo-crate/index.md
@@ -35,10 +35,12 @@ This allows callers to parse entire source files (`ProductionKind::SourceUnit`),
 methods (`ProductionKind::FunctionDefinition`), or any other syntax nodes.
 
 ```rust
-use slang_solidity::syntax::{
+use slang_solidity::{
     language::Language,
-    nodes::{Node, RuleKind, TokenKind},
-    parser::{ProductionKind},
+    syntax::{
+        nodes::{Node, RuleKind, TokenKind},
+        parser::ProductionKind,
+    },
 };
 
 let language = Language::new(Version::parse("0.8.0")?)?;


### PR DESCRIPTION
- rename `textLen()` to `textLength()` to be TypeScript idiomatic.
- hide the private `tokensThatWouldHaveAllowedMoreProgress()` API.
- fix code examples.