### PR TITLE
use Cargo resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [workspace]
+resolver = "2"
 members = [
     "crates/codegen/ebnf",
     "crates/codegen/grammar",


### PR DESCRIPTION
After upgrading to Rust 1.72.0 (see #603), we now get this warning:

```log    
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

This fixes the warning by setting the resolver explicitly in `Cargo.toml`.