### PR TITLE
consolidating terminology in codegen crates

### DIFF
--- a/crates/codegen/ebnf/src/nodes.rs
+++ b/crates/codegen/ebnf/src/nodes.rs
@@ -1,21 +1,21 @@
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub enum EbnfNode {
     BaseProduction,
-    Choices {
-        choices: Vec<EbnfNode>,
+    Choice {
+        nodes: Vec<EbnfNode>,
     },
     Difference {
         minuend: Box<EbnfNode>,
         subtrahend: Box<EbnfNode>,
     },
     Not {
-        body: Box<EbnfNode>,
+        node: Box<EbnfNode>,
     },
     OneOrMore {
-        body: Box<EbnfNode>,
+        node: Box<EbnfNode>,
     },
     Optional {
-        body: Box<EbnfNode>,
+        node: Box<EbnfNode>,
     },
     ProductionRef {
         name: String,
@@ -25,24 +25,24 @@ pub enum EbnfNode {
         to: char,
     },
     Sequence {
-        elements: Vec<EbnfNode>,
+        nodes: Vec<EbnfNode>,
     },
     SubStatement {
         name: String,
         comment: Option<String>,
-        body: Box<EbnfNode>,
+        root_node: Box<EbnfNode>,
     },
     Terminal {
         value: String,
     },
     ZeroOrMore {
-        body: Box<EbnfNode>,
+        node: Box<EbnfNode>,
     },
 }
 
 impl EbnfNode {
-    pub fn choices(choices: Vec<EbnfNode>) -> Self {
-        Self::Choices { choices }
+    pub fn choice(nodes: Vec<EbnfNode>) -> Self {
+        Self::Choice { nodes }
     }
 
     pub fn difference(minuend: EbnfNode, subtrahend: EbnfNode) -> Self {
@@ -52,21 +52,21 @@ impl EbnfNode {
         }
     }
 
-    pub fn not(body: EbnfNode) -> Self {
+    pub fn not(node: EbnfNode) -> Self {
         Self::Not {
-            body: Box::new(body),
+            node: Box::new(node),
         }
     }
 
-    pub fn one_or_more(body: EbnfNode) -> Self {
+    pub fn one_or_more(node: EbnfNode) -> Self {
         Self::OneOrMore {
-            body: Box::new(body),
+            node: Box::new(node),
         }
     }
 
-    pub fn optional(body: EbnfNode) -> Self {
+    pub fn optional(node: EbnfNode) -> Self {
         Self::Optional {
-            body: Box::new(body),
+            node: Box::new(node),
         }
     }
 
@@ -78,15 +78,15 @@ impl EbnfNode {
         Self::Range { from, to }
     }
 
-    pub fn sequence(elements: Vec<EbnfNode>) -> Self {
-        Self::Sequence { elements }
+    pub fn sequence(nodes: Vec<EbnfNode>) -> Self {
+        Self::Sequence { nodes }
     }
 
-    pub fn sub_statement(name: String, comment: Option<String>, body: EbnfNode) -> Self {
+    pub fn sub_statement(name: String, comment: Option<String>, root_node: EbnfNode) -> Self {
         Self::SubStatement {
             name,
             comment,
-            body: Box::new(body),
+            root_node: Box::new(root_node),
         }
     }
 
@@ -94,9 +94,9 @@ impl EbnfNode {
         Self::Terminal { value }
     }
 
-    pub fn zero_or_more(body: EbnfNode) -> Self {
+    pub fn zero_or_more(node: EbnfNode) -> Self {
         Self::ZeroOrMore {
-            body: Box::new(body),
+            node: Box::new(node),
         }
     }
 }

--- a/crates/codegen/ebnf/src/parser.rs
+++ b/crates/codegen/ebnf/src/parser.rs
@@ -11,73 +11,67 @@ impl GenerateEbnf for ParserRef {
 impl GenerateEbnf for ParserDefinition {
     fn generate_ebnf(&self) -> EbnfNode {
         match &self {
-            ParserDefinition::Choice(sub_exprs) => {
-                return EbnfNode::choices(
-                    sub_exprs
+            ParserDefinition::Choice(parsers) => {
+                return EbnfNode::choice(
+                    parsers
                         .iter()
-                        .map(|choice| choice.generate_ebnf())
+                        .map(|parser| parser.generate_ebnf())
                         .collect(),
                 );
             }
 
             ParserDefinition::DelimitedBy {
                 open,
-                expression,
+                parser,
                 close,
             } => {
                 return EbnfNode::sequence(vec![
                     EbnfNode::production_ref(open.reference.to_owned()),
-                    expression.generate_ebnf(),
+                    parser.generate_ebnf(),
                     EbnfNode::production_ref(close.reference.to_owned()),
                 ]);
             }
 
-            ParserDefinition::OneOrMore(expr) => {
-                return EbnfNode::one_or_more(expr.generate_ebnf());
+            ParserDefinition::OneOrMore(parser) => {
+                return EbnfNode::one_or_more(parser.generate_ebnf());
             }
 
-            ParserDefinition::Optional(expr) => {
-                return EbnfNode::optional(expr.generate_ebnf());
+            ParserDefinition::Optional(parser) => {
+                return EbnfNode::optional(parser.generate_ebnf());
             }
 
             ParserDefinition::Reference(name) => {
                 return EbnfNode::production_ref(name.to_owned());
             }
 
-            ParserDefinition::SeparatedBy {
-                expression,
-                separator,
-            } => {
+            ParserDefinition::SeparatedBy { parser, separator } => {
                 return EbnfNode::sequence(vec![
-                    expression.generate_ebnf(),
+                    parser.generate_ebnf(),
                     EbnfNode::zero_or_more(EbnfNode::sequence(vec![
                         EbnfNode::production_ref(separator.reference.to_owned()),
-                        expression.generate_ebnf(),
+                        parser.generate_ebnf(),
                     ])),
                 ]);
             }
 
-            ParserDefinition::Sequence(elements) => {
+            ParserDefinition::Sequence(parsers) => {
                 return EbnfNode::sequence(
-                    elements
+                    parsers
                         .iter()
-                        .map(|element| element.generate_ebnf())
+                        .map(|parser| parser.generate_ebnf())
                         .collect(),
                 );
             }
 
-            ParserDefinition::TerminatedBy {
-                expression,
-                terminator,
-            } => {
+            ParserDefinition::TerminatedBy { parser, terminator } => {
                 return EbnfNode::sequence(vec![
-                    expression.generate_ebnf(),
+                    parser.generate_ebnf(),
                     EbnfNode::production_ref(terminator.reference.to_owned()),
                 ]);
             }
 
-            ParserDefinition::ZeroOrMore(expr) => {
-                return EbnfNode::zero_or_more(expr.generate_ebnf());
+            ParserDefinition::ZeroOrMore(parser) => {
+                return EbnfNode::zero_or_more(parser.generate_ebnf());
             }
         }
     }

--- a/crates/codegen/ebnf/src/precedence_parser.rs
+++ b/crates/codegen/ebnf/src/precedence_parser.rs
@@ -4,15 +4,15 @@ use crate::{nodes::EbnfNode, serialization::GenerateEbnf};
 
 impl GenerateEbnf for PrecedenceParserRef {
     fn generate_ebnf(&self) -> EbnfNode {
-        let mut choices = vec![];
+        let mut nodes = vec![];
 
-        for definition in &self.operators {
+        for expression in &self.operator_expressions {
             let mut comment = None;
 
-            let operator = match definition.model {
+            let operator = match expression.model {
                 OperatorModel::BinaryLeftAssociative => EbnfNode::sequence(vec![
                     EbnfNode::BaseProduction,
-                    definition.operator.generate_ebnf(),
+                    expression.operator.generate_ebnf(),
                     EbnfNode::BaseProduction,
                 ]),
 
@@ -21,30 +21,30 @@ impl GenerateEbnf for PrecedenceParserRef {
 
                     EbnfNode::sequence(vec![
                         EbnfNode::BaseProduction,
-                        definition.operator.generate_ebnf(),
+                        expression.operator.generate_ebnf(),
                         EbnfNode::BaseProduction,
                     ])
                 }
                 OperatorModel::UnaryPrefix => EbnfNode::sequence(vec![
-                    definition.operator.generate_ebnf(),
+                    expression.operator.generate_ebnf(),
                     EbnfNode::BaseProduction,
                 ]),
 
                 OperatorModel::UnaryPostfix => EbnfNode::sequence(vec![
                     EbnfNode::BaseProduction,
-                    definition.operator.generate_ebnf(),
+                    expression.operator.generate_ebnf(),
                 ]),
             };
 
-            choices.push(EbnfNode::sub_statement(
-                definition.name.to_owned(),
+            nodes.push(EbnfNode::sub_statement(
+                expression.name.to_owned(),
                 comment,
                 operator,
             ));
         }
 
-        choices.push(self.primary_expression.generate_ebnf());
+        nodes.push(self.primary_expression.generate_ebnf());
 
-        return EbnfNode::choices(choices);
+        return EbnfNode::choice(nodes);
     }
 }

--- a/crates/codegen/ebnf/src/scanner.rs
+++ b/crates/codegen/ebnf/src/scanner.rs
@@ -11,11 +11,11 @@ impl GenerateEbnf for ScannerRef {
 impl GenerateEbnf for ScannerDefinition {
     fn generate_ebnf(&self) -> EbnfNode {
         match &self {
-            ScannerDefinition::Choice(choices) => {
-                return EbnfNode::choices(
-                    choices
+            ScannerDefinition::Choice(scanners) => {
+                return EbnfNode::choice(
+                    scanners
                         .iter()
-                        .map(|choice| choice.generate_ebnf())
+                        .map(|scanner| scanner.generate_ebnf())
                         .collect(),
                 );
             }
@@ -27,16 +27,16 @@ impl GenerateEbnf for ScannerDefinition {
                 return EbnfNode::difference(minuend.generate_ebnf(), subtrahend.generate_ebnf());
             }
 
-            ScannerDefinition::Not(sub_expr) => {
-                return EbnfNode::not(sub_expr.generate_ebnf());
+            ScannerDefinition::Not(scanner) => {
+                return EbnfNode::not(scanner.generate_ebnf());
             }
 
-            ScannerDefinition::OneOrMore(expr) => {
-                return EbnfNode::one_or_more(expr.generate_ebnf());
+            ScannerDefinition::OneOrMore(scanner) => {
+                return EbnfNode::one_or_more(scanner.generate_ebnf());
             }
 
-            ScannerDefinition::Optional(expr) => {
-                return EbnfNode::optional(expr.generate_ebnf());
+            ScannerDefinition::Optional(scanner) => {
+                return EbnfNode::optional(scanner.generate_ebnf());
             }
 
             ScannerDefinition::Range { from, to } => {
@@ -47,11 +47,11 @@ impl GenerateEbnf for ScannerDefinition {
                 return EbnfNode::production_ref(name.to_owned());
             }
 
-            ScannerDefinition::Sequence(elements) => {
+            ScannerDefinition::Sequence(scanners) => {
                 return EbnfNode::sequence(
-                    elements
+                    scanners
                         .iter()
-                        .map(|element| element.generate_ebnf())
+                        .map(|scanner| scanner.generate_ebnf())
                         .collect(),
                 );
             }
@@ -60,12 +60,12 @@ impl GenerateEbnf for ScannerDefinition {
                 return EbnfNode::terminal(string.to_owned());
             }
 
-            ScannerDefinition::TrailingContext { expression, .. } => {
-                return expression.generate_ebnf();
+            ScannerDefinition::TrailingContext { scanner, .. } => {
+                return scanner.generate_ebnf();
             }
 
-            ScannerDefinition::ZeroOrMore(expr) => {
-                return EbnfNode::zero_or_more(expr.generate_ebnf());
+            ScannerDefinition::ZeroOrMore(scanner) => {
+                return EbnfNode::zero_or_more(scanner.generate_ebnf());
             }
         };
     }

--- a/crates/codegen/schema/src/json_schema.rs
+++ b/crates/codegen/schema/src/json_schema.rs
@@ -40,8 +40,8 @@ fn relax_schema(value: Value) -> Value {
             return value;
         }
 
-        Value::Array(items) => {
-            return Value::Array(items.into_iter().map(relax_schema).collect());
+        Value::Array(nodes) => {
+            return Value::Array(nodes.into_iter().map(relax_schema).collect());
         }
 
         Value::Object(entries) => {

--- a/crates/codegen/schema/src/types/parser.rs
+++ b/crates/codegen/schema/src/types/parser.rs
@@ -15,40 +15,40 @@ pub struct Parser {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum ParserDefinition {
-    #[schemars(title = "Choice Expression")]
+    #[schemars(title = "Choice Parser")]
     Choice(Vec<ParserRef>),
 
-    #[schemars(title = "DelimitedBy Expression")]
+    #[schemars(title = "DelimitedBy Parser")]
     DelimitedBy {
         open: Reference,
-        expression: ParserRef,
+        parser: ParserRef,
         close: Reference,
     },
 
-    #[schemars(title = "OneOrMore Expression")]
+    #[schemars(title = "OneOrMore Parser")]
     OneOrMore(ParserRef),
 
-    #[schemars(title = "Optional Expression")]
+    #[schemars(title = "Optional Parser")]
     Optional(ParserRef),
 
-    #[schemars(title = "Reference Expression")]
+    #[schemars(title = "Reference Parser")]
     Reference(String),
 
-    #[schemars(title = "SeparatedBy Expression")]
+    #[schemars(title = "SeparatedBy Parser")]
     SeparatedBy {
-        expression: ParserRef,
+        parser: ParserRef,
         separator: Reference,
     },
 
-    #[schemars(title = "Sequence Expression")]
+    #[schemars(title = "Sequence Parser")]
     Sequence(Vec<ParserRef>),
 
-    #[schemars(title = "TerminatedBy Expression")]
+    #[schemars(title = "TerminatedBy Parser")]
     TerminatedBy {
-        expression: ParserRef,
+        parser: ParserRef,
         terminator: Reference,
     },
 
-    #[schemars(title = "ZeroOrMore Expression")]
+    #[schemars(title = "ZeroOrMore Parser")]
     ZeroOrMore(ParserRef),
 }

--- a/crates/codegen/schema/src/types/precedence_parser.rs
+++ b/crates/codegen/schema/src/types/precedence_parser.rs
@@ -8,8 +8,8 @@ pub type PrecedenceParserRef = std::rc::Rc<PrecedenceParser>;
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PrecedenceParser {
-    #[schemars(title = "Operator Definitions")]
-    pub operators: Vec<OperatorDefinition>,
+    #[schemars(title = "Operator Expressions")]
+    pub operator_expressions: Vec<OperatorExpression>,
 
     #[schemars(title = "Primary Expression")]
     pub primary_expression: ParserRef,
@@ -17,7 +17,7 @@ pub struct PrecedenceParser {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct OperatorDefinition {
+pub struct OperatorExpression {
     pub name: String,
     pub model: OperatorModel,
     pub operator: ParserRef,

--- a/crates/codegen/schema/src/types/scanner.rs
+++ b/crates/codegen/schema/src/types/scanner.rs
@@ -13,43 +13,43 @@ pub struct Scanner {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum ScannerDefinition {
-    #[schemars(title = "Choice Expression")]
+    #[schemars(title = "Choice Scanner")]
     Choice(Vec<ScannerRef>),
 
-    #[schemars(title = "Difference Expression")]
+    #[schemars(title = "Difference Scanner")]
     Difference {
         minuend: ScannerRef,
         subtrahend: ScannerRef,
     },
 
-    #[schemars(title = "Not Expression")]
+    #[schemars(title = "Not Scanner")]
     Not(ScannerRef),
 
-    #[schemars(title = "OneOrMore Expression")]
+    #[schemars(title = "OneOrMore Scanner")]
     OneOrMore(ScannerRef),
 
-    #[schemars(title = "Optional Expression")]
+    #[schemars(title = "Optional Scanner")]
     Optional(ScannerRef),
 
-    #[schemars(title = "Range Expression")]
+    #[schemars(title = "Range Scanner")]
     Range { from: char, to: char },
 
-    #[schemars(title = "Reference Expression")]
+    #[schemars(title = "Reference Scanner")]
     Reference(String),
 
-    #[schemars(title = "Sequence Expression")]
+    #[schemars(title = "Sequence Scanner")]
     Sequence(Vec<ScannerRef>),
 
-    #[schemars(title = "TrailingContext Expression")]
+    #[schemars(title = "TrailingContext Scanner")]
     #[serde(rename_all = "camelCase")]
     TrailingContext {
-        expression: ScannerRef,
+        scanner: ScannerRef,
         not_followed_by: ScannerRef,
     },
 
-    #[schemars(title = "Terminal Expression")]
+    #[schemars(title = "Terminal Scanner")]
     Terminal(String),
 
-    #[schemars(title = "ZeroOrMore Expression")]
+    #[schemars(title = "ZeroOrMore Scanner")]
     ZeroOrMore(ScannerRef),
 }

--- a/crates/codegen/schema/src/validation/rules/definitions/keywords/collector.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/keywords/collector.rs
@@ -53,8 +53,8 @@ impl Visitor for KeywordsCollector {
         reporter: &mut Reporter,
     ) -> bool {
         let identifier =
-            if let ScannerDefinition::TrailingContext { expression, .. } = &scanner.definition {
-                expression
+            if let ScannerDefinition::TrailingContext { scanner, .. } = &scanner.definition {
+                scanner
             } else {
                 return true;
             };
@@ -96,10 +96,10 @@ impl KeywordsCollector {
         // https://github.com/NomicFoundation/slang/issues/505
 
         match &scanner.definition {
-            ScannerDefinition::Choice(choices) => {
+            ScannerDefinition::Choice(scanners) => {
                 let mut variations = Vec::new();
-                for choice in choices {
-                    variations.extend(Self::collect_variations(&choice)?);
+                for scanner in scanners {
+                    variations.extend(Self::collect_variations(&scanner)?);
                 }
 
                 return Some(variations);
@@ -143,8 +143,8 @@ impl KeywordsCollector {
 
                 return Some(existing_variations);
             }
-            ScannerDefinition::TrailingContext { expression, .. } => {
-                return Self::collect_variations(expression);
+            ScannerDefinition::TrailingContext { scanner, .. } => {
+                return Self::collect_variations(scanner);
             }
             ScannerDefinition::Terminal(terminal) => {
                 if terminal.chars().all(|c| c == '_' || c.is_alphanumeric()) {

--- a/crates/codegen/schema/src/validation/rules/definitions/operators/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/operators/mod.rs
@@ -59,8 +59,8 @@ impl Visitor for Operators {
         location: &LocationRef,
         reporter: &mut Reporter,
     ) -> bool {
-        for operator in parser.operators.iter() {
-            let name = &operator.name;
+        for expression in parser.operator_expressions.iter() {
+            let name = &expression.name;
             if self.language.productions.contains_key(name) {
                 reporter.report(location, Errors::OperatorNamedAsProduction(name.to_owned()));
                 continue;

--- a/crates/codegen/schema/src/validation/rules/lints/children_count.rs
+++ b/crates/codegen/schema/src/validation/rules/lints/children_count.rs
@@ -75,7 +75,7 @@ impl Visitor for ChildrenCount {
         location: &LocationRef,
         reporter: &mut Reporter,
     ) -> bool {
-        if precedence_parser.operators.is_empty() {
+        if precedence_parser.operator_expressions.is_empty() {
             reporter.report(location, Errors::MinChildrenCount(1));
         }
 

--- a/crates/codegen/schema/src/validation/visitors/receivers.rs
+++ b/crates/codegen/schema/src/validation/visitors/receivers.rs
@@ -139,10 +139,10 @@ impl Receiver for ScannerDefinition {
         reporter: &mut Reporter,
     ) {
         match self {
-            ScannerDefinition::Choice(expressions) => {
+            ScannerDefinition::Choice(scanners) => {
                 let location = location.field("choice");
-                for (i, expression) in expressions.iter().enumerate() {
-                    expression.receive(visitor, language, location.index(i), reporter);
+                for (i, scanner) in scanners.iter().enumerate() {
+                    scanner.receive(visitor, language, location.index(i), reporter);
                 }
             }
             ScannerDefinition::Difference {
@@ -153,30 +153,30 @@ impl Receiver for ScannerDefinition {
                 minuend.receive(visitor, language, location.field("minuend"), reporter);
                 subtrahend.receive(visitor, language, location.field("subtrahend"), reporter);
             }
-            ScannerDefinition::Not(expression) => {
-                expression.receive(visitor, language, location.field("not"), reporter);
+            ScannerDefinition::Not(scanner) => {
+                scanner.receive(visitor, language, location.field("not"), reporter);
             }
-            ScannerDefinition::OneOrMore(expression) => {
-                expression.receive(visitor, language, location.field("oneOrMore"), reporter);
+            ScannerDefinition::OneOrMore(scanner) => {
+                scanner.receive(visitor, language, location.field("oneOrMore"), reporter);
             }
-            ScannerDefinition::Optional(expression) => {
-                expression.receive(visitor, language, location.field("optional"), reporter);
+            ScannerDefinition::Optional(scanner) => {
+                scanner.receive(visitor, language, location.field("optional"), reporter);
             }
             ScannerDefinition::Range { .. } => {}
             ScannerDefinition::Reference(_) => {}
-            ScannerDefinition::Sequence(expressions) => {
+            ScannerDefinition::Sequence(scanners) => {
                 let location = location.field("sequence");
-                for (i, expression) in expressions.iter().enumerate() {
-                    expression.receive(visitor, language, location.index(i), reporter);
+                for (i, scanner) in scanners.iter().enumerate() {
+                    scanner.receive(visitor, language, location.index(i), reporter);
                 }
             }
             ScannerDefinition::Terminal(_) => {}
             ScannerDefinition::TrailingContext {
-                expression,
+                scanner,
                 not_followed_by,
             } => {
                 let location = location.field("trailingContext");
-                expression.receive(visitor, language, location.field("expression"), reporter);
+                scanner.receive(visitor, language, location.field("scanner"), reporter);
                 not_followed_by.receive(
                     visitor,
                     language,
@@ -184,8 +184,8 @@ impl Receiver for ScannerDefinition {
                     reporter,
                 );
             }
-            ScannerDefinition::ZeroOrMore(expression) => {
-                expression.receive(visitor, language, location.field("zeroOrMore"), reporter);
+            ScannerDefinition::ZeroOrMore(scanner) => {
+                scanner.receive(visitor, language, location.field("zeroOrMore"), reporter);
             }
         };
     }
@@ -217,39 +217,39 @@ impl Receiver for ParserDefinition {
         reporter: &mut Reporter,
     ) {
         match self {
-            ParserDefinition::Choice(expressions) => {
+            ParserDefinition::Choice(parsers) => {
                 let location = location.field("choice");
-                for (i, expression) in expressions.iter().enumerate() {
-                    expression.receive(visitor, language, location.index(i), reporter);
+                for (i, parser) in parsers.iter().enumerate() {
+                    parser.receive(visitor, language, location.index(i), reporter);
                 }
             }
-            ParserDefinition::DelimitedBy { expression, .. } => {
+            ParserDefinition::DelimitedBy { parser, .. } => {
                 let location = location.field("delimitedBy");
-                expression.receive(visitor, language, location.field("expression"), reporter);
+                parser.receive(visitor, language, location.field("parser"), reporter);
             }
-            ParserDefinition::OneOrMore(expression) => {
-                expression.receive(visitor, language, location.field("oneOrMore"), reporter);
+            ParserDefinition::OneOrMore(parser) => {
+                parser.receive(visitor, language, location.field("oneOrMore"), reporter);
             }
-            ParserDefinition::Optional(expression) => {
-                expression.receive(visitor, language, location.field("optional"), reporter);
+            ParserDefinition::Optional(parser) => {
+                parser.receive(visitor, language, location.field("optional"), reporter);
             }
             ParserDefinition::Reference(_) => {}
-            ParserDefinition::SeparatedBy { expression, .. } => {
+            ParserDefinition::SeparatedBy { parser, .. } => {
                 let location = location.field("separatedBy");
-                expression.receive(visitor, language, location.field("expression"), reporter);
+                parser.receive(visitor, language, location.field("parser"), reporter);
             }
-            ParserDefinition::Sequence(expressions) => {
+            ParserDefinition::Sequence(parsers) => {
                 let location = location.field("sequence");
-                for (i, expression) in expressions.iter().enumerate() {
-                    expression.receive(visitor, language, location.index(i), reporter);
+                for (i, parser) in parsers.iter().enumerate() {
+                    parser.receive(visitor, language, location.index(i), reporter);
                 }
             }
-            ParserDefinition::TerminatedBy { expression, .. } => {
+            ParserDefinition::TerminatedBy { parser, .. } => {
                 let location = location.field("terminatedBy");
-                expression.receive(visitor, language, location.field("expression"), reporter);
+                parser.receive(visitor, language, location.field("parser"), reporter);
             }
-            ParserDefinition::ZeroOrMore(expression) => {
-                expression.receive(visitor, language, location.field("zeroOrMore"), reporter);
+            ParserDefinition::ZeroOrMore(parser) => {
+                parser.receive(visitor, language, location.field("zeroOrMore"), reporter);
             }
         };
     }
@@ -268,10 +268,10 @@ impl Receiver for PrecedenceParserRef {
         }
 
         {
-            let location = location.field("operators");
-            for (i, definition) in self.operators.iter().enumerate() {
+            let location = location.field("operatorExpressions");
+            for (i, expression) in self.operator_expressions.iter().enumerate() {
                 let location = location.index(i).field("operator");
-                definition
+                expression
                     .operator
                     .receive(visitor, language, location, reporter);
             }

--- a/crates/codegen/schema/src/yaml/cst.rs
+++ b/crates/codegen/schema/src/yaml/cst.rs
@@ -12,7 +12,7 @@ pub enum Node {
     },
     Array {
         range: Range,
-        items: Vec<NodeRef>,
+        nodes: Vec<NodeRef>,
     },
     Object {
         range: Range,
@@ -39,7 +39,7 @@ impl Node {
 
     pub fn index(&self, index: usize) -> &NodeRef {
         return match self {
-            Node::Array { items, .. } => items
+            Node::Array { nodes, .. } => nodes
                 .get(index)
                 .expect(&format!("Expected array to have index '{index}'.")),
             _ => unreachable!("Expected an array."),

--- a/crates/codegen/schema/src/yaml/parser.rs
+++ b/crates/codegen/schema/src/yaml/parser.rs
@@ -77,7 +77,7 @@ impl<'context> Parser<'context> {
                 Node::Value { range: start..end }
             }
             Event::SequenceStart(_) => {
-                let mut items = Vec::new();
+                let mut nodes = Vec::new();
 
                 let mut start = start;
                 let mut end = loop {
@@ -85,17 +85,17 @@ impl<'context> Parser<'context> {
                         break self.consume()?.position;
                     }
 
-                    items.push(self.parse_value()?);
+                    nodes.push(self.parse_value()?);
                 };
 
-                if !items.is_empty() {
-                    start = min(start, items.first().unwrap().range().start);
-                    end = max(end, items.last().unwrap().range().end);
+                if !nodes.is_empty() {
+                    start = min(start, nodes.first().unwrap().range().start);
+                    end = max(end, nodes.last().unwrap().range().end);
                 }
 
                 Node::Array {
                     range: start..end,
-                    items,
+                    nodes,
                 }
             }
             Event::MappingStart(_) => {

--- a/crates/codegen/syntax/src/to_scanner_code.rs
+++ b/crates/codegen/syntax/src/to_scanner_code.rs
@@ -33,37 +33,37 @@ impl<'context> CombinatorNode<'context> {
             /**********************************************************************
              * Sequence and Choice
              */
-            Self::Sequence { elements, .. } => {
-                let elements = elements
+            Self::Sequence { nodes, .. } => {
+                let scanners = nodes
                     .iter()
                     .map(|e| e.to_scanner_code(code))
                     .collect::<Vec<_>>();
-                quote! { scan_sequence!(#(#elements),*) }
+                quote! { scan_sequence!(#(#scanners),*) }
             }
 
-            Self::Choice { elements, .. } => {
-                let elements = elements
+            Self::Choice { nodes, .. } => {
+                let scanners = nodes
                     .iter()
                     .map(|e| e.to_scanner_code(code))
                     .collect::<Vec<_>>();
-                quote! { scan_choice!(stream, #(#elements),*) }
+                quote! { scan_choice!(stream, #(#scanners),*) }
             }
 
             /**********************************************************************
              * Numeric qualification
              */
-            Self::Optional { expr } => {
-                let expr = expr.to_scanner_code(code);
-                quote! { scan_optional!(stream, #expr) }
+            Self::Optional { node } => {
+                let scanner = node.to_scanner_code(code);
+                quote! { scan_optional!(stream, #scanner) }
             }
 
-            Self::ZeroOrMore { expr, .. } => {
-                let expr = expr.to_scanner_code(code);
-                quote! { scan_zero_or_more!(stream, #expr) }
+            Self::ZeroOrMore { node, .. } => {
+                let scanner = node.to_scanner_code(code);
+                quote! { scan_zero_or_more!(stream, #scanner) }
             }
-            Self::OneOrMore { expr, .. } => {
-                let expr = expr.to_scanner_code(code);
-                quote! { scan_one_or_more!(stream, #expr) }
+            Self::OneOrMore { node, .. } => {
+                let scanner = node.to_scanner_code(code);
+                quote! { scan_one_or_more!(stream, #scanner) }
             }
 
             /**********************************************************************
@@ -84,8 +84,8 @@ impl<'context> CombinatorNode<'context> {
             /**********************************************************************
              * Precedence parsing
              */
-            Self::PrecedenceExpressionRule { .. } => {
-                unreachable!("PrecedenceExpressionRule cannot be generated from a scanner")
+            Self::PrecedenceParser { .. } => {
+                unreachable!("PrecedenceParser cannot be generated from a scanner")
             }
 
             /**********************************************************************
@@ -105,12 +105,12 @@ impl<'context> CombinatorNode<'context> {
             }
 
             Self::TrailingContext {
-                expression,
+                node,
                 not_followed_by,
             } => {
-                let expression = expression.to_scanner_code(code);
+                let scanner = node.to_scanner_code(code);
                 let not_followed_by = not_followed_by.to_scanner_code(code);
-                quote! { scan_not_followed_by!(stream, #expression, #not_followed_by) }
+                quote! { scan_not_followed_by!(stream, #scanner, #not_followed_by) }
             }
         }
     }

--- a/crates/codegen/syntax/src/trie.rs
+++ b/crates/codegen/syntax/src/trie.rs
@@ -106,7 +106,7 @@ pub fn from_scanner(tree: &CombinatorTree, scanner: ScannerRef) -> Option<Termin
         scanner: ScannerRef,
     ) -> bool {
         match &scanner.definition {
-            ScannerDefinition::Choice(exprs) => exprs.iter().fold(true, |accum, scanner| {
+            ScannerDefinition::Choice(scanners) => scanners.iter().fold(true, |accum, scanner| {
                 accum && collect_terminals(trie, tree, scanner.clone())
             }),
 

--- a/crates/codegen/syntax_templates/src/shared/parser_helpers.rs
+++ b/crates/codegen/syntax_templates/src/shared/parser_helpers.rs
@@ -48,7 +48,7 @@ impl ParserResult {
                     *self = next_result;
                 }
                 ParserResult::PrattOperatorMatch(_) => {
-                    unreachable!("Pratt operators are not supported in sequence expressions")
+                    unreachable!("Pratt operators are not supported in sequence parsers")
                 }
             }
         } else {
@@ -74,7 +74,7 @@ impl ParserResult {
                     unreachable!("Choice has continued to run after it has already succeeded")
                 }
                 ParserResult::PrattOperatorMatch(_) => {
-                    unreachable!("Pratt operators are not supported in choice expressions")
+                    unreachable!("Pratt operators are not supported in choice parsers")
                 }
             },
             ParserResult::NoMatch(no_match) => {
@@ -85,7 +85,7 @@ impl ParserResult {
                 }
             }
             ParserResult::PrattOperatorMatch(_) => {
-                unreachable!("Pratt operators are not supported in choice expressions")
+                unreachable!("Pratt operators are not supported in choice parsers")
             }
         }
         return false;
@@ -116,7 +116,7 @@ impl ParserResult {
                     );
                 }
                 ParserResult::PrattOperatorMatch(_) => {
-                    unreachable!("Pratt operators are not supported in zero-or-more expressions")
+                    unreachable!("Pratt operators are not supported in zero-or-more parsers")
                 }
             }
         } else {
@@ -153,7 +153,7 @@ impl ParserResult {
                     *self = result;
                 }
                 ParserResult::PrattOperatorMatch(_) => {
-                    unreachable!("Pratt operators are not supported in one-or-more expressions")
+                    unreachable!("Pratt operators are not supported in one-or-more parsers")
                 }
             }
         } else {
@@ -171,40 +171,40 @@ pub fn transform_option_result(result: ParserResult) -> ParserResult {
             no_match.tokens_that_would_have_allowed_more_progress,
         ),
         ParserResult::PrattOperatorMatch(_) => {
-            unreachable!("Pratt operators are not supported in optional expressions")
+            unreachable!("Pratt operators are not supported in optional parsers")
         }
     }
 }
 
-pub fn reduce_pratt_elements<F>(operator_argument_transformer: F, elements: &mut Vec<ParserResult>)
+pub fn reduce_pratt_elements<F>(operator_argument_transformer: F, results: &mut Vec<ParserResult>)
 where
     F: Fn(Vec<cst::Node>) -> Vec<cst::Node>,
 {
     let mut i = 0;
-    while elements.len() > 1 {
+    while results.len() > 1 {
         if let ParserResult::PrattOperatorMatch(PrattOperatorMatch {
             right_binding_power,
             left_binding_power,
             ..
-        }) = &elements[i]
+        }) = &results[i]
         {
-            let next_left_binding_power = if elements.len() == i + 1 {
+            let next_left_binding_power = if results.len() == i + 1 {
                 // ... operator
                 0
             } else if let ParserResult::PrattOperatorMatch(PrattOperatorMatch {
                 left_binding_power,
                 ..
-            }) = &elements[i + 1]
+            }) = &results[i + 1]
             {
                 // ... operator operator ...?
                 *left_binding_power
-            } else if elements.len() == i + 2 {
+            } else if results.len() == i + 2 {
                 // ... operator expr
                 0
             } else if let ParserResult::PrattOperatorMatch(PrattOperatorMatch {
                 left_binding_power,
                 ..
-            }) = &elements[i + 2]
+            }) = &results[i + 2]
             {
                 // ... operator expr operator ...?
                 *left_binding_power
@@ -218,8 +218,8 @@ where
             }
 
             if *right_binding_power == 255 {
-                let left = elements.remove(i - 1);
-                let op = elements.remove(i - 1);
+                let left = results.remove(i - 1);
+                let op = results.remove(i - 1);
                 if let (
                     ParserResult::Match(left),
                     ParserResult::PrattOperatorMatch(PrattOperatorMatch {
@@ -232,7 +232,7 @@ where
                     let mut children = vec![];
                     children.extend(operator_argument_transformer(left.nodes));
                     children.extend(nodes);
-                    elements.insert(
+                    results.insert(
                         i - 1,
                         ParserResult::r#match(
                             vec![cst::Node::rule(operator_kind, children)],
@@ -244,8 +244,8 @@ where
                     unreachable!("This is a malformed pratt parser sequence")
                 }
             } else if *left_binding_power == 255 {
-                let op = elements.remove(i);
-                let right = elements.remove(i);
+                let op = results.remove(i);
+                let right = results.remove(i);
                 if let (
                     ParserResult::PrattOperatorMatch(PrattOperatorMatch {
                         nodes,
@@ -258,7 +258,7 @@ where
                     let mut children = vec![];
                     children.extend(nodes);
                     children.extend(operator_argument_transformer(right.nodes));
-                    elements.insert(
+                    results.insert(
                         i,
                         ParserResult::r#match(
                             vec![cst::Node::rule(operator_kind, children)],
@@ -269,10 +269,10 @@ where
                 } else {
                     unreachable!("This is a malformed pratt parser sequence")
                 }
-            } else if 3 <= elements.len() {
-                let left = elements.remove(i - 1);
-                let op = elements.remove(i - 1);
-                let right = elements.remove(i - 1);
+            } else if 3 <= results.len() {
+                let left = results.remove(i - 1);
+                let op = results.remove(i - 1);
+                let right = results.remove(i - 1);
                 if let (
                     ParserResult::Match(left),
                     ParserResult::PrattOperatorMatch(PrattOperatorMatch {
@@ -287,7 +287,7 @@ where
                     children.extend(operator_argument_transformer(left.nodes));
                     children.extend(nodes);
                     children.extend(operator_argument_transformer(right.nodes));
-                    elements.insert(
+                    results.insert(
                         i - 1,
                         ParserResult::r#match(
                             vec![cst::Node::rule(operator_kind, children)],
@@ -299,9 +299,9 @@ where
                     unreachable!("This is a malformed pratt parser sequence")
                 }
             } else {
-                // We have not enough elements because of an previous error
-                let left = elements.remove(i - 1);
-                let op = elements.remove(i - 1);
+                // We have not enough results because of an previous error
+                let left = results.remove(i - 1);
+                let op = results.remove(i - 1);
                 if let (
                     ParserResult::Match(left),
                     ParserResult::PrattOperatorMatch(PrattOperatorMatch {
@@ -314,7 +314,7 @@ where
                     let mut children = vec![];
                     children.extend(operator_argument_transformer(left.nodes));
                     children.extend(nodes);
-                    elements.insert(
+                    results.insert(
                         i - 1,
                         ParserResult::incomplete_match(
                             vec![cst::Node::rule(operator_kind, children)],

--- a/crates/codegen/syntax_templates/src/shared/scanner_macros.rs
+++ b/crates/codegen/syntax_templates/src/shared/scanner_macros.rs
@@ -49,18 +49,18 @@ macro_rules! scan_trie {
 
 #[allow(unused_macros)]
 macro_rules! scan_sequence {
-    ($($expr:expr),*) => {
-        $(($expr))&&*
+    ($($scanner:expr),*) => {
+        $(($scanner))&&*
     };
 }
 
 #[allow(unused_macros)]
 macro_rules! scan_choice {
-    ($stream:ident, $($expr:expr),*) => {
+    ($stream:ident, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
-                if ($expr) { break true }
+                if ($scanner) { break true }
                 $stream.set_position(save);
             )*
             break false
@@ -70,10 +70,10 @@ macro_rules! scan_choice {
 
 #[allow(unused_macros)]
 macro_rules! scan_zero_or_more {
-    ($stream:ident, $expr:expr) => {
+    ($stream:ident, $scanner:expr) => {
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 $stream.set_position(save);
                 break true;
             }
@@ -83,11 +83,11 @@ macro_rules! scan_zero_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_one_or_more {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let mut count = 0;
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 if count < 1 {
                     break false;
                 } else {
@@ -102,9 +102,9 @@ macro_rules! scan_one_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_optional {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let save = $stream.position();
-        if !($expr) {
+        if !($scanner) {
             $stream.set_position(save)
         }
         true
@@ -131,8 +131,8 @@ macro_rules! scan_difference {
 
 #[allow(unused_macros)]
 macro_rules! scan_not_followed_by {
-    ($stream:ident, $expression:expr, $not_followed_by:expr) => {
-        ($expression)
+    ($stream:ident, $scanner:expr, $not_followed_by:expr) => {
+        ($scanner)
             && ({
                 let end = $stream.position();
                 let following = $not_followed_by;

--- a/crates/solidity/inputs/language/definition/01-file-structure/03-pragmas/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/03-pragmas/productions.yml
@@ -4,7 +4,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "PragmaKeyword"
           - choice:
@@ -47,7 +47,7 @@
 - name: "VersionPragmaExpression"
   kind: "PrecedenceParser"
   unversioned:
-    operators:
+    operatorExpressions:
       - name: "VersionPragmaBinaryExpression"
         model: "BinaryLeftAssociative"
         operator:
@@ -95,7 +95,7 @@
   kind: "Parser"
   unversioned:
     separatedBy:
-      expression:
+      parser:
         reference: "VersionPragmaValue"
       separator:
         reference: "Period"

--- a/crates/solidity/inputs/language/definition/01-file-structure/04-imports/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/04-imports/productions.yml
@@ -4,7 +4,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "ImportKeyword"
           - choice:
@@ -41,7 +41,7 @@
       - delimitedBy:
           open:
             reference: "OpenBrace"
-          expression:
+          parser:
             reference: "DeconstructionImportSymbolsList"
           close:
             reference: "CloseBrace"
@@ -54,7 +54,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "DeconstructionImportSymbol"
 
 - name: "DeconstructionImportSymbol"
@@ -71,7 +71,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "UsingKeyword"
           - choice:
@@ -97,7 +97,7 @@
     delimitedBy:
       open:
         reference: "OpenBrace"
-      expression:
+      parser:
         reference: "UsingDirectiveSymbolsList"
       close:
         reference: "CloseBrace"
@@ -108,7 +108,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "UsingDirectiveSymbol"
 
 - name: "UsingDirectiveSymbol"

--- a/crates/solidity/inputs/language/definition/01-file-structure/05-trivia/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/05-trivia/productions.yml
@@ -56,7 +56,7 @@
             - not:
                 terminal: "*"
             - trailingContext:
-                expression:
+                scanner:
                   terminal: "*"
                 notFollowedBy:
                   terminal: "/"

--- a/crates/solidity/inputs/language/definition/01-file-structure/07-keywords/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/07-keywords/productions.yml
@@ -2,7 +2,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "abicoder"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -12,7 +12,7 @@
   versioned:
     0.6.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "abstract"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -21,7 +21,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "address"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -30,7 +30,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "anonymous"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -39,7 +39,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "as"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -48,7 +48,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "assembly"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -57,7 +57,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "bool"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -66,7 +66,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "break"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -76,7 +76,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "byte"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -87,7 +87,7 @@
   versioned:
     0.5.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "calldata"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -96,7 +96,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "case"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -106,7 +106,7 @@
   versioned:
     0.6.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "catch"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -115,7 +115,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "constant"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -125,7 +125,7 @@
   versioned:
     0.4.22:
       trailingContext:
-        expression:
+        scanner:
           terminal: "constructor"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -134,7 +134,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "continue"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -143,7 +143,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "contract"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -152,7 +152,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "days"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -161,7 +161,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "default"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -170,7 +170,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "delete"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -179,7 +179,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "do"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -188,7 +188,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "else"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -198,7 +198,7 @@
   versioned:
     0.4.21:
       trailingContext:
-        expression:
+        scanner:
           terminal: "emit"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -207,7 +207,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "enum"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -216,7 +216,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "error"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -225,7 +225,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "ether"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -234,7 +234,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "event"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -243,7 +243,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "experimental"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -252,7 +252,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "external"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -261,7 +261,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "fallback"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -270,7 +270,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "false"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -280,7 +280,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "finney"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -290,7 +290,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "for"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -299,7 +299,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "from"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -308,7 +308,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "function"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -317,7 +317,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "global"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -327,7 +327,7 @@
   versioned:
     0.6.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "gwei"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -336,7 +336,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "hours"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -345,7 +345,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "if"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -355,7 +355,7 @@
   versioned:
     0.6.5:
       trailingContext:
-        expression:
+        scanner:
           terminal: "immutable"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -364,7 +364,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "import"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -373,7 +373,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "indexed"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -382,7 +382,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "interface"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -391,7 +391,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "internal"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -400,7 +400,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "is"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -410,7 +410,7 @@
   versioned:
     0.6.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "leave"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -419,7 +419,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "let"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -428,7 +428,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "library"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -437,7 +437,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "mapping"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -446,7 +446,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "memory"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -455,7 +455,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "minutes"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -464,7 +464,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "modifier"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -473,7 +473,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "new"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -482,7 +482,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "override"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -491,7 +491,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "payable"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -500,7 +500,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "pragma"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -509,7 +509,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "private"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -518,7 +518,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "public"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -527,7 +527,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "pure"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -536,7 +536,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "receive"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -545,7 +545,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "return"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -554,7 +554,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "returns"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -563,7 +563,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "revert"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -572,7 +572,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "seconds"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -581,7 +581,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "solidity"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -590,7 +590,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "storage"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -599,7 +599,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "string"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -608,7 +608,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "struct"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -617,7 +617,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "switch"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -627,7 +627,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "szabo"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -638,7 +638,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "throw"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -648,7 +648,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "true"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -658,7 +658,7 @@
   versioned:
     0.6.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "try"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -668,7 +668,7 @@
   versioned:
     0.5.3:
       trailingContext:
-        expression:
+        scanner:
           terminal: "type"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -678,7 +678,7 @@
   versioned:
     0.8.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "unchecked"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -687,7 +687,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "using"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -697,7 +697,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "var"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -707,7 +707,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "view"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -717,7 +717,7 @@
   versioned:
     0.6.0:
       trailingContext:
-        expression:
+        scanner:
           terminal: "virtual"
         notFollowedBy:
           reference: "IdentifierPart"
@@ -726,7 +726,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "weeks"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -735,7 +735,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "wei"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -744,7 +744,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "while"
       notFollowedBy:
         reference: "IdentifierPart"
@@ -754,7 +754,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           terminal: "years"
         notFollowedBy:
           reference: "IdentifierPart"

--- a/crates/solidity/inputs/language/definition/01-file-structure/08-punctuation/productions.yml
+++ b/crates/solidity/inputs/language/definition/01-file-structure/08-punctuation/productions.yml
@@ -52,7 +52,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: ":"
       notFollowedBy:
         terminal: "="
@@ -66,7 +66,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "="
       notFollowedBy:
         choice:
@@ -87,7 +87,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "*"
       notFollowedBy:
         choice:
@@ -108,7 +108,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "|"
       notFollowedBy:
         choice:
@@ -129,7 +129,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "&"
       notFollowedBy:
         choice:
@@ -150,7 +150,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "<"
       notFollowedBy:
         choice:
@@ -166,7 +166,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "<<"
       notFollowedBy:
         terminal: "="
@@ -180,7 +180,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: ">"
       notFollowedBy:
         choice:
@@ -196,7 +196,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: ">>"
       notFollowedBy:
         choice:
@@ -212,7 +212,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: ">>>"
       notFollowedBy:
         terminal: "="
@@ -226,7 +226,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "+"
       notFollowedBy:
         choice:
@@ -247,7 +247,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "-"
       notFollowedBy:
         choice:
@@ -274,7 +274,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "/"
       notFollowedBy:
         terminal: "="
@@ -288,7 +288,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "%"
       notFollowedBy:
         terminal: "="
@@ -302,7 +302,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "!"
       notFollowedBy:
         terminal: "="
@@ -316,7 +316,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         terminal: "^"
       notFollowedBy:
         terminal: "="

--- a/crates/solidity/inputs/language/definition/02-definitions/01-contracts/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/01-contracts/productions.yml
@@ -12,7 +12,7 @@
         - delimitedBy:
             open:
               reference: "OpenBrace"
-            expression:
+            parser:
               optional:
                 reference: "ContractMembersList"
             close:
@@ -29,7 +29,7 @@
         - delimitedBy:
             open:
               reference: "OpenBrace"
-            expression:
+            parser:
               optional:
                 reference: "ContractMembersList"
             close:
@@ -48,7 +48,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "InheritanceType"
 
 - name: "InheritanceType"

--- a/crates/solidity/inputs/language/definition/02-definitions/02-interfaces/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/02-interfaces/productions.yml
@@ -11,7 +11,7 @@
       - delimitedBy:
           open:
             reference: "OpenBrace"
-          expression:
+          parser:
             optional:
               reference: "InterfaceMembersList"
           close:

--- a/crates/solidity/inputs/language/definition/02-definitions/03-libraries/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/03-libraries/productions.yml
@@ -9,7 +9,7 @@
       - delimitedBy:
           open:
             reference: "OpenBrace"
-          expression:
+          parser:
             optional:
               reference: "LibraryMembersList"
           close:

--- a/crates/solidity/inputs/language/definition/02-definitions/04-structs/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/04-structs/productions.yml
@@ -9,7 +9,7 @@
       - delimitedBy:
           open:
             reference: "OpenBrace"
-          expression:
+          parser:
             optional:
               reference: "StructMembersList"
           close:
@@ -25,7 +25,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "TypeName"
           - reference: "Identifier"

--- a/crates/solidity/inputs/language/definition/02-definitions/05-enums/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/05-enums/productions.yml
@@ -9,7 +9,7 @@
       - delimitedBy:
           open:
             reference: "OpenBrace"
-          expression:
+          parser:
             optional:
               reference: "IdentifiersList"
           close:

--- a/crates/solidity/inputs/language/definition/02-definitions/06-constants/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/06-constants/productions.yml
@@ -4,7 +4,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "TypeName"
           - reference: "ConstantKeyword"

--- a/crates/solidity/inputs/language/definition/02-definitions/07-state-variables/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/07-state-variables/productions.yml
@@ -4,7 +4,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "TypeName"
           - optional:

--- a/crates/solidity/inputs/language/definition/02-definitions/08-functions/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/08-functions/productions.yml
@@ -82,7 +82,7 @@
           delimitedBy:
             open:
               reference: "OpenParen"
-            expression:
+            parser:
               optional:
                 reference: "IdentifierPathsList"
             close:
@@ -94,7 +94,7 @@
     delimitedBy:
       open:
         reference: "OpenParen"
-      expression:
+      parser:
         optional:
           reference: "ParametersList"
       close:
@@ -106,7 +106,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "Parameter"
 
 - name: "Parameter"

--- a/crates/solidity/inputs/language/definition/02-definitions/10-events/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/10-events/productions.yml
@@ -4,14 +4,14 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "EventKeyword"
           - reference: "Identifier"
           - delimitedBy:
               open:
                 reference: "OpenParen"
-              expression:
+              parser:
                 optional:
                   reference: "EventParametersList"
               close:
@@ -27,7 +27,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "EventParameter"
 
 - name: "EventParameter"

--- a/crates/solidity/inputs/language/definition/02-definitions/11-user-defined-value-types/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/11-user-defined-value-types/productions.yml
@@ -5,7 +5,7 @@
   versioned:
     0.8.8:
       terminatedBy:
-        expression:
+        parser:
           sequence:
             - reference: "TypeKeyword"
             - reference: "Identifier"

--- a/crates/solidity/inputs/language/definition/02-definitions/12-errors/productions.yml
+++ b/crates/solidity/inputs/language/definition/02-definitions/12-errors/productions.yml
@@ -4,14 +4,14 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "ErrorKeyword"
           - reference: "Identifier"
           - delimitedBy:
               open:
                 reference: "OpenParen"
-              expression:
+              parser:
                 optional:
                   reference: "ErrorParametersList"
               close:
@@ -25,7 +25,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "ErrorParameter"
 
 - name: "ErrorParameter"

--- a/crates/solidity/inputs/language/definition/03-types/01-advanced-types/productions.yml
+++ b/crates/solidity/inputs/language/definition/03-types/01-advanced-types/productions.yml
@@ -3,7 +3,7 @@
 - name: "TypeName"
   kind: "PrecedenceParser"
   unversioned:
-    operators:
+    operatorExpressions:
       - name: "ArrayTypeName"
         model: "UnaryPostfix"
         operator:
@@ -23,7 +23,7 @@
     delimitedBy:
       open:
         reference: "OpenBracket"
-      expression:
+      parser:
         optional:
           reference: "Expression"
       close:
@@ -67,7 +67,7 @@
       - delimitedBy:
           open:
             reference: "OpenParen"
-          expression:
+          parser:
             sequence:
               - reference: "MappingKeyType"
               - reference: "EqualGreaterThan"

--- a/crates/solidity/inputs/language/definition/03-types/02-elementary-types/productions.yml
+++ b/crates/solidity/inputs/language/definition/03-types/02-elementary-types/productions.yml
@@ -41,7 +41,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "bytes"
           - reference: "FixedBytesTypeSize"
@@ -90,7 +90,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "int"
           - optional:
@@ -102,7 +102,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "uint"
           - optional:
@@ -152,7 +152,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "fixed"
           - optional:
@@ -164,7 +164,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "ufixed"
           - optional:

--- a/crates/solidity/inputs/language/definition/04-statements/01-blocks/productions.yml
+++ b/crates/solidity/inputs/language/definition/04-statements/01-blocks/productions.yml
@@ -6,7 +6,7 @@
     delimitedBy:
       open:
         reference: "OpenBrace"
-      expression:
+      parser:
         optional:
           reference: "StatementsList"
       close:
@@ -107,7 +107,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         reference: "Expression"
       terminator:
         reference: "Semicolon"

--- a/crates/solidity/inputs/language/definition/04-statements/02-declaration-statements/productions.yml
+++ b/crates/solidity/inputs/language/definition/04-statements/02-declaration-statements/productions.yml
@@ -4,12 +4,12 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - delimitedBy:
               open:
                 reference: "OpenParen"
-              expression:
+              parser:
                 optional:
                   reference: "TupleMembersList"
               close:
@@ -25,7 +25,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "TupleMember"
 
 - name: "TupleMember"
@@ -47,7 +47,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "VariableDeclaration"
           - optional:

--- a/crates/solidity/inputs/language/definition/04-statements/03-control-statements/productions.yml
+++ b/crates/solidity/inputs/language/definition/04-statements/03-control-statements/productions.yml
@@ -8,7 +8,7 @@
       - delimitedBy:
           open:
             reference: "OpenParen"
-          expression:
+          parser:
             reference: "Expression"
           close:
             reference: "CloseParen"
@@ -26,7 +26,7 @@
       - delimitedBy:
           open:
             reference: "OpenParen"
-          expression:
+          parser:
             sequence:
               - choice:
                   - reference: "SimpleStatement"
@@ -48,7 +48,7 @@
       - delimitedBy:
           open:
             reference: "OpenParen"
-          expression:
+          parser:
             reference: "Expression"
           close:
             reference: "CloseParen"
@@ -58,7 +58,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "DoKeyword"
           - reference: "Statement"
@@ -66,7 +66,7 @@
           - delimitedBy:
               open:
                 reference: "OpenParen"
-              expression:
+              parser:
                 reference: "Expression"
               close:
                 reference: "CloseParen"
@@ -77,7 +77,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         reference: "ContinueKeyword"
       terminator:
         reference: "Semicolon"
@@ -86,7 +86,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         reference: "BreakKeyword"
       terminator:
         reference: "Semicolon"
@@ -95,7 +95,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "ReturnKeyword"
           - optional:
@@ -108,7 +108,7 @@
   versioned:
     0.4.21:
       terminatedBy:
-        expression:
+        parser:
           sequence:
             - reference: "EmitKeyword"
             - reference: "IdentifierPath"
@@ -120,7 +120,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "DeleteKeyword"
           - reference: "Expression"

--- a/crates/solidity/inputs/language/definition/04-statements/04-error-handling/productions.yml
+++ b/crates/solidity/inputs/language/definition/04-statements/04-error-handling/productions.yml
@@ -42,7 +42,7 @@
   kind: "Parser"
   unversioned:
     terminatedBy:
-      expression:
+      parser:
         sequence:
           - reference: "RevertKeyword"
           - optional:
@@ -56,7 +56,7 @@
   versioned:
     0.4.11:
       terminatedBy:
-        expression:
+        parser:
           reference: "ThrowKeyword"
         terminator:
           reference: "Semicolon"

--- a/crates/solidity/inputs/language/definition/05-expressions/01-base-expressions/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/01-base-expressions/productions.yml
@@ -4,7 +4,7 @@
   kind: "PrecedenceParser"
   versioned:
     0.4.11:
-      operators:
+      operatorExpressions:
         - name: "BinaryExpression"
           model: "BinaryLeftAssociative"
           operator:
@@ -100,7 +100,7 @@
 
     0.6.0:
       # ExponentiationExpression is now BinaryRightAssociative
-      operators:
+      operatorExpressions:
         - name: "BinaryExpression"
           model: "BinaryLeftAssociative"
           operator:
@@ -360,7 +360,7 @@
     delimitedBy:
       open:
         reference: "OpenBracket"
-      expression:
+      parser:
         sequence:
           - optional:
               reference: "Expression"

--- a/crates/solidity/inputs/language/definition/05-expressions/02-function-calls/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/02-function-calls/productions.yml
@@ -6,7 +6,7 @@
     delimitedBy:
       open:
         reference: "OpenParen"
-      expression:
+      parser:
         optional:
           choice:
             - reference: "PositionalArgumentsList"
@@ -20,7 +20,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "Expression"
 
 - name: "FunctionCallOptions"
@@ -38,7 +38,7 @@
     delimitedBy:
       open:
         reference: "OpenBrace"
-      expression:
+      parser:
         optional:
           reference: "NamedArgumentsList"
       close:
@@ -50,7 +50,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "NamedArgument"
 
 - name: "NamedArgument"

--- a/crates/solidity/inputs/language/definition/05-expressions/03-primary-expressions/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/03-primary-expressions/productions.yml
@@ -36,7 +36,7 @@
         - delimitedBy:
             open:
               reference: "OpenParen"
-            expression:
+            parser:
               reference: "TypeName"
             close:
               reference: "CloseParen"
@@ -54,7 +54,7 @@
     delimitedBy:
       open:
         reference: "OpenParen"
-      expression:
+      parser:
         reference: "TupleValuesList"
       close:
         reference: "CloseParen"
@@ -65,7 +65,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         optional:
           reference: "Expression"
 
@@ -75,7 +75,7 @@
     delimitedBy:
       open:
         reference: "OpenBracket"
-      expression:
+      parser:
         reference: "ArrayValuesList"
       close:
         reference: "CloseBracket"
@@ -86,7 +86,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "Expression"
 
 - name: "BooleanExpression"

--- a/crates/solidity/inputs/language/definition/05-expressions/04-numbers/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/04-numbers/productions.yml
@@ -24,7 +24,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           sequence:
             - choice:
                 - terminal: "0x" # lowercase
@@ -41,7 +41,7 @@
     0.5.0:
       # removed uppercase "0X"
       trailingContext:
-        expression:
+        scanner:
           sequence:
             - terminal: "0x" # lowercase
             - oneOrMore:
@@ -59,7 +59,7 @@
   versioned:
     0.4.11:
       trailingContext:
-        expression:
+        scanner:
           sequence:
             - choice:
                 - sequence:
@@ -79,7 +79,7 @@
     0.5.0:
       # Second "DecimalDigits" is no longer "optional"
       trailingContext:
-        expression:
+        scanner:
           sequence:
             - choice:
                 - sequence:

--- a/crates/solidity/inputs/language/definition/05-expressions/05-strings/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/05-strings/productions.yml
@@ -25,7 +25,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         choice:
           - reference: "SingleQuotedHexStringLiteral"
           - reference: "DoubleQuotedHexStringLiteral"
@@ -93,7 +93,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         choice:
           - reference: "SingleQuotedAsciiStringLiteral"
           - reference: "DoubleQuotedAsciiStringLiteral"
@@ -152,7 +152,7 @@
   versioned:
     0.7.0:
       trailingContext:
-        expression:
+        scanner:
           choice:
             - reference: "SingleQuotedUnicodeStringLiteral"
             - reference: "DoubleQuotedUnicodeStringLiteral"

--- a/crates/solidity/inputs/language/definition/05-expressions/06-identifiers/productions.yml
+++ b/crates/solidity/inputs/language/definition/05-expressions/06-identifiers/productions.yml
@@ -6,14 +6,14 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "IdentifierPath"
 
 - name: "IdentifierPath"
   kind: "Parser"
   unversioned:
     separatedBy:
-      expression:
+      parser:
         reference: "Identifier"
       separator:
         reference: "Period"
@@ -24,7 +24,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "Identifier"
 
 - name: "Identifier"

--- a/crates/solidity/inputs/language/definition/06-yul/01-assembly-block/productions.yml
+++ b/crates/solidity/inputs/language/definition/06-yul/01-assembly-block/productions.yml
@@ -11,7 +11,7 @@
           delimitedBy:
             open:
               reference: "OpenParen"
-            expression:
+            parser:
               reference: "AssemblyFlagsList"
             close:
               reference: "CloseParen"
@@ -21,7 +21,7 @@
   kind: "Parser"
   unversioned:
     separatedBy:
-      expression:
+      parser:
         reference: "AsciiStringLiteral"
       separator:
         reference: "Comma"

--- a/crates/solidity/inputs/language/definition/06-yul/02-yul-statements/productions.yml
+++ b/crates/solidity/inputs/language/definition/06-yul/02-yul-statements/productions.yml
@@ -6,7 +6,7 @@
     delimitedBy:
       open:
         reference: "OpenBrace"
-      expression:
+      parser:
         optional:
           reference: "YulStatementsList"
       close:
@@ -76,7 +76,7 @@
     delimitedBy:
       open:
         reference: "OpenParen"
-      expression:
+      parser:
         optional:
           reference: "YulIdentifiersList"
       close:

--- a/crates/solidity/inputs/language/definition/06-yul/03-yul-expressions/productions.yml
+++ b/crates/solidity/inputs/language/definition/06-yul/03-yul-expressions/productions.yml
@@ -6,13 +6,13 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "YulExpression"
 
 - name: "YulExpression"
   kind: "PrecedenceParser"
   unversioned:
-    operators:
+    operatorExpressions:
       - name: "YulFunctionCallExpression"
         model: "UnaryPostfix"
         operator:
@@ -30,7 +30,7 @@
     delimitedBy:
       open:
         reference: "OpenParen"
-      expression:
+      parser:
         optional:
           reference: "YulExpressionsList"
       close:
@@ -42,7 +42,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "YulIdentifierPath"
 
 - name: "YulIdentifierPath"
@@ -51,7 +51,7 @@
     separatedBy:
       separator:
         reference: "Period"
-      expression:
+      parser:
         reference: "YulIdentifier"
 
 - name: "YulIdentifiersList"
@@ -60,7 +60,7 @@
     separatedBy:
       separator:
         reference: "Comma"
-      expression:
+      parser:
         reference: "YulIdentifier"
 
 - name: "YulIdentifier"
@@ -129,7 +129,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         sequence:
           - terminal: "0x"
           - oneOrMore:
@@ -141,7 +141,7 @@
   kind: "Scanner"
   unversioned:
     trailingContext:
-      expression:
+      scanner:
         choice:
           - terminal: "0"
           - sequence:

--- a/crates/solidity/inputs/language/generated/productions.schema.json
+++ b/crates/solidity/inputs/language/generated/productions.schema.json
@@ -185,7 +185,7 @@
       "type": "object",
       "anyOf": [
         {
-          "title": "Choice Expression",
+          "title": "Choice Scanner",
           "type": "object",
           "required": ["choice"],
           "properties": {
@@ -198,7 +198,7 @@
           }
         },
         {
-          "title": "Difference Expression",
+          "title": "Difference Scanner",
           "type": "object",
           "required": ["difference"],
           "properties": {
@@ -217,7 +217,7 @@
           }
         },
         {
-          "title": "Not Expression",
+          "title": "Not Scanner",
           "type": "object",
           "required": ["not"],
           "properties": {
@@ -227,7 +227,7 @@
           }
         },
         {
-          "title": "OneOrMore Expression",
+          "title": "OneOrMore Scanner",
           "type": "object",
           "required": ["oneOrMore"],
           "properties": {
@@ -237,7 +237,7 @@
           }
         },
         {
-          "title": "Optional Expression",
+          "title": "Optional Scanner",
           "type": "object",
           "required": ["optional"],
           "properties": {
@@ -247,7 +247,7 @@
           }
         },
         {
-          "title": "Range Expression",
+          "title": "Range Scanner",
           "type": "object",
           "required": ["range"],
           "properties": {
@@ -270,7 +270,7 @@
           }
         },
         {
-          "title": "Reference Expression",
+          "title": "Reference Scanner",
           "type": "object",
           "required": ["reference"],
           "properties": {
@@ -280,7 +280,7 @@
           }
         },
         {
-          "title": "Sequence Expression",
+          "title": "Sequence Scanner",
           "type": "object",
           "required": ["sequence"],
           "properties": {
@@ -293,15 +293,15 @@
           }
         },
         {
-          "title": "TrailingContext Expression",
+          "title": "TrailingContext Scanner",
           "type": "object",
           "required": ["trailingContext"],
           "properties": {
             "trailingContext": {
               "type": "object",
-              "required": ["expression", "notFollowedBy"],
+              "required": ["notFollowedBy", "scanner"],
               "properties": {
-                "expression": {
+                "scanner": {
                   "$ref": "#/definitions/Scanner"
                 },
                 "notFollowedBy": {
@@ -312,7 +312,7 @@
           }
         },
         {
-          "title": "Terminal Expression",
+          "title": "Terminal Scanner",
           "type": "object",
           "required": ["terminal"],
           "properties": {
@@ -322,7 +322,7 @@
           }
         },
         {
-          "title": "ZeroOrMore Expression",
+          "title": "ZeroOrMore Scanner",
           "type": "object",
           "required": ["zeroOrMore"],
           "properties": {
@@ -337,7 +337,7 @@
       "type": "object",
       "anyOf": [
         {
-          "title": "Choice Expression",
+          "title": "Choice Parser",
           "type": "object",
           "required": ["choice"],
           "properties": {
@@ -350,18 +350,18 @@
           }
         },
         {
-          "title": "DelimitedBy Expression",
+          "title": "DelimitedBy Parser",
           "type": "object",
           "required": ["delimitedBy"],
           "properties": {
             "delimitedBy": {
               "type": "object",
-              "required": ["close", "expression", "open"],
+              "required": ["close", "open", "parser"],
               "properties": {
                 "open": {
                   "$ref": "#/definitions/Reference"
                 },
-                "expression": {
+                "parser": {
                   "$ref": "#/definitions/Parser"
                 },
                 "close": {
@@ -372,7 +372,7 @@
           }
         },
         {
-          "title": "OneOrMore Expression",
+          "title": "OneOrMore Parser",
           "type": "object",
           "required": ["oneOrMore"],
           "properties": {
@@ -382,7 +382,7 @@
           }
         },
         {
-          "title": "Optional Expression",
+          "title": "Optional Parser",
           "type": "object",
           "required": ["optional"],
           "properties": {
@@ -392,7 +392,7 @@
           }
         },
         {
-          "title": "Reference Expression",
+          "title": "Reference Parser",
           "type": "object",
           "required": ["reference"],
           "properties": {
@@ -402,15 +402,15 @@
           }
         },
         {
-          "title": "SeparatedBy Expression",
+          "title": "SeparatedBy Parser",
           "type": "object",
           "required": ["separatedBy"],
           "properties": {
             "separatedBy": {
               "type": "object",
-              "required": ["expression", "separator"],
+              "required": ["parser", "separator"],
               "properties": {
-                "expression": {
+                "parser": {
                   "$ref": "#/definitions/Parser"
                 },
                 "separator": {
@@ -421,7 +421,7 @@
           }
         },
         {
-          "title": "Sequence Expression",
+          "title": "Sequence Parser",
           "type": "object",
           "required": ["sequence"],
           "properties": {
@@ -434,15 +434,15 @@
           }
         },
         {
-          "title": "TerminatedBy Expression",
+          "title": "TerminatedBy Parser",
           "type": "object",
           "required": ["terminatedBy"],
           "properties": {
             "terminatedBy": {
               "type": "object",
-              "required": ["expression", "terminator"],
+              "required": ["parser", "terminator"],
               "properties": {
-                "expression": {
+                "parser": {
                   "$ref": "#/definitions/Parser"
                 },
                 "terminator": {
@@ -453,7 +453,7 @@
           }
         },
         {
-          "title": "ZeroOrMore Expression",
+          "title": "ZeroOrMore Parser",
           "type": "object",
           "required": ["zeroOrMore"],
           "properties": {
@@ -476,13 +476,13 @@
     },
     "PrecedenceParser": {
       "type": "object",
-      "required": ["operators", "primaryExpression"],
+      "required": ["operatorExpressions", "primaryExpression"],
       "properties": {
-        "operators": {
-          "title": "Operator Definitions",
+        "operatorExpressions": {
+          "title": "Operator Expressions",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/OperatorDefinition"
+            "$ref": "#/definitions/OperatorExpression"
           }
         },
         "primaryExpression": {
@@ -495,7 +495,7 @@
         }
       }
     },
-    "OperatorDefinition": {
+    "OperatorExpression": {
       "type": "object",
       "required": ["model", "name", "operator"],
       "properties": {

--- a/crates/solidity/outputs/cargo/crate/src/generated/parsers.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parsers.rs
@@ -2949,14 +2949,14 @@ impl Language {
     #[allow(dead_code, non_snake_case)]
     fn expression__0_4_11(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
                         .unary_prefix_operator(stream)
                         .to_pratt_element_operator(RuleKind::UnaryPrefixExpression, 255, 29u8);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -2969,7 +2969,7 @@ impl Language {
                 {
                     let result = self.primary_expression(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -3036,7 +3036,7 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3193,24 +3193,24 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::Expression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -3271,14 +3271,14 @@ impl Language {
     #[allow(dead_code, non_snake_case)]
     fn expression__0_6_0(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
                         .unary_prefix_operator(stream)
                         .to_pratt_element_operator(RuleKind::UnaryPrefixExpression, 255, 29u8);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3291,7 +3291,7 @@ impl Language {
                 {
                     let result = self.primary_expression(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -3358,7 +3358,7 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3515,24 +3515,24 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::Expression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -8244,7 +8244,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn type_name(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 {
                     let result = {
@@ -8280,7 +8280,7 @@ impl Language {
                         running_result
                     };
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -8290,7 +8290,7 @@ impl Language {
                         .array_type_name_operator(stream)
                         .to_pratt_element_operator(RuleKind::ArrayTypeName, 1u8, 255);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -8302,20 +8302,20 @@ impl Language {
                 }
                 break ParserResult::no_match(vec![]);
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::TypeName, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -9444,7 +9444,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn version_pragma_expression(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
@@ -9455,7 +9455,7 @@ impl Language {
                             5u8,
                         );
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -9468,7 +9468,7 @@ impl Language {
                 {
                     let result = self.version_pragma_specifier(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -9509,24 +9509,24 @@ impl Language {
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::VersionPragmaExpression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -9895,7 +9895,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn yul_expression(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 {
                     let result = {
@@ -9920,7 +9920,7 @@ impl Language {
                         running_result
                     };
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -9930,7 +9930,7 @@ impl Language {
                         .yul_function_call_operator(stream)
                         .to_pratt_element_operator(RuleKind::YulFunctionCallExpression, 1u8, 255);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -9942,20 +9942,20 @@ impl Language {
                 }
                 break ParserResult::no_match(vec![]);
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::YulExpression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);

--- a/crates/solidity/outputs/cargo/crate/src/generated/scanner_macros.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/scanner_macros.rs
@@ -51,18 +51,18 @@ macro_rules! scan_trie {
 
 #[allow(unused_macros)]
 macro_rules! scan_sequence {
-    ($($expr:expr),*) => {
-        $(($expr))&&*
+    ($($scanner:expr),*) => {
+        $(($scanner))&&*
     };
 }
 
 #[allow(unused_macros)]
 macro_rules! scan_choice {
-    ($stream:ident, $($expr:expr),*) => {
+    ($stream:ident, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
-                if ($expr) { break true }
+                if ($scanner) { break true }
                 $stream.set_position(save);
             )*
             break false
@@ -72,10 +72,10 @@ macro_rules! scan_choice {
 
 #[allow(unused_macros)]
 macro_rules! scan_zero_or_more {
-    ($stream:ident, $expr:expr) => {
+    ($stream:ident, $scanner:expr) => {
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 $stream.set_position(save);
                 break true;
             }
@@ -85,11 +85,11 @@ macro_rules! scan_zero_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_one_or_more {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let mut count = 0;
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 if count < 1 {
                     break false;
                 } else {
@@ -104,9 +104,9 @@ macro_rules! scan_one_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_optional {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let save = $stream.position();
-        if !($expr) {
+        if !($scanner) {
             $stream.set_position(save)
         }
         true
@@ -133,8 +133,8 @@ macro_rules! scan_difference {
 
 #[allow(unused_macros)]
 macro_rules! scan_not_followed_by {
-    ($stream:ident, $expression:expr, $not_followed_by:expr) => {
-        ($expression)
+    ($stream:ident, $scanner:expr, $not_followed_by:expr) => {
+        ($scanner)
             && ({
                 let end = $stream.position();
                 let following = $not_followed_by;

--- a/crates/solidity/outputs/npm/crate/src/generated/parsers.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/parsers.rs
@@ -2949,14 +2949,14 @@ impl Language {
     #[allow(dead_code, non_snake_case)]
     fn expression__0_4_11(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
                         .unary_prefix_operator(stream)
                         .to_pratt_element_operator(RuleKind::UnaryPrefixExpression, 255, 29u8);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -2969,7 +2969,7 @@ impl Language {
                 {
                     let result = self.primary_expression(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -3036,7 +3036,7 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3193,24 +3193,24 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::Expression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -3271,14 +3271,14 @@ impl Language {
     #[allow(dead_code, non_snake_case)]
     fn expression__0_6_0(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
                         .unary_prefix_operator(stream)
                         .to_pratt_element_operator(RuleKind::UnaryPrefixExpression, 255, 29u8);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3291,7 +3291,7 @@ impl Language {
                 {
                     let result = self.primary_expression(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -3358,7 +3358,7 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -3515,24 +3515,24 @@ impl Language {
                         break ParserResult::no_match(vec![]);
                     };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::Expression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -8244,7 +8244,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn type_name(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 {
                     let result = {
@@ -8280,7 +8280,7 @@ impl Language {
                         running_result
                     };
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -8290,7 +8290,7 @@ impl Language {
                         .array_type_name_operator(stream)
                         .to_pratt_element_operator(RuleKind::ArrayTypeName, 1u8, 255);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -8302,20 +8302,20 @@ impl Language {
                 }
                 break ParserResult::no_match(vec![]);
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::TypeName, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -9444,7 +9444,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn version_pragma_expression(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 let result = loop {
                     let result = self
@@ -9455,7 +9455,7 @@ impl Language {
                             5u8,
                         );
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -9468,7 +9468,7 @@ impl Language {
                 {
                     let result = self.version_pragma_specifier(stream);
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -9509,24 +9509,24 @@ impl Language {
                     break ParserResult::no_match(vec![]);
                 };
                 match result {
-                    ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                    ParserResult::PrattOperatorMatch(_) => results.push(result),
                     _ => break result,
                 }
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::VersionPragmaExpression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);
@@ -9895,7 +9895,7 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     pub(crate) fn yul_expression(&self, stream: &mut Stream) -> ParserResult {
         loop {
-            let mut elements: Vec<ParserResult> = Vec::new();
+            let mut results: Vec<ParserResult> = Vec::new();
             let initial_result = loop {
                 {
                     let result = {
@@ -9920,7 +9920,7 @@ impl Language {
                         running_result
                     };
                     if result.is_match() {
-                        elements.push(result);
+                        results.push(result);
                     } else {
                         break result;
                     }
@@ -9930,7 +9930,7 @@ impl Language {
                         .yul_function_call_operator(stream)
                         .to_pratt_element_operator(RuleKind::YulFunctionCallExpression, 1u8, 255);
                     match result {
-                        ParserResult::PrattOperatorMatch(_) => elements.push(result),
+                        ParserResult::PrattOperatorMatch(_) => results.push(result),
                         _ => break result,
                     }
                 };
@@ -9942,20 +9942,20 @@ impl Language {
                 }
                 break ParserResult::no_match(vec![]);
             };
-            if elements.is_empty() {
+            if results.is_empty() {
                 break initial_result;
             }
             reduce_pratt_elements(
                 |children| vec![cst::Node::rule(RuleKind::YulExpression, children)],
-                &mut elements,
+                &mut results,
             );
-            if elements.len() != 1 {
+            if results.len() != 1 {
                 unreachable!(
                     "Pratt parser failed to reduce to a single result: {:?}",
-                    elements
+                    results
                 );
             }
-            match elements.remove(0) {
+            match results.remove(0) {
                 ParserResult::Match(r#match) => {
                     if let ParserResult::IncompleteMatch(_) = initial_result {
                         break ParserResult::incomplete_match(r#match.nodes, vec![]);

--- a/crates/solidity/outputs/npm/crate/src/generated/scanner_macros.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/scanner_macros.rs
@@ -51,18 +51,18 @@ macro_rules! scan_trie {
 
 #[allow(unused_macros)]
 macro_rules! scan_sequence {
-    ($($expr:expr),*) => {
-        $(($expr))&&*
+    ($($scanner:expr),*) => {
+        $(($scanner))&&*
     };
 }
 
 #[allow(unused_macros)]
 macro_rules! scan_choice {
-    ($stream:ident, $($expr:expr),*) => {
+    ($stream:ident, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
-                if ($expr) { break true }
+                if ($scanner) { break true }
                 $stream.set_position(save);
             )*
             break false
@@ -72,10 +72,10 @@ macro_rules! scan_choice {
 
 #[allow(unused_macros)]
 macro_rules! scan_zero_or_more {
-    ($stream:ident, $expr:expr) => {
+    ($stream:ident, $scanner:expr) => {
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 $stream.set_position(save);
                 break true;
             }
@@ -85,11 +85,11 @@ macro_rules! scan_zero_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_one_or_more {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let mut count = 0;
         loop {
             let save = $stream.position();
-            if !($expr) {
+            if !($scanner) {
                 if count < 1 {
                     break false;
                 } else {
@@ -104,9 +104,9 @@ macro_rules! scan_one_or_more {
 
 #[allow(unused_macros)]
 macro_rules! scan_optional {
-    ($stream:ident, $expr:expr) => {{
+    ($stream:ident, $scanner:expr) => {{
         let save = $stream.position();
-        if !($expr) {
+        if !($scanner) {
             $stream.set_position(save)
         }
         true
@@ -133,8 +133,8 @@ macro_rules! scan_difference {
 
 #[allow(unused_macros)]
 macro_rules! scan_not_followed_by {
-    ($stream:ident, $expression:expr, $not_followed_by:expr) => {
-        ($expression)
+    ($stream:ident, $scanner:expr, $not_followed_by:expr) => {
+        ($scanner)
             && ({
                 let end = $stream.position();
                 let following = $not_followed_by;


### PR DESCRIPTION
Cleanup of pre-release changes, to make it easier for onboarding.

- Replace the older notation of EBNF "expressions" in codegen with the newer/consistent parser/scanner terminology.
- Rename `PrecedenceParser::Operators` to `PrecedenceParser::Expressions` for accuracy, as each contain their own operator.

Closes #373