### PR TITLE
fix old changesets metadata

### DIFF
--- a/.changeset/sharp-garlics-clean.md
+++ b/.changeset/sharp-garlics-clean.md
@@ -1,5 +1,5 @@
 ---
-"changelog": patch
+"@nomicfoundation/slang": patch
 ---
 
 Add preliminary documentation for the `solidity_language` Rust package


### PR DESCRIPTION
Looks like one escaped validation because of the release infra broken earlier. This just updates the package name in one of them.