### PR TITLE
Don't unconditionally parse twice in the CST tests

### DIFF
--- a/crates/codegen/testing/src/cst_output.rs
+++ b/crates/codegen/testing/src/cst_output.rs
@@ -90,14 +90,20 @@ fn generate_mod_file(
     let version_breaks_len = version_breaks.len();
     let version_breaks_str = version_breaks
         .iter()
-        .map(|version| format!("\"{version}\","))
+        .map(|version| {
+            format!(
+                "Version::new({}, {}, {}),",
+                version.major, version.minor, version.patch
+            )
+        })
         .collect::<String>();
 
     let contents = format!(
         "
+            use semver::Version;
             {module_declarations}
 
-            pub const VERSION_BREAKS: [&str; {version_breaks_len}] = [
+            pub const VERSION_BREAKS: [Version; {version_breaks_len}] = [
                 {version_breaks_str}
             ];
         ",

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/mod.rs
@@ -1,5 +1,6 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+use semver::Version;
 #[allow(non_snake_case)]
 mod AsciiStringLiteralsList;
 #[allow(non_snake_case)]
@@ -73,7 +74,23 @@ mod YulExpression;
 #[allow(non_snake_case)]
 mod YulStatement;
 
-pub const VERSION_BREAKS: [&str; 18] = [
-    "0.4.11", "0.4.21", "0.4.22", "0.5.0", "0.5.3", "0.6.0", "0.6.2", "0.6.5", "0.6.11", "0.7.0",
-    "0.7.1", "0.7.4", "0.8.0", "0.8.4", "0.8.8", "0.8.13", "0.8.18", "0.8.19",
+pub const VERSION_BREAKS: [Version; 18] = [
+    Version::new(0, 4, 11),
+    Version::new(0, 4, 21),
+    Version::new(0, 4, 22),
+    Version::new(0, 5, 0),
+    Version::new(0, 5, 3),
+    Version::new(0, 6, 0),
+    Version::new(0, 6, 2),
+    Version::new(0, 6, 5),
+    Version::new(0, 6, 11),
+    Version::new(0, 7, 0),
+    Version::new(0, 7, 1),
+    Version::new(0, 7, 4),
+    Version::new(0, 8, 0),
+    Version::new(0, 8, 4),
+    Version::new(0, 8, 8),
+    Version::new(0, 8, 13),
+    Version::new(0, 8, 18),
+    Version::new(0, 8, 19),
 ];

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
@@ -39,15 +39,12 @@ pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
 
         let output = Language::new(version.to_owned())?.parse(production_kind, &source);
 
-        if Some(&output) == last_output.as_ref() {
+        let output = match last_output {
             // Skip this version if it produces the same output.
             // Note: comparing objects cheaply before expensive serialization.
-            continue;
-        }
-
-        last_output = Some(output);
-
-        let output = Language::new(version.to_owned())?.parse(production_kind, &source);
+            Some(ref last) if last == &output => continue,
+            _ => &*last_output.insert(output),
+        };
 
         let errors = output
             .errors()


### PR DESCRIPTION
This speeds up the CST snapshot test suite and is less spammy when debugging these tests.

Locally that's from 725ms (+- 25ms) down to 650ms (+- 21ms), so not great, not terrible, but most importantly I wanted to remove the duplicated version 0.4.11 parses.