### PR TITLE
chore: Remove now unused `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,6 @@ dependencies = [
  "codegen_grammar",
  "codegen_schema",
  "infra_utils",
- "once_cell",
  "semver",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ markdown = { version = "0.3.0" }
 napi = { version = "2.13.1", features = ["compat-mode", "napi8", "serde-json"] }
 napi-build = { version = "2.0.1" }
 napi-derive = { version = "2.13.0" }
-once_cell = { version = "1.8.0" }
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 proc-macro2 = { version = "1.0.53" }
 quote = { version = "1.0.26" }

--- a/crates/codegen/grammar/src/dsl.rs
+++ b/crates/codegen/grammar/src/dsl.rs
@@ -174,23 +174,18 @@ macro_rules! slang_grammar_lexical_context {
 #[macro_export]
 macro_rules! slang_grammar_definition {
     ($context:ident $trait:ident $trait_ref:ident $node_type:ident $dsl_macro:ident $is_inline:tt $name:ident $value:tt) => {
-        #[derive(Debug)]
+        #[derive(Debug, Default)]
         struct $name {
-            node: once_cell::unsync::OnceCell<$crate::$node_type>,
+            node: ::std::cell::OnceCell<$crate::$node_type>,
         }
 
         impl $name {
             const SOURCE_LOCATION: $crate::SourceLocation = slang_location!();
             const NAME: &str = stringify!($name);
-            const INSTANCE: once_cell::unsync::OnceCell<std::rc::Rc<Self>> =
-                once_cell::unsync::OnceCell::new();
+            const INSTANCE: ::std::cell::OnceCell<std::rc::Rc<Self>> = ::std::cell::OnceCell::new();
             fn instance() -> $crate::$trait_ref {
                 Self::INSTANCE
-                    .get_or_init(|| {
-                        std::rc::Rc::new(Self {
-                            node: once_cell::unsync::OnceCell::new(),
-                        })
-                    })
+                    .get_or_init(::std::default::Default::default)
                     .clone()
             }
         }

--- a/crates/solidity/inputs/language/Cargo.toml
+++ b/crates/solidity/inputs/language/Cargo.toml
@@ -18,5 +18,4 @@ anyhow = { workspace = true }
 bson = { workspace = true }
 codegen_schema = { workspace = true }
 codegen_grammar = { workspace = true }
-once_cell = { workspace = true }
 semver = { workspace = true }


### PR DESCRIPTION
Rust 1.70 includes the now-stable version in the standard library, so let's use that.