### PR TITLE
update language definition DSL based on feedback

### DIFF
--- a/crates/codegen/language/definition/src/compiler/analysis/mod.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/mod.rs
@@ -1,6 +1,7 @@
 mod definitions;
 mod reachability;
 mod references;
+mod utils;
 
 use crate::{
     compiler::analysis::{

--- a/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
@@ -66,6 +66,7 @@ fn collect_trivia<'l>(parser: &'l TriviaParser, acc: &mut Vec<&'l Identifier>) {
         TriviaParser::Trivia { trivia } => {
             acc.push(trivia);
         }
+        TriviaParser::EndOfInput => {}
     };
 }
 

--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -99,13 +99,18 @@ fn check_enum(analysis: &mut Analysis, item: &EnumItem, enablement: &VersionSet)
         let EnumVariant {
             name: _,
             enabled,
-            error_recovery: _,
-            fields,
+            reference,
         } = &**variant;
 
         let enablement = update_enablement(analysis, &enablement, &enabled);
 
-        check_fields(analysis, Some(name), &fields, &enablement);
+        check_reference(
+            analysis,
+            Some(name),
+            reference,
+            &enablement,
+            ReferenceFilter::Nodes,
+        );
     }
 }
 

--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -263,6 +263,7 @@ fn check_trivia_parser(analysis: &mut Analysis, parser: &TriviaParser, enablemen
         TriviaParser::Trivia { trivia } => {
             check_reference(analysis, None, trivia, &enablement, ReferenceFilter::Trivia);
         }
+        TriviaParser::EndOfInput => {}
     };
 }
 

--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -90,18 +90,8 @@ fn check_enum(analysis: &mut Analysis, item: &EnumItem, enablement: &VersionSet)
     let EnumItem {
         name,
         enabled,
-        default_variant,
         variants,
     } = item;
-
-    if !variants
-        .iter()
-        .any(|variant| variant.name == *default_variant)
-    {
-        analysis
-            .errors
-            .add(default_variant, &Errors::VariantDoesNotExist);
-    }
 
     let enablement = update_enablement(analysis, &enablement, &enabled);
 
@@ -169,20 +159,9 @@ fn check_precedence(analysis: &mut Analysis, item: &PrecedenceItem, enablement: 
     let PrecedenceItem {
         name,
         enabled,
-        default_primary_expression,
         precedence_expressions,
         primary_expressions,
     } = item;
-
-    if !primary_expressions
-        .iter()
-        .any(|primary_expression| primary_expression.expression == *default_primary_expression)
-    {
-        analysis.errors.add(
-            default_primary_expression,
-            &Errors::PrimaryExpressionDoesNotExist,
-        );
-    }
 
     let enablement = update_enablement(analysis, &enablement, &enabled);
 
@@ -541,10 +520,6 @@ fn check_version(analysis: &mut Analysis, version: &Spanned<Version>) -> bool {
 
 #[derive(thiserror::Error, Debug)]
 enum Errors<'err> {
-    #[error("Variant does not exist.")]
-    VariantDoesNotExist,
-    #[error("Primary expression does not exist.")]
-    PrimaryExpressionDoesNotExist,
     #[error("Version '{0}' does not exist in the language definition.")]
     VersionNotFound(&'err Version),
     #[error("Version '{0}' must be less than corresponding version '{1}'.")]

--- a/crates/codegen/language/definition/src/compiler/analysis/utils.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/utils.rs
@@ -1,0 +1,24 @@
+use crate::{compiler::analysis::Analysis, model::spanned::VersionSpecifier, utils::VersionSet};
+
+impl Analysis {
+    pub fn add_specifier(&self, set: &mut VersionSet, specifier: &VersionSpecifier) {
+        match specifier {
+            VersionSpecifier::Never => {
+                // Do nothing.
+            }
+            VersionSpecifier::From { from } => {
+                set.add_versions_starting_from(from);
+            }
+            VersionSpecifier::Till { till } => {
+                set.add_version_range(&self.language.versions[0], till);
+            }
+            VersionSpecifier::Range { from, till } => {
+                set.add_version_range(from, till);
+            }
+        }
+    }
+
+    pub fn add_all_versions(&self, set: &mut VersionSet) {
+        set.add_versions_starting_from(&self.language.versions[0]);
+    }
+}

--- a/crates/codegen/language/definition/src/model/types.rs
+++ b/crates/codegen/language/definition/src/model/types.rs
@@ -77,7 +77,6 @@ mod wrapper {
 
         pub enabled: Option<VersionSpecifier>,
 
-        pub default_variant: Identifier,
         pub variants: Vec<EnumVariant>,
     }
 
@@ -119,8 +118,6 @@ mod wrapper {
         pub enabled: Option<VersionSpecifier>,
 
         pub precedence_expressions: Vec<PrecedenceExpression>,
-
-        pub default_primary_expression: Identifier,
         pub primary_expressions: Vec<PrimaryExpression>,
     }
 

--- a/crates/codegen/language/definition/src/model/types.rs
+++ b/crates/codegen/language/definition/src/model/types.rs
@@ -86,8 +86,7 @@ mod wrapper {
 
         pub enabled: Option<VersionSpecifier>,
 
-        pub error_recovery: Option<FieldsErrorRecovery>,
-        pub fields: IndexMap<Identifier, Field>,
+        pub reference: Identifier,
     }
 
     #[derive(Debug, Eq, PartialEq, Serialize)]

--- a/crates/codegen/language/definition/src/model/types.rs
+++ b/crates/codegen/language/definition/src/model/types.rs
@@ -65,8 +65,7 @@ mod wrapper {
     pub struct StructItem {
         pub name: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub error_recovery: Option<FieldsErrorRecovery>,
         pub fields: IndexMap<Identifier, Field>,
@@ -76,8 +75,7 @@ mod wrapper {
     pub struct EnumItem {
         pub name: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub default_variant: Identifier,
         pub variants: Vec<EnumVariant>,
@@ -87,8 +85,7 @@ mod wrapper {
     pub struct EnumVariant {
         pub name: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub error_recovery: Option<FieldsErrorRecovery>,
         pub fields: IndexMap<Identifier, Field>,
@@ -99,8 +96,7 @@ mod wrapper {
         pub name: Identifier,
         pub repeated: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub allow_empty: Option<bool>,
     }
@@ -111,8 +107,7 @@ mod wrapper {
         pub separated: Identifier,
         pub separator: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub allow_empty: Option<bool>,
     }
@@ -121,8 +116,7 @@ mod wrapper {
     pub struct PrecedenceItem {
         pub name: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub precedence_expressions: Vec<PrecedenceExpression>,
 
@@ -141,8 +135,7 @@ mod wrapper {
     pub struct PrecedenceOperator {
         pub model: OperatorModel,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub error_recovery: Option<FieldsErrorRecovery>,
         pub fields: IndexMap<Identifier, Field>,
@@ -160,8 +153,7 @@ mod wrapper {
     pub struct PrimaryExpression {
         pub expression: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
     }
 
     #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -184,8 +176,7 @@ mod wrapper {
         Optional {
             kind: FieldKind,
 
-            enabled_in: Option<Version>,
-            disabled_in: Option<Version>,
+            enabled: Option<VersionSpecifier>,
         },
     }
 
@@ -223,11 +214,8 @@ mod wrapper {
 
     #[derive(Debug, Eq, PartialEq, Serialize)]
     pub struct KeywordDefinition {
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
-
-        pub reserved_in: Option<Version>,
-        pub unreserved_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
+        pub reserved: Option<VersionSpecifier>,
 
         pub value: KeywordValue,
     }
@@ -249,8 +237,7 @@ mod wrapper {
 
     #[derive(Debug, Eq, PartialEq, Serialize)]
     pub struct TokenDefinition {
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub scanner: Scanner,
     }
@@ -259,8 +246,7 @@ mod wrapper {
     pub struct FragmentItem {
         pub name: Identifier,
 
-        pub enabled_in: Option<Version>,
-        pub disabled_in: Option<Version>,
+        pub enabled: Option<VersionSpecifier>,
 
         pub scanner: Scanner,
     }
@@ -299,5 +285,13 @@ mod wrapper {
         Fragment {
             reference: Identifier,
         },
+    }
+
+    #[derive(Debug, Eq, PartialEq, Serialize)]
+    pub enum VersionSpecifier {
+        Never,
+        From { from: Version },
+        Till { till: Version },
+        Range { from: Version, till: Version },
     }
 }

--- a/crates/codegen/language/definition/src/model/types.rs
+++ b/crates/codegen/language/definition/src/model/types.rs
@@ -192,6 +192,7 @@ mod wrapper {
         Optional { parser: Box<TriviaParser> },
 
         Trivia { trivia: Identifier },
+        EndOfInput,
     }
 
     #[derive(Debug, Eq, PartialEq, Serialize)]

--- a/crates/codegen/language/definition/src/utils/versions.rs
+++ b/crates/codegen/language/definition/src/utils/versions.rs
@@ -1,140 +1,66 @@
-use itertools::Itertools;
 use semver::Version;
-use std::{
-    cmp::{max, min},
-    fmt::Display,
-    iter::once,
-};
+use std::{fmt::Display, mem::swap, ops::Range};
 
 const MAX_VERSION: Version = Version::new(u64::MAX, u64::MAX, u64::MAX);
 
 #[derive(Clone, Debug)]
-pub struct VersionRange {
-    pub inclusive_start: Version,
-    pub exclusive_end: Version,
-}
-
-impl VersionRange {
-    pub fn starting_from(inclusive_start: &Version) -> Self {
-        return Self {
-            inclusive_start: inclusive_start.to_owned(),
-            exclusive_end: MAX_VERSION,
-        };
-    }
-
-    pub fn between(inclusive_start: &Version, exclusive_end: &Version) -> Self {
-        if inclusive_start <= exclusive_end {
-            return Self {
-                inclusive_start: inclusive_start.to_owned(),
-                exclusive_end: exclusive_end.to_owned(),
-            };
-        } else {
-            // This is an invalid state, which we still produce errors for.
-            // However, for validation to continue, let's correct the order:
-            return Self {
-                inclusive_start: exclusive_end.to_owned(),
-                exclusive_end: inclusive_start.to_owned(),
-            };
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        return self.inclusive_start == self.exclusive_end;
-    }
-
-    pub fn contains(&self, version: &Version) -> bool {
-        return &self.inclusive_start <= version && version < &self.exclusive_end;
-    }
-}
-
-impl Display for VersionRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.inclusive_start == MAX_VERSION {
-            "MAX".fmt(f)?;
-        } else {
-            self.inclusive_start.fmt(f)?;
-        }
-
-        "..".fmt(f)?;
-
-        if self.exclusive_end == MAX_VERSION {
-            "MAX".fmt(f)?;
-        } else {
-            self.exclusive_end.fmt(f)?;
-        }
-
-        return Ok(());
-    }
-}
-
-#[derive(Debug)]
 pub struct VersionSet {
-    ranges: Vec<VersionRange>,
+    ranges: Vec<Range<Version>>,
 }
 
 impl VersionSet {
-    pub fn empty() -> Self {
+    pub fn new() -> Self {
         return Self { ranges: vec![] };
-    }
-
-    pub fn from_range(range: VersionRange) -> Self {
-        let mut instance = Self::empty();
-
-        instance.add(&range);
-
-        return instance;
-    }
-
-    pub fn from_ranges(ranges: impl IntoIterator<Item = VersionRange>) -> Self {
-        let mut instance = Self::empty();
-
-        for range in ranges.into_iter() {
-            instance.add(&range);
-        }
-
-        return instance;
     }
 
     pub fn is_empty(&self) -> bool {
         return self.ranges.is_empty();
     }
 
-    pub fn add(&mut self, range: &VersionRange) {
-        if range.is_empty() {
-            return;
-        }
+    pub fn add_versions_starting_from(&mut self, from: &Version) {
+        self.add_version_range(from, &MAX_VERSION);
+    }
 
-        let mut result = vec![];
+    pub fn add_version_range(&mut self, from: &Version, till: &Version) {
+        let mut from = from.to_owned();
+        let mut till = till.to_owned();
+        assert_eq!(from < till, true, "Invalid range: '{from}..{till}'");
 
-        // Iterate on both (existing and new) in-order, combining them if they overlap:
-        let mut input_iter = self
-            .ranges
-            .iter()
-            .chain(once(range))
-            .sorted_by_key(|range| &range.inclusive_start);
-
-        let mut current = input_iter.next().unwrap().to_owned();
-
-        for next in input_iter {
-            if current.exclusive_end < next.inclusive_start {
-                // current fully exists before next:
-                result.push(current);
-                current = next.to_owned();
-            } else {
-                // current and next overlap, combine them:
-                current = VersionRange::between(
-                    min(&current.inclusive_start, &next.inclusive_start),
-                    max(&current.exclusive_end, &next.exclusive_end),
-                );
+        self.ranges.retain_mut(|range| {
+            if till < range.start {
+                // 'range' starts later. swap with 'from..till' and keep going:
+                swap(&mut from, &mut range.start);
+                swap(&mut till, &mut range.end);
+                return true;
             }
-        }
 
-        result.push(current);
-        self.ranges = result;
+            if range.end < from {
+                // 'range' ends earlier. keep it:
+                return true;
+            }
+
+            // there is some overlap:
+            //  make sure 'range' is included in 'from..till', then remove it:
+            if range.start < from {
+                from = range.start.to_owned();
+            }
+            if till < range.end {
+                till = range.end.to_owned();
+            }
+            return false;
+        });
+
+        self.ranges.push(from..till);
+    }
+
+    pub fn add_version_set(&mut self, other: &Self) {
+        for range in &other.ranges {
+            self.add_version_range(&range.start, &range.end);
+        }
     }
 
     pub fn difference(&self, other: &Self) -> Self {
-        let mut result = vec![];
+        let mut ranges = vec![];
 
         let mut first_iter = self.ranges.iter().cloned().peekable();
         let mut second_iter = other.ranges.iter().peekable();
@@ -144,13 +70,13 @@ impl VersionSet {
                 break;
             };
 
-            if first.exclusive_end <= second.inclusive_start {
+            if first.end <= second.start {
                 // first fully exists before second: take it, and advance first:
-                result.push(first_iter.next().unwrap());
+                ranges.push(first_iter.next().unwrap());
                 continue;
             }
 
-            if second.exclusive_end <= first.inclusive_start {
+            if second.end <= first.start {
                 // second fully exists before first: advance second:
                 second_iter.next();
                 continue;
@@ -158,31 +84,28 @@ impl VersionSet {
 
             // first and second overlap:
 
-            if first.inclusive_start < second.inclusive_start {
+            if first.start < second.start {
                 // take part of first that exists before second:
-                result.push(VersionRange::between(
-                    &first.inclusive_start,
-                    &second.inclusive_start,
-                ));
+                ranges.push(first.start.to_owned()..second.start.to_owned());
             }
 
-            if first.exclusive_end <= second.exclusive_end {
+            if first.end <= second.end {
                 // first ends before second: advance first, as it's been fully processed:
                 first_iter.next();
                 continue;
             }
 
             // keep part of first that exists after second:
-            first.inclusive_start = second.exclusive_end.to_owned();
+            first.start = second.end.to_owned();
 
             // advance second, as it's been fully processed:
             second_iter.next();
         }
 
         // Take anything remaining in first:
-        result.extend(first_iter);
+        ranges.extend(first_iter);
 
-        return Self { ranges: result };
+        return Self { ranges };
     }
 }
 
@@ -197,7 +120,19 @@ impl Display for VersionSet {
                 " | ".fmt(f)?;
             }
 
-            range.fmt(f)?;
+            if range.start == MAX_VERSION {
+                "MAX".fmt(f)?;
+            } else {
+                range.start.fmt(f)?;
+            }
+
+            "..".fmt(f)?;
+
+            if range.end == MAX_VERSION {
+                "MAX".fmt(f)?;
+            } else {
+                range.end.fmt(f)?;
+            }
         }
 
         return Ok(());
@@ -209,45 +144,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_ranges() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(3, 0, 0)),
-            VersionRange::between(&Version::new(4, 0, 0), &Version::new(5, 0, 0)),
-        ]);
-
-        assert_eq!(set.to_string(), "1.0.0..2.0.0 | 4.0.0..5.0.0");
-    }
-
-    #[test]
     fn connected_ranges_in_order() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(2, 0, 0), &Version::new(3, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-        ]);
+        let mut set = VersionSet::new();
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        set.add_version_range(&Version::new(2, 0, 0), &Version::new(3, 0, 0));
+        set.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
 
         assert_eq!(set.to_string(), "1.0.0..4.0.0");
     }
 
     #[test]
     fn connected_ranges_out_of_order() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-            VersionRange::between(&Version::new(2, 0, 0), &Version::new(3, 0, 0)),
-        ]);
+        let mut set = VersionSet::new();
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        set.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
+        set.add_version_range(&Version::new(2, 0, 0), &Version::new(3, 0, 0));
 
         assert_eq!(set.to_string(), "1.0.0..4.0.0");
     }
 
     #[test]
     fn disconnected_ranges_in_order() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-            VersionRange::between(&Version::new(5, 0, 0), &Version::new(6, 0, 0)),
-        ]);
+        let mut set = VersionSet::new();
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        set.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
+        set.add_version_range(&Version::new(5, 0, 0), &Version::new(6, 0, 0));
 
         assert_eq!(
             set.to_string(),
@@ -257,11 +178,10 @@ mod tests {
 
     #[test]
     fn disconnected_ranges_out_of_order() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(5, 0, 0), &Version::new(6, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-        ]);
+        let mut set = VersionSet::new();
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        set.add_version_range(&Version::new(5, 0, 0), &Version::new(6, 0, 0));
+        set.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
 
         assert_eq!(
             set.to_string(),
@@ -271,42 +191,33 @@ mod tests {
 
     #[test]
     fn overlap_with_multiple() {
-        let set = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-            VersionRange::between(&Version::new(5, 0, 0), &Version::new(6, 0, 0)),
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(5, 0, 0)),
-        ]);
+        let mut set = VersionSet::new();
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        set.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
+        set.add_version_range(&Version::new(5, 0, 0), &Version::new(6, 0, 0));
+        set.add_version_range(&Version::new(1, 0, 0), &Version::new(5, 0, 0));
 
         assert_eq!(set.to_string(), "1.0.0..6.0.0");
     }
 
     #[test]
     fn difference_between_same_sets_is_empty() {
-        let first = VersionSet::from_range(VersionRange::between(
-            &Version::new(1, 0, 0),
-            &Version::new(2, 0, 0),
-        ));
+        let mut first = VersionSet::new();
+        first.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
 
-        let second = VersionSet::from_range(VersionRange::between(
-            &Version::new(1, 0, 0),
-            &Version::new(2, 0, 0),
-        ));
+        let mut second = VersionSet::new();
+        second.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
 
         assert!(first.difference(&second).is_empty());
     }
 
     #[test]
     fn difference_between_connected_sets() {
-        let first = VersionSet::from_range(VersionRange::between(
-            &Version::new(1, 0, 0),
-            &Version::new(5, 0, 0),
-        ));
+        let mut first = VersionSet::new();
+        first.add_version_range(&Version::new(1, 0, 0), &Version::new(5, 0, 0));
 
-        let second = VersionSet::from_range(VersionRange::between(
-            &Version::new(3, 0, 0),
-            &Version::new(8, 0, 0),
-        ));
+        let mut second = VersionSet::new();
+        second.add_version_range(&Version::new(3, 0, 0), &Version::new(8, 0, 0));
 
         assert_eq!(first.difference(&second).to_string(), "1.0.0..3.0.0");
 
@@ -315,15 +226,11 @@ mod tests {
 
     #[test]
     fn difference_between_disconnected_sets() {
-        let first = VersionSet::from_range(VersionRange::between(
-            &Version::new(1, 0, 0),
-            &Version::new(4, 0, 0),
-        ));
+        let mut first = VersionSet::new();
+        first.add_version_range(&Version::new(1, 0, 0), &Version::new(4, 0, 0));
 
-        let second = VersionSet::from_range(VersionRange::between(
-            &Version::new(6, 0, 0),
-            &Version::new(10, 0, 0),
-        ));
+        let mut second = VersionSet::new();
+        second.add_version_range(&Version::new(6, 0, 0), &Version::new(10, 0, 0));
 
         assert_eq!(first.difference(&second).to_string(), "1.0.0..4.0.0");
 
@@ -332,15 +239,11 @@ mod tests {
 
     #[test]
     fn difference_between_contained_sets() {
-        let first = VersionSet::from_range(VersionRange::between(
-            &Version::new(1, 0, 0),
-            &Version::new(8, 0, 0),
-        ));
+        let mut first = VersionSet::new();
+        first.add_version_range(&Version::new(1, 0, 0), &Version::new(8, 0, 0));
 
-        let second = VersionSet::from_range(VersionRange::between(
-            &Version::new(3, 0, 0),
-            &Version::new(5, 0, 0),
-        ));
+        let mut second = VersionSet::new();
+        second.add_version_range(&Version::new(3, 0, 0), &Version::new(5, 0, 0));
 
         assert_eq!(
             first.difference(&second).to_string(),
@@ -352,16 +255,13 @@ mod tests {
 
     #[test]
     fn difference_between_multiple_contained_sets() {
-        let first = VersionSet::from_ranges([
-            VersionRange::between(&Version::new(1, 0, 0), &Version::new(2, 0, 0)),
-            VersionRange::between(&Version::new(3, 0, 0), &Version::new(4, 0, 0)),
-            VersionRange::between(&Version::new(5, 0, 0), &Version::new(6, 0, 0)),
-        ]);
+        let mut first = VersionSet::new();
+        first.add_version_range(&Version::new(1, 0, 0), &Version::new(2, 0, 0));
+        first.add_version_range(&Version::new(3, 0, 0), &Version::new(4, 0, 0));
+        first.add_version_range(&Version::new(5, 0, 0), &Version::new(6, 0, 0));
 
-        let second = VersionSet::from_range(VersionRange::between(
-            &Version::new(0, 0, 0),
-            &Version::new(7, 0, 0),
-        ));
+        let mut second = VersionSet::new();
+        second.add_version_range(&Version::new(0, 0, 0), &Version::new(7, 0, 0));
 
         assert!(first.difference(&second).is_empty());
 

--- a/crates/codegen/language/tests/src/fail/definitions/duplicate_expression_name/test.rs
+++ b/crates/codegen/language/tests/src/fail/definitions/duplicate_expression_name/test.rs
@@ -18,7 +18,6 @@ codegen_language_macros::compile!(Language(
                         PrecedenceExpression(name = Expression2, operators = []),
                         PrecedenceExpression(name = Expression1, operators = [])
                     ],
-                    default_primary_expression = Baz,
                     primary_expressions = [PrimaryExpression(expression = Baz)]
                 ),
                 Token(

--- a/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.rs
+++ b/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.rs
@@ -10,14 +10,20 @@ codegen_language_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
-            items = [Enum(
-                name = Bar,
-                variants = [
-                    EnumVariant(name = Variant1, fields = ()),
-                    EnumVariant(name = Variant2, fields = ()),
-                    EnumVariant(name = Variant1, fields = ())
-                ]
-            )]
+            items = [
+                Enum(
+                    name = Bar,
+                    variants = [
+                        EnumVariant(name = Variant1, reference = Baz),
+                        EnumVariant(name = Variant2, reference = Baz),
+                        EnumVariant(name = Variant1, reference = Baz)
+                    ]
+                ),
+                Token(
+                    name = Baz,
+                    definitions = [TokenDefinition(scanner = Atom("baz"))]
+                )
+            ]
         )]
     )]
 ));

--- a/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.rs
+++ b/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.rs
@@ -12,7 +12,6 @@ codegen_language_macros::compile!(Language(
             title = "Topic One",
             items = [Enum(
                 name = Bar,
-                default_variant = Variant1,
                 variants = [
                     EnumVariant(name = Variant1, fields = ()),
                     EnumVariant(name = Variant2, fields = ()),

--- a/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.stderr
+++ b/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.stderr
@@ -1,5 +1,5 @@
 error: A variant with the name 'Variant1' already exists.
-  --> src/fail/definitions/duplicate_variant_name/test.rs:18:40
+  --> src/fail/definitions/duplicate_variant_name/test.rs:19:44
    |
-18 |                     EnumVariant(name = Variant1, fields = ())
-   |                                        ^^^^^^^^
+19 |                         EnumVariant(name = Variant1, reference = Baz)
+   |                                            ^^^^^^^^

--- a/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.stderr
+++ b/crates/codegen/language/tests/src/fail/definitions/duplicate_variant_name/test.stderr
@@ -1,5 +1,5 @@
 error: A variant with the name 'Variant1' already exists.
-  --> src/fail/definitions/duplicate_variant_name/test.rs:19:40
+  --> src/fail/definitions/duplicate_variant_name/test.rs:18:40
    |
-19 |                     EnumVariant(name = Variant1, fields = ())
+18 |                     EnumVariant(name = Variant1, fields = ())
    |                                        ^^^^^^^^

--- a/crates/codegen/language/tests/src/fail/reachability/unused_version/test.rs
+++ b/crates/codegen/language/tests/src/fail/reachability/unused_version/test.rs
@@ -13,7 +13,7 @@ codegen_language_macros::compile!(Language(
             items = [
                 Struct(
                     name = Bar,
-                    fields = (field_1 = Optional(kind = Terminal([Baz]), enabled_in = "2.0.0"))
+                    fields = (field_1 = Optional(kind = Terminal([Baz]), enabled = From("2.0.0")))
                 ),
                 Token(
                     name = Baz,

--- a/crates/codegen/language/tests/src/fail/references/disabled_too_late/test.rs
+++ b/crates/codegen/language/tests/src/fail/references/disabled_too_late/test.rs
@@ -16,17 +16,16 @@ codegen_language_macros::compile!(Language(
                     fields = (
                         field_1 = Optional(
                             kind = NonTerminal(Two),
-                            enabled_in = "2.0.0",
-                            disabled_in = "3.0.0"
+                            enabled = Range(from = "2.0.0", till = "3.0.0")
                         ),
                         field_2 = Optional(kind = Terminal([Three]))
                     )
                 ),
                 Struct(
                     name = Two,
-                    enabled_in = "2.0.0",
-                    disabled_in = "3.0.0",
-                    fields = (field_1 = Optional(kind = Terminal([Three]), disabled_in = "4.0.0"))
+                    enabled = Range(from = "2.0.0", till = "3.0.0"),
+                    fields =
+                        (field_1 = Optional(kind = Terminal([Three]), enabled = Till("4.0.0")))
                 ),
                 Token(
                     name = Three,

--- a/crates/codegen/language/tests/src/fail/references/disabled_too_late/test.stderr
+++ b/crates/codegen/language/tests/src/fail/references/disabled_too_late/test.stderr
@@ -1,5 +1,5 @@
-error: Parent scope is disabled in '3.0.0'.
-  --> src/fail/references/disabled_too_late/test.rs:29:90
+error: Parent scope is only enabled in '2.0.0..3.0.0'.
+  --> src/fail/references/disabled_too_late/test.rs:28:81
    |
-29 |                     fields = (field_1 = Optional(kind = Terminal([Three]), disabled_in = "4.0.0"))
-   |                                                                                          ^^^^^^^
+28 |                         (field_1 = Optional(kind = Terminal([Three]), enabled = Till("4.0.0")))
+   |                                                                                 ^^^^

--- a/crates/codegen/language/tests/src/fail/references/enabled_too_early/test.rs
+++ b/crates/codegen/language/tests/src/fail/references/enabled_too_early/test.rs
@@ -16,17 +16,16 @@ codegen_language_macros::compile!(Language(
                     fields = (
                         field_1 = Optional(
                             kind = NonTerminal(Two),
-                            enabled_in = "2.0.0",
-                            disabled_in = "3.0.0"
+                            enabled = Range(from = "2.0.0", till = "3.0.0")
                         ),
                         field_2 = Optional(kind = Terminal([Three]))
                     )
                 ),
                 Struct(
                     name = Two,
-                    enabled_in = "2.0.0",
-                    disabled_in = "3.0.0",
-                    fields = (field_1 = Optional(kind = Terminal([Three]), enabled_in = "1.0.0"))
+                    enabled = Range(from = "2.0.0", till = "3.0.0"),
+                    fields =
+                        (field_1 = Optional(kind = Terminal([Three]), enabled = From("1.0.0")))
                 ),
                 Token(
                     name = Three,

--- a/crates/codegen/language/tests/src/fail/references/enabled_too_early/test.stderr
+++ b/crates/codegen/language/tests/src/fail/references/enabled_too_early/test.stderr
@@ -1,5 +1,5 @@
-error: Parent scope is enabled in '2.0.0'.
-  --> src/fail/references/enabled_too_early/test.rs:29:89
+error: Parent scope is only enabled in '2.0.0..3.0.0'.
+  --> src/fail/references/enabled_too_early/test.rs:28:81
    |
-29 |                     fields = (field_1 = Optional(kind = Terminal([Three]), enabled_in = "1.0.0"))
-   |                                                                                         ^^^^^^^
+28 |                         (field_1 = Optional(kind = Terminal([Three]), enabled = From("1.0.0")))
+   |                                                                                 ^^^^

--- a/crates/codegen/language/tests/src/fail/references/invalid_version/test.rs
+++ b/crates/codegen/language/tests/src/fail/references/invalid_version/test.rs
@@ -17,12 +17,12 @@ codegen_language_macros::compile!(Language(
                         field_1 = Optional(
                             // should have been disabled in "3.0.0"
                             kind = Terminal([Baz]),
-                            enabled_in = "2.0.0"
+                            enabled = From("2.0.0")
                         ),
                         field_2 = Optional(
                             // should have been enabled in "2.0.0"
                             kind = Terminal([Baz]),
-                            disabled_in = "3.0.0"
+                            enabled = Till("3.0.0")
                         ),
                         field_3 = Optional(
                             // should have been enabled in "2.0.0" and disabled in "3.0.0"
@@ -31,16 +31,14 @@ codegen_language_macros::compile!(Language(
                         field_4 = Optional(
                             // correct
                             kind = Terminal([Baz]),
-                            enabled_in = "2.0.0",
-                            disabled_in = "3.0.0"
+                            enabled = Range(from = "2.0.0", till = "3.0.0")
                         )
                     )
                 ),
                 Token(
                     name = Baz,
                     definitions = [TokenDefinition(
-                        enabled_in = "2.0.0",
-                        disabled_in = "3.0.0",
+                        enabled = Range(from = "2.0.0", till = "3.0.0"),
                         scanner = Atom("baz")
                     )]
                 )

--- a/crates/codegen/language/tests/src/fail/references/invalid_version/test.stderr
+++ b/crates/codegen/language/tests/src/fail/references/invalid_version/test.stderr
@@ -1,16 +1,16 @@
-error: Reference 'Baz' is not defined in versions '3.0.0..MAX'.
+error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '3.0.0..MAX'.
   --> src/fail/references/invalid_version/test.rs:19:46
    |
 19 | ...                   kind = Terminal([Baz]),
    |                                        ^^^
 
-error: Reference 'Baz' is not defined in versions '1.0.0..2.0.0'.
+error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '1.0.0..2.0.0'.
   --> src/fail/references/invalid_version/test.rs:24:46
    |
 24 | ...                   kind = Terminal([Baz]),
    |                                        ^^^
 
-error: Reference 'Baz' is not defined in versions '1.0.0..2.0.0 | 3.0.0..MAX'.
+error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '1.0.0..2.0.0 | 3.0.0..MAX'.
   --> src/fail/references/invalid_version/test.rs:29:46
    |
 29 | ...                   kind = Terminal([Baz])

--- a/crates/codegen/language/tests/src/fail/references/unordered_version_pair/test.rs
+++ b/crates/codegen/language/tests/src/fail/references/unordered_version_pair/test.rs
@@ -16,8 +16,7 @@ codegen_language_macros::compile!(Language(
                     fields = (
                         field_1 = Optional(
                             kind = Terminal([Two]),
-                            enabled_in = "3.0.0",
-                            disabled_in = "2.0.0"
+                            enabled = Range(from = "3.0.0", till = "2.0.0")
                         ),
                         field_2 = Optional(kind = Terminal([Two]))
                     )

--- a/crates/codegen/language/tests/src/fail/references/unordered_version_pair/test.stderr
+++ b/crates/codegen/language/tests/src/fail/references/unordered_version_pair/test.stderr
@@ -1,5 +1,5 @@
 error: Version '3.0.0' must be less than corresponding version '2.0.0'.
-  --> src/fail/references/unordered_version_pair/test.rs:19:42
+  --> src/fail/references/unordered_version_pair/test.rs:19:52
    |
-19 | ...                   enabled_in = "3.0.0",
-   |                                    ^^^^^^^
+19 | ...                   enabled = Range(from = "3.0.0", till = "2.0.0")
+   |                                              ^^^^^^^

--- a/crates/codegen/language/tests/src/fail/references/version_not_found/test.rs
+++ b/crates/codegen/language/tests/src/fail/references/version_not_found/test.rs
@@ -14,7 +14,7 @@ codegen_language_macros::compile!(Language(
                 Struct(
                     name = One,
                     fields = (
-                        field_1 = Optional(kind = Terminal([Two]), enabled_in = "3.0.0"),
+                        field_1 = Optional(kind = Terminal([Two]), enabled = From("3.0.0")),
                         field_2 = Optional(kind = Terminal([Two]))
                     )
                 ),

--- a/crates/codegen/language/tests/src/fail/references/version_not_found/test.stderr
+++ b/crates/codegen/language/tests/src/fail/references/version_not_found/test.stderr
@@ -1,5 +1,5 @@
 error: Version '3.0.0' does not exist in the language definition.
-  --> src/fail/references/version_not_found/test.rs:17:81
+  --> src/fail/references/version_not_found/test.rs:17:83
    |
-17 |                         field_1 = Optional(kind = Terminal([Two]), enabled_in = "3.0.0"),
-   |                                                                                 ^^^^^^^
+17 |                         field_1 = Optional(kind = Terminal([Two]), enabled = From("3.0.0")),
+   |                                                                                   ^^^^^^^

--- a/crates/codegen/language/tests/src/pass/tiny_language.rs
+++ b/crates/codegen/language/tests/src/pass/tiny_language.rs
@@ -61,8 +61,7 @@ fn definition() {
                         Item::Struct {
                             item: StructItem {
                                 name: "Foo".into(),
-                                enabled_in: None,
-                                disabled_in: None,
+                                enabled: None,
                                 error_recovery: None,
                                 fields: [
                                     (
@@ -101,8 +100,7 @@ fn definition() {
                             item: TokenItem {
                                 name: "Bar".into(),
                                 definitions: [TokenDefinition {
-                                    enabled_in: None,
-                                    disabled_in: None,
+                                    enabled: None,
                                     scanner: Scanner::Atom { atom: "bar".into() }
                                 }]
                                 .into()
@@ -113,8 +111,7 @@ fn definition() {
                             item: TokenItem {
                                 name: "Baz".into(),
                                 definitions: [TokenDefinition {
-                                    enabled_in: None,
-                                    disabled_in: None,
+                                    enabled: None,
                                     scanner: Scanner::Atom { atom: "baz".into() }
                                 }]
                                 .into()

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -10,9 +10,16 @@ codegen_language_macros::compile!(Language(
         Trivia(MultilineComment)
     ])),
     trailing_trivia = Sequence([
-        Optional(Trivia(Whitespace)),
-        Optional(Trivia(SingleLineComment)),
-        Optional(Trivia(EndOfLine))
+        ZeroOrMore(Choice([
+            Trivia(Whitespace),
+            Trivia(SingleLineComment),
+            Trivia(MultilineComment)
+        ])),
+        Choice([
+            Trivia(EndOfLine),
+            EndOfInput
+
+        ])
     ]),
     versions = [
         "0.4.11", "0.4.12", "0.4.13", "0.4.14", "0.4.15", "0.4.16", "0.4.17", "0.4.18", "0.4.19",

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -69,40 +69,40 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Struct,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (definition = Required(NonTerminal(StructDefinition)))
                                 ),
                                 EnumVariant(
                                     name = Enum,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (definition = Required(NonTerminal(EnumDefinition)))
                                 ),
                                 EnumVariant(
                                     name = Function,
-                                    enabled_in = "0.7.1",
+                                    enabled = From("0.7.1"),
                                     fields =
                                         (definition = Required(NonTerminal(FunctionDefinition)))
                                 ),
                                 EnumVariant(
                                     name = Constant,
-                                    enabled_in = "0.7.4",
+                                    enabled = From("0.7.4"),
                                     fields =
                                         (definition = Required(NonTerminal(ConstantDefinition)))
                                 ),
                                 EnumVariant(
                                     name = Error,
-                                    enabled_in = "0.8.4",
+                                    enabled = From("0.8.4"),
                                     fields = (definition = Required(NonTerminal(ErrorDefinition)))
                                 ),
                                 EnumVariant(
                                     name = UserDefinedValueType,
-                                    enabled_in = "0.8.8",
+                                    enabled = From("0.8.8"),
                                     fields = (definition =
                                         Required(NonTerminal(UserDefinedValueTypeDefinition)))
                                 ),
                                 EnumVariant(
                                     name = Using,
-                                    enabled_in = "0.8.13",
+                                    enabled = From("0.8.13"),
                                     fields = (directive = Required(NonTerminal(UsingDirective)))
                                 )
                             ]
@@ -294,7 +294,7 @@ codegen_language_macros::compile!(Language(
                                 target = Required(NonTerminal(UsingTarget)),
                                 global_keyword = Optional(
                                     kind = Terminal([GlobalKeyword]),
-                                    enabled_in = "0.8.13"
+                                    enabled = From("0.8.13")
                                 ),
                                 semicolon = Required(Terminal([Semicolon]))
                             )
@@ -309,7 +309,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Deconstruction,
-                                    enabled_in = "0.8.13",
+                                    enabled = From("0.8.13"),
                                     error_recovery = FieldsErrorRecovery(
                                         delimiters =
                                             FieldDelimiters(open = open_brace, close = close_brace)
@@ -326,21 +326,23 @@ codegen_language_macros::compile!(Language(
                             name = UsingDeconstructionFields,
                             separated = UsingDeconstructionField,
                             separator = Comma,
-                            enabled_in = "0.8.13",
+                            enabled = From("0.8.13"),
                             allow_empty = true
                         ),
                         Struct(
                             name = UsingDeconstructionField,
-                            enabled_in = "0.8.13",
+                            enabled = From("0.8.13"),
                             fields = (
                                 name = Required(NonTerminal(IdentifierPath)),
-                                alias =
-                                    Optional(kind = NonTerminal(UsingAlias), enabled_in = "0.8.19")
+                                alias = Optional(
+                                    kind = NonTerminal(UsingAlias),
+                                    enabled = From("0.8.19")
+                                )
                             )
                         ),
                         Struct(
                             name = UsingAlias,
-                            enabled_in = "0.8.19",
+                            enabled = From("0.8.19"),
                             fields = (
                                 as_keyword = Required(Terminal([AsKeyword])),
                                 operator = Required(Terminal([
@@ -418,7 +420,7 @@ codegen_language_macros::compile!(Language(
                             name = AbicoderKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                unreserved_in = "0.4.11",
+                                reserved = Never,
                                 value = Atom("abicoder")
                             )]
                         ),
@@ -426,7 +428,7 @@ codegen_language_macros::compile!(Language(
                             name = AbstractKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.0",
+                                enabled = From("0.6.0"),
                                 value = Atom("abstract")
                             )]
                         ),
@@ -438,17 +440,15 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = AfterKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("after")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("after"))]
                         ),
                         Keyword(
                             name = AliasKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("alias")
                             )]
                         ),
@@ -461,8 +461,8 @@ codegen_language_macros::compile!(Language(
                             name = ApplyKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("apply")
                             )]
                         ),
@@ -480,8 +480,8 @@ codegen_language_macros::compile!(Language(
                             name = AutoKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("auto")
                             )]
                         ),
@@ -499,7 +499,7 @@ codegen_language_macros::compile!(Language(
                             name = ByteKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.8.0",
+                                enabled = Till("0.8.0"),
                                 value = Atom("byte")
                             )]
                         ),
@@ -550,24 +550,22 @@ codegen_language_macros::compile!(Language(
                             name = CallDataKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.5.0",
-                                reserved_in = "0.5.0",
+                                enabled = From("0.5.0"),
+                                reserved = From("0.5.0"),
                                 value = Atom("calldata")
                             )]
                         ),
                         Keyword(
                             name = CaseKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("case")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("case"))]
                         ),
                         Keyword(
                             name = CatchKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.0",
+                                enabled = From("0.6.0"),
                                 value = Atom("catch")
                             )]
                         ),
@@ -580,8 +578,8 @@ codegen_language_macros::compile!(Language(
                             name = ConstructorKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.4.22",
-                                reserved_in = "0.5.0",
+                                enabled = From("0.4.22"),
+                                reserved = From("0.5.0"),
                                 value = Atom("constructor")
                             )]
                         ),
@@ -599,8 +597,8 @@ codegen_language_macros::compile!(Language(
                             name = CopyOfKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("copyof")
                             )]
                         ),
@@ -612,17 +610,15 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = DefaultKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("default")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("default"))]
                         ),
                         Keyword(
                             name = DefineKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("define")
                             )]
                         ),
@@ -645,8 +641,8 @@ codegen_language_macros::compile!(Language(
                             name = EmitKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.4.21",
-                                reserved_in = "0.5.0",
+                                enabled = From("0.4.21"),
+                                reserved = From("0.5.0"),
                                 value = Atom("emit")
                             )]
                         ),
@@ -659,8 +655,8 @@ codegen_language_macros::compile!(Language(
                             name = ErrorKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.8.4",
-                                unreserved_in = "0.4.11",
+                                enabled = From("0.8.4"),
+                                reserved = Never,
                                 value = Atom("error")
                             )]
                         ),
@@ -678,7 +674,7 @@ codegen_language_macros::compile!(Language(
                             name = ExperimentalKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                unreserved_in = "0.4.11",
+                                reserved = Never,
                                 value = Atom("experimental")
                             )]
                         ),
@@ -691,7 +687,7 @@ codegen_language_macros::compile!(Language(
                             name = FallbackKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                reserved_in = "0.6.0",
+                                reserved = From("0.6.0"),
                                 value = Atom("fallback")
                             )]
                         ),
@@ -703,17 +699,15 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = FinalKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("final")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("final"))]
                         ),
                         Keyword(
                             name = FinneyKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.7.0",
-                                unreserved_in = "0.7.0",
+                                enabled = Till("0.7.0"),
+                                reserved = Till("0.7.0"),
                                 value = Atom("finney")
                             )]
                         ),
@@ -817,7 +811,7 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    reserved_in = "0.4.14",
+                                    reserved = From("0.4.14"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -880,7 +874,7 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    reserved_in = "0.4.14",
+                                    reserved = From("0.4.14"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -1003,10 +997,8 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = FromKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                unreserved_in = "0.4.11",
-                                value = Atom("from")
-                            )]
+                            definitions =
+                                [KeywordDefinition(reserved = Never, value = Atom("from"))]
                         ),
                         Keyword(
                             name = FunctionKeyword,
@@ -1017,8 +1009,8 @@ codegen_language_macros::compile!(Language(
                             name = GlobalKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.8.13",
-                                unreserved_in = "0.4.11",
+                                enabled = From("0.8.13"),
+                                reserved = Never,
                                 value = Atom("global")
                             )]
                         ),
@@ -1026,18 +1018,15 @@ codegen_language_macros::compile!(Language(
                             name = GweiKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.11",
-                                reserved_in = "0.7.0",
+                                enabled = From("0.6.11"),
+                                reserved = From("0.7.0"),
                                 value = Atom("gwei")
                             )]
                         ),
                         Keyword(
                             name = HexKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("hex")
-                            )]
+                            definitions = [KeywordDefinition(enabled = Never, value = Atom("hex"))]
                         ),
                         Keyword(
                             name = HoursKeyword,
@@ -1053,8 +1042,8 @@ codegen_language_macros::compile!(Language(
                             name = ImmutableKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.5",
-                                reserved_in = "0.5.0",
+                                enabled = From("0.6.5"),
+                                reserved = From("0.5.0"),
                                 value = Atom("immutable")
                             )]
                         ),
@@ -1062,8 +1051,8 @@ codegen_language_macros::compile!(Language(
                             name = ImplementsKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("implements")
                             )]
                         ),
@@ -1080,18 +1069,13 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = InKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("in")
-                            )]
+                            definitions = [KeywordDefinition(enabled = Never, value = Atom("in"))]
                         ),
                         Keyword(
                             name = InlineKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("inline")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("inline"))]
                         ),
                         Keyword(
                             name = InterfaceKeyword,
@@ -1154,10 +1138,7 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = LetKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("let")
-                            )]
+                            definitions = [KeywordDefinition(enabled = Never, value = Atom("let"))]
                         ),
                         Keyword(
                             name = LibraryKeyword,
@@ -1168,8 +1149,8 @@ codegen_language_macros::compile!(Language(
                             name = MacroKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("macro")
                             )]
                         ),
@@ -1181,10 +1162,8 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = MatchKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("match")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("match"))]
                         ),
                         Keyword(
                             name = MemoryKeyword,
@@ -1205,8 +1184,8 @@ codegen_language_macros::compile!(Language(
                             name = MutableKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("mutable")
                             )]
                         ),
@@ -1218,24 +1197,19 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = NullKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("null")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("null"))]
                         ),
                         Keyword(
                             name = OfKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("of")
-                            )]
+                            definitions = [KeywordDefinition(enabled = Never, value = Atom("of"))]
                         ),
                         Keyword(
                             name = OverrideKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                reserved_in = "0.5.0",
+                                reserved = From("0.5.0"),
                                 value = Atom("override")
                             )]
                         ),
@@ -1243,8 +1217,8 @@ codegen_language_macros::compile!(Language(
                             name = PartialKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("partial")
                             )]
                         ),
@@ -1267,8 +1241,8 @@ codegen_language_macros::compile!(Language(
                             name = PromiseKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("promise")
                             )]
                         ),
@@ -1286,7 +1260,7 @@ codegen_language_macros::compile!(Language(
                             name = ReceiveKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                reserved_in = "0.6.0",
+                                reserved = From("0.6.0"),
                                 value = Atom("receive")
                             )]
                         ),
@@ -1294,8 +1268,8 @@ codegen_language_macros::compile!(Language(
                             name = ReferenceKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("reference")
                             )]
                         ),
@@ -1303,7 +1277,7 @@ codegen_language_macros::compile!(Language(
                             name = RelocatableKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
+                                enabled = Never,
                                 value = Atom("relocatable")
                             )]
                         ),
@@ -1321,8 +1295,8 @@ codegen_language_macros::compile!(Language(
                             name = RevertKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.8.4",
-                                unreserved_in = "0.4.11",
+                                enabled = From("0.8.4"),
+                                reserved = Never,
                                 value = Atom("revert")
                             )]
                         ),
@@ -1330,8 +1304,8 @@ codegen_language_macros::compile!(Language(
                             name = SealedKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("sealed")
                             )]
                         ),
@@ -1344,8 +1318,8 @@ codegen_language_macros::compile!(Language(
                             name = SizeOfKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("sizeof")
                             )]
                         ),
@@ -1353,17 +1327,15 @@ codegen_language_macros::compile!(Language(
                             name = SolidityKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                unreserved_in = "0.4.11",
+                                reserved = Never,
                                 value = Atom("solidity")
                             )]
                         ),
                         Keyword(
                             name = StaticKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("static")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("static"))]
                         ),
                         Keyword(
                             name = StorageKeyword,
@@ -1384,25 +1356,23 @@ codegen_language_macros::compile!(Language(
                             name = SupportsKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("supports")
                             )]
                         ),
                         Keyword(
                             name = SwitchKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("switch")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("switch"))]
                         ),
                         Keyword(
                             name = SzaboKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.7.0",
-                                unreserved_in = "0.7.0",
+                                enabled = Till("0.7.0"),
+                                reserved = Till("0.7.0"),
                                 value = Atom("szabo")
                             )]
                         ),
@@ -1410,7 +1380,7 @@ codegen_language_macros::compile!(Language(
                             name = ThrowKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.5.0",
+                                enabled = Till("0.5.0"),
                                 value = Atom("throw")
                             )]
                         ),
@@ -1422,15 +1392,17 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = TryKeyword,
                             identifier = Identifier,
-                            definitions =
-                                [KeywordDefinition(enabled_in = "0.6.0", value = Atom("try"))]
+                            definitions = [KeywordDefinition(
+                                enabled = From("0.6.0"),
+                                value = Atom("try")
+                            )]
                         ),
                         Keyword(
                             name = TypeDefKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
+                                enabled = Never,
+                                reserved = From("0.5.0"),
                                 value = Atom("typedef")
                             )]
                         ),
@@ -1438,17 +1410,15 @@ codegen_language_macros::compile!(Language(
                             name = TypeKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.5.3",
+                                enabled = From("0.5.3"),
                                 value = Atom("type")
                             )]
                         ),
                         Keyword(
                             name = TypeOfKeyword,
                             identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("typeof")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("typeof"))]
                         ),
                         Keyword(
                             name = UfixedKeyword,
@@ -1550,7 +1520,7 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    reserved_in = "0.4.14",
+                                    reserved = From("0.4.14"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -1613,7 +1583,7 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    reserved_in = "0.4.14",
+                                    reserved = From("0.4.14"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -1775,8 +1745,8 @@ codegen_language_macros::compile!(Language(
                             name = UncheckedKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.8.0",
-                                reserved_in = "0.5.0",
+                                enabled = From("0.8.0"),
+                                reserved = From("0.5.0"),
                                 value = Atom("unchecked")
                             )]
                         ),
@@ -1789,7 +1759,7 @@ codegen_language_macros::compile!(Language(
                             name = VarKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.5.0",
+                                enabled = Till("0.5.0"),
                                 value = Atom("var")
                             )]
                         ),
@@ -1802,8 +1772,8 @@ codegen_language_macros::compile!(Language(
                             name = VirtualKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.0",
-                                reserved_in = "0.6.0",
+                                enabled = From("0.6.0"),
+                                reserved = From("0.6.0"),
                                 value = Atom("virtual")
                             )]
                         ),
@@ -1826,7 +1796,7 @@ codegen_language_macros::compile!(Language(
                             name = YearsKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.5.0",
+                                enabled = Till("0.5.0"),
                                 value = Atom("years")
                             )]
                         )
@@ -2134,7 +2104,7 @@ codegen_language_macros::compile!(Language(
                             fields = (
                                 abstract_keyword = Optional(
                                     kind = Terminal([AbstractKeyword]),
-                                    enabled_in = "0.6.0"
+                                    enabled = From("0.6.0")
                                 ),
                                 contract_keyword = Required(Terminal([ContractKeyword])),
                                 name = Required(Terminal([Identifier])),
@@ -2183,25 +2153,25 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Constructor,
-                                    enabled_in = "0.4.22",
+                                    enabled = From("0.4.22"),
                                     fields =
                                         (definition = Required(NonTerminal(ConstructorDefinition)))
                                 ),
                                 EnumVariant(
                                     name = ReceiveFunction,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (definition =
                                         Required(NonTerminal(ReceiveFunctionDefinition)))
                                 ),
                                 EnumVariant(
                                     name = FallbackFunction,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (definition =
                                         Required(NonTerminal(FallbackFunctionDefinition)))
                                 ),
                                 EnumVariant(
                                     name = UnnamedFunction,
-                                    disabled_in = "0.6.0",
+                                    enabled = Till("0.6.0"),
                                     fields = (definition =
                                         Required(NonTerminal(UnnamedFunctionDefinition)))
                                 ),
@@ -2229,12 +2199,12 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Error,
-                                    enabled_in = "0.8.4",
+                                    enabled = From("0.8.4"),
                                     fields = (definition = Required(NonTerminal(ErrorDefinition)))
                                 ),
                                 EnumVariant(
                                     name = UserDefinedValueType,
-                                    enabled_in = "0.8.8",
+                                    enabled = From("0.8.8"),
                                     fields = (definition =
                                         Required(NonTerminal(UserDefinedValueTypeDefinition)))
                                 )
@@ -2353,7 +2323,7 @@ codegen_language_macros::compile!(Language(
                     title = "Constants",
                     items = [Struct(
                         name = ConstantDefinition,
-                        enabled_in = "0.7.4",
+                        enabled = From("0.7.4"),
                         error_recovery = FieldsErrorRecovery(terminator = semicolon),
                         fields = (
                             type_name = Required(NonTerminal(TypeName)),
@@ -2417,7 +2387,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Immutable,
-                                    enabled_in = "0.6.5",
+                                    enabled = From("0.6.5"),
                                     fields = (keyword = Required(Terminal([ImmutableKeyword])))
                                 )
                             ]
@@ -2487,7 +2457,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Constant,
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     fields = (keyword = Required(Terminal([ConstantKeyword])))
                                 ),
                                 EnumVariant(
@@ -2520,7 +2490,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Virtual,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (keyword = Required(Terminal([VirtualKeyword])))
                                 )
                             ]
@@ -2566,7 +2536,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = ConstructorDefinition,
-                            enabled_in = "0.4.22",
+                            enabled = From("0.4.22"),
                             fields = (
                                 constructor_keyword = Required(Terminal([ConstructorKeyword])),
                                 parameters = Required(NonTerminal(ParametersDeclaration)),
@@ -2577,12 +2547,12 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = ConstructorAttributes,
                             repeated = ConstructorAttribute,
-                            enabled_in = "0.4.22",
+                            enabled = From("0.4.22"),
                             allow_empty = true
                         ),
                         Enum(
                             name = ConstructorAttribute,
-                            enabled_in = "0.4.22",
+                            enabled = From("0.4.22"),
                             default_variant = Public,
                             variants = [
                                 EnumVariant(
@@ -2605,7 +2575,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = UnnamedFunctionDefinition,
-                            disabled_in = "0.6.0",
+                            enabled = Till("0.6.0"),
                             fields = (
                                 function_keyword = Required(Terminal([FunctionKeyword])),
                                 parameters = Required(NonTerminal(ParametersDeclaration)),
@@ -2616,12 +2586,12 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = UnnamedFunctionAttributes,
                             repeated = UnnamedFunctionAttribute,
-                            disabled_in = "0.6.0",
+                            enabled = Till("0.6.0"),
                             allow_empty = true
                         ),
                         Enum(
                             name = UnnamedFunctionAttribute,
-                            disabled_in = "0.6.0",
+                            enabled = Till("0.6.0"),
                             default_variant = View,
                             variants = [
                                 EnumVariant(
@@ -2652,7 +2622,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = FallbackFunctionDefinition,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (
                                 fallback_keyword = Required(Terminal([FallbackKeyword])),
                                 parameters = Required(NonTerminal(ParametersDeclaration)),
@@ -2664,12 +2634,12 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = FallbackFunctionAttributes,
                             repeated = FallbackFunctionAttribute,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             allow_empty = true
                         ),
                         Enum(
                             name = FallbackFunctionAttribute,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             default_variant = View,
                             variants = [
                                 EnumVariant(
@@ -2704,7 +2674,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = ReceiveFunctionDefinition,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (
                                 receive_keyword = Required(Terminal([ReceiveKeyword])),
                                 parameters = Required(NonTerminal(ParametersDeclaration)),
@@ -2715,12 +2685,12 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = ReceiveFunctionAttributes,
                             repeated = ReceiveFunctionAttribute,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             allow_empty = true
                         ),
                         Enum(
                             name = ReceiveFunctionAttribute,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             default_variant = Virtual,
                             variants = [
                                 EnumVariant(
@@ -2775,7 +2745,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Virtual,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (keyword = Required(Terminal([VirtualKeyword])))
                                 )
                             ]
@@ -2836,7 +2806,7 @@ codegen_language_macros::compile!(Language(
                     title = "User Defined Value Types",
                     items = [Struct(
                         name = UserDefinedValueTypeDefinition,
-                        enabled_in = "0.8.8",
+                        enabled = From("0.8.8"),
                         error_recovery = FieldsErrorRecovery(terminator = semicolon),
                         fields = (
                             type_keyword = Required(Terminal([TypeKeyword])),
@@ -2852,7 +2822,7 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Struct(
                             name = ErrorDefinition,
-                            enabled_in = "0.8.4",
+                            enabled = From("0.8.4"),
                             error_recovery = FieldsErrorRecovery(terminator = semicolon),
                             fields = (
                                 error_keyword = Required(Terminal([ErrorKeyword])),
@@ -2863,7 +2833,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = ErrorParametersDeclaration,
-                            enabled_in = "0.8.4",
+                            enabled = From("0.8.4"),
                             error_recovery = FieldsErrorRecovery(
                                 delimiters =
                                     FieldDelimiters(open = open_paren, close = close_paren)
@@ -2878,12 +2848,12 @@ codegen_language_macros::compile!(Language(
                             name = ErrorParameters,
                             separated = ErrorParameter,
                             separator = Comma,
-                            enabled_in = "0.8.4",
+                            enabled = From("0.8.4"),
                             allow_empty = true
                         ),
                         Struct(
                             name = ErrorParameter,
-                            enabled_in = "0.8.4",
+                            enabled = From("0.8.4"),
                             fields = (
                                 type_name = Required(NonTerminal(TypeName)),
                                 name = Optional(kind = Terminal([Identifier]))
@@ -2993,8 +2963,10 @@ codegen_language_macros::compile!(Language(
                             name = MappingKey,
                             fields = (
                                 key_type = Required(NonTerminal(MappingKeyType)),
-                                name =
-                                    Optional(kind = Terminal([Identifier]), enabled_in = "0.8.18")
+                                name = Optional(
+                                    kind = Terminal([Identifier]),
+                                    enabled = From("0.8.18")
+                                )
                             )
                         ),
                         Enum(
@@ -3015,8 +2987,10 @@ codegen_language_macros::compile!(Language(
                             name = MappingValue,
                             fields = (
                                 type_name = Required(NonTerminal(TypeName)),
-                                name =
-                                    Optional(kind = Terminal([Identifier]), enabled_in = "0.8.18")
+                                name = Optional(
+                                    kind = Terminal([Identifier]),
+                                    enabled = From("0.8.18")
+                                )
                             )
                         )
                     ]
@@ -3034,7 +3008,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Byte,
-                                    disabled_in = "0.8.0",
+                                    enabled = Till("0.8.0"),
                                     fields = (type_name = Required(Terminal([ByteKeyword])))
                                 ),
                                 EnumVariant(
@@ -3157,22 +3131,22 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Throw,
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     fields = (statement = Required(NonTerminal(ThrowStatement)))
                                 ),
                                 EnumVariant(
                                     name = Emit,
-                                    enabled_in = "0.4.21",
+                                    enabled = From("0.4.21"),
                                     fields = (statement = Required(NonTerminal(EmitStatement)))
                                 ),
                                 EnumVariant(
                                     name = Try,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (statement = Required(NonTerminal(TryStatement)))
                                 ),
                                 EnumVariant(
                                     name = Revert,
-                                    enabled_in = "0.8.4",
+                                    enabled = From("0.8.4"),
                                     fields = (statement = Required(NonTerminal(RevertStatement)))
                                 ),
                                 EnumVariant(
@@ -3185,7 +3159,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = UncheckedBlock,
-                                    enabled_in = "0.8.0",
+                                    enabled = From("0.8.0"),
                                     fields = (block = Required(NonTerminal(UncheckedBlock)))
                                 ),
                                 EnumVariant(
@@ -3197,7 +3171,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = UncheckedBlock,
-                            enabled_in = "0.8.0",
+                            enabled = From("0.8.0"),
                             fields = (
                                 unchecked_keyword = Required(Terminal([UncheckedKeyword])),
                                 block = Required(NonTerminal(Block))
@@ -3286,7 +3260,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Untyped,
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     fields = (type_name = Required(Terminal([VarKeyword])))
                                 )
                             ]
@@ -3312,7 +3286,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = CallData,
-                                    enabled_in = "0.5.0",
+                                    enabled = From("0.5.0"),
                                     fields = (keyword = Required(Terminal([CallDataKeyword])))
                                 )
                             ]
@@ -3458,7 +3432,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = EmitStatement,
-                            enabled_in = "0.4.21",
+                            enabled = From("0.4.21"),
                             error_recovery = FieldsErrorRecovery(terminator = semicolon),
                             fields = (
                                 emit_keyword = Required(Terminal([EmitKeyword])),
@@ -3483,7 +3457,7 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Struct(
                             name = TryStatement,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (
                                 try_keyword = Required(Terminal([TryKeyword])),
                                 expression = Required(NonTerminal(Expression)),
@@ -3495,11 +3469,11 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = CatchClauses,
                             repeated = CatchClause,
-                            enabled_in = "0.6.0"
+                            enabled = From("0.6.0")
                         ),
                         Struct(
                             name = CatchClause,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (
                                 catch_keyword = Required(Terminal([CatchKeyword])),
                                 error = Optional(kind = NonTerminal(CatchClauseError)),
@@ -3508,7 +3482,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = CatchClauseError,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (
                                 name = Optional(kind = Terminal([Identifier])),
                                 parameters = Required(NonTerminal(ParametersDeclaration))
@@ -3516,7 +3490,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = RevertStatement,
-                            enabled_in = "0.8.4",
+                            enabled = From("0.8.4"),
                             error_recovery = FieldsErrorRecovery(terminator = semicolon),
                             fields = (
                                 revert_keyword = Required(Terminal([RevertKeyword])),
@@ -3527,7 +3501,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = ThrowStatement,
-                            disabled_in = "0.5.0",
+                            enabled = Till("0.5.0"),
                             error_recovery = FieldsErrorRecovery(terminator = semicolon),
                             fields = (
                                 throw_keyword = Required(Terminal([ThrowKeyword])),
@@ -3667,14 +3641,14 @@ codegen_language_macros::compile!(Language(
                                         // Before '0.6.0', it was left-associative:
                                         PrecedenceOperator(
                                             model = BinaryLeftAssociative,
-                                            disabled_in = "0.6.0",
+                                            enabled = Till("0.6.0"),
                                             fields =
                                                 (operator = Required(Terminal([AsteriskAsterisk])))
                                         ),
                                         // In '0.6.0', it became right-associative:
                                         PrecedenceOperator(
                                             model = BinaryRightAssociative,
-                                            enabled_in = "0.6.0",
+                                            enabled = From("0.6.0"),
                                             fields =
                                                 (operator = Required(Terminal([AsteriskAsterisk])))
                                         )
@@ -3694,7 +3668,7 @@ codegen_language_macros::compile!(Language(
                                         // Before '0.5.0', 'Plus' was supported:
                                         PrecedenceOperator(
                                             model = Prefix,
-                                            disabled_in = "0.5.0",
+                                            enabled = Till("0.5.0"),
                                             fields = (operator = Required(Terminal([
                                                 PlusPlus, MinusMinus, Tilde, Bang, Minus, Plus
                                             ])))
@@ -3702,7 +3676,7 @@ codegen_language_macros::compile!(Language(
                                         // In '0.5.0', 'Plus' was removed:
                                         PrecedenceOperator(
                                             model = Prefix,
-                                            enabled_in = "0.5.0",
+                                            enabled = From("0.5.0"),
                                             fields = (operator = Required(Terminal([
                                                 PlusPlus, MinusMinus, Tilde, Bang, Minus
                                             ])))
@@ -3755,7 +3729,7 @@ codegen_language_macros::compile!(Language(
                                 PrimaryExpression(expression = TupleExpression),
                                 PrimaryExpression(
                                     expression = TypeExpression,
-                                    enabled_in = "0.5.3"
+                                    enabled = From("0.5.3")
                                 ),
                                 PrimaryExpression(expression = ArrayExpression),
                                 PrimaryExpression(expression = NumberExpression),
@@ -3784,18 +3758,17 @@ codegen_language_macros::compile!(Language(
                             variants = [
                                 EnumVariant(
                                     name = Multiple,
-                                    enabled_in = "0.6.2",
-                                    disabled_in = "0.8.0",
+                                    enabled = Range(from = "0.6.2", till = "0.8.0"),
                                     fields = (options =
                                         Required(NonTerminal(NamedArgumentsDeclarations)))
                                 ),
                                 EnumVariant(
                                     name = Single,
-                                    enabled_in = "0.8.0",
+                                    enabled = From("0.8.0"),
                                     fields = (options =
                                         Optional(kind = NonTerminal(NamedArgumentsDeclaration)))
                                 ),
-                                EnumVariant(name = None, disabled_in = "0.6.2", fields = ())
+                                EnumVariant(name = None, enabled = Till("0.6.2"), fields = ())
                             ]
                         ),
                         Enum(
@@ -3838,8 +3811,7 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = NamedArgumentsDeclarations,
                             repeated = NamedArgumentsDeclaration,
-                            enabled_in = "0.6.2",
-                            disabled_in = "0.8.0",
+                            enabled = Range(from = "0.6.2", till = "0.8.0"),
                             allow_empty = true
                         ),
                         Struct(
@@ -3875,7 +3847,7 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Struct(
                             name = TypeExpression,
-                            enabled_in = "0.5.3",
+                            enabled = From("0.5.3"),
                             error_recovery = FieldsErrorRecovery(
                                 delimiters =
                                     FieldDelimiters(open = open_paren, close = close_paren)
@@ -3947,7 +3919,7 @@ codegen_language_macros::compile!(Language(
                                         literal = Required(Terminal([HexLiteral])),
                                         unit = Optional(
                                             kind = NonTerminal(NumberUnit),
-                                            disabled_in = "0.5.0"
+                                            enabled = Till("0.5.0")
                                         )
                                     )
                                 ),
@@ -3963,8 +3935,8 @@ codegen_language_macros::compile!(Language(
                         Token(
                             name = HexLiteral,
                             definitions = [
+                                // Lowercase "0x" enabled in all versions:
                                 TokenDefinition(
-                                    // Lowercase "0x" enabled in all versions:
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Atom("0x"),
@@ -3977,9 +3949,9 @@ codegen_language_macros::compile!(Language(
                                         not_followed_by = Fragment(IdentifierPart)
                                     )
                                 ),
+                                // Uppercase "0X" only enabled before "0.5.0":
                                 TokenDefinition(
-                                    // Uppercase "0X" only enabled before "0.5.0":
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Atom("0X"),
@@ -3997,8 +3969,8 @@ codegen_language_macros::compile!(Language(
                         Token(
                             name = DecimalLiteral,
                             definitions = [
+                                // An integer (without a dot or a fraction) is enabled in all versions:
                                 TokenDefinition(
-                                    // An integer (without a dot or a fraction) is enabled in all versions:
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Fragment(DecimalDigits),
@@ -4007,9 +3979,9 @@ codegen_language_macros::compile!(Language(
                                         not_followed_by = Fragment(IdentifierPart)
                                     )
                                 ),
+                                // An integer and a dot (without a fraction) is disabled in "0.5.0"
                                 TokenDefinition(
-                                    // An integer and a dot (without a fraction) is disabled in "0.5.0"
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Fragment(DecimalDigits),
@@ -4019,8 +3991,8 @@ codegen_language_macros::compile!(Language(
                                         not_followed_by = Fragment(IdentifierPart)
                                     )
                                 ),
+                                // A dot and a fraction (without an integer) is enabled in all versions:
                                 TokenDefinition(
-                                    // A dot and a fraction (without an integer) is enabled in all versions:
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Atom("."),
@@ -4030,8 +4002,8 @@ codegen_language_macros::compile!(Language(
                                         not_followed_by = Fragment(IdentifierPart)
                                     )
                                 ),
+                                // An integer, a dot, and a fraction is enabled in all versions:
                                 TokenDefinition(
-                                    // An integer, a dot, and a fraction is enabled in all versions:
                                     scanner = TrailingContext(
                                         scanner = Sequence([
                                             Fragment(DecimalDigits),
@@ -4066,32 +4038,32 @@ codegen_language_macros::compile!(Language(
                             name = NumberUnit,
                             default_variant = Seconds,
                             variants = [
+                                // 1e-18 ETH
                                 EnumVariant(
                                     name = Wei,
-                                    // 1e-18 ETH
                                     fields = (keyword = Required(Terminal([WeiKeyword])))
                                 ),
+                                // 1e-9 ETH
                                 EnumVariant(
                                     name = Gwei,
-                                    // 1e-9 ETH
-                                    enabled_in = "0.6.11",
+                                    enabled = From("0.6.11"),
                                     fields = (keyword = Required(Terminal([GweiKeyword])))
                                 ),
+                                // 1e-6 ETH
                                 EnumVariant(
                                     name = Szabo,
-                                    // 1e-6 ETH
-                                    disabled_in = "0.7.0",
+                                    enabled = Till("0.7.0"),
                                     fields = (keyword = Required(Terminal([SzaboKeyword])))
                                 ),
+                                // 1e-3 ETH
                                 EnumVariant(
                                     name = Finney,
-                                    // 1e-3 ETH
-                                    disabled_in = "0.7.0",
+                                    enabled = Till("0.7.0"),
                                     fields = (keyword = Required(Terminal([FinneyKeyword])))
                                 ),
+                                // 1 ETH
                                 EnumVariant(
                                     name = Ether,
-                                    // 1 ETH
                                     fields = (keyword = Required(Terminal([EtherKeyword])))
                                 ),
                                 EnumVariant(
@@ -4116,7 +4088,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Years,
-                                    disabled_in = "0.5.0",
+                                    enabled = Till("0.5.0"),
                                     fields = (keyword = Required(Terminal([YearsKeyword])))
                                 )
                             ]
@@ -4141,7 +4113,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Unicode,
-                                    enabled_in = "0.7.0",
+                                    enabled = From("0.7.0"),
                                     fields =
                                         (literals = Required(NonTerminal(UnicodeStringLiterals)))
                                 )
@@ -4238,12 +4210,12 @@ codegen_language_macros::compile!(Language(
                         Repeated(
                             name = UnicodeStringLiterals,
                             repeated = UnicodeStringLiteral,
-                            enabled_in = "0.7.0"
+                            enabled = From("0.7.0")
                         ),
                         Token(
                             name = UnicodeStringLiteral,
                             definitions = [TokenDefinition(
-                                enabled_in = "0.7.0",
+                                enabled = From("0.7.0"),
                                 scanner = TrailingContext(
                                     scanner = Choice([
                                         Fragment(SingleQuotedUnicodeString),
@@ -4255,7 +4227,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Fragment(
                             name = SingleQuotedUnicodeString,
-                            enabled_in = "0.7.0",
+                            enabled = From("0.7.0"),
                             scanner = Sequence([
                                 Atom("unicode'"),
                                 ZeroOrMore(Choice([
@@ -4267,7 +4239,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Fragment(
                             name = DoubleQuotedUnicodeString,
-                            enabled_in = "0.7.0",
+                            enabled = From("0.7.0"),
                             scanner = Sequence([
                                 Atom("unicode\""),
                                 ZeroOrMore(Choice([
@@ -4449,7 +4421,7 @@ codegen_language_macros::compile!(Language(
                                 ),
                                 EnumVariant(
                                     name = Leave,
-                                    enabled_in = "0.6.0",
+                                    enabled = From("0.6.0"),
                                     fields = (statement = Required(NonTerminal(YulLeaveStatement)))
                                 ),
                                 EnumVariant(
@@ -4540,7 +4512,7 @@ codegen_language_macros::compile!(Language(
                         ),
                         Struct(
                             name = YulLeaveStatement,
-                            enabled_in = "0.6.0",
+                            enabled = From("0.6.0"),
                             fields = (leave_keyword = Required(Terminal([YulLeaveKeyword])))
                         ),
                         Struct(
@@ -4708,25 +4680,23 @@ codegen_language_macros::compile!(Language(
                             name = YulAbstractKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("abstract")
                             )]
                         ),
                         Keyword(
                             name = YulAddressKeyword,
                             identifier = YulIdentifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("address")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("address"))]
                         ),
                         Keyword(
                             name = YulAfterKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("after")
                             )]
                         ),
@@ -4734,9 +4704,8 @@ codegen_language_macros::compile!(Language(
                             name = YulAliasKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("alias")
                             )]
                         ),
@@ -4744,8 +4713,8 @@ codegen_language_macros::compile!(Language(
                             name = YulAnonymousKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("anonymous")
                             )]
                         ),
@@ -4753,9 +4722,8 @@ codegen_language_macros::compile!(Language(
                             name = YulApplyKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("apply")
                             )]
                         ),
@@ -4763,8 +4731,8 @@ codegen_language_macros::compile!(Language(
                             name = YulAsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("as")
                             )]
                         ),
@@ -4772,8 +4740,8 @@ codegen_language_macros::compile!(Language(
                             name = YulAssemblyKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("assembly")
                             )]
                         ),
@@ -4781,9 +4749,8 @@ codegen_language_macros::compile!(Language(
                             name = YulAutoKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("auto")
                             )]
                         ),
@@ -4791,8 +4758,8 @@ codegen_language_macros::compile!(Language(
                             name = YulBoolKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.5.10",
+                                enabled = Never,
+                                reserved = Till("0.5.10"),
                                 value = Atom("bool")
                             )]
                         ),
@@ -4804,17 +4771,15 @@ codegen_language_macros::compile!(Language(
                         Keyword(
                             name = YulByteKeyword,
                             identifier = YulIdentifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("byte")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("byte"))]
                         ),
                         Keyword(
                             name = YulBytesKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Sequence([
                                     Atom("bytes"),
                                     Choice([
@@ -4858,9 +4823,8 @@ codegen_language_macros::compile!(Language(
                             name = YulCallDataKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("calldata")
                             )]
                         ),
@@ -4873,8 +4837,8 @@ codegen_language_macros::compile!(Language(
                             name = YulCatchKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("catch")
                             )]
                         ),
@@ -4882,8 +4846,8 @@ codegen_language_macros::compile!(Language(
                             name = YulConstantKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("constant")
                             )]
                         ),
@@ -4891,9 +4855,8 @@ codegen_language_macros::compile!(Language(
                             name = YulConstructorKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("constructor")
                             )]
                         ),
@@ -4906,8 +4869,8 @@ codegen_language_macros::compile!(Language(
                             name = YulContractKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("contract")
                             )]
                         ),
@@ -4915,9 +4878,8 @@ codegen_language_macros::compile!(Language(
                             name = YulCopyOfKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("copyof")
                             )]
                         ),
@@ -4925,8 +4887,8 @@ codegen_language_macros::compile!(Language(
                             name = YulDaysKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("days")
                             )]
                         ),
@@ -4939,9 +4901,8 @@ codegen_language_macros::compile!(Language(
                             name = YulDefineKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("define")
                             )]
                         ),
@@ -4949,8 +4910,8 @@ codegen_language_macros::compile!(Language(
                             name = YulDeleteKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("delete")
                             )]
                         ),
@@ -4958,8 +4919,8 @@ codegen_language_macros::compile!(Language(
                             name = YulDoKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("do")
                             )]
                         ),
@@ -4967,8 +4928,8 @@ codegen_language_macros::compile!(Language(
                             name = YulElseKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("else")
                             )]
                         ),
@@ -4976,9 +4937,8 @@ codegen_language_macros::compile!(Language(
                             name = YulEmitKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("emit")
                             )]
                         ),
@@ -4986,8 +4946,8 @@ codegen_language_macros::compile!(Language(
                             name = YulEnumKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("enum")
                             )]
                         ),
@@ -4995,8 +4955,8 @@ codegen_language_macros::compile!(Language(
                             name = YulEtherKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("ether")
                             )]
                         ),
@@ -5004,8 +4964,8 @@ codegen_language_macros::compile!(Language(
                             name = YulEventKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("event")
                             )]
                         ),
@@ -5013,8 +4973,8 @@ codegen_language_macros::compile!(Language(
                             name = YulExternalKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("external")
                             )]
                         ),
@@ -5022,9 +4982,8 @@ codegen_language_macros::compile!(Language(
                             name = YulFallbackKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.6.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.6.0", till = "0.7.1"),
                                 value = Atom("fallback")
                             )]
                         ),
@@ -5037,8 +4996,8 @@ codegen_language_macros::compile!(Language(
                             name = YulFinalKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("final")
                             )]
                         ),
@@ -5046,8 +5005,8 @@ codegen_language_macros::compile!(Language(
                             name = YulFinneyKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.0",
+                                enabled = Never,
+                                reserved = Till("0.7.0"),
                                 value = Atom("finney")
                             )]
                         ),
@@ -5056,13 +5015,13 @@ codegen_language_macros::compile!(Language(
                             identifier = YulIdentifier,
                             definitions = [
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Atom("fixed")
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -5105,8 +5064,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -5159,9 +5118,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    reserved_in = "0.4.14",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Range(from = "0.4.14", till = "0.7.1"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -5224,9 +5182,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    reserved_in = "0.4.14",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Range(from = "0.4.14", till = "0.7.1"),
                                     value = Sequence([
                                         Atom("fixed"),
                                         Choice([
@@ -5355,26 +5312,22 @@ codegen_language_macros::compile!(Language(
                             name = YulGweiKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.7.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.7.0", till = "0.7.1"),
                                 value = Atom("gwei")
                             )]
                         ),
                         Keyword(
                             name = YulHexKeyword,
                             identifier = YulIdentifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("hex")
-                            )]
+                            definitions = [KeywordDefinition(enabled = Never, value = Atom("hex"))]
                         ),
                         Keyword(
                             name = YulHoursKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("hours")
                             )]
                         ),
@@ -5387,9 +5340,8 @@ codegen_language_macros::compile!(Language(
                             name = YulImmutableKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("immutable")
                             )]
                         ),
@@ -5397,9 +5349,8 @@ codegen_language_macros::compile!(Language(
                             name = YulImplementsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("implements")
                             )]
                         ),
@@ -5407,8 +5358,8 @@ codegen_language_macros::compile!(Language(
                             name = YulImportKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("import")
                             )]
                         ),
@@ -5416,8 +5367,8 @@ codegen_language_macros::compile!(Language(
                             name = YulIndexedKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("indexed")
                             )]
                         ),
@@ -5425,8 +5376,8 @@ codegen_language_macros::compile!(Language(
                             name = YulInKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.6.8",
+                                enabled = Never,
+                                reserved = Till("0.6.8"),
                                 value = Atom("in")
                             )]
                         ),
@@ -5434,8 +5385,8 @@ codegen_language_macros::compile!(Language(
                             name = YulInlineKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("inline")
                             )]
                         ),
@@ -5443,8 +5394,8 @@ codegen_language_macros::compile!(Language(
                             name = YulInterfaceKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("interface")
                             )]
                         ),
@@ -5452,8 +5403,8 @@ codegen_language_macros::compile!(Language(
                             name = YulInternalKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("internal")
                             )]
                         ),
@@ -5461,8 +5412,8 @@ codegen_language_macros::compile!(Language(
                             name = YulIntKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Sequence([
                                     Atom("int"),
                                     Optional(Choice([
@@ -5506,8 +5457,8 @@ codegen_language_macros::compile!(Language(
                             name = YulIsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("is")
                             )]
                         ),
@@ -5515,8 +5466,8 @@ codegen_language_macros::compile!(Language(
                             name = YulLeaveKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                enabled_in = "0.6.0",
-                                reserved_in = "0.7.1",
+                                enabled = From("0.6.0"),
+                                reserved = From("0.7.1"),
                                 value = Atom("leave")
                             )]
                         ),
@@ -5529,8 +5480,8 @@ codegen_language_macros::compile!(Language(
                             name = YulLibraryKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("library")
                             )]
                         ),
@@ -5538,9 +5489,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMacroKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("macro")
                             )]
                         ),
@@ -5548,8 +5498,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMappingKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("mapping")
                             )]
                         ),
@@ -5557,8 +5507,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMatchKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("match")
                             )]
                         ),
@@ -5566,8 +5516,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMemoryKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("memory")
                             )]
                         ),
@@ -5575,8 +5525,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMinutesKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("minutes")
                             )]
                         ),
@@ -5584,8 +5534,8 @@ codegen_language_macros::compile!(Language(
                             name = YulModifierKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("modifier")
                             )]
                         ),
@@ -5593,9 +5543,8 @@ codegen_language_macros::compile!(Language(
                             name = YulMutableKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("mutable")
                             )]
                         ),
@@ -5603,8 +5552,8 @@ codegen_language_macros::compile!(Language(
                             name = YulNewKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("new")
                             )]
                         ),
@@ -5612,8 +5561,8 @@ codegen_language_macros::compile!(Language(
                             name = YulNullKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("null")
                             )]
                         ),
@@ -5621,8 +5570,8 @@ codegen_language_macros::compile!(Language(
                             name = YulOfKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("of")
                             )]
                         ),
@@ -5630,9 +5579,8 @@ codegen_language_macros::compile!(Language(
                             name = YulOverrideKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("override")
                             )]
                         ),
@@ -5640,9 +5588,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPartialKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("partial")
                             )]
                         ),
@@ -5650,8 +5597,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPayableKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("payable")
                             )]
                         ),
@@ -5659,8 +5606,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPragmaKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("pragma")
                             )]
                         ),
@@ -5668,8 +5615,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPrivateKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("private")
                             )]
                         ),
@@ -5677,9 +5624,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPromiseKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("promise")
                             )]
                         ),
@@ -5687,8 +5633,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPublicKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("public")
                             )]
                         ),
@@ -5696,8 +5642,8 @@ codegen_language_macros::compile!(Language(
                             name = YulPureKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("pure")
                             )]
                         ),
@@ -5705,9 +5651,8 @@ codegen_language_macros::compile!(Language(
                             name = YulReceiveKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.6.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.6.0", till = "0.7.1"),
                                 value = Atom("receive")
                             )]
                         ),
@@ -5715,9 +5660,8 @@ codegen_language_macros::compile!(Language(
                             name = YulReferenceKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("reference")
                             )]
                         ),
@@ -5725,43 +5669,38 @@ codegen_language_macros::compile!(Language(
                             name = YulRelocatableKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("relocatable")
                             )]
                         ),
                         Keyword(
                             name = YulReturnKeyword,
                             identifier = YulIdentifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("return")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("return"))]
                         ),
                         Keyword(
                             name = YulReturnsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("returns")
                             )]
                         ),
                         Keyword(
                             name = YulRevertKeyword,
                             identifier = YulIdentifier,
-                            definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                value = Atom("revert")
-                            )]
+                            definitions =
+                                [KeywordDefinition(enabled = Never, value = Atom("revert"))]
                         ),
                         Keyword(
                             name = YulSealedKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("sealed")
                             )]
                         ),
@@ -5769,8 +5708,8 @@ codegen_language_macros::compile!(Language(
                             name = YulSecondsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("seconds")
                             )]
                         ),
@@ -5778,9 +5717,8 @@ codegen_language_macros::compile!(Language(
                             name = YulSizeOfKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("sizeof")
                             )]
                         ),
@@ -5788,8 +5726,8 @@ codegen_language_macros::compile!(Language(
                             name = YulStaticKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("static")
                             )]
                         ),
@@ -5797,8 +5735,8 @@ codegen_language_macros::compile!(Language(
                             name = YulStorageKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("storage")
                             )]
                         ),
@@ -5806,8 +5744,8 @@ codegen_language_macros::compile!(Language(
                             name = YulStringKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("string")
                             )]
                         ),
@@ -5815,8 +5753,8 @@ codegen_language_macros::compile!(Language(
                             name = YulStructKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("struct")
                             )]
                         ),
@@ -5824,9 +5762,8 @@ codegen_language_macros::compile!(Language(
                             name = YulSupportsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("supports")
                             )]
                         ),
@@ -5839,8 +5776,8 @@ codegen_language_macros::compile!(Language(
                             name = YulSzaboKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.0",
+                                enabled = Never,
+                                reserved = Till("0.7.0"),
                                 value = Atom("szabo")
                             )]
                         ),
@@ -5848,8 +5785,8 @@ codegen_language_macros::compile!(Language(
                             name = YulThrowKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("throw")
                             )]
                         ),
@@ -5862,8 +5799,8 @@ codegen_language_macros::compile!(Language(
                             name = YulTryKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("try")
                             )]
                         ),
@@ -5871,9 +5808,8 @@ codegen_language_macros::compile!(Language(
                             name = YulTypeDefKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("typedef")
                             )]
                         ),
@@ -5881,8 +5817,8 @@ codegen_language_macros::compile!(Language(
                             name = YulTypeKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("type")
                             )]
                         ),
@@ -5890,8 +5826,8 @@ codegen_language_macros::compile!(Language(
                             name = YulTypeOfKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("typeof")
                             )]
                         ),
@@ -5900,13 +5836,13 @@ codegen_language_macros::compile!(Language(
                             identifier = YulIdentifier,
                             definitions = [
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Atom("ufixed")
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -5949,8 +5885,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Till("0.7.1"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -6003,9 +5939,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    reserved_in = "0.4.14",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Range(from = "0.4.14", till = "0.7.1"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -6068,9 +6003,8 @@ codegen_language_macros::compile!(Language(
                                     ])
                                 ),
                                 KeywordDefinition(
-                                    disabled_in = "0.4.11",
-                                    reserved_in = "0.4.14",
-                                    unreserved_in = "0.7.1",
+                                    enabled = Never,
+                                    reserved = Range(from = "0.4.14", till = "0.7.1"),
                                     value = Sequence([
                                         Atom("ufixed"),
                                         Choice([
@@ -6189,8 +6123,8 @@ codegen_language_macros::compile!(Language(
                             name = YulUintKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Sequence([
                                     Atom("uint"),
                                     Optional(Choice([
@@ -6234,9 +6168,8 @@ codegen_language_macros::compile!(Language(
                             name = YulUncheckedKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.5.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.5.0", till = "0.7.1"),
                                 value = Atom("unchecked")
                             )]
                         ),
@@ -6244,8 +6177,8 @@ codegen_language_macros::compile!(Language(
                             name = YulUsingKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("using")
                             )]
                         ),
@@ -6253,8 +6186,8 @@ codegen_language_macros::compile!(Language(
                             name = YulVarKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.6.5",
+                                enabled = Never,
+                                reserved = Till("0.6.5"),
                                 value = Atom("var")
                             )]
                         ),
@@ -6262,8 +6195,8 @@ codegen_language_macros::compile!(Language(
                             name = YulViewKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("view")
                             )]
                         ),
@@ -6271,9 +6204,8 @@ codegen_language_macros::compile!(Language(
                             name = YulVirtualKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                reserved_in = "0.6.0",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Range(from = "0.6.0", till = "0.7.1"),
                                 value = Atom("virtual")
                             )]
                         ),
@@ -6281,8 +6213,8 @@ codegen_language_macros::compile!(Language(
                             name = YulWeeksKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("weeks")
                             )]
                         ),
@@ -6290,8 +6222,8 @@ codegen_language_macros::compile!(Language(
                             name = YulWeiKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("wei")
                             )]
                         ),
@@ -6299,8 +6231,8 @@ codegen_language_macros::compile!(Language(
                             name = YulWhileKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("while")
                             )]
                         ),
@@ -6308,8 +6240,8 @@ codegen_language_macros::compile!(Language(
                             name = YulYearsKeyword,
                             identifier = YulIdentifier,
                             definitions = [KeywordDefinition(
-                                disabled_in = "0.4.11",
-                                unreserved_in = "0.7.1",
+                                enabled = Never,
+                                reserved = Till("0.7.1"),
                                 value = Atom("years")
                             )]
                         )

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -42,7 +42,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = SourceUnitMember,
-                            default_variant = Contract,
                             variants = [
                                 EnumVariant(
                                     name = Pragma,
@@ -124,7 +123,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = Pragma,
-                            default_variant = Version,
                             variants = [
                                 EnumVariant(
                                     name = ABICoder,
@@ -189,7 +187,6 @@ codegen_language_macros::compile!(Language(
                                     )]
                                 )
                             ],
-                            default_primary_expression = VersionPragmaSpecifier,
                             primary_expressions =
                                 [PrimaryExpression(expression = VersionPragmaSpecifier)]
                         ),
@@ -225,7 +222,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ImportSymbol,
-                            default_variant = Path,
                             variants = [
                                 EnumVariant(
                                     name = Path,
@@ -301,7 +297,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = UsingSymbol,
-                            default_variant = Path,
                             variants = [
                                 EnumVariant(
                                     name = Path,
@@ -366,7 +361,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = UsingTarget,
-                            default_variant = Asterisk,
                             variants = [
                                 EnumVariant(
                                     name = TypeName,
@@ -2140,7 +2134,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ContractMember,
-                            default_variant = StateVariable,
                             variants = [
                                 EnumVariant(
                                     name = Using,
@@ -2363,7 +2356,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = StateVariableAttribute,
-                            default_variant = Public,
                             variants = [
                                 EnumVariant(
                                     name = Override,
@@ -2445,7 +2437,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = FunctionAttribute,
-                            default_variant = Public,
                             variants = [
                                 EnumVariant(
                                     name = Modifier,
@@ -2522,7 +2513,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = FunctionBody,
-                            default_variant = Semicolon,
                             variants = [
                                 EnumVariant(
                                     name = Block,
@@ -2553,7 +2543,6 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ConstructorAttribute,
                             enabled = From("0.4.22"),
-                            default_variant = Public,
                             variants = [
                                 EnumVariant(
                                     name = Modifier,
@@ -2592,7 +2581,6 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = UnnamedFunctionAttribute,
                             enabled = Till("0.6.0"),
-                            default_variant = View,
                             variants = [
                                 EnumVariant(
                                     name = Modifier,
@@ -2640,7 +2628,6 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = FallbackFunctionAttribute,
                             enabled = From("0.6.0"),
-                            default_variant = View,
                             variants = [
                                 EnumVariant(
                                     name = Modifier,
@@ -2691,7 +2678,6 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ReceiveFunctionAttribute,
                             enabled = From("0.6.0"),
-                            default_variant = Virtual,
                             variants = [
                                 EnumVariant(
                                     name = Modifier,
@@ -2737,7 +2723,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ModifierAttribute,
-                            default_variant = Virtual,
                             variants = [
                                 EnumVariant(
                                     name = Override,
@@ -2888,7 +2873,6 @@ codegen_language_macros::compile!(Language(
                                     )
                                 )]
                             )],
-                            default_primary_expression = ElementaryType,
                             primary_expressions = [
                                 PrimaryExpression(expression = FunctionType),
                                 PrimaryExpression(expression = MappingType),
@@ -2912,7 +2896,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = FunctionTypeAttribute,
-                            default_variant = Public,
                             variants = [
                                 EnumVariant(
                                     name = Internal,
@@ -2971,7 +2954,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = MappingKeyType,
-                            default_variant = ElementaryType,
                             variants = [
                                 EnumVariant(
                                     name = ElementaryType,
@@ -3000,7 +2982,6 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Enum(
                             name = ElementaryType,
-                            default_variant = Bool,
                             variants = [
                                 EnumVariant(
                                     name = Bool,
@@ -3043,7 +3024,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = AddressType,
-                            default_variant = Address,
                             variants = [
                                 EnumVariant(
                                     name = Address,
@@ -3085,7 +3065,6 @@ codegen_language_macros::compile!(Language(
                         Repeated(name = Statements, repeated = Statement, allow_empty = true),
                         Enum(
                             name = Statement,
-                            default_variant = Block,
                             variants = [
                                 EnumVariant(
                                     name = TupleDeconstruction,
@@ -3218,7 +3197,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = TupleMember,
-                            default_variant = Typed,
                             variants = [
                                 EnumVariant(
                                     name = Typed,
@@ -3252,7 +3230,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = VariableDeclarationType,
-                            default_variant = Typed,
                             variants = [
                                 EnumVariant(
                                     name = Typed,
@@ -3274,7 +3251,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = StorageLocation,
-                            default_variant = Memory,
                             variants = [
                                 EnumVariant(
                                     name = Memory,
@@ -3336,7 +3312,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ForStatementInitialization,
-                            default_variant = Semicolon,
                             variants = [
                                 EnumVariant(
                                     name = Expression,
@@ -3361,7 +3336,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ForStatementCondition,
-                            default_variant = Semicolon,
                             variants = [
                                 EnumVariant(
                                     name = Expression,
@@ -3723,7 +3697,6 @@ codegen_language_macros::compile!(Language(
                                     )]
                                 )
                             ],
-                            default_primary_expression = Identifier,
                             primary_expressions = [
                                 PrimaryExpression(expression = NewExpression),
                                 PrimaryExpression(expression = TupleExpression),
@@ -3754,7 +3727,6 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Enum(
                             name = FunctionCallOptions,
-                            default_variant = None,
                             variants = [
                                 EnumVariant(
                                     name = Multiple,
@@ -3773,7 +3745,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = ArgumentsDeclaration,
-                            default_variant = Positional,
                             variants = [
                                 EnumVariant(
                                     name = Positional,
@@ -3911,7 +3882,6 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Enum(
                             name = NumberExpression,
-                            default_variant = Decimal,
                             variants = [
                                 EnumVariant(
                                     name = Hex,
@@ -4036,7 +4006,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = NumberUnit,
-                            default_variant = Seconds,
                             variants = [
                                 // 1e-18 ETH
                                 EnumVariant(
@@ -4100,7 +4069,6 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Enum(
                             name = StringExpression,
-                            default_variant = Ascii,
                             variants = [
                                 EnumVariant(
                                     name = Hex,
@@ -4385,7 +4353,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = YulStatement,
-                            default_variant = Block,
                             variants = [
                                 EnumVariant(
                                     name = Block,
@@ -4544,7 +4511,6 @@ codegen_language_macros::compile!(Language(
                         Repeated(name = YulSwitchCases, repeated = YulSwitchCase),
                         Enum(
                             name = YulSwitchCase,
-                            default_variant = Default,
                             variants = [
                                 EnumVariant(
                                     name = Default,
@@ -4586,7 +4552,6 @@ codegen_language_macros::compile!(Language(
                                     )
                                 )]
                             )],
-                            default_primary_expression = YulLiteral,
                             primary_expressions = [
                                 PrimaryExpression(expression = YulLiteral),
                                 PrimaryExpression(expression = YulIdentifierPath)
@@ -4614,7 +4579,6 @@ codegen_language_macros::compile!(Language(
                         ),
                         Enum(
                             name = YulLiteral,
-                            default_variant = Decimal,
                             variants = [
                                 EnumVariant(
                                     name = True,

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -15,11 +15,7 @@ codegen_language_macros::compile!(Language(
             Trivia(SingleLineComment),
             Trivia(MultilineComment)
         ])),
-        Choice([
-            Trivia(EndOfLine),
-            EndOfInput
-
-        ])
+        Choice([Trivia(EndOfLine), EndOfInput])
     ]),
     versions = [
         "0.4.11", "0.4.12", "0.4.13", "0.4.14", "0.4.15", "0.4.16", "0.4.17", "0.4.18", "0.4.19",
@@ -50,66 +46,45 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = SourceUnitMember,
                             variants = [
-                                EnumVariant(
-                                    name = Pragma,
-                                    fields = (directive = Required(NonTerminal(PragmaDirective)))
-                                ),
-                                EnumVariant(
-                                    name = Import,
-                                    fields = (directive = Required(NonTerminal(ImportDirective)))
-                                ),
-                                EnumVariant(
-                                    name = Contract,
-                                    fields =
-                                        (definition = Required(NonTerminal(ContractDefinition)))
-                                ),
-                                EnumVariant(
-                                    name = Interface,
-                                    fields =
-                                        (definition = Required(NonTerminal(InterfaceDefinition)))
-                                ),
-                                EnumVariant(
-                                    name = Library,
-                                    fields =
-                                        (definition = Required(NonTerminal(LibraryDefinition)))
-                                ),
+                                EnumVariant(name = Pragma, reference = PragmaDirective),
+                                EnumVariant(name = Import, reference = ImportDirective),
+                                EnumVariant(name = Contract, reference = ContractDefinition),
+                                EnumVariant(name = Interface, reference = InterfaceDefinition),
+                                EnumVariant(name = Library, reference = LibraryDefinition),
                                 EnumVariant(
                                     name = Struct,
                                     enabled = From("0.6.0"),
-                                    fields = (definition = Required(NonTerminal(StructDefinition)))
+                                    reference = StructDefinition
                                 ),
                                 EnumVariant(
                                     name = Enum,
                                     enabled = From("0.6.0"),
-                                    fields = (definition = Required(NonTerminal(EnumDefinition)))
+                                    reference = EnumDefinition
                                 ),
                                 EnumVariant(
                                     name = Function,
                                     enabled = From("0.7.1"),
-                                    fields =
-                                        (definition = Required(NonTerminal(FunctionDefinition)))
+                                    reference = FunctionDefinition
                                 ),
                                 EnumVariant(
                                     name = Constant,
                                     enabled = From("0.7.4"),
-                                    fields =
-                                        (definition = Required(NonTerminal(ConstantDefinition)))
+                                    reference = ConstantDefinition
                                 ),
                                 EnumVariant(
                                     name = Error,
                                     enabled = From("0.8.4"),
-                                    fields = (definition = Required(NonTerminal(ErrorDefinition)))
+                                    reference = ErrorDefinition
                                 ),
                                 EnumVariant(
                                     name = UserDefinedValueType,
                                     enabled = From("0.8.8"),
-                                    fields = (definition =
-                                        Required(NonTerminal(UserDefinedValueTypeDefinition)))
+                                    reference = UserDefinedValueTypeDefinition
                                 ),
                                 EnumVariant(
                                     name = Using,
                                     enabled = From("0.8.13"),
-                                    fields = (directive = Required(NonTerminal(UsingDirective)))
+                                    reference = UsingDirective
                                 )
                             ]
                         )
@@ -131,31 +106,31 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = Pragma,
                             variants = [
-                                EnumVariant(
-                                    name = ABICoder,
-                                    fields = (
-                                        abicoder_keyword = Required(Terminal([AbicoderKeyword])),
-                                        version = Required(Terminal([Identifier]))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Experimental,
-                                    fields = (
-                                        experimental_keyword =
-                                            Required(Terminal([ExperimentalKeyword])),
-                                        feature =
-                                            Required(Terminal([AsciiStringLiteral, Identifier]))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Version,
-                                    fields = (
-                                        solidity_keyword = Required(Terminal([SolidityKeyword])),
-                                        expressions =
-                                            Required(NonTerminal(VersionPragmaExpressions))
-                                    )
-                                )
+                                EnumVariant(name = ABICoder, reference = ABICoderPragma),
+                                EnumVariant(name = Experimental, reference = ExperimentalPragma),
+                                EnumVariant(name = Version, reference = VersionPragma)
                             ]
+                        ),
+                        Struct(
+                            name = ABICoderPragma,
+                            fields = (
+                                abicoder_keyword = Required(Terminal([AbicoderKeyword])),
+                                version = Required(Terminal([Identifier]))
+                            )
+                        ),
+                        Struct(
+                            name = ExperimentalPragma,
+                            fields = (
+                                experimental_keyword = Required(Terminal([ExperimentalKeyword])),
+                                feature = Required(Terminal([AsciiStringLiteral, Identifier]))
+                            )
+                        ),
+                        Struct(
+                            name = VersionPragma,
+                            fields = (
+                                solidity_keyword = Required(Terminal([SolidityKeyword])),
+                                expressions = Required(NonTerminal(VersionPragmaExpressions))
+                            )
                         ),
                         Repeated(
                             name = VersionPragmaExpressions,
@@ -230,37 +205,43 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ImportSymbol,
                             variants = [
-                                EnumVariant(
-                                    name = Path,
-                                    fields = (
-                                        path = Required(Terminal([AsciiStringLiteral])),
-                                        alias = Optional(kind = NonTerminal(ImportAlias))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Named,
-                                    fields = (
-                                        asterisk = Required(Terminal([Asterisk])),
-                                        alias = Required(NonTerminal(ImportAlias)),
-                                        from_keyword = Required(Terminal([FromKeyword])),
-                                        path = Required(Terminal([AsciiStringLiteral]))
-                                    )
-                                ),
+                                EnumVariant(name = Path, reference = PathImportSymbol),
+                                EnumVariant(name = Named, reference = NamedImportSymbol),
                                 EnumVariant(
                                     name = Deconstruction,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
-                                    fields = (
-                                        open_brace = Required(Terminal([OpenBrace])),
-                                        fields = Required(NonTerminal(ImportDeconstructionFields)),
-                                        close_brace = Required(Terminal([CloseBrace])),
-                                        from_keyword = Required(Terminal([FromKeyword])),
-                                        path = Required(Terminal([AsciiStringLiteral]))
-                                    )
+                                    reference = ImportSymbolDeconstruction
                                 )
                             ]
+                        ),
+                        Struct(
+                            name = PathImportSymbol,
+                            fields = (
+                                path = Required(Terminal([AsciiStringLiteral])),
+                                alias = Optional(kind = NonTerminal(ImportAlias))
+                            )
+                        ),
+                        Struct(
+                            name = NamedImportSymbol,
+                            fields = (
+                                asterisk = Required(Terminal([Asterisk])),
+                                alias = Required(NonTerminal(ImportAlias)),
+                                from_keyword = Required(Terminal([FromKeyword])),
+                                path = Required(Terminal([AsciiStringLiteral]))
+                            )
+                        ),
+                        Struct(
+                            name = ImportSymbolDeconstruction,
+                            error_recovery = FieldsErrorRecovery(
+                                delimiters =
+                                    FieldDelimiters(open = open_brace, close = close_brace)
+                            ),
+                            fields = (
+                                open_brace = Required(Terminal([OpenBrace])),
+                                fields = Required(NonTerminal(ImportDeconstructionFields)),
+                                close_brace = Required(Terminal([CloseBrace])),
+                                from_keyword = Required(Terminal([FromKeyword])),
+                                path = Required(Terminal([AsciiStringLiteral]))
+                            )
                         ),
                         Separated(
                             name = ImportDeconstructionFields,
@@ -305,24 +286,26 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = UsingSymbol,
                             variants = [
-                                EnumVariant(
-                                    name = Path,
-                                    fields = (path = Required(NonTerminal(IdentifierPath)))
-                                ),
+                                EnumVariant(name = Path, reference = IdentifierPath),
                                 EnumVariant(
                                     name = Deconstruction,
                                     enabled = From("0.8.13"),
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
-                                    fields = (
-                                        open_brace = Required(Terminal([OpenBrace])),
-                                        fields = Required(NonTerminal(UsingDeconstructionFields)),
-                                        close_brace = Required(Terminal([CloseBrace]))
-                                    )
+                                    reference = UsingSymbolDeconstruction
                                 )
                             ]
+                        ),
+                        Struct(
+                            name = UsingSymbolDeconstruction,
+                            enabled = From("0.8.13"),
+                            error_recovery = FieldsErrorRecovery(
+                                delimiters =
+                                    FieldDelimiters(open = open_brace, close = close_brace)
+                            ),
+                            fields = (
+                                open_brace = Required(Terminal([OpenBrace])),
+                                fields = Required(NonTerminal(UsingDeconstructionFields)),
+                                close_brace = Required(Terminal([CloseBrace]))
+                            )
                         ),
                         Separated(
                             name = UsingDeconstructionFields,
@@ -369,14 +352,8 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = UsingTarget,
                             variants = [
-                                EnumVariant(
-                                    name = TypeName,
-                                    fields = (type_name = Required(NonTerminal(TypeName)))
-                                ),
-                                EnumVariant(
-                                    name = Asterisk,
-                                    fields = (asterisk = Required(Terminal([Asterisk])))
-                                )
+                                EnumVariant(name = TypeName, reference = TypeName),
+                                EnumVariant(name = Asterisk, reference = Asterisk)
                             ]
                         )
                     ]
@@ -2142,71 +2119,45 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ContractMember,
                             variants = [
-                                EnumVariant(
-                                    name = Using,
-                                    fields = (directive = Required(NonTerminal(UsingDirective)))
-                                ),
-                                EnumVariant(
-                                    name = Function,
-                                    fields =
-                                        (definition = Required(NonTerminal(FunctionDefinition)))
-                                ),
+                                EnumVariant(name = Using, reference = UsingDirective),
+                                EnumVariant(name = Function, reference = FunctionDefinition),
                                 EnumVariant(
                                     name = Constructor,
                                     enabled = From("0.4.22"),
-                                    fields =
-                                        (definition = Required(NonTerminal(ConstructorDefinition)))
+                                    reference = ConstructorDefinition
                                 ),
                                 EnumVariant(
                                     name = ReceiveFunction,
                                     enabled = From("0.6.0"),
-                                    fields = (definition =
-                                        Required(NonTerminal(ReceiveFunctionDefinition)))
+                                    reference = ReceiveFunctionDefinition
                                 ),
                                 EnumVariant(
                                     name = FallbackFunction,
                                     enabled = From("0.6.0"),
-                                    fields = (definition =
-                                        Required(NonTerminal(FallbackFunctionDefinition)))
+                                    reference = FallbackFunctionDefinition
                                 ),
                                 EnumVariant(
                                     name = UnnamedFunction,
                                     enabled = Till("0.6.0"),
-                                    fields = (definition =
-                                        Required(NonTerminal(UnnamedFunctionDefinition)))
+                                    reference = UnnamedFunctionDefinition
                                 ),
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields =
-                                        (definition = Required(NonTerminal(ModifierDefinition)))
-                                ),
-                                EnumVariant(
-                                    name = Struct,
-                                    fields = (definition = Required(NonTerminal(StructDefinition)))
-                                ),
-                                EnumVariant(
-                                    name = Enum,
-                                    fields = (definition = Required(NonTerminal(EnumDefinition)))
-                                ),
-                                EnumVariant(
-                                    name = Event,
-                                    fields = (definition = Required(NonTerminal(EventDefinition)))
-                                ),
+                                EnumVariant(name = Modifier, reference = ModifierDefinition),
+                                EnumVariant(name = Struct, reference = StructDefinition),
+                                EnumVariant(name = Enum, reference = EnumDefinition),
+                                EnumVariant(name = Event, reference = EventDefinition),
                                 EnumVariant(
                                     name = StateVariable,
-                                    fields = (definition =
-                                        Required(NonTerminal(StateVariableDefinition)))
+                                    reference = StateVariableDefinition
                                 ),
                                 EnumVariant(
                                     name = Error,
                                     enabled = From("0.8.4"),
-                                    fields = (definition = Required(NonTerminal(ErrorDefinition)))
+                                    reference = ErrorDefinition
                                 ),
                                 EnumVariant(
                                     name = UserDefinedValueType,
                                     enabled = From("0.8.8"),
-                                    fields = (definition =
-                                        Required(NonTerminal(UserDefinedValueTypeDefinition)))
+                                    reference = UserDefinedValueTypeDefinition
                                 )
                             ]
                         )
@@ -2364,30 +2315,15 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = StateVariableAttribute,
                             variants = [
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
-                                EnumVariant(
-                                    name = Constant,
-                                    fields = (keyword = Required(Terminal([ConstantKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Internal,
-                                    fields = (keyword = Required(Terminal([InternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Private,
-                                    fields = (keyword = Required(Terminal([PrivateKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Public,
-                                    fields = (keyword = Required(Terminal([PublicKeyword])))
-                                ),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
+                                EnumVariant(name = Constant, reference = ConstantKeyword),
+                                EnumVariant(name = Internal, reference = InternalKeyword),
+                                EnumVariant(name = Private, reference = PrivateKeyword),
+                                EnumVariant(name = Public, reference = PublicKeyword),
                                 EnumVariant(
                                     name = Immutable,
                                     enabled = From("0.6.5"),
-                                    fields = (keyword = Required(Terminal([ImmutableKeyword])))
+                                    reference = ImmutableKeyword
                                 )
                             ]
                         )
@@ -2445,51 +2381,24 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = FunctionAttribute,
                             variants = [
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields = (modifier = Required(NonTerminal(ModifierInvocation)))
-                                ),
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
+                                EnumVariant(name = Modifier, reference = ModifierInvocation),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
                                 EnumVariant(
                                     name = Constant,
                                     enabled = Till("0.5.0"),
-                                    fields = (keyword = Required(Terminal([ConstantKeyword])))
+                                    reference = ConstantKeyword
                                 ),
-                                EnumVariant(
-                                    name = External,
-                                    fields = (keyword = Required(Terminal([ExternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Internal,
-                                    fields = (keyword = Required(Terminal([InternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Private,
-                                    fields = (keyword = Required(Terminal([PrivateKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Public,
-                                    fields = (keyword = Required(Terminal([PublicKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Pure,
-                                    fields = (keyword = Required(Terminal([PureKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = View,
-                                    fields = (keyword = Required(Terminal([ViewKeyword])))
-                                ),
+                                EnumVariant(name = External, reference = ExternalKeyword),
+                                EnumVariant(name = Internal, reference = InternalKeyword),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = Private, reference = PrivateKeyword),
+                                EnumVariant(name = Public, reference = PublicKeyword),
+                                EnumVariant(name = Pure, reference = PureKeyword),
+                                EnumVariant(name = View, reference = ViewKeyword),
                                 EnumVariant(
                                     name = Virtual,
                                     enabled = From("0.6.0"),
-                                    fields = (keyword = Required(Terminal([VirtualKeyword])))
+                                    reference = VirtualKeyword
                                 )
                             ]
                         ),
@@ -2521,14 +2430,8 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = FunctionBody,
                             variants = [
-                                EnumVariant(
-                                    name = Block,
-                                    fields = (block = Required(NonTerminal(Block)))
-                                ),
-                                EnumVariant(
-                                    name = Semicolon,
-                                    fields = (semicolon = Required(Terminal([Semicolon])))
-                                )
+                                EnumVariant(name = Block, reference = Block),
+                                EnumVariant(name = Semicolon, reference = Semicolon)
                             ]
                         ),
                         Struct(
@@ -2551,22 +2454,10 @@ codegen_language_macros::compile!(Language(
                             name = ConstructorAttribute,
                             enabled = From("0.4.22"),
                             variants = [
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields = (modifier = Required(NonTerminal(ModifierInvocation)))
-                                ),
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Public,
-                                    fields = (keyword = Required(Terminal([PublicKeyword])))
-                                )
+                                EnumVariant(name = Modifier, reference = ModifierInvocation),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = Public, reference = PublicKeyword)
                             ]
                         ),
                         Struct(
@@ -2589,30 +2480,12 @@ codegen_language_macros::compile!(Language(
                             name = UnnamedFunctionAttribute,
                             enabled = Till("0.6.0"),
                             variants = [
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields = (modifier = Required(NonTerminal(ModifierInvocation)))
-                                ),
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
-                                EnumVariant(
-                                    name = External,
-                                    fields = (keyword = Required(Terminal([ExternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Pure,
-                                    fields = (keyword = Required(Terminal([PureKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = View,
-                                    fields = (keyword = Required(Terminal([ViewKeyword])))
-                                )
+                                EnumVariant(name = Modifier, reference = ModifierInvocation),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
+                                EnumVariant(name = External, reference = ExternalKeyword),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = Pure, reference = PureKeyword),
+                                EnumVariant(name = View, reference = ViewKeyword)
                             ]
                         ),
                         Struct(
@@ -2636,34 +2509,13 @@ codegen_language_macros::compile!(Language(
                             name = FallbackFunctionAttribute,
                             enabled = From("0.6.0"),
                             variants = [
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields = (modifier = Required(NonTerminal(ModifierInvocation)))
-                                ),
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
-                                EnumVariant(
-                                    name = External,
-                                    fields = (keyword = Required(Terminal([ExternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Pure,
-                                    fields = (keyword = Required(Terminal([PureKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = View,
-                                    fields = (keyword = Required(Terminal([ViewKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Virtual,
-                                    fields = (keyword = Required(Terminal([VirtualKeyword])))
-                                )
+                                EnumVariant(name = Modifier, reference = ModifierInvocation),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
+                                EnumVariant(name = External, reference = ExternalKeyword),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = Pure, reference = PureKeyword),
+                                EnumVariant(name = View, reference = ViewKeyword),
+                                EnumVariant(name = Virtual, reference = VirtualKeyword)
                             ]
                         ),
                         Struct(
@@ -2686,26 +2538,11 @@ codegen_language_macros::compile!(Language(
                             name = ReceiveFunctionAttribute,
                             enabled = From("0.6.0"),
                             variants = [
-                                EnumVariant(
-                                    name = Modifier,
-                                    fields = (modifier = Required(NonTerminal(ModifierInvocation)))
-                                ),
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
-                                EnumVariant(
-                                    name = External,
-                                    fields = (keyword = Required(Terminal([ExternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Virtual,
-                                    fields = (keyword = Required(Terminal([VirtualKeyword])))
-                                )
+                                EnumVariant(name = Modifier, reference = ModifierInvocation),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
+                                EnumVariant(name = External, reference = ExternalKeyword),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = Virtual, reference = VirtualKeyword)
                             ]
                         )
                     ]
@@ -2731,14 +2568,11 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ModifierAttribute,
                             variants = [
-                                EnumVariant(
-                                    name = Override,
-                                    fields = (specifier = Required(NonTerminal(OverrideSpecifier)))
-                                ),
+                                EnumVariant(name = Override, reference = OverrideSpecifier),
                                 EnumVariant(
                                     name = Virtual,
                                     enabled = From("0.6.0"),
-                                    fields = (keyword = Required(Terminal([VirtualKeyword])))
+                                    reference = VirtualKeyword
                                 )
                             ]
                         ),
@@ -2904,34 +2738,13 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = FunctionTypeAttribute,
                             variants = [
-                                EnumVariant(
-                                    name = Internal,
-                                    fields = (keyword = Required(Terminal([InternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = External,
-                                    fields = (keyword = Required(Terminal([ExternalKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Private,
-                                    fields = (keyword = Required(Terminal([PrivateKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Public,
-                                    fields = (keyword = Required(Terminal([PublicKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Pure,
-                                    fields = (keyword = Required(Terminal([PureKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = View,
-                                    fields = (keyword = Required(Terminal([ViewKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields = (keyword = Required(Terminal([PayableKeyword])))
-                                )
+                                EnumVariant(name = Internal, reference = InternalKeyword),
+                                EnumVariant(name = External, reference = ExternalKeyword),
+                                EnumVariant(name = Private, reference = PrivateKeyword),
+                                EnumVariant(name = Public, reference = PublicKeyword),
+                                EnumVariant(name = Pure, reference = PureKeyword),
+                                EnumVariant(name = View, reference = ViewKeyword),
+                                EnumVariant(name = Payable, reference = PayableKeyword)
                             ]
                         ),
                         Struct(
@@ -2962,14 +2775,8 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = MappingKeyType,
                             variants = [
-                                EnumVariant(
-                                    name = ElementaryType,
-                                    fields = (type_name = Required(NonTerminal(ElementaryType)))
-                                ),
-                                EnumVariant(
-                                    name = IdentifierPath,
-                                    fields = (type_name = Required(NonTerminal(IdentifierPath)))
-                                )
+                                EnumVariant(name = ElementaryType, reference = ElementaryType),
+                                EnumVariant(name = IdentifierPath, reference = IdentifierPath)
                             ]
                         ),
                         Struct(
@@ -2990,62 +2797,34 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ElementaryType,
                             variants = [
-                                EnumVariant(
-                                    name = Bool,
-                                    fields = (type_name = Required(Terminal([BoolKeyword])))
-                                ),
+                                EnumVariant(name = Bool, reference = BoolKeyword),
                                 EnumVariant(
                                     name = Byte,
                                     enabled = Till("0.8.0"),
-                                    fields = (type_name = Required(Terminal([ByteKeyword])))
+                                    reference = ByteKeyword
                                 ),
-                                EnumVariant(
-                                    name = String,
-                                    fields = (type_name = Required(Terminal([StringKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Address,
-                                    fields = (type_name = Required(NonTerminal(AddressType)))
-                                ),
-                                EnumVariant(
-                                    name = ByteArray,
-                                    fields = (type_name = Required(Terminal([BytesKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = SignedInteger,
-                                    fields = (type_name = Required(Terminal([IntKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = UnsignedInteger,
-                                    fields = (type_name = Required(Terminal([UintKeyword])))
-                                ),
+                                EnumVariant(name = String, reference = StringKeyword),
+                                EnumVariant(name = Address, reference = AddressType),
+                                EnumVariant(name = Payable, reference = PayableKeyword),
+                                EnumVariant(name = ByteArray, reference = BytesKeyword),
+                                EnumVariant(name = SignedInteger, reference = IntKeyword),
+                                EnumVariant(name = UnsignedInteger, reference = UintKeyword),
                                 EnumVariant(
                                     name = SignedFixedPointNumber,
-                                    fields = (type_name = Required(Terminal([FixedKeyword])))
+                                    reference = FixedKeyword
                                 ),
                                 EnumVariant(
                                     name = UnsignedFixedPointNumber,
-                                    fields = (type_name = Required(Terminal([UfixedKeyword])))
+                                    reference = UfixedKeyword
                                 )
                             ]
                         ),
-                        Enum(
+                        Struct(
                             name = AddressType,
-                            variants = [
-                                EnumVariant(
-                                    name = Address,
-                                    fields = (
-                                        address_keyword = Required(Terminal([AddressKeyword])),
-                                        payable_keyword =
-                                            Optional(kind = Terminal([PayableKeyword]))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Payable,
-                                    fields =
-                                        (payable_keyword = Required(Terminal([PayableKeyword])))
-                                )
-                            ]
+                            fields = (
+                                address_keyword = Required(Terminal([AddressKeyword])),
+                                payable_keyword = Optional(kind = Terminal([PayableKeyword]))
+                            )
                         )
                     ]
                 )
@@ -3075,84 +2854,48 @@ codegen_language_macros::compile!(Language(
                             variants = [
                                 EnumVariant(
                                     name = TupleDeconstruction,
-                                    fields = (statement =
-                                        Required(NonTerminal(TupleDeconstructionStatement)))
+                                    reference = TupleDeconstructionStatement
                                 ),
                                 EnumVariant(
                                     name = VariableDeclaration,
-                                    fields = (statement =
-                                        Required(NonTerminal(VariableDeclarationStatement)))
+                                    reference = VariableDeclarationStatement
                                 ),
-                                EnumVariant(
-                                    name = If,
-                                    fields = (statement = Required(NonTerminal(IfStatement)))
-                                ),
-                                EnumVariant(
-                                    name = For,
-                                    fields = (statement = Required(NonTerminal(ForStatement)))
-                                ),
-                                EnumVariant(
-                                    name = While,
-                                    fields = (statement = Required(NonTerminal(WhileStatement)))
-                                ),
-                                EnumVariant(
-                                    name = DoWhile,
-                                    fields = (statement = Required(NonTerminal(DoWhileStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Continue,
-                                    fields = (statement = Required(NonTerminal(ContinueStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Break,
-                                    fields = (statement = Required(NonTerminal(BreakStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Delete,
-                                    fields = (statement = Required(NonTerminal(DeleteStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Return,
-                                    fields = (statement = Required(NonTerminal(ReturnStatement)))
-                                ),
+                                EnumVariant(name = If, reference = IfStatement),
+                                EnumVariant(name = For, reference = ForStatement),
+                                EnumVariant(name = While, reference = WhileStatement),
+                                EnumVariant(name = DoWhile, reference = DoWhileStatement),
+                                EnumVariant(name = Continue, reference = ContinueStatement),
+                                EnumVariant(name = Break, reference = BreakStatement),
+                                EnumVariant(name = Delete, reference = DeleteStatement),
+                                EnumVariant(name = Return, reference = ReturnStatement),
                                 EnumVariant(
                                     name = Throw,
                                     enabled = Till("0.5.0"),
-                                    fields = (statement = Required(NonTerminal(ThrowStatement)))
+                                    reference = ThrowStatement
                                 ),
                                 EnumVariant(
                                     name = Emit,
                                     enabled = From("0.4.21"),
-                                    fields = (statement = Required(NonTerminal(EmitStatement)))
+                                    reference = EmitStatement
                                 ),
                                 EnumVariant(
                                     name = Try,
                                     enabled = From("0.6.0"),
-                                    fields = (statement = Required(NonTerminal(TryStatement)))
+                                    reference = TryStatement
                                 ),
                                 EnumVariant(
                                     name = Revert,
                                     enabled = From("0.8.4"),
-                                    fields = (statement = Required(NonTerminal(RevertStatement)))
+                                    reference = RevertStatement
                                 ),
-                                EnumVariant(
-                                    name = Assembly,
-                                    fields = (statement = Required(NonTerminal(AssemblyStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Block,
-                                    fields = (block = Required(NonTerminal(Block)))
-                                ),
+                                EnumVariant(name = Assembly, reference = AssemblyStatement),
+                                EnumVariant(name = Block, reference = Block),
                                 EnumVariant(
                                     name = UncheckedBlock,
                                     enabled = From("0.8.0"),
-                                    fields = (block = Required(NonTerminal(UncheckedBlock)))
+                                    reference = UncheckedBlock
                                 ),
-                                EnumVariant(
-                                    name = Expression,
-                                    fields =
-                                        (statement = Required(NonTerminal(ExpressionStatement)))
-                                )
+                                EnumVariant(name = Expression, reference = ExpressionStatement)
                             ]
                         ),
                         Struct(
@@ -3205,24 +2948,24 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = TupleMember,
                             variants = [
-                                EnumVariant(
-                                    name = Typed,
-                                    fields = (
-                                        type_name = Required(NonTerminal(TypeName)),
-                                        storage_location =
-                                            Optional(kind = NonTerminal(StorageLocation)),
-                                        name = Required(Terminal([Identifier]))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Untyped,
-                                    fields = (
-                                        storage_location =
-                                            Optional(kind = NonTerminal(StorageLocation)),
-                                        name = Required(Terminal([Identifier]))
-                                    )
-                                )
+                                EnumVariant(name = Typed, reference = TypedTupleMember),
+                                EnumVariant(name = Untyped, reference = UntypedTupleMember)
                             ]
+                        ),
+                        Struct(
+                            name = TypedTupleMember,
+                            fields = (
+                                type_name = Required(NonTerminal(TypeName)),
+                                storage_location = Optional(kind = NonTerminal(StorageLocation)),
+                                name = Required(Terminal([Identifier]))
+                            )
+                        ),
+                        Struct(
+                            name = UntypedTupleMember,
+                            fields = (
+                                storage_location = Optional(kind = NonTerminal(StorageLocation)),
+                                name = Required(Terminal([Identifier]))
+                            )
                         ),
                         Struct(
                             name = VariableDeclarationStatement,
@@ -3238,14 +2981,11 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = VariableDeclarationType,
                             variants = [
-                                EnumVariant(
-                                    name = Typed,
-                                    fields = (type_name = Required(NonTerminal(TypeName)))
-                                ),
+                                EnumVariant(name = Typed, reference = TypeName),
                                 EnumVariant(
                                     name = Untyped,
                                     enabled = Till("0.5.0"),
-                                    fields = (type_name = Required(Terminal([VarKeyword])))
+                                    reference = VarKeyword
                                 )
                             ]
                         ),
@@ -3259,18 +2999,12 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = StorageLocation,
                             variants = [
-                                EnumVariant(
-                                    name = Memory,
-                                    fields = (keyword = Required(Terminal([MemoryKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Storage,
-                                    fields = (keyword = Required(Terminal([StorageKeyword])))
-                                ),
+                                EnumVariant(name = Memory, reference = MemoryKeyword),
+                                EnumVariant(name = Storage, reference = StorageKeyword),
                                 EnumVariant(
                                     name = CallData,
                                     enabled = From("0.5.0"),
-                                    fields = (keyword = Required(Terminal([CallDataKeyword])))
+                                    reference = CallDataKeyword
                                 )
                             ]
                         )
@@ -3320,39 +3054,23 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = ForStatementInitialization,
                             variants = [
-                                EnumVariant(
-                                    name = Expression,
-                                    fields =
-                                        (statement = Required(NonTerminal(ExpressionStatement)))
-                                ),
+                                EnumVariant(name = Expression, reference = ExpressionStatement),
                                 EnumVariant(
                                     name = VariableDeclaration,
-                                    fields = (statement =
-                                        Required(NonTerminal(VariableDeclarationStatement)))
+                                    reference = VariableDeclarationStatement
                                 ),
                                 EnumVariant(
                                     name = TupleDeconstruction,
-                                    fields = (statement =
-                                        Required(NonTerminal(TupleDeconstructionStatement)))
+                                    reference = TupleDeconstructionStatement
                                 ),
-                                EnumVariant(
-                                    name = Semicolon,
-                                    fields = (semicolon = Required(Terminal([Semicolon])))
-                                )
+                                EnumVariant(name = Semicolon, reference = Semicolon)
                             ]
                         ),
                         Enum(
                             name = ForStatementCondition,
                             variants = [
-                                EnumVariant(
-                                    name = Expression,
-                                    fields =
-                                        (statement = Required(NonTerminal(ExpressionStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Semicolon,
-                                    fields = (semicolon = Required(Terminal([Semicolon])))
-                                )
+                                EnumVariant(name = Expression, reference = ExpressionStatement),
+                                EnumVariant(name = Semicolon, reference = Semicolon)
                             ]
                         ),
                         Struct(
@@ -3669,7 +3387,10 @@ codegen_language_macros::compile!(Language(
                                     operators = [PrecedenceOperator(
                                         model = Postfix,
                                         fields = (
-                                            options = Required(NonTerminal(FunctionCallOptions)),
+                                            options = Optional(
+                                                kind = NonTerminal(FunctionCallOptions),
+                                                enabled = From("0.6.2")
+                                            ),
                                             arguments = Required(NonTerminal(ArgumentsDeclaration))
                                         )
                                     )]
@@ -3712,7 +3433,8 @@ codegen_language_macros::compile!(Language(
                                     enabled = From("0.5.3")
                                 ),
                                 PrimaryExpression(expression = ArrayExpression),
-                                PrimaryExpression(expression = NumberExpression),
+                                PrimaryExpression(expression = HexNumberExpression),
+                                PrimaryExpression(expression = DecimalNumberExpression),
                                 PrimaryExpression(expression = StringExpression),
                                 PrimaryExpression(expression = ElementaryType),
                                 PrimaryExpression(expression = TrueKeyword),
@@ -3734,20 +3456,18 @@ codegen_language_macros::compile!(Language(
                     items = [
                         Enum(
                             name = FunctionCallOptions,
+                            enabled = From("0.6.2"),
                             variants = [
                                 EnumVariant(
                                     name = Multiple,
                                     enabled = Range(from = "0.6.2", till = "0.8.0"),
-                                    fields = (options =
-                                        Required(NonTerminal(NamedArgumentsDeclarations)))
+                                    reference = NamedArgumentGroups
                                 ),
                                 EnumVariant(
                                     name = Single,
                                     enabled = From("0.8.0"),
-                                    fields = (options =
-                                        Optional(kind = NonTerminal(NamedArgumentsDeclaration)))
-                                ),
-                                EnumVariant(name = None, enabled = Till("0.6.2"), fields = ())
+                                    reference = NamedArgumentGroup
+                                )
                             ]
                         ),
                         Enum(
@@ -3755,30 +3475,22 @@ codegen_language_macros::compile!(Language(
                             variants = [
                                 EnumVariant(
                                     name = Positional,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
-                                    fields = (
-                                        open_paren = Required(Terminal([OpenParen])),
-                                        arguments = Required(NonTerminal(PositionalArguments)),
-                                        close_paren = Required(Terminal([CloseParen]))
-                                    )
+                                    reference = PositionalArgumentsDeclaration
                                 ),
-                                EnumVariant(
-                                    name = Named,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
-                                    fields = (
-                                        open_paren = Required(Terminal([OpenParen])),
-                                        arguments =
-                                            Optional(kind = NonTerminal(NamedArgumentsDeclaration)),
-                                        close_paren = Required(Terminal([CloseParen]))
-                                    )
-                                )
+                                EnumVariant(name = Named, reference = NamedArgumentsDeclaration)
                             ]
+                        ),
+                        Struct(
+                            name = PositionalArgumentsDeclaration,
+                            error_recovery = FieldsErrorRecovery(
+                                delimiters =
+                                    FieldDelimiters(open = open_paren, close = close_paren)
+                            ),
+                            fields = (
+                                open_paren = Required(Terminal([OpenParen])),
+                                arguments = Required(NonTerminal(PositionalArguments)),
+                                close_paren = Required(Terminal([CloseParen]))
+                            )
                         ),
                         Separated(
                             name = PositionalArguments,
@@ -3786,14 +3498,25 @@ codegen_language_macros::compile!(Language(
                             separator = Comma,
                             allow_empty = true
                         ),
-                        Repeated(
-                            name = NamedArgumentsDeclarations,
-                            repeated = NamedArgumentsDeclaration,
-                            enabled = Range(from = "0.6.2", till = "0.8.0"),
-                            allow_empty = true
-                        ),
                         Struct(
                             name = NamedArgumentsDeclaration,
+                            error_recovery = FieldsErrorRecovery(
+                                delimiters =
+                                    FieldDelimiters(open = open_paren, close = close_paren)
+                            ),
+                            fields = (
+                                open_paren = Required(Terminal([OpenParen])),
+                                arguments = Optional(kind = NonTerminal(NamedArgumentGroup)),
+                                close_paren = Required(Terminal([CloseParen]))
+                            )
+                        ),
+                        Repeated(
+                            name = NamedArgumentGroups,
+                            repeated = NamedArgumentGroup,
+                            enabled = Range(from = "0.6.2", till = "0.8.0")
+                        ),
+                        Struct(
+                            name = NamedArgumentGroup,
                             error_recovery = FieldsErrorRecovery(
                                 delimiters =
                                     FieldDelimiters(open = open_brace, close = close_brace)
@@ -3887,27 +3610,22 @@ codegen_language_macros::compile!(Language(
                 Topic(
                     title = "Numbers",
                     items = [
-                        Enum(
-                            name = NumberExpression,
-                            variants = [
-                                EnumVariant(
-                                    name = Hex,
-                                    fields = (
-                                        literal = Required(Terminal([HexLiteral])),
-                                        unit = Optional(
-                                            kind = NonTerminal(NumberUnit),
-                                            enabled = Till("0.5.0")
-                                        )
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Decimal,
-                                    fields = (
-                                        literal = Required(Terminal([DecimalLiteral])),
-                                        unit = Optional(kind = NonTerminal(NumberUnit))
-                                    )
+                        Struct(
+                            name = HexNumberExpression,
+                            fields = (
+                                literal = Required(Terminal([HexLiteral])),
+                                unit = Optional(
+                                    kind = NonTerminal(NumberUnit),
+                                    enabled = Till("0.5.0")
                                 )
-                            ]
+                            )
+                        ),
+                        Struct(
+                            name = DecimalNumberExpression,
+                            fields = (
+                                literal = Required(Terminal([DecimalLiteral])),
+                                unit = Optional(kind = NonTerminal(NumberUnit))
+                            )
                         ),
                         Token(
                             name = HexLiteral,
@@ -4015,57 +3733,36 @@ codegen_language_macros::compile!(Language(
                             name = NumberUnit,
                             variants = [
                                 // 1e-18 ETH
-                                EnumVariant(
-                                    name = Wei,
-                                    fields = (keyword = Required(Terminal([WeiKeyword])))
-                                ),
+                                EnumVariant(name = Wei, reference = WeiKeyword),
                                 // 1e-9 ETH
                                 EnumVariant(
                                     name = Gwei,
                                     enabled = From("0.6.11"),
-                                    fields = (keyword = Required(Terminal([GweiKeyword])))
+                                    reference = GweiKeyword
                                 ),
                                 // 1e-6 ETH
                                 EnumVariant(
                                     name = Szabo,
                                     enabled = Till("0.7.0"),
-                                    fields = (keyword = Required(Terminal([SzaboKeyword])))
+                                    reference = SzaboKeyword
                                 ),
                                 // 1e-3 ETH
                                 EnumVariant(
                                     name = Finney,
                                     enabled = Till("0.7.0"),
-                                    fields = (keyword = Required(Terminal([FinneyKeyword])))
+                                    reference = FinneyKeyword
                                 ),
                                 // 1 ETH
-                                EnumVariant(
-                                    name = Ether,
-                                    fields = (keyword = Required(Terminal([EtherKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Seconds,
-                                    fields = (keyword = Required(Terminal([SecondsKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Minutes,
-                                    fields = (keyword = Required(Terminal([MinutesKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Hours,
-                                    fields = (keyword = Required(Terminal([HoursKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Days,
-                                    fields = (keyword = Required(Terminal([DaysKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Weeks,
-                                    fields = (keyword = Required(Terminal([WeeksKeyword])))
-                                ),
+                                EnumVariant(name = Ether, reference = EtherKeyword),
+                                EnumVariant(name = Seconds, reference = SecondsKeyword),
+                                EnumVariant(name = Minutes, reference = MinutesKeyword),
+                                EnumVariant(name = Hours, reference = HoursKeyword),
+                                EnumVariant(name = Days, reference = DaysKeyword),
+                                EnumVariant(name = Weeks, reference = WeeksKeyword),
                                 EnumVariant(
                                     name = Years,
                                     enabled = Till("0.5.0"),
-                                    fields = (keyword = Required(Terminal([YearsKeyword])))
+                                    reference = YearsKeyword
                                 )
                             ]
                         )
@@ -4077,20 +3774,12 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = StringExpression,
                             variants = [
-                                EnumVariant(
-                                    name = Hex,
-                                    fields = (literals = Required(NonTerminal(HexStringLiterals)))
-                                ),
-                                EnumVariant(
-                                    name = Ascii,
-                                    fields =
-                                        (literals = Required(NonTerminal(AsciiStringLiterals)))
-                                ),
+                                EnumVariant(name = Hex, reference = HexStringLiterals),
+                                EnumVariant(name = Ascii, reference = AsciiStringLiterals),
                                 EnumVariant(
                                     name = Unicode,
                                     enabled = From("0.7.0"),
-                                    fields =
-                                        (literals = Required(NonTerminal(UnicodeStringLiterals)))
+                                    reference = UnicodeStringLiterals
                                 )
                             ]
                         ),
@@ -4361,56 +4050,24 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = YulStatement,
                             variants = [
-                                EnumVariant(
-                                    name = Block,
-                                    fields = (block = Required(NonTerminal(YulBlock)))
-                                ),
-                                EnumVariant(
-                                    name = Function,
-                                    fields =
-                                        (definition = Required(NonTerminal(YulFunctionDefinition)))
-                                ),
+                                EnumVariant(name = Block, reference = YulBlock),
+                                EnumVariant(name = Function, reference = YulFunctionDefinition),
                                 EnumVariant(
                                     name = VariableDeclaration,
-                                    fields = (statement =
-                                        Required(NonTerminal(YulVariableDeclarationStatement)))
+                                    reference = YulVariableDeclarationStatement
                                 ),
-                                EnumVariant(
-                                    name = Assignment,
-                                    fields =
-                                        (statement = Required(NonTerminal(YulAssignmentStatement)))
-                                ),
-                                EnumVariant(
-                                    name = If,
-                                    fields = (statement = Required(NonTerminal(YulIfStatement)))
-                                ),
-                                EnumVariant(
-                                    name = For,
-                                    fields = (statement = Required(NonTerminal(YulForStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Switch,
-                                    fields =
-                                        (statement = Required(NonTerminal(YulSwitchStatement)))
-                                ),
+                                EnumVariant(name = Assignment, reference = YulAssignmentStatement),
+                                EnumVariant(name = If, reference = YulIfStatement),
+                                EnumVariant(name = For, reference = YulForStatement),
+                                EnumVariant(name = Switch, reference = YulSwitchStatement),
                                 EnumVariant(
                                     name = Leave,
                                     enabled = From("0.6.0"),
-                                    fields = (statement = Required(NonTerminal(YulLeaveStatement)))
+                                    reference = YulLeaveStatement
                                 ),
-                                EnumVariant(
-                                    name = Break,
-                                    fields = (statement = Required(NonTerminal(YulBreakStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Continue,
-                                    fields =
-                                        (statement = Required(NonTerminal(YulContinueStatement)))
-                                ),
-                                EnumVariant(
-                                    name = Expression,
-                                    fields = (expression = Required(NonTerminal(YulExpression)))
-                                )
+                                EnumVariant(name = Break, reference = YulBreakStatement),
+                                EnumVariant(name = Continue, reference = YulContinueStatement),
+                                EnumVariant(name = Expression, reference = YulExpression)
                             ]
                         ),
                         Struct(
@@ -4519,22 +4176,24 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = YulSwitchCase,
                             variants = [
-                                EnumVariant(
-                                    name = Default,
-                                    fields = (
-                                        default_keyword = Required(Terminal([YulDefaultKeyword])),
-                                        body = Required(NonTerminal(YulBlock))
-                                    )
-                                ),
-                                EnumVariant(
-                                    name = Case,
-                                    fields = (
-                                        case_keyword = Required(Terminal([YulCaseKeyword])),
-                                        value = Required(NonTerminal(YulLiteral)),
-                                        body = Required(NonTerminal(YulBlock))
-                                    )
-                                )
+                                EnumVariant(name = Default, reference = YulDefaultCase),
+                                EnumVariant(name = Value, reference = YulValueCase)
                             ]
+                        ),
+                        Struct(
+                            name = YulDefaultCase,
+                            fields = (
+                                default_keyword = Required(Terminal([YulDefaultKeyword])),
+                                body = Required(NonTerminal(YulBlock))
+                            )
+                        ),
+                        Struct(
+                            name = YulValueCase,
+                            fields = (
+                                case_keyword = Required(Terminal([YulCaseKeyword])),
+                                value = Required(NonTerminal(YulLiteral)),
+                                body = Required(NonTerminal(YulBlock))
+                            )
                         )
                     ]
                 ),
@@ -4587,30 +4246,12 @@ codegen_language_macros::compile!(Language(
                         Enum(
                             name = YulLiteral,
                             variants = [
-                                EnumVariant(
-                                    name = True,
-                                    fields = (literal = Required(Terminal([YulTrueKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = False,
-                                    fields = (literal = Required(Terminal([YulFalseKeyword])))
-                                ),
-                                EnumVariant(
-                                    name = Decimal,
-                                    fields = (literal = Required(Terminal([YulDecimalLiteral])))
-                                ),
-                                EnumVariant(
-                                    name = Hex,
-                                    fields = (literal = Required(Terminal([YulHexLiteral])))
-                                ),
-                                EnumVariant(
-                                    name = HexString,
-                                    fields = (literal = Required(Terminal([HexStringLiteral])))
-                                ),
-                                EnumVariant(
-                                    name = AsciiString,
-                                    fields = (literal = Required(Terminal([AsciiStringLiteral])))
-                                )
+                                EnumVariant(name = True, reference = YulTrueKeyword),
+                                EnumVariant(name = False, reference = YulFalseKeyword),
+                                EnumVariant(name = Decimal, reference = YulDecimalLiteral),
+                                EnumVariant(name = Hex, reference = YulHexLiteral),
+                                EnumVariant(name = HexString, reference = HexStringLiteral),
+                                EnumVariant(name = AsciiString, reference = AsciiStringLiteral)
                             ]
                         ),
                         Token(


### PR DESCRIPTION
- group enabled and reserved specifiers
- remove default variants and primary expressions
- add EndOfInput to trailing_trivia
- using single references for enums to eliminate backtracking