### PR TITLE
absorb remaining 0.8.0 changesets

### DIFF
--- a/.changeset/nice-flowers-peel.md
+++ b/.changeset/nice-flowers-peel.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/slang": patch
----
-
-Make ESM named imports work in Node.js.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Patch Changes
 
 -   [#527](https://github.com/NomicFoundation/slang/pull/527) [`7ccca87`](https://github.com/NomicFoundation/slang/commit/7ccca87beaa9cb96ad294d1af8a02f115481b71a) Thanks [@AntonyBlakey](https://github.com/AntonyBlakey)! - Fix pratt parser behavior in the face of error correction
+-   [#531](https://github.com/NomicFoundation/slang/pull/531) [`e3450be4`](https://github.com/NomicFoundation/slang/commit/e3450be4722845bcfce7a9ec3b3046ba6eb6961d) Thanks [@alcuadrado](https://github.com/alcuadrado)! - Make ESM named imports work in Node.js.
 
 ## 0.7.0
 

--- a/crates/solidity/outputs/cargo/crate/CHANGELOG.md
+++ b/crates/solidity/outputs/cargo/crate/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Patch Changes
 
 -   [#527](https://github.com/NomicFoundation/slang/pull/527) [`7ccca87`](https://github.com/NomicFoundation/slang/commit/7ccca87beaa9cb96ad294d1af8a02f115481b71a) Thanks [@AntonyBlakey](https://github.com/AntonyBlakey)! - Fix pratt parser behavior in the face of error correction
+-   [#531](https://github.com/NomicFoundation/slang/pull/531) [`e3450be4`](https://github.com/NomicFoundation/slang/commit/e3450be4722845bcfce7a9ec3b3046ba6eb6961d) Thanks [@alcuadrado](https://github.com/alcuadrado)! - Make ESM named imports work in Node.js.
 
 ## 0.7.0
 

--- a/crates/solidity/outputs/npm/package/CHANGELOG.md
+++ b/crates/solidity/outputs/npm/package/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Patch Changes
 
 -   [#527](https://github.com/NomicFoundation/slang/pull/527) [`7ccca87`](https://github.com/NomicFoundation/slang/commit/7ccca87beaa9cb96ad294d1af8a02f115481b71a) Thanks [@AntonyBlakey](https://github.com/AntonyBlakey)! - Fix pratt parser behavior in the face of error correction
+-   [#531](https://github.com/NomicFoundation/slang/pull/531) [`e3450be4`](https://github.com/NomicFoundation/slang/commit/e3450be4722845bcfce7a9ec3b3046ba6eb6961d) Thanks [@alcuadrado](https://github.com/alcuadrado)! - Make ESM named imports work in Node.js.
 
 ## 0.7.0
 

--- a/scripts/changelog/CHANGELOG.md
+++ b/scripts/changelog/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Patch Changes
 
 -   [#527](https://github.com/NomicFoundation/slang/pull/527) [`7ccca87`](https://github.com/NomicFoundation/slang/commit/7ccca87beaa9cb96ad294d1af8a02f115481b71a) Thanks [@AntonyBlakey](https://github.com/AntonyBlakey)! - Fix pratt parser behavior in the face of error correction
+-   [#531](https://github.com/NomicFoundation/slang/pull/531) [`e3450be4`](https://github.com/NomicFoundation/slang/commit/e3450be4722845bcfce7a9ec3b3046ba6eb6961d) Thanks [@alcuadrado](https://github.com/alcuadrado)! - Make ESM named imports work in Node.js.
 
 ## 0.7.0
 


### PR DESCRIPTION
Looks like #531 broke CI, since it used a changeset with a different package name. This absorbs the remaining changeset to unblock CI.