### PR TITLE
Move pragma-specific keywords under dedicated topic

### DIFF
--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -200,6 +200,21 @@ codegen_language_macros::compile!(Language(
                                     Atom("*")
                                 ]))
                             )]
+                        ),
+                        Keyword(
+                            name = SolidityKeyword,
+                            identifier = Identifier,
+                            definitions = [KeywordDefinition(value = Atom("solidity"))]
+                        ),
+                        Keyword(
+                            name = ExperimentalKeyword,
+                            identifier = Identifier,
+                            definitions = [KeywordDefinition(value = Atom("experimental"))]
+                        ),
+                        Keyword(
+                            name = AbicoderKeyword,
+                            identifier = Identifier,
+                            definitions = [KeywordDefinition(value = Atom("abicoder"))]
                         )
                     ]
                 ),
@@ -407,14 +422,6 @@ codegen_language_macros::compile!(Language(
                 Topic(
                     title = "Keywords",
                     items = [
-                        Keyword(
-                            name = AbicoderKeyword,
-                            identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                reserved = Never,
-                                value = Atom("abicoder")
-                            )]
-                        ),
                         Keyword(
                             name = AbstractKeyword,
                             identifier = Identifier,
@@ -660,14 +667,6 @@ codegen_language_macros::compile!(Language(
                             name = EventKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(value = Atom("event"))]
-                        ),
-                        Keyword(
-                            name = ExperimentalKeyword,
-                            identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                reserved = Never,
-                                value = Atom("experimental")
-                            )]
                         ),
                         Keyword(
                             name = ExternalKeyword,
@@ -1312,14 +1311,6 @@ codegen_language_macros::compile!(Language(
                                 enabled = Never,
                                 reserved = From("0.5.0"),
                                 value = Atom("sizeof")
-                            )]
-                        ),
-                        Keyword(
-                            name = SolidityKeyword,
-                            identifier = Identifier,
-                            definitions = [KeywordDefinition(
-                                reserved = Never,
-                                value = Atom("solidity")
                             )]
                         ),
                         Keyword(


### PR DESCRIPTION
Split from #650 

We talked about this recently at our stand-up.

These are never reserved in the default context and are only used in the (lexical) context of pragmas, so let's reflect that in the spec.

Not updating v1 in this context since #650 is about to obsolete that and v0 does not have lexical contexts that might be impacted.