### PR TITLE
Improve error recovery in delimited groups when can't parse anything inside

### DIFF
--- a/.changeset/nervous-elephants-change.md
+++ b/.changeset/nervous-elephants-change.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": patch
+---
+
+Attempt parser error recovery between bracket delimiters

--- a/crates/codegen/parser/generator/src/parser_definition.rs
+++ b/crates/codegen/parser/generator/src/parser_definition.rs
@@ -187,6 +187,7 @@ impl ParserDefinitionNodeExtensions for ParserDefinitionNode {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::#close_token,
                                 Self::#delimiters(),
+                                RecoverFromNoMatch::Yes,
                             )
                         )?;
                     },
@@ -251,6 +252,7 @@ impl ParserDefinitionNodeExtensions for ParserDefinitionNode {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::#terminator_token_kind,
                                 Self::#delimiters(),
+                                RecoverFromNoMatch::No,
                             )
                         )?;
                     },

--- a/crates/codegen/parser/runtime/src/support/recovery.rs
+++ b/crates/codegen/parser/runtime/src/support/recovery.rs
@@ -7,6 +7,18 @@ use crate::text_index::TextRangeExtensions as _;
 use super::parser_result::SkippedUntil;
 use super::ParserContext;
 
+/// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
+pub enum RecoverFromNoMatch {
+    Yes,
+    No,
+}
+
+impl RecoverFromNoMatch {
+    pub fn as_bool(&self) -> bool {
+        matches!(self, RecoverFromNoMatch::Yes)
+    }
+}
+
 fn opt_parse(
     input: &mut ParserContext,
     parse: impl Fn(&mut ParserContext) -> ParserResult,
@@ -34,6 +46,7 @@ impl ParserResult {
         leading_trivia: impl Fn(&mut ParserContext) -> ParserResult,
         expected: TokenKind,
         delims: &[(TokenKind, TokenKind)],
+        recover_from_no_match: RecoverFromNoMatch,
     ) -> ParserResult {
         let before_recovery = input.position();
 
@@ -47,10 +60,23 @@ impl ParserResult {
             token
         };
 
-        let (mut nodes, mut expected_tokens, is_incomplete) = match self {
-            ParserResult::IncompleteMatch(result) => (result.nodes, result.expected_tokens, true),
+        enum ParseResultKind {
+            Match,
+            Incomplete,
+            NoMatch,
+        }
+
+        let (mut nodes, mut expected_tokens, result_kind) = match self {
+            ParserResult::IncompleteMatch(result) => (
+                result.nodes,
+                result.expected_tokens,
+                ParseResultKind::Incomplete,
+            ),
             ParserResult::Match(result) if peek_token_after_trivia() != Some(expected) => {
-                (result.nodes, result.expected_tokens, false)
+                (result.nodes, result.expected_tokens, ParseResultKind::Match)
+            }
+            ParserResult::NoMatch(result) if recover_from_no_match.as_bool() => {
+                (vec![], result.expected_tokens, ParseResultKind::NoMatch)
             }
             // No need to recover, so just return as-is.
             _ => return self,
@@ -70,7 +96,7 @@ impl ParserResult {
                         && (token == expected || input.closing_delimiters().contains(&token)) =>
                 {
                     nodes.extend(leading_trivia);
-                    if !is_incomplete {
+                    if matches!(result_kind, ParseResultKind::Match) {
                         expected_tokens.push(expected);
                     }
 
@@ -106,11 +132,13 @@ impl ParserResult {
                 None => {
                     input.set_position(before_recovery);
 
-                    if is_incomplete {
-                        return ParserResult::incomplete_match(nodes, expected_tokens);
-                    } else {
-                        return ParserResult::r#match(nodes, expected_tokens);
-                    }
+                    return match result_kind {
+                        ParseResultKind::Match => ParserResult::r#match(nodes, expected_tokens),
+                        ParseResultKind::Incomplete => {
+                            ParserResult::incomplete_match(nodes, expected_tokens)
+                        }
+                        ParseResultKind::NoMatch => ParserResult::no_match(expected_tokens),
+                    };
                 }
             }
         }

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -286,6 +286,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -308,6 +309,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBracket,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -379,6 +381,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -404,6 +407,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -423,6 +427,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -495,6 +500,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -566,6 +572,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -599,6 +606,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -676,6 +684,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -735,6 +744,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -765,6 +775,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ))?;
                         seq.elem(
                             self.default_parse_token_with_trivia(input, TokenKind::CloseParen),
@@ -779,6 +790,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -806,6 +818,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -854,6 +867,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -894,6 +908,7 @@ impl Language {
                                         |input| Lexer::leading_trivia(self, input),
                                         TokenKind::CloseParen,
                                         Self::default_delimiters(),
+                                        RecoverFromNoMatch::Yes,
                                     ),
                             )?;
                             seq.elem(
@@ -909,6 +924,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -981,6 +997,7 @@ impl Language {
                                     |input| Lexer::leading_trivia(self, input),
                                     TokenKind::CloseParen,
                                     Self::default_delimiters(),
+                                    RecoverFromNoMatch::Yes,
                                 ),
                         )?;
                         seq.elem(
@@ -999,6 +1016,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -1352,6 +1370,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBracket,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                     )?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -1530,6 +1549,7 @@ impl Language {
                 |input| Lexer::leading_trivia(self, input),
                 TokenKind::Semicolon,
                 Self::default_delimiters(),
+                RecoverFromNoMatch::No,
             ))?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
             seq.finish()
@@ -1642,6 +1662,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -1851,6 +1872,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ))?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                 seq.finish()
@@ -1891,6 +1913,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -1955,6 +1978,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2052,6 +2076,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2188,6 +2213,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2287,6 +2313,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2480,6 +2507,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2533,6 +2561,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2612,6 +2641,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2692,6 +2722,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2728,6 +2759,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2848,6 +2880,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2943,6 +2976,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2968,6 +3002,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2996,6 +3031,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::Semicolon,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::No,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3062,6 +3098,7 @@ impl Language {
                                     |input| Lexer::leading_trivia(self, input),
                                     TokenKind::CloseParen,
                                     Self::default_delimiters(),
+                                    RecoverFromNoMatch::Yes,
                                 ),
                         )?;
                         seq.elem(
@@ -3079,6 +3116,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3101,6 +3139,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -3209,6 +3248,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ))?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                     seq.finish()
@@ -3243,6 +3283,7 @@ impl Language {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::CloseBracket,
                                 Self::default_delimiters(),
+                                RecoverFromNoMatch::Yes,
                             ),
                     )?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -3460,6 +3501,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3506,6 +3548,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3528,6 +3571,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -3681,6 +3725,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3839,6 +3884,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ))?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                 seq.finish()
@@ -3876,6 +3922,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::yul_block_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -3933,6 +3980,7 @@ impl Language {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::CloseParen,
                                 Self::yul_block_delimiters(),
+                                RecoverFromNoMatch::Yes,
                             ),
                     )?;
                     seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -4125,6 +4173,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::yul_block_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseParen))?;

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/recovery.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/recovery.rs
@@ -9,6 +9,18 @@ use crate::text_index::TextRangeExtensions as _;
 use super::parser_result::SkippedUntil;
 use super::ParserContext;
 
+/// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
+pub enum RecoverFromNoMatch {
+    Yes,
+    No,
+}
+
+impl RecoverFromNoMatch {
+    pub fn as_bool(&self) -> bool {
+        matches!(self, RecoverFromNoMatch::Yes)
+    }
+}
+
 fn opt_parse(
     input: &mut ParserContext,
     parse: impl Fn(&mut ParserContext) -> ParserResult,
@@ -36,6 +48,7 @@ impl ParserResult {
         leading_trivia: impl Fn(&mut ParserContext) -> ParserResult,
         expected: TokenKind,
         delims: &[(TokenKind, TokenKind)],
+        recover_from_no_match: RecoverFromNoMatch,
     ) -> ParserResult {
         let before_recovery = input.position();
 
@@ -49,10 +62,23 @@ impl ParserResult {
             token
         };
 
-        let (mut nodes, mut expected_tokens, is_incomplete) = match self {
-            ParserResult::IncompleteMatch(result) => (result.nodes, result.expected_tokens, true),
+        enum ParseResultKind {
+            Match,
+            Incomplete,
+            NoMatch,
+        }
+
+        let (mut nodes, mut expected_tokens, result_kind) = match self {
+            ParserResult::IncompleteMatch(result) => (
+                result.nodes,
+                result.expected_tokens,
+                ParseResultKind::Incomplete,
+            ),
             ParserResult::Match(result) if peek_token_after_trivia() != Some(expected) => {
-                (result.nodes, result.expected_tokens, false)
+                (result.nodes, result.expected_tokens, ParseResultKind::Match)
+            }
+            ParserResult::NoMatch(result) if recover_from_no_match.as_bool() => {
+                (vec![], result.expected_tokens, ParseResultKind::NoMatch)
             }
             // No need to recover, so just return as-is.
             _ => return self,
@@ -72,7 +98,7 @@ impl ParserResult {
                         && (token == expected || input.closing_delimiters().contains(&token)) =>
                 {
                     nodes.extend(leading_trivia);
-                    if !is_incomplete {
+                    if matches!(result_kind, ParseResultKind::Match) {
                         expected_tokens.push(expected);
                     }
 
@@ -108,11 +134,13 @@ impl ParserResult {
                 None => {
                     input.set_position(before_recovery);
 
-                    if is_incomplete {
-                        return ParserResult::incomplete_match(nodes, expected_tokens);
-                    } else {
-                        return ParserResult::r#match(nodes, expected_tokens);
-                    }
+                    return match result_kind {
+                        ParseResultKind::Match => ParserResult::r#match(nodes, expected_tokens),
+                        ParseResultKind::Incomplete => {
+                            ParserResult::incomplete_match(nodes, expected_tokens)
+                        }
+                        ParseResultKind::NoMatch => ParserResult::no_match(expected_tokens),
+                    };
                 }
             }
         }

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -286,6 +286,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -308,6 +309,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBracket,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -379,6 +381,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -404,6 +407,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -423,6 +427,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -495,6 +500,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -566,6 +572,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -599,6 +606,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -676,6 +684,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -735,6 +744,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -765,6 +775,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ))?;
                         seq.elem(
                             self.default_parse_token_with_trivia(input, TokenKind::CloseParen),
@@ -779,6 +790,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -806,6 +818,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -854,6 +867,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -894,6 +908,7 @@ impl Language {
                                         |input| Lexer::leading_trivia(self, input),
                                         TokenKind::CloseParen,
                                         Self::default_delimiters(),
+                                        RecoverFromNoMatch::Yes,
                                     ),
                             )?;
                             seq.elem(
@@ -909,6 +924,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -981,6 +997,7 @@ impl Language {
                                     |input| Lexer::leading_trivia(self, input),
                                     TokenKind::CloseParen,
                                     Self::default_delimiters(),
+                                    RecoverFromNoMatch::Yes,
                                 ),
                         )?;
                         seq.elem(
@@ -999,6 +1016,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -1352,6 +1370,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBracket,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                     )?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -1530,6 +1549,7 @@ impl Language {
                 |input| Lexer::leading_trivia(self, input),
                 TokenKind::Semicolon,
                 Self::default_delimiters(),
+                RecoverFromNoMatch::No,
             ))?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
             seq.finish()
@@ -1642,6 +1662,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -1851,6 +1872,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ))?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                 seq.finish()
@@ -1891,6 +1913,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -1955,6 +1978,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2052,6 +2076,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2188,6 +2213,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2287,6 +2313,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2480,6 +2507,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseParen,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2533,6 +2561,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -2612,6 +2641,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2692,6 +2722,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2728,6 +2759,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2848,6 +2880,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2943,6 +2976,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::CloseBrace,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::Yes,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -2968,6 +3002,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -2996,6 +3031,7 @@ impl Language {
                             |input| Lexer::leading_trivia(self, input),
                             TokenKind::Semicolon,
                             Self::default_delimiters(),
+                            RecoverFromNoMatch::No,
                         ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3062,6 +3098,7 @@ impl Language {
                                     |input| Lexer::leading_trivia(self, input),
                                     TokenKind::CloseParen,
                                     Self::default_delimiters(),
+                                    RecoverFromNoMatch::Yes,
                                 ),
                         )?;
                         seq.elem(
@@ -3079,6 +3116,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3101,6 +3139,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -3209,6 +3248,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ))?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                     seq.finish()
@@ -3243,6 +3283,7 @@ impl Language {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::CloseBracket,
                                 Self::default_delimiters(),
+                                RecoverFromNoMatch::Yes,
                             ),
                     )?;
                     seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBracket))?;
@@ -3460,6 +3501,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::Semicolon,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::No,
                     ),
                 )?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3506,6 +3548,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3528,6 +3571,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::default_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -3681,6 +3725,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::Semicolon,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::No,
                 ),
             )?;
             seq.elem(self.default_parse_token_with_trivia(input, TokenKind::Semicolon))?;
@@ -3839,6 +3884,7 @@ impl Language {
                     |input| Lexer::leading_trivia(self, input),
                     TokenKind::CloseParen,
                     Self::default_delimiters(),
+                    RecoverFromNoMatch::Yes,
                 ))?;
                 seq.elem(self.default_parse_token_with_trivia(input, TokenKind::CloseParen))?;
                 seq.finish()
@@ -3876,6 +3922,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseBrace,
                         Self::yul_block_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseBrace))?;
@@ -3933,6 +3980,7 @@ impl Language {
                                 |input| Lexer::leading_trivia(self, input),
                                 TokenKind::CloseParen,
                                 Self::yul_block_delimiters(),
+                                RecoverFromNoMatch::Yes,
                             ),
                     )?;
                     seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseParen))?;
@@ -4125,6 +4173,7 @@ impl Language {
                         |input| Lexer::leading_trivia(self, input),
                         TokenKind::CloseParen,
                         Self::yul_block_delimiters(),
+                        RecoverFromNoMatch::Yes,
                     ),
             )?;
             seq.elem(self.yul_block_parse_token_with_trivia(input, TokenKind::CloseParen))?;

--- a/crates/solidity/outputs/npm/crate/src/generated/support/recovery.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/recovery.rs
@@ -9,6 +9,18 @@ use crate::text_index::TextRangeExtensions as _;
 use super::parser_result::SkippedUntil;
 use super::ParserContext;
 
+/// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
+pub enum RecoverFromNoMatch {
+    Yes,
+    No,
+}
+
+impl RecoverFromNoMatch {
+    pub fn as_bool(&self) -> bool {
+        matches!(self, RecoverFromNoMatch::Yes)
+    }
+}
+
 fn opt_parse(
     input: &mut ParserContext,
     parse: impl Fn(&mut ParserContext) -> ParserResult,
@@ -36,6 +48,7 @@ impl ParserResult {
         leading_trivia: impl Fn(&mut ParserContext) -> ParserResult,
         expected: TokenKind,
         delims: &[(TokenKind, TokenKind)],
+        recover_from_no_match: RecoverFromNoMatch,
     ) -> ParserResult {
         let before_recovery = input.position();
 
@@ -49,10 +62,23 @@ impl ParserResult {
             token
         };
 
-        let (mut nodes, mut expected_tokens, is_incomplete) = match self {
-            ParserResult::IncompleteMatch(result) => (result.nodes, result.expected_tokens, true),
+        enum ParseResultKind {
+            Match,
+            Incomplete,
+            NoMatch,
+        }
+
+        let (mut nodes, mut expected_tokens, result_kind) = match self {
+            ParserResult::IncompleteMatch(result) => (
+                result.nodes,
+                result.expected_tokens,
+                ParseResultKind::Incomplete,
+            ),
             ParserResult::Match(result) if peek_token_after_trivia() != Some(expected) => {
-                (result.nodes, result.expected_tokens, false)
+                (result.nodes, result.expected_tokens, ParseResultKind::Match)
+            }
+            ParserResult::NoMatch(result) if recover_from_no_match.as_bool() => {
+                (vec![], result.expected_tokens, ParseResultKind::NoMatch)
             }
             // No need to recover, so just return as-is.
             _ => return self,
@@ -72,7 +98,7 @@ impl ParserResult {
                         && (token == expected || input.closing_delimiters().contains(&token)) =>
                 {
                     nodes.extend(leading_trivia);
-                    if !is_incomplete {
+                    if matches!(result_kind, ParseResultKind::Match) {
                         expected_tokens.push(expected);
                     }
 
@@ -108,11 +134,13 @@ impl ParserResult {
                 None => {
                     input.set_position(before_recovery);
 
-                    if is_incomplete {
-                        return ParserResult::incomplete_match(nodes, expected_tokens);
-                    } else {
-                        return ParserResult::r#match(nodes, expected_tokens);
-                    }
+                    return match result_kind {
+                        ParseResultKind::Match => ParserResult::r#match(nodes, expected_tokens),
+                        ParseResultKind::Incomplete => {
+                            ParserResult::incomplete_match(nodes, expected_tokens)
+                        }
+                        ParseResultKind::NoMatch => ParserResult::no_match(expected_tokens),
+                    };
                 }
             }
         }

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.4.11-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.4.11-failure.yml
@@ -27,11 +27,9 @@ Errors: # 3 total
     Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or ByteKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or UnsignedFixedType or UnsignedIntegerType.
        ╭─[crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/input.sol:3:6]
        │
-     3 │ ╭─▶        if(while == pair && !_isExcludedFromFee[to]){
-       ┆ ┆   
-     6 │ ├─▶     }
-       │ │           
-       │ ╰─────────── Error occurred here.
+     3 │        if(while == pair && !_isExcludedFromFee[to]){
+       │           ────────────────────┬───────────────────  
+       │                               ╰───────────────────── Error occurred here.
     ───╯
   - >
     Error: Expected Ampersand or AmpersandAmpersand or AmpersandEqual or Asterisk or AsteriskAsterisk or AsteriskEqual or BangEqual or Bar or BarBar or BarEqual or Caret or CaretEqual or Equal or EqualEqual or GreaterThan or GreaterThanEqual or GreaterThanGreaterThan or GreaterThanGreaterThanEqual or GreaterThanGreaterThanGreaterThan or GreaterThanGreaterThanGreaterThanEqual or LessThan or LessThanEqual or LessThanLessThan or LessThanLessThanEqual or Minus or MinusEqual or Percent or PercentEqual or Plus or PlusEqual or Semicolon or Slash or SlashEqual.
@@ -65,12 +63,29 @@ Tree:
                   - PrivateKeyword (Token): "private" # 55..62
               - Block (Rule): # 62..138 " {\n\t\tif(while == pair && !_isExcludedFromFee[to]){..."
                   - OpenBrace (Token): "{" # 63..64
-                  - StatementsList (Rule): # 65..70 "\t\tif("
-                      - Statement (Rule): # 65..70 "\t\tif("
-                          - IfStatement (Rule): # 65..70 "\t\tif("
+                  - StatementsList (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                      - Statement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                          - IfStatement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
                               - IfKeyword (Token): "if" # 67..69
                               - OpenParen (Token): "(" # 69..70
-                  - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]){\n\t\t\tuint..." # 70..136
+                              - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]" # 70..110
+                              - CloseParen (Token): ")" # 110..111
+                              - Statement (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                  - Block (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                      - OpenBrace (Token): "{" # 111..112
+                                      - StatementsList (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                          - Statement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                              - VariableDeclarationStatement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                                  - VariableDeclaration (Rule): # 113..125 "\t\t\tuint256 a"
+                                                      - TypeName (Rule): # 113..123 "\t\t\tuint256"
+                                                          - UnsignedIntegerType (Token): "uint256" # 116..123
+                                                      - Identifier (Token): "a" # 124..125
+                                                  - Equal (Token): "=" # 126..127
+                                                  - Expression (Rule): # 127..129 " 1"
+                                                      - NumericExpression (Rule): # 127..129 " 1"
+                                                          - DecimalLiteral (Token): "1" # 128..129
+                                                  - Semicolon (Token): ";" # 129..130
+                                      - CloseBrace (Token): "}" # 133..134
                   - CloseBrace (Token): "}" # 136..137
           - FunctionDefinition (Rule): # 138..210 "\n\tfunction abc() {\n\t\tuint256 x = 0;\n\t\tunchecked { ..."
               - FunctionKeyword (Token): "function" # 140..148

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.5.3-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.5.3-failure.yml
@@ -27,11 +27,9 @@ Errors: # 3 total
     Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or ByteKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or TypeKeyword or UnsignedFixedType or UnsignedIntegerType.
        ╭─[crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/input.sol:3:6]
        │
-     3 │ ╭─▶        if(while == pair && !_isExcludedFromFee[to]){
-       ┆ ┆   
-     6 │ ├─▶     }
-       │ │           
-       │ ╰─────────── Error occurred here.
+     3 │        if(while == pair && !_isExcludedFromFee[to]){
+       │           ────────────────────┬───────────────────  
+       │                               ╰───────────────────── Error occurred here.
     ───╯
   - >
     Error: Expected Ampersand or AmpersandAmpersand or AmpersandEqual or Asterisk or AsteriskAsterisk or AsteriskEqual or BangEqual or Bar or BarBar or BarEqual or Caret or CaretEqual or Equal or EqualEqual or GreaterThan or GreaterThanEqual or GreaterThanGreaterThan or GreaterThanGreaterThanEqual or GreaterThanGreaterThanGreaterThan or GreaterThanGreaterThanGreaterThanEqual or LessThan or LessThanEqual or LessThanLessThan or LessThanLessThanEqual or Minus or MinusEqual or Percent or PercentEqual or Plus or PlusEqual or Semicolon or Slash or SlashEqual.
@@ -65,12 +63,29 @@ Tree:
                   - PrivateKeyword (Token): "private" # 55..62
               - Block (Rule): # 62..138 " {\n\t\tif(while == pair && !_isExcludedFromFee[to]){..."
                   - OpenBrace (Token): "{" # 63..64
-                  - StatementsList (Rule): # 65..70 "\t\tif("
-                      - Statement (Rule): # 65..70 "\t\tif("
-                          - IfStatement (Rule): # 65..70 "\t\tif("
+                  - StatementsList (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                      - Statement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                          - IfStatement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
                               - IfKeyword (Token): "if" # 67..69
                               - OpenParen (Token): "(" # 69..70
-                  - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]){\n\t\t\tuint..." # 70..136
+                              - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]" # 70..110
+                              - CloseParen (Token): ")" # 110..111
+                              - Statement (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                  - Block (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                      - OpenBrace (Token): "{" # 111..112
+                                      - StatementsList (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                          - Statement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                              - VariableDeclarationStatement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                                  - VariableDeclaration (Rule): # 113..125 "\t\t\tuint256 a"
+                                                      - TypeName (Rule): # 113..123 "\t\t\tuint256"
+                                                          - UnsignedIntegerType (Token): "uint256" # 116..123
+                                                      - Identifier (Token): "a" # 124..125
+                                                  - Equal (Token): "=" # 126..127
+                                                  - Expression (Rule): # 127..129 " 1"
+                                                      - NumericExpression (Rule): # 127..129 " 1"
+                                                          - DecimalLiteral (Token): "1" # 128..129
+                                                  - Semicolon (Token): ";" # 129..130
+                                      - CloseBrace (Token): "}" # 133..134
                   - CloseBrace (Token): "}" # 136..137
           - FunctionDefinition (Rule): # 138..210 "\n\tfunction abc() {\n\t\tuint256 x = 0;\n\t\tunchecked { ..."
               - FunctionKeyword (Token): "function" # 140..148

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.7.0-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.7.0-failure.yml
@@ -27,11 +27,9 @@ Errors: # 3 total
     Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or ByteKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or TypeKeyword or UnicodeStringLiteral or UnsignedFixedType or UnsignedIntegerType.
        ╭─[crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/input.sol:3:6]
        │
-     3 │ ╭─▶        if(while == pair && !_isExcludedFromFee[to]){
-       ┆ ┆   
-     6 │ ├─▶     }
-       │ │           
-       │ ╰─────────── Error occurred here.
+     3 │        if(while == pair && !_isExcludedFromFee[to]){
+       │           ────────────────────┬───────────────────  
+       │                               ╰───────────────────── Error occurred here.
     ───╯
   - >
     Error: Expected Ampersand or AmpersandAmpersand or AmpersandEqual or Asterisk or AsteriskAsterisk or AsteriskEqual or BangEqual or Bar or BarBar or BarEqual or Caret or CaretEqual or Equal or EqualEqual or GreaterThan or GreaterThanEqual or GreaterThanGreaterThan or GreaterThanGreaterThanEqual or GreaterThanGreaterThanGreaterThan or GreaterThanGreaterThanGreaterThanEqual or LessThan or LessThanEqual or LessThanLessThan or LessThanLessThanEqual or Minus or MinusEqual or Percent or PercentEqual or Plus or PlusEqual or Semicolon or Slash or SlashEqual.
@@ -65,12 +63,29 @@ Tree:
                   - PrivateKeyword (Token): "private" # 55..62
               - Block (Rule): # 62..138 " {\n\t\tif(while == pair && !_isExcludedFromFee[to]){..."
                   - OpenBrace (Token): "{" # 63..64
-                  - StatementsList (Rule): # 65..70 "\t\tif("
-                      - Statement (Rule): # 65..70 "\t\tif("
-                          - IfStatement (Rule): # 65..70 "\t\tif("
+                  - StatementsList (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                      - Statement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                          - IfStatement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
                               - IfKeyword (Token): "if" # 67..69
                               - OpenParen (Token): "(" # 69..70
-                  - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]){\n\t\t\tuint..." # 70..136
+                              - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]" # 70..110
+                              - CloseParen (Token): ")" # 110..111
+                              - Statement (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                  - Block (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                      - OpenBrace (Token): "{" # 111..112
+                                      - StatementsList (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                          - Statement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                              - VariableDeclarationStatement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                                  - VariableDeclaration (Rule): # 113..125 "\t\t\tuint256 a"
+                                                      - TypeName (Rule): # 113..123 "\t\t\tuint256"
+                                                          - UnsignedIntegerType (Token): "uint256" # 116..123
+                                                      - Identifier (Token): "a" # 124..125
+                                                  - Equal (Token): "=" # 126..127
+                                                  - Expression (Rule): # 127..129 " 1"
+                                                      - NumericExpression (Rule): # 127..129 " 1"
+                                                          - DecimalLiteral (Token): "1" # 128..129
+                                                  - Semicolon (Token): ";" # 129..130
+                                      - CloseBrace (Token): "}" # 133..134
                   - CloseBrace (Token): "}" # 136..137
           - FunctionDefinition (Rule): # 138..210 "\n\tfunction abc() {\n\t\tuint256 x = 0;\n\t\tunchecked { ..."
               - FunctionKeyword (Token): "function" # 140..148

--- a/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.8.0-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/generated/0.8.0-failure.yml
@@ -27,11 +27,9 @@ Errors: # 3 total
     Error: Expected AddressKeyword or AsciiStringLiteral or BoolKeyword or DecimalLiteral or FalseKeyword or FixedBytesType or HexLiteral or HexStringLiteral or Identifier or NewKeyword or OpenBracket or OpenParen or PayableKeyword or SignedFixedType or SignedIntegerType or StringKeyword or TrueKeyword or TypeKeyword or UnicodeStringLiteral or UnsignedFixedType or UnsignedIntegerType.
        ╭─[crates/solidity/testing/snapshots/cst_output/ContractDefinition/recovery_testbed/input.sol:3:6]
        │
-     3 │ ╭─▶        if(while == pair && !_isExcludedFromFee[to]){
-       ┆ ┆   
-     6 │ ├─▶     }
-       │ │           
-       │ ╰─────────── Error occurred here.
+     3 │        if(while == pair && !_isExcludedFromFee[to]){
+       │           ────────────────────┬───────────────────  
+       │                               ╰───────────────────── Error occurred here.
     ───╯
   - >
     Error: Expected Equal or Semicolon.
@@ -64,12 +62,29 @@ Tree:
                   - PrivateKeyword (Token): "private" # 55..62
               - Block (Rule): # 62..138 " {\n\t\tif(while == pair && !_isExcludedFromFee[to]){..."
                   - OpenBrace (Token): "{" # 63..64
-                  - StatementsList (Rule): # 65..70 "\t\tif("
-                      - Statement (Rule): # 65..70 "\t\tif("
-                          - IfStatement (Rule): # 65..70 "\t\tif("
+                  - StatementsList (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                      - Statement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
+                          - IfStatement (Rule): # 65..135 "\t\tif(while == pair && !_isExcludedFromFee[to]){\n\t\t..."
                               - IfKeyword (Token): "if" # 67..69
                               - OpenParen (Token): "(" # 69..70
-                  - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]){\n\t\t\tuint..." # 70..136
+                              - SKIPPED (Token): "while == pair && !_isExcludedFromFee[to]" # 70..110
+                              - CloseParen (Token): ")" # 110..111
+                              - Statement (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                  - Block (Rule): # 111..135 "{\n\t\t\tuint256 a = 1;\n\t\t}\n"
+                                      - OpenBrace (Token): "{" # 111..112
+                                      - StatementsList (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                          - Statement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                              - VariableDeclarationStatement (Rule): # 113..131 "\t\t\tuint256 a = 1;\n"
+                                                  - VariableDeclaration (Rule): # 113..125 "\t\t\tuint256 a"
+                                                      - TypeName (Rule): # 113..123 "\t\t\tuint256"
+                                                          - UnsignedIntegerType (Token): "uint256" # 116..123
+                                                      - Identifier (Token): "a" # 124..125
+                                                  - Equal (Token): "=" # 126..127
+                                                  - Expression (Rule): # 127..129 " 1"
+                                                      - NumericExpression (Rule): # 127..129 " 1"
+                                                          - DecimalLiteral (Token): "1" # 128..129
+                                                  - Semicolon (Token): ";" # 129..130
+                                      - CloseBrace (Token): "}" # 133..134
                   - CloseBrace (Token): "}" # 136..137
           - FunctionDefinition (Rule): # 138..210 "\n\tfunction abc() {\n\t\tuint256 x = 0;\n\t\tunchecked { ..."
               - FunctionKeyword (Token): "function" # 140..148


### PR DESCRIPTION
Simpler variant of #594.

While writing an issue for the potential null parse recovery, it just hit me that we might not need to support that generally but rather just limiting that to the delimited group would give us enough bang for the buck.

TerminatedBy null parse recovery can be a bit too greedy, i.e. we might recover some unexpected item definition just because... we recovered at the final terminator. However, the delimited group is a reasonable boundary since it's simple (2-3 kinds of general delimiters versus different kinds of potentially versioned terminated statements) and the opening delimiter must always match the closing one, so it produces more reliable and self-contained recovered phrases, hence attempting to recover from a null parse in a delimited group makes more sense.