### PR TITLE
kill previous github ci runs before starting a new one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
     branches-ignore:
       - "main"
 
+# In the event that there is a new push to the ref, cancel any running jobs because there are now obsolete, and wasting resources.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: "./.github/workflows/_jobs_ci.yml"


### PR DESCRIPTION
Copied a line from the stack-graph project to kill the old ci action before starting a new one