### PR TITLE
Re-run the local codegen if DSL or parser-generator changes

### DIFF
--- a/crates/solidity/outputs/cargo/build/src/main.rs
+++ b/crates/solidity/outputs/cargo/build/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         rerun_if_changed!(crate_dir.join("Cargo.toml").unwrap_str());
         rerun_if_changed!(crate_dir.join("src").unwrap_str());
         // Emitting the `rerun-if-changed` for non-existent files always causes a rebuild, so first check if a build
-        // script event exists. It's worth noting that adding/removing one will trip up
+        // script event exists. It's worth noting that adding/removing one will trip this up.
         if crate_dir.join("build.rs").exists() {
             rerun_if_changed!(crate_dir.join("build.rs").unwrap_str());
         }

--- a/crates/solidity/outputs/cargo/build/src/main.rs
+++ b/crates/solidity/outputs/cargo/build/src/main.rs
@@ -13,6 +13,13 @@ use solidity_language::GrammarConstructor;
 // 3) We want to avoid having dependencies from the source crate to codegen crates.
 //
 fn main() -> Result<()> {
+    // The parser generator itself affects the build, so make sure we rerun the build script if it changes:
+    {
+        let codegen_dir = CargoWorkspace::locate_source_crate("codegen_parser_generator")?;
+
+        rerun_if_changed!(codegen_dir.unwrap_str());
+    }
+
     // Generate files in the source crate:
 
     {

--- a/crates/solidity/outputs/npm/build/src/main.rs
+++ b/crates/solidity/outputs/npm/build/src/main.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use cargo_emit::rerun_if_changed;
+
 use codegen_grammar::Grammar;
 use codegen_parser_generator::code_generator::CodeGenerator;
 use infra_utils::{cargo::CargoWorkspace, paths::PathExtensions};
 use solidity_language::GrammarConstructor;
 
-// Instead of the soure crate calling codegen APIs directly, it invokes this binary, which in turn calls the codegen APIs.
+// Instead of the soure crate calling codegen APIs directly in the build script, it invokes this binary, which in turn
+// calls the codegen APIs (and hence why it's emitting `cargo:` directives).
 // This indirection is needed because:
 //
 // 1) We want to run codegen, even if there are git conflicts in output files (Cargo fails to build in that case).
@@ -13,15 +15,7 @@ use solidity_language::GrammarConstructor;
 // 3) We want to avoid having dependencies from the source crate to codegen crates.
 //
 fn main() -> Result<()> {
-    // The parser generator itself affects the build, so make sure we rerun the build script if it changes:
-    {
-        let codegen_dir = CargoWorkspace::locate_source_crate("codegen_parser_generator")?;
-
-        rerun_if_changed!(codegen_dir.unwrap_str());
-    }
-
     // Generate files in the source crate:
-
     {
         let grammar = Grammar::new();
         let crate_dir = CargoWorkspace::locate_source_crate("solidity_npm_crate")?;
@@ -29,14 +23,25 @@ fn main() -> Result<()> {
         CodeGenerator::write_source(&crate_dir.join("src/generated"), grammar)?;
     }
 
-    // Instruct the caller source crate to rebuild itself if the this build crate changes:
+    // This build script is not directly depended on by the caller source crate, so we need to manually
+    // instruct Cargo on our invocation to rebuild if any of our dependencies (or we) change:
+    for crate_name in &[
+        env!("CARGO_CRATE_NAME"),
+        "codegen_grammar",
+        "codegen_parser_generator",
+        "solidity_language",
+    ] {
+        let crate_dir = CargoWorkspace::locate_source_crate(crate_name)?;
 
-    {
-        let build_crate_dir = CargoWorkspace::locate_source_crate("solidity_npm_build")?;
-
-        rerun_if_changed!(build_crate_dir.join("Cargo.toml").unwrap_str());
-        rerun_if_changed!(build_crate_dir.join("src").unwrap_str());
+        // This is not accurate, but it's good enough for now.
+        rerun_if_changed!(crate_dir.join("Cargo.toml").unwrap_str());
+        rerun_if_changed!(crate_dir.join("src").unwrap_str());
+        // Emitting the `rerun-if-changed` for non-existent files always causes a rebuild, so first check if a build
+        // script event exists. It's worth noting that adding/removing one will trip up
+        if crate_dir.join("build.rs").exists() {
+            rerun_if_changed!(crate_dir.join("build.rs").unwrap_str());
+        }
     }
 
-    return Ok(());
+    Ok(())
 }

--- a/crates/solidity/outputs/npm/build/src/main.rs
+++ b/crates/solidity/outputs/npm/build/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         rerun_if_changed!(crate_dir.join("Cargo.toml").unwrap_str());
         rerun_if_changed!(crate_dir.join("src").unwrap_str());
         // Emitting the `rerun-if-changed` for non-existent files always causes a rebuild, so first check if a build
-        // script event exists. It's worth noting that adding/removing one will trip up
+        // script event exists. It's worth noting that adding/removing one will trip this up.
         if crate_dir.join("build.rs").exists() {
             rerun_if_changed!(crate_dir.join("build.rs").unwrap_str());
         }

--- a/crates/solidity/outputs/npm/build/src/main.rs
+++ b/crates/solidity/outputs/npm/build/src/main.rs
@@ -13,6 +13,13 @@ use solidity_language::GrammarConstructor;
 // 3) We want to avoid having dependencies from the source crate to codegen crates.
 //
 fn main() -> Result<()> {
+    // The parser generator itself affects the build, so make sure we rerun the build script if it changes:
+    {
+        let codegen_dir = CargoWorkspace::locate_source_crate("codegen_parser_generator")?;
+
+        rerun_if_changed!(codegen_dir.unwrap_str());
+    }
+
     // Generate files in the source crate:
 
     {


### PR DESCRIPTION
Changing the parser generator code obviously affects the resulting build, so make sure we re-run the build script then.

This fixes the case where modifying the code in PG does not re-run the codegen, e.g. changing the code in `quote!` macros or other logic.