### PR TITLE
fix: Don't ignore IncompleteMatch in OneOrMoreHelper

### DIFF
--- a/crates/codegen/parser/runtime/src/support/repetition_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/repetition_helper.rs
@@ -17,7 +17,6 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
             unimplemented!("RepetitionHelper only supports min_count of 0 or 1")
         }
 
-        let save = input.mark();
         let mut accum = match parser(input) {
             // First item parsed correctly
             result @ ParserResult::Match(_) => result,
@@ -25,13 +24,9 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
             // Couldn't get a full match but we allow 0 items - return an empty match
             // so the parse is considered valid but note the expected tokens
-            ParserResult::IncompleteMatch(IncompleteMatch {
-                expected_tokens, ..
-            })
-            | ParserResult::NoMatch(NoMatch {
+            ParserResult::NoMatch(NoMatch {
                 expected_tokens, ..
             }) if MIN_COUNT == 0 => {
-                input.rewind(save);
                 return ParserResult::r#match(vec![], expected_tokens);
             }
             // Don't try repeating if we don't have a full match and we require at least one

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/repetition_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/repetition_helper.rs
@@ -19,7 +19,6 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
             unimplemented!("RepetitionHelper only supports min_count of 0 or 1")
         }
 
-        let save = input.mark();
         let mut accum = match parser(input) {
             // First item parsed correctly
             result @ ParserResult::Match(_) => result,
@@ -27,13 +26,9 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
             // Couldn't get a full match but we allow 0 items - return an empty match
             // so the parse is considered valid but note the expected tokens
-            ParserResult::IncompleteMatch(IncompleteMatch {
-                expected_tokens, ..
-            })
-            | ParserResult::NoMatch(NoMatch {
+            ParserResult::NoMatch(NoMatch {
                 expected_tokens, ..
             }) if MIN_COUNT == 0 => {
-                input.rewind(save);
                 return ParserResult::r#match(vec![], expected_tokens);
             }
             // Don't try repeating if we don't have a full match and we require at least one

--- a/crates/solidity/outputs/npm/crate/src/generated/support/repetition_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/repetition_helper.rs
@@ -19,7 +19,6 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
             unimplemented!("RepetitionHelper only supports min_count of 0 or 1")
         }
 
-        let save = input.mark();
         let mut accum = match parser(input) {
             // First item parsed correctly
             result @ ParserResult::Match(_) => result,
@@ -27,13 +26,9 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
             // Couldn't get a full match but we allow 0 items - return an empty match
             // so the parse is considered valid but note the expected tokens
-            ParserResult::IncompleteMatch(IncompleteMatch {
-                expected_tokens, ..
-            })
-            | ParserResult::NoMatch(NoMatch {
+            ParserResult::NoMatch(NoMatch {
                 expected_tokens, ..
             }) if MIN_COUNT == 0 => {
-                input.rewind(save);
                 return ParserResult::r#match(vec![], expected_tokens);
             }
             // Don't try repeating if we don't have a full match and we require at least one

--- a/crates/solidity/testing/snapshots/cst_output/Block/unchecked/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Block/unchecked/generated/0.6.2-failure.yml
@@ -6,36 +6,36 @@ Source: >
 Errors: # 2 total
   - >
     Error: Expected Colon.
-       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:16]
+       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:17]
        │
      1 │ { unchecked { x = 1; } }
-       │                ──┬─  
-       │                  ╰─── Error occurred here.
+       │                 ──┬──  
+       │                   ╰──── Error occurred here.
     ───╯
   - >
-    Error: Expected end of file.
-       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:23]
+    Error: Expected OpenBrace or OpenParen.
+       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:24]
        │
      1 │ { unchecked { x = 1; } }
-       │                       ─┬  
-       │                        ╰── Error occurred here.
+       │                        │ 
+       │                        ╰─ Error occurred here.
     ───╯
 
 Tree:
   - Block (Rule): # 0..24 "{ unchecked { x = 1; } }"
       - OpenBrace (Token): "{" # 0..1
-      - StatementsList (Rule): # 1..20 " unchecked { x = 1;"
-          - Statement (Rule): # 1..20 " unchecked { x = 1;"
-              - ExpressionStatement (Rule): # 1..20 " unchecked { x = 1;"
-                  - Expression (Rule): # 1..15 " unchecked { x"
+      - StatementsList (Rule): # 1..23 " unchecked { x = 1; } "
+          - Statement (Rule): # 1..23 " unchecked { x = 1; } "
+              - ExpressionStatement (Rule): # 1..23 " unchecked { x = 1; } "
+                  - Expression (Rule): # 1..22 " unchecked { x = 1; }"
                       - Identifier (Token): "unchecked" # 2..11
-                      - FunctionCallOptions (Rule): # 11..15 " { x"
-                          - NamedArgumentsDeclaration (Rule): # 11..15 " { x"
+                      - FunctionCallOptions (Rule): # 11..22 " { x = 1; }"
+                          - NamedArgumentsDeclaration (Rule): # 11..22 " { x = 1; }"
                               - OpenBrace (Token): "{" # 12..13
                               - NamedArgumentsList (Rule): # 13..15 " x"
                                   - NamedArgument (Rule): # 13..15 " x"
                                       - Identifier (Token): "x" # 14..15
-                  - SKIPPED (Token): " = 1" # 15..19
-                  - Semicolon (Token): ";" # 19..20
-      - CloseBrace (Token): "}" # 21..22
-      - SKIPPED (Token): " }" # 22..24
+                              - SKIPPED (Token): "= 1; " # 16..21
+                              - CloseBrace (Token): "}" # 21..22
+      - SKIPPED (Token): "" # 23..23
+      - CloseBrace (Token): "}" # 23..24

--- a/crates/solidity/testing/snapshots/cst_output/Block/unchecked/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Block/unchecked/generated/0.6.2-failure.yml
@@ -1,0 +1,41 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ { unchecked { x = 1; } }                                                         │ 0..24
+
+Errors: # 2 total
+  - >
+    Error: Expected Colon.
+       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:16]
+       │
+     1 │ { unchecked { x = 1; } }
+       │                ──┬─  
+       │                  ╰─── Error occurred here.
+    ───╯
+  - >
+    Error: Expected end of file.
+       ╭─[crates/solidity/testing/snapshots/cst_output/Block/unchecked/input.sol:1:23]
+       │
+     1 │ { unchecked { x = 1; } }
+       │                       ─┬  
+       │                        ╰── Error occurred here.
+    ───╯
+
+Tree:
+  - Block (Rule): # 0..24 "{ unchecked { x = 1; } }"
+      - OpenBrace (Token): "{" # 0..1
+      - StatementsList (Rule): # 1..20 " unchecked { x = 1;"
+          - Statement (Rule): # 1..20 " unchecked { x = 1;"
+              - ExpressionStatement (Rule): # 1..20 " unchecked { x = 1;"
+                  - Expression (Rule): # 1..15 " unchecked { x"
+                      - Identifier (Token): "unchecked" # 2..11
+                      - FunctionCallOptions (Rule): # 11..15 " { x"
+                          - NamedArgumentsDeclaration (Rule): # 11..15 " { x"
+                              - OpenBrace (Token): "{" # 12..13
+                              - NamedArgumentsList (Rule): # 13..15 " x"
+                                  - NamedArgument (Rule): # 13..15 " x"
+                                      - Identifier (Token): "x" # 14..15
+                  - SKIPPED (Token): " = 1" # 15..19
+                  - Semicolon (Token): ";" # 19..20
+      - CloseBrace (Token): "}" # 21..22
+      - SKIPPED (Token): " }" # 22..24

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.6.2-failure.yml
@@ -24,7 +24,7 @@ Errors: # 4 total
        │                                  ╰──── Error occurred here.
     ───╯
   - >
-    Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or ByteKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or TypeKeyword or UnicodeStringLiteral or UnsignedFixedType or UnsignedIntegerType.
+    Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or ByteKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or TypeKeyword or UnsignedFixedType or UnsignedIntegerType.
        ╭─[crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/input.sol:3:6]
        │
      3 │ ╭─▶        if(while == pair && !_isExcludedFromFee[to]){

--- a/crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/generated/0.4.11-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/generated/0.4.11-failure.yml
@@ -6,15 +6,19 @@ Source: >
 Errors: # 1 total
   - >
     Error: Expected AddressKeyword or BoolKeyword or ByteKeyword or FixedBytesType or FunctionKeyword or Identifier or MappingKeyword or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or UnsignedFixedType or UnsignedIntegerType.
-       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/input.sol:1:2]
+       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/input.sol:1:9]
        │
      1 │ 2 * new
-       │  ───┬───  
-       │     ╰───── Error occurred here.
+       │         │ 
+       │         ╰─ Error occurred here.
     ───╯
 
 Tree:
   - Expression (Rule): # 0..8 "2 * new\n"
       - NumericExpression (Rule): # 0..1 "2"
           - DecimalLiteral (Token): "2" # 0..1
-      - SKIPPED (Token): " * new\n" # 1..8
+      - BinaryExpression (Rule): # 1..3 " *"
+          - Asterisk (Token): "*" # 2..3
+      - NewExpression (Rule): # 3..8 " new\n"
+          - NewKeyword (Token): "new" # 4..7
+      - SKIPPED (Token): "" # 8..8

--- a/crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/generated/0.8.0-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/generated/0.8.0-failure.yml
@@ -6,15 +6,19 @@ Source: >
 Errors: # 1 total
   - >
     Error: Expected AddressKeyword or BoolKeyword or FixedBytesType or FunctionKeyword or Identifier or MappingKeyword or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or UnsignedFixedType or UnsignedIntegerType.
-       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/input.sol:1:2]
+       ╭─[crates/solidity/testing/snapshots/cst_output/Expression/incomplete_operand/input.sol:1:9]
        │
      1 │ 2 * new
-       │  ───┬───  
-       │     ╰───── Error occurred here.
+       │         │ 
+       │         ╰─ Error occurred here.
     ───╯
 
 Tree:
   - Expression (Rule): # 0..8 "2 * new\n"
       - NumericExpression (Rule): # 0..1 "2"
           - DecimalLiteral (Token): "2" # 0..1
-      - SKIPPED (Token): " * new\n" # 1..8
+      - BinaryExpression (Rule): # 1..3 " *"
+          - Asterisk (Token): "*" # 2..3
+      - NewExpression (Rule): # 3..8 " new\n"
+          - NewKeyword (Token): "new" # 4..7
+      - SKIPPED (Token): "" # 8..8

--- a/crates/solidity/testing/snapshots/cst_output/SourceUnit/SafeMath/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/SourceUnit/SafeMath/generated/0.6.2-failure.yml
@@ -1,0 +1,88 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ library SafeMath {                                                               │ 0..18
+  2  │   function tryAdd(uint256 a, uint256 b) internal pure returns (bool, uint256) {  │ 19..98
+  3  │     unchecked {                                                                  │ 99..114
+  4  │       uint256 c = a + b;                                                         │ 115..139
+  5  │       if (c < a) return (false, 0);                                              │ 140..175
+  6  │       return (true, c);                                                          │ 176..199
+  7  │     }                                                                            │ 200..205
+  8  │   }                                                                              │ 206..209
+  9  │ }                                                                                │ 210..211
+
+Errors: # 2 total
+  - >
+    Error: Expected CloseBrace or Identifier.
+       ╭─[crates/solidity/testing/snapshots/cst_output/SourceUnit/SafeMath/input.sol:4:7]
+       │
+     4 │ ╭─▶       uint256 c = a + b;
+       ┆ ┆   
+     7 │ ├─▶     }
+       │ │           
+       │ ╰─────────── Error occurred here.
+    ───╯
+  - >
+    Error: Expected OpenBrace or OpenParen.
+       ╭─[crates/solidity/testing/snapshots/cst_output/SourceUnit/SafeMath/input.sol:8:3]
+       │
+     8 │   }
+       │   │ 
+       │   ╰─ Error occurred here.
+    ───╯
+
+Tree:
+  - SourceUnit (Rule): # 0..212 "library SafeMath {\n  function tryAdd(uint256 a, ui..."
+      - SourceUnitMembersList (Rule): # 0..212 "library SafeMath {\n  function tryAdd(uint256 a, ui..."
+          - LibraryDefinition (Rule): # 0..212 "library SafeMath {\n  function tryAdd(uint256 a, ui..."
+              - LibraryKeyword (Token): "library" # 0..7
+              - Identifier (Token): "SafeMath" # 8..16
+              - OpenBrace (Token): "{" # 17..18
+              - LibraryMembersList (Rule): # 19..210 "  function tryAdd(uint256 a, uint256 b) internal p..."
+                  - FunctionDefinition (Rule): # 19..210 "  function tryAdd(uint256 a, uint256 b) internal p..."
+                      - FunctionKeyword (Token): "function" # 21..29
+                      - Identifier (Token): "tryAdd" # 30..36
+                      - ParametersDeclaration (Rule): # 36..58 "(uint256 a, uint256 b)"
+                          - OpenParen (Token): "(" # 36..37
+                          - ParametersList (Rule): # 37..57 "uint256 a, uint256 b"
+                              - Parameter (Rule): # 37..46 "uint256 a"
+                                  - TypeName (Rule): # 37..44 "uint256"
+                                      - UnsignedIntegerType (Token): "uint256" # 37..44
+                                  - Identifier (Token): "a" # 45..46
+                              - Comma (Token): "," # 46..47
+                              - Parameter (Rule): # 47..57 " uint256 b"
+                                  - TypeName (Rule): # 47..55 " uint256"
+                                      - UnsignedIntegerType (Token): "uint256" # 48..55
+                                  - Identifier (Token): "b" # 56..57
+                          - CloseParen (Token): ")" # 57..58
+                      - FunctionAttributesList (Rule): # 58..72 " internal pure"
+                          - InternalKeyword (Token): "internal" # 59..67
+                          - PureKeyword (Token): "pure" # 68..72
+                      - ReturnsDeclaration (Rule): # 72..96 " returns (bool, uint256)"
+                          - ReturnsKeyword (Token): "returns" # 73..80
+                          - ParametersDeclaration (Rule): # 80..96 " (bool, uint256)"
+                              - OpenParen (Token): "(" # 81..82
+                              - ParametersList (Rule): # 82..95 "bool, uint256"
+                                  - Parameter (Rule): # 82..86 "bool"
+                                      - TypeName (Rule): # 82..86 "bool"
+                                          - BoolKeyword (Token): "bool" # 82..86
+                                  - Comma (Token): "," # 86..87
+                                  - Parameter (Rule): # 87..95 " uint256"
+                                      - TypeName (Rule): # 87..95 " uint256"
+                                          - UnsignedIntegerType (Token): "uint256" # 88..95
+                              - CloseParen (Token): ")" # 95..96
+                      - Block (Rule): # 96..210 " {\n    unchecked {\n      uint256 c = a + b;\n      ..."
+                          - OpenBrace (Token): "{" # 97..98
+                          - StatementsList (Rule): # 99..208 "    unchecked {\n      uint256 c = a + b;\n      if ..."
+                              - Statement (Rule): # 99..208 "    unchecked {\n      uint256 c = a + b;\n      if ..."
+                                  - ExpressionStatement (Rule): # 99..208 "    unchecked {\n      uint256 c = a + b;\n      if ..."
+                                      - Expression (Rule): # 99..206 "    unchecked {\n      uint256 c = a + b;\n      if ..."
+                                          - Identifier (Token): "unchecked" # 103..112
+                                          - FunctionCallOptions (Rule): # 112..206 " {\n      uint256 c = a + b;\n      if (c < a) retur..."
+                                              - NamedArgumentsDeclaration (Rule): # 112..206 " {\n      uint256 c = a + b;\n      if (c < a) retur..."
+                                                  - OpenBrace (Token): "{" # 113..114
+                                                  - SKIPPED (Token): "uint256 c = a + b;\n      if (c < a) return (false,..." # 121..204
+                                                  - CloseBrace (Token): "}" # 204..205
+                          - SKIPPED (Token): "" # 208..208
+                          - CloseBrace (Token): "}" # 208..209
+              - CloseBrace (Token): "}" # 210..211

--- a/crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/generated/0.6.2-failure.yml
@@ -1,0 +1,47 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ (a, b) = (123, 135)                                                              │ 0..19
+  2  │ /**/                                                                             │ 20..24
+  3  │ { throw;                                                                         │ 25..34
+
+Errors: # 1 total
+  - >
+    Error: Expected CloseBrace or Identifier.
+       ╭─[crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/input.sol:3:2]
+       │
+     3 │ { throw;
+       │  ───┬──  
+       │     ╰──── Error occurred here.
+    ───╯
+
+Tree:
+  - TupleDeconstructionStatement (Rule): # 0..35 "(a, b) = (123, 135)\n/**/\n{ throw; \n"
+      - OpenParen (Token): "(" # 0..1
+      - TupleMembersList (Rule): # 1..5 "a, b"
+          - TupleMember (Rule): # 1..2 "a"
+              - Identifier (Token): "a" # 1..2
+          - Comma (Token): "," # 2..3
+          - TupleMember (Rule): # 3..5 " b"
+              - Identifier (Token): "b" # 4..5
+      - CloseParen (Token): ")" # 5..6
+      - Equal (Token): "=" # 7..8
+      - Expression (Rule): # 8..26 " (123, 135)\n/**/\n{"
+          - TupleExpression (Rule): # 8..20 " (123, 135)\n"
+              - OpenParen (Token): "(" # 9..10
+              - TupleValuesList (Rule): # 10..18 "123, 135"
+                  - Expression (Rule): # 10..13 "123"
+                      - NumericExpression (Rule): # 10..13 "123"
+                          - DecimalLiteral (Token): "123" # 10..13
+                  - Comma (Token): "," # 13..14
+                  - Expression (Rule): # 14..18 " 135"
+                      - NumericExpression (Rule): # 14..18 " 135"
+                          - DecimalLiteral (Token): "135" # 15..18
+              - CloseParen (Token): ")" # 18..19
+          - FunctionCallOptions (Rule): # 20..26 "/**/\n{"
+              - NamedArgumentsDeclaration (Rule): # 20..26 "/**/\n{"
+                  - LeadingTrivia (Rule): # 20..25 "/**/\n"
+                      - MultilineComment (Trivia): "/**/" # 20..24
+                  - OpenBrace (Token): "{" # 25..26
+      - SKIPPED (Token): " throw" # 26..32
+      - Semicolon (Token): ";" # 32..33

--- a/crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/generated/0.6.2-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/generated/0.6.2-failure.yml
@@ -8,10 +8,10 @@ Source: >
 Errors: # 1 total
   - >
     Error: Expected CloseBrace or Identifier.
-       ╭─[crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/input.sol:3:2]
+       ╭─[crates/solidity/testing/snapshots/cst_output/TupleDeconstructionStatement/invalid_termination/input.sol:3:3]
        │
      3 │ { throw;
-       │  ───┬──  
+       │   ──┬──  
        │     ╰──── Error occurred here.
     ───╯
 
@@ -43,5 +43,5 @@ Tree:
                   - LeadingTrivia (Rule): # 20..25 "/**/\n"
                       - MultilineComment (Trivia): "/**/" # 20..24
                   - OpenBrace (Token): "{" # 25..26
-      - SKIPPED (Token): " throw" # 26..32
+      - SKIPPED (Token): "throw" # 27..32
       - Semicolon (Token): ";" # 32..33


### PR DESCRIPTION
Parsing *some* input in when the first element is optional shouldn't be accepted as empty.