### PR TITLE
unify cargo check and clippy commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,6 @@
   "rust-analyzer.check.allTargets": true,
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.check.features": "all",
-  "rust-analyzer.checkOnSave": true,
   "rust-analyzer.server.path": "${workspaceFolder}/bin/rust-analyzer",
   "search.exclude": {
     // Packages and Dependencies

--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::{commands::Command, github::GitHub};
+use infra_utils::cargo::CargoWorkspace;
 
 use crate::{
     toolchains::{
@@ -45,20 +45,7 @@ impl OrderedCommand for CheckCommand {
 }
 
 fn check_cargo() -> Result<()> {
-    let mut command = Command::new("cargo")
-        .arg("check")
-        .flag("--offline")
-        .flag("--all")
-        .flag("--all-targets")
-        .flag("--all-features");
-
-    if GitHub::is_running_in_ci() {
-        let rustflags = serde_json::to_string(&["--deny", "warnings"])?;
-
-        command = command.property("--config", format!("build.rustflags = {rustflags}"));
-    }
-
-    return command.run();
+    return CargoWorkspace::get_check_command("check")?.run();
 }
 
 fn check_npm() -> Result<()> {

--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -45,7 +45,7 @@ impl OrderedCommand for CheckCommand {
 }
 
 fn check_cargo() -> Result<()> {
-    return CargoWorkspace::get_check_command("check")?.run();
+    return CargoWorkspace::get_command("check")?.run();
 }
 
 fn check_npm() -> Result<()> {

--- a/crates/infra/cli/src/commands/lint/mod.rs
+++ b/crates/infra/cli/src/commands/lint/mod.rs
@@ -65,7 +65,7 @@ impl OrderedCommand for LintCommand {
 }
 
 fn run_clippy() -> Result<()> {
-    return CargoWorkspace::get_check_command("clippy")?.run();
+    return CargoWorkspace::get_command("clippy")?.run();
 }
 
 fn run_cargo_fmt() -> Result<()> {

--- a/crates/infra/cli/src/commands/lint/mod.rs
+++ b/crates/infra/cli/src/commands/lint/mod.rs
@@ -65,13 +65,7 @@ impl OrderedCommand for LintCommand {
 }
 
 fn run_clippy() -> Result<()> {
-    let mut clippy = Command::new("cargo").flag("clippy").flag("--");
-
-    if GitHub::is_running_in_ci() {
-        clippy = clippy.property("-D", "warnings");
-    }
-
-    clippy.run()
+    return CargoWorkspace::get_check_command("clippy")?.run();
 }
 
 fn run_cargo_fmt() -> Result<()> {

--- a/crates/infra/cli/src/commands/run/mod.rs
+++ b/crates/infra/cli/src/commands/run/mod.rs
@@ -76,7 +76,6 @@ impl RunController {
 
         command
             .property("--bin", &crate_name)
-            .flag("--offline")
             .arg("--")
             .args(&self.args)
             // Execute in the crate dir, to make use of a local './target' dir if it exists:

--- a/crates/infra/cli/src/commands/setup/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/setup/cargo/mod.rs
@@ -2,9 +2,13 @@ use anyhow::Result;
 use infra_utils::{commands::Command, github::GitHub};
 
 pub fn setup_cargo() -> Result<()> {
-    return if GitHub::is_running_in_ci() {
-        Command::new("cargo").arg("fetch").flag("--locked").run()
-    } else {
-        Command::new("cargo").arg("fetch").run()
-    };
+    let mut command = Command::new("cargo").arg("fetch");
+
+    if GitHub::is_running_in_ci() {
+        // In CI, run with '--locked' to make sure `Cargo.lock` is up to date.
+        // Don't use '--frozen', because the cache is rarely up to date.
+        command = command.flag("--locked");
+    }
+
+    return command.run();
 }

--- a/crates/infra/cli/src/commands/test/mod.rs
+++ b/crates/infra/cli/src/commands/test/mod.rs
@@ -1,7 +1,7 @@
 use crate::utils::{ClapExtensions, OrderedCommand, Terminal};
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::{commands::Command, github::GitHub};
+use infra_utils::{cargo::CargoWorkspace, commands::Command, github::GitHub};
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct TestController {
@@ -35,13 +35,7 @@ impl OrderedCommand for TestCommand {
 }
 
 fn test_cargo() -> Result<()> {
-    let mut command = Command::new("cargo")
-        .arg("test")
-        .flag("--quiet")
-        .flag("--offline")
-        .flag("--all")
-        .flag("--all-targets")
-        .flag("--all-features");
+    let mut command = CargoWorkspace::get_command("test")?.flag("--quiet");
 
     if GitHub::is_running_in_ci() {
         command = command.flag("--no-fail-fast");

--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -102,13 +102,6 @@ impl CargoWorkspace {
     pub fn get_command(subcommand: impl AsRef<str>) -> Result<Command> {
         let mut command = Command::new("cargo")
             .arg(subcommand.as_ref())
-            .flag(
-                // Cargo will periodically try to update its manifest/local cache from internet before running these
-                // commands. This periodically means 1min+ interruptions for local development, and even blocking
-                // development completely if you are working offline. Using '--offline' prevents that, making sure
-                // that the command always reuses the dependencies already downloaded by 'infra setup'.
-                "--offline",
-            )
             .flag("--all")
             .flag("--all-targets")
             .flag("--all-features");


### PR DESCRIPTION
So that all targets/features/packages are checked in the same way.
Additionally, I'm removing `rust-analyzer.checkOnSave` from settings, as I suggest leaving this up to individual user preferences. Running checks for a large workspace is expensive.