### PR TITLE
chore: Run smoke test suite in --release mode

### DIFF
--- a/crates/infra/cli/generated/infra.zsh-completions
+++ b/crates/infra/cli/generated/infra.zsh-completions
@@ -79,7 +79,7 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':command:((slang_solidity\:"Run the public '\''slang_solidity'\'' crate shapped to Cargo users"
+':command:((slang_solidity\:"Run the public '\''slang_solidity'\'' crate shipped to Cargo users"
 solidity_testing_smoke\:"Run smoke tests of the Solidity parser against source files from the Sanctuary repositories"))' \
 '*::args:' \
 && ret=0

--- a/crates/infra/cli/src/commands/run/mod.rs
+++ b/crates/infra/cli/src/commands/run/mod.rs
@@ -12,14 +12,14 @@ pub struct RunController {
     args: Vec<String>,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
 enum RunCommand {
     /*
      *
      * User-facing:
      *
      */
-    /// Run the public 'slang_solidity' crate shapped to Cargo users.
+    /// Run the public 'slang_solidity' crate shipped to Cargo users.
     #[clap(name = "slang_solidity")]
     SlangSolidity,
 
@@ -48,6 +48,11 @@ impl RunController {
 
         return Command::new("cargo")
             .arg("run")
+            .arg(if self.command == RunCommand::SolidityTestingSmoke {
+                "--release"
+            } else {
+                ""
+            })
             .property("--bin", &crate_name)
             .arg("--")
             .args(&self.args)

--- a/crates/infra/cli/src/commands/run/mod.rs
+++ b/crates/infra/cli/src/commands/run/mod.rs
@@ -46,18 +46,18 @@ impl RunController {
 
         Terminal::step(format!("run {crate_name}"));
 
-        return Command::new("cargo")
-            .arg("run")
-            .arg(if self.command == RunCommand::SolidityTestingSmoke {
-                "--release"
-            } else {
-                ""
-            })
+        let mut command = Command::new("cargo").arg("run");
+
+        if self.command == RunCommand::SolidityTestingSmoke {
+            command = command.flag("--release");
+        }
+
+        command
             .property("--bin", &crate_name)
             .arg("--")
             .args(&self.args)
             // Execute in the crate dir, to make use of a local './target' dir if it exists:
             .current_dir(crate_dir)
-            .run();
+            .run()
     }
 }


### PR DESCRIPTION
This cuts down from ETA 3-5 hours down ETA ~15 minutes on the sanctuary-arbitrum dataset on Ryzen 3900X