### PR TITLE
Appease most of the Clippy lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ rustflags = [
 	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
-	"clippy::write_literal",
-	"-A",
 	"clippy::writeln_empty_string",
 	"-A",
 	"clippy::wrong_self_convention",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::cmp_owned",
-	"-A",
 	"clippy::collapsible_if",
 	"-A",
 	"clippy::comparison_chain",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::manual_range_contains",
-	"-A",
 	"clippy::match_like_matches_macro",
 	"-A",
 	"clippy::needless_borrow",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::comparison_chain",
-	"-A",
 	"clippy::enum_variant_names",
 	"-A",
 	"clippy::expect_fun_call",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::bool_assert_comparison",
-	"-A",
 	"clippy::cmp_owned",
 	"-A",
 	"clippy::collapsible_if",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,8 +16,6 @@ rustflags = [
 	"-A",
 	"clippy::should_implement_trait",
 	"-A",
-	"clippy::single_char_add_str",
-	"-A",
 	"clippy::single_char_pattern",
 	"-A",
 	"clippy::to_string_in_format_args",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::needless_borrow",
-	"-A",
 	"clippy::needless_range_loop",
 	"-A",
 	"clippy::needless_return",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::match_like_matches_macro",
-	"-A",
 	"clippy::needless_borrow",
 	"-A",
 	"clippy::needless_range_loop",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::redundant_static_lifetimes",
-	"-A",
 	"clippy::should_implement_trait",
 	"-A",
 	"clippy::single_char_add_str",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,8 +16,6 @@ rustflags = [
 	"-A",
 	"clippy::should_implement_trait",
 	"-A",
-	"clippy::single_char_pattern",
-	"-A",
 	"clippy::to_string_in_format_args",
 	"-A",
 	"clippy::upper_case_acronyms",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ rustflags = [
 	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
-	"clippy::useless_format",
-	"-A",
 	"clippy::write_literal",
 	"-A",
 	"clippy::writeln_empty_string",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::redundant_closure",
-	"-A",
 	"clippy::redundant_pattern",
 	"-A",
 	"clippy::redundant_pattern_matching",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::needless_range_loop",
-	"-A",
 	"clippy::needless_return",
 	"-A",
 	"clippy::new_without_default",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,8 +16,6 @@ rustflags = [
 	"-A",
 	"clippy::should_implement_trait",
 	"-A",
-	"clippy::to_string_in_format_args",
-	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
 	"clippy::useless_asref",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::new_without_default",
-	"-A",
 	"clippy::println_empty_string",
 	"-A",
 	"clippy::redundant_closure",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::redundant_pattern",
-	"-A",
 	"clippy::redundant_pattern_matching",
 	"-A",
 	"clippy::redundant_static_lifetimes",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -50,8 +50,6 @@ rustflags = [
 	"-A",
 	"clippy::println_empty_string",
 	"-A",
-	"clippy::ptr_arg",
-	"-A",
 	"clippy::redundant_closure",
 	"-A",
 	"clippy::redundant_pattern",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,4 @@ rustflags = [
 	"clippy::needless_return",
 	"-A",
 	"clippy::should_implement_trait",
-	"-A",
-	"clippy::upper_case_acronyms",
-
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::from_over_into",
-	"-A",
 	"clippy::inherent_to_string",
 	"-A",
 	"clippy::into_iter_on_ref",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::enum_variant_names",
-	"-A",
 	"clippy::expect_fun_call",
 	"-A",
 	"clippy::explicit_auto_deref",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::into_iter_on_ref",
-	"-A",
 	"clippy::len_without_is_empty",
 	"-A",
 	"clippy::len_zero",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ rustflags = [
 	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
-	"clippy::useless_conversion",
-	"-A",
 	"clippy::useless_format",
 	"-A",
 	"clippy::write_literal",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::len_zero",
-	"-A",
 	"clippy::manual_range_contains",
 	"-A",
 	"clippy::match_like_matches_macro",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::inherent_to_string",
-	"-A",
 	"clippy::into_iter_on_ref",
 	"-A",
 	"clippy::len_without_is_empty",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,7 +17,5 @@ rustflags = [
 	"clippy::should_implement_trait",
 	"-A",
 	"clippy::upper_case_acronyms",
-	"-A",
-	"clippy::wrong_self_convention",
 
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::println_empty_string",
-	"-A",
 	"clippy::redundant_closure",
 	"-A",
 	"clippy::redundant_pattern",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::len_without_is_empty",
-	"-A",
 	"clippy::len_zero",
 	"-A",
 	"clippy::manual_range_contains",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::collapsible_if",
-	"-A",
 	"clippy::comparison_chain",
 	"-A",
 	"clippy::enum_variant_names",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ rustflags = [
 	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
-	"clippy::writeln_empty_string",
-	"-A",
 	"clippy::wrong_self_convention",
 
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::explicit_auto_deref",
-	"-A",
 	"clippy::from_over_into",
 	"-A",
 	"clippy::inherent_to_string",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,6 @@ rustflags = [
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",
-	"clippy::expect_fun_call",
-	"-A",
 	"clippy::explicit_auto_deref",
 	"-A",
 	"clippy::from_over_into",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,6 @@ rustflags = [
 	"-A",
 	"clippy::needless_return",
 	"-A",
-	"clippy::redundant_pattern_matching",
-	"-A",
 	"clippy::redundant_static_lifetimes",
 	"-A",
 	"clippy::should_implement_trait",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ rustflags = [
 	"-A",
 	"clippy::upper_case_acronyms",
 	"-A",
-	"clippy::useless_asref",
-	"-A",
 	"clippy::useless_conversion",
 	"-A",
 	"clippy::useless_format",

--- a/crates/codegen/ebnf/src/parser.rs
+++ b/crates/codegen/ebnf/src/parser.rs
@@ -16,29 +16,29 @@ impl EbnfNode {
             } => {
                 return Self::sequence(vec![
                     Self::production_ref(&open.reference),
-                    Self::from_parser(&parser),
+                    Self::from_parser(parser),
                     Self::production_ref(&close.reference),
                 ]);
             }
 
             ParserDefinition::OneOrMore(parser) => {
-                return Self::one_or_more(Self::from_parser(&parser));
+                return Self::one_or_more(Self::from_parser(parser));
             }
 
             ParserDefinition::Optional(parser) => {
-                return Self::optional(Self::from_parser(&parser));
+                return Self::optional(Self::from_parser(parser));
             }
 
             ParserDefinition::Reference(name) => {
-                return Self::production_ref(&name);
+                return Self::production_ref(name);
             }
 
             ParserDefinition::SeparatedBy { parser, separator } => {
                 return Self::sequence(vec![
-                    Self::from_parser(&parser),
+                    Self::from_parser(parser),
                     Self::zero_or_more(Self::sequence(vec![
                         Self::production_ref(&separator.reference),
-                        Self::from_parser(&parser),
+                        Self::from_parser(parser),
                     ])),
                 ]);
             }
@@ -49,13 +49,13 @@ impl EbnfNode {
 
             ParserDefinition::TerminatedBy { parser, terminator } => {
                 return Self::sequence(vec![
-                    Self::from_parser(&parser),
+                    Self::from_parser(parser),
                     Self::production_ref(&terminator.reference),
                 ]);
             }
 
             ParserDefinition::ZeroOrMore(parser) => {
-                return Self::zero_or_more(Self::from_parser(&parser));
+                return Self::zero_or_more(Self::from_parser(parser));
             }
         };
     }

--- a/crates/codegen/ebnf/src/serialization.rs
+++ b/crates/codegen/ebnf/src/serialization.rs
@@ -127,7 +127,7 @@ impl EbnfSerializer {
     pub fn serialize_node(&mut self, top_node: &EbnfNode, buffer: &mut String) {
         match top_node {
             EbnfNode::Choice { nodes } => {
-                for (i, node) in nodes.into_iter().enumerate() {
+                for (i, node) in nodes.iter().enumerate() {
                     if i > 0 {
                         buffer.push_str(" | ");
                     }
@@ -164,7 +164,7 @@ impl EbnfSerializer {
                 buffer.push_str(&self.display_name(name));
             }
             EbnfNode::Sequence { nodes } => {
-                for (i, node) in nodes.into_iter().enumerate() {
+                for (i, node) in nodes.iter().enumerate() {
                     if i > 0 {
                         buffer.push_str(" ");
                     }

--- a/crates/codegen/ebnf/src/serialization.rs
+++ b/crates/codegen/ebnf/src/serialization.rs
@@ -224,7 +224,7 @@ impl EbnfSerializer {
 }
 
 fn format_string_literal(value: &str) -> String {
-    let delimiter = if value.contains('"') && !value.contains("'") {
+    let delimiter = if value.contains('"') && !value.contains('\'') {
         '\''
     } else {
         '"'

--- a/crates/codegen/ebnf/src/serialization.rs
+++ b/crates/codegen/ebnf/src/serialization.rs
@@ -178,7 +178,7 @@ impl EbnfSerializer {
             EbnfNode::WithComment { node, comment } => {
                 self.serialize_child_node(top_node, node, buffer);
                 buffer.push_str(" (* ");
-                buffer.push_str(&comment);
+                buffer.push_str(comment);
                 buffer.push_str(" *)");
             }
             EbnfNode::ZeroOrMore { node } => {

--- a/crates/codegen/ebnf/src/serialization.rs
+++ b/crates/codegen/ebnf/src/serialization.rs
@@ -70,12 +70,12 @@ impl EbnfSerializer {
         buffer.push_str(&self.display_name(name));
         buffer.push_str(" = ");
         buffer.push_str(&self.serialize_root_node(name, root_node));
-        buffer.push_str(";");
+        buffer.push(';');
 
         match self.outputs.get_mut(name) {
             Some(existing) => {
                 if !existing.is_empty() {
-                    existing.push_str("\n");
+                    existing.push('\n');
                 }
 
                 existing.push_str(&buffer);
@@ -144,20 +144,20 @@ impl EbnfSerializer {
                 self.serialize_child_node(top_node, subtrahend, buffer);
             }
             EbnfNode::Not { node } => {
-                buffer.push_str("!");
+                buffer.push('!');
                 self.serialize_child_node(top_node, node, buffer);
             }
             EbnfNode::OneOrMore { node } => {
                 self.serialize_child_node(top_node, node, buffer);
-                buffer.push_str("+");
+                buffer.push('+');
             }
             EbnfNode::Optional { node } => {
                 self.serialize_child_node(top_node, node, buffer);
-                buffer.push_str("?");
+                buffer.push('?');
             }
             EbnfNode::Range { from, to } => {
                 buffer.push_str(&format_string_literal(&from.to_string()));
-                buffer.push_str("…");
+                buffer.push('…');
                 buffer.push_str(&format_string_literal(&to.to_string()));
             }
             EbnfNode::ProductionRef { name } => {
@@ -166,7 +166,7 @@ impl EbnfSerializer {
             EbnfNode::Sequence { nodes } => {
                 for (i, node) in nodes.iter().enumerate() {
                     if i > 0 {
-                        buffer.push_str(" ");
+                        buffer.push(' ');
                     }
 
                     self.serialize_child_node(top_node, node, buffer);
@@ -183,7 +183,7 @@ impl EbnfSerializer {
             }
             EbnfNode::ZeroOrMore { node } => {
                 self.serialize_child_node(top_node, node, buffer);
-                buffer.push_str("*");
+                buffer.push('*');
             }
         };
     }
@@ -191,9 +191,9 @@ impl EbnfSerializer {
     fn serialize_child_node(&mut self, parent: &EbnfNode, child: &EbnfNode, buffer: &mut String) {
         if discriminant(parent) != discriminant(child) && child.precedence() <= parent.precedence()
         {
-            buffer.push_str("(");
+            buffer.push('(');
             self.serialize_node(child, buffer);
-            buffer.push_str(")");
+            buffer.push(')');
         } else {
             self.serialize_node(child, buffer);
         }

--- a/crates/codegen/ebnf/src/serialization.rs
+++ b/crates/codegen/ebnf/src/serialization.rs
@@ -241,7 +241,7 @@ fn format_string_literal(value: &str) -> String {
             _ => {
                 panic!(
                     "Unexpected character in string literal: '{c}'",
-                    c = c.escape_unicode().to_string()
+                    c = c.escape_unicode()
                 );
             }
         })

--- a/crates/codegen/grammar/src/grammar.rs
+++ b/crates/codegen/grammar/src/grammar.rs
@@ -50,27 +50,27 @@ impl GrammarElement {
     }
 }
 
-impl Into<GrammarElement> for ScannerDefinitionRef {
-    fn into(self) -> GrammarElement {
-        GrammarElement::ScannerDefinition(self)
+impl From<ScannerDefinitionRef> for GrammarElement {
+    fn from(def: ScannerDefinitionRef) -> Self {
+        GrammarElement::ScannerDefinition(def)
     }
 }
 
-impl Into<GrammarElement> for TriviaParserDefinitionRef {
-    fn into(self) -> GrammarElement {
-        GrammarElement::TriviaParserDefinition(self)
+impl From<TriviaParserDefinitionRef> for GrammarElement {
+    fn from(def: TriviaParserDefinitionRef) -> Self {
+        GrammarElement::TriviaParserDefinition(def)
     }
 }
 
-impl Into<GrammarElement> for ParserDefinitionRef {
-    fn into(self) -> GrammarElement {
-        GrammarElement::ParserDefinition(self)
+impl From<ParserDefinitionRef> for GrammarElement {
+    fn from(def: ParserDefinitionRef) -> Self {
+        GrammarElement::ParserDefinition(def)
     }
 }
 
-impl Into<GrammarElement> for PrecedenceParserDefinitionRef {
-    fn into(self) -> GrammarElement {
-        GrammarElement::PrecedenceParserDefinition(self)
+impl From<PrecedenceParserDefinitionRef> for GrammarElement {
+    fn from(def: PrecedenceParserDefinitionRef) -> Self {
+        GrammarElement::PrecedenceParserDefinition(def)
     }
 }
 

--- a/crates/codegen/grammar/src/parser_definition.rs
+++ b/crates/codegen/grammar/src/parser_definition.rs
@@ -51,27 +51,27 @@ pub enum ParserDefinitionNode {
     TerminatedBy(Box<Self>, Box<Self>),
 }
 
-impl Into<ParserDefinitionNode> for ScannerDefinitionRef {
-    fn into(self) -> ParserDefinitionNode {
-        ParserDefinitionNode::ScannerDefinition(self)
+impl From<ScannerDefinitionRef> for ParserDefinitionNode {
+    fn from(def: ScannerDefinitionRef) -> Self {
+        ParserDefinitionNode::ScannerDefinition(def)
     }
 }
 
-impl Into<ParserDefinitionNode> for TriviaParserDefinitionRef {
-    fn into(self) -> ParserDefinitionNode {
-        ParserDefinitionNode::TriviaParserDefinition(self)
+impl From<TriviaParserDefinitionRef> for ParserDefinitionNode {
+    fn from(def: TriviaParserDefinitionRef) -> Self {
+        ParserDefinitionNode::TriviaParserDefinition(def)
     }
 }
 
-impl Into<ParserDefinitionNode> for ParserDefinitionRef {
-    fn into(self) -> ParserDefinitionNode {
-        ParserDefinitionNode::ParserDefinition(self)
+impl From<ParserDefinitionRef> for ParserDefinitionNode {
+    fn from(def: ParserDefinitionRef) -> Self {
+        ParserDefinitionNode::ParserDefinition(def)
     }
 }
 
-impl Into<ParserDefinitionNode> for PrecedenceParserDefinitionRef {
-    fn into(self) -> ParserDefinitionNode {
-        ParserDefinitionNode::PrecedenceParserDefinition(self)
+impl From<PrecedenceParserDefinitionRef> for ParserDefinitionNode {
+    fn from(def: PrecedenceParserDefinitionRef) -> Self {
+        ParserDefinitionNode::PrecedenceParserDefinition(def)
     }
 }
 

--- a/crates/codegen/grammar/src/scanner_definition.rs
+++ b/crates/codegen/grammar/src/scanner_definition.rs
@@ -32,9 +32,9 @@ pub enum ScannerDefinitionNode {
     ScannerDefinition(ScannerDefinitionRef),
 }
 
-impl Into<ScannerDefinitionNode> for ScannerDefinitionRef {
-    fn into(self) -> ScannerDefinitionNode {
-        ScannerDefinitionNode::ScannerDefinition(self)
+impl From<ScannerDefinitionRef> for ScannerDefinitionNode {
+    fn from(def_ref: ScannerDefinitionRef) -> Self {
+        ScannerDefinitionNode::ScannerDefinition(def_ref)
     }
 }
 

--- a/crates/codegen/language/definition/src/compiler/analysis/definitions.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/definitions.rs
@@ -161,6 +161,7 @@ fn calculate_defined_in(analysis: &mut Analysis, item: &Item) -> VersionSet {
     return defined_in;
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
 enum Errors<'err> {
     #[error("An item with the name '{0}' already exists.")]

--- a/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
@@ -48,7 +48,7 @@ fn check_unreachabable_items(analysis: &mut Analysis) {
         if !metadata.defined_in.is_empty() && !visited.contains(&*metadata.name) {
             analysis
                 .errors
-                .add(&metadata.name, &Errors::Unreachable(&*metadata.name));
+                .add(&metadata.name, &Errors::Unreachable(&metadata.name));
         }
     }
 }

--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -44,31 +44,31 @@ pub fn analyze_references(analysis: &mut Analysis) {
 fn check_item(analysis: &mut Analysis, item: &Item, enablement: &VersionSet) {
     match item {
         Item::Struct { item } => {
-            check_struct(analysis, item, &enablement);
+            check_struct(analysis, item, enablement);
         }
         Item::Enum { item } => {
-            check_enum(analysis, item, &enablement);
+            check_enum(analysis, item, enablement);
         }
         Item::Repeated { item } => {
-            check_repeated(analysis, item, &enablement);
+            check_repeated(analysis, item, enablement);
         }
         Item::Separated { item } => {
-            check_separated(analysis, item, &enablement);
+            check_separated(analysis, item, enablement);
         }
         Item::Precedence { item } => {
-            check_precedence(analysis, item, &enablement);
+            check_precedence(analysis, item, enablement);
         }
         Item::Trivia { item } => {
-            check_trivia(analysis, item, &enablement);
+            check_trivia(analysis, item, enablement);
         }
         Item::Keyword { item } => {
-            check_keyword(analysis, item, &enablement);
+            check_keyword(analysis, item, enablement);
         }
         Item::Token { item } => {
-            check_token(analysis, item, &enablement);
+            check_token(analysis, item, enablement);
         }
         Item::Fragment { item } => {
-            check_fragment(analysis, item, &enablement);
+            check_fragment(analysis, item, enablement);
         }
     }
 }
@@ -81,7 +81,7 @@ fn check_struct(analysis: &mut Analysis, item: &StructItem, enablement: &Version
         fields,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     check_fields(analysis, Some(name), fields, &enablement);
 }
@@ -93,7 +93,7 @@ fn check_enum(analysis: &mut Analysis, item: &EnumItem, enablement: &VersionSet)
         variants,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     for variant in variants {
         let EnumVariant {
@@ -102,7 +102,7 @@ fn check_enum(analysis: &mut Analysis, item: &EnumItem, enablement: &VersionSet)
             reference,
         } = &**variant;
 
-        let enablement = update_enablement(analysis, &enablement, &enabled);
+        let enablement = update_enablement(analysis, &enablement, enabled);
 
         check_reference(
             analysis,
@@ -122,7 +122,7 @@ fn check_repeated(analysis: &mut Analysis, item: &RepeatedItem, enablement: &Ver
         enabled,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     check_reference(
         analysis,
@@ -142,7 +142,7 @@ fn check_separated(analysis: &mut Analysis, item: &SeparatedItem, enablement: &V
         enabled,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     check_reference(
         analysis,
@@ -168,7 +168,7 @@ fn check_precedence(analysis: &mut Analysis, item: &PrecedenceItem, enablement: 
         primary_expressions,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     for precedence_expression in precedence_expressions {
         let PrecedenceExpression { name: _, operators } = &**precedence_expression;
@@ -181,9 +181,9 @@ fn check_precedence(analysis: &mut Analysis, item: &PrecedenceItem, enablement: 
                 fields,
             } = &**operator;
 
-            let enablement = update_enablement(analysis, &enablement, &enabled);
+            let enablement = update_enablement(analysis, &enablement, enabled);
 
-            check_fields(analysis, Some(name), &fields, &enablement);
+            check_fields(analysis, Some(name), fields, &enablement);
         }
     }
 
@@ -193,12 +193,12 @@ fn check_precedence(analysis: &mut Analysis, item: &PrecedenceItem, enablement: 
             enabled,
         } = &**primary_expression;
 
-        let enablement = update_enablement(analysis, &enablement, &enabled);
+        let enablement = update_enablement(analysis, &enablement, enabled);
 
         check_reference(
             analysis,
             Some(name),
-            &expression,
+            expression,
             &enablement,
             ReferenceFilter::Nodes,
         );
@@ -214,12 +214,12 @@ fn check_fields(
     for field in fields.values() {
         match &**field {
             Field::Required { kind } => {
-                check_field_kind(analysis, source, &kind, &enablement);
+                check_field_kind(analysis, source, kind, enablement);
             }
             Field::Optional { kind, enabled } => {
-                let enablement = update_enablement(analysis, &enablement, &enabled);
+                let enablement = update_enablement(analysis, enablement, enabled);
 
-                check_field_kind(analysis, source, &kind, &enablement);
+                check_field_kind(analysis, source, kind, &enablement);
             }
         };
     }
@@ -237,7 +237,7 @@ fn check_field_kind(
                 analysis,
                 source,
                 item,
-                &enablement,
+                enablement,
                 ReferenceFilter::NonTerminals,
             );
         }
@@ -247,7 +247,7 @@ fn check_field_kind(
                     analysis,
                     source,
                     item,
-                    &enablement,
+                    enablement,
                     ReferenceFilter::Terminals,
                 );
             }
@@ -259,14 +259,14 @@ fn check_trivia_parser(analysis: &mut Analysis, parser: &TriviaParser, enablemen
     match parser {
         TriviaParser::Sequence { parsers } | TriviaParser::Choice { parsers } => {
             for parser in parsers {
-                check_trivia_parser(analysis, parser, &enablement);
+                check_trivia_parser(analysis, parser, enablement);
             }
         }
         TriviaParser::ZeroOrMore { parser } | TriviaParser::Optional { parser } => {
-            check_trivia_parser(analysis, parser, &enablement);
+            check_trivia_parser(analysis, parser, enablement);
         }
         TriviaParser::Trivia { trivia } => {
-            check_reference(analysis, None, trivia, &enablement, ReferenceFilter::Trivia);
+            check_reference(analysis, None, trivia, enablement, ReferenceFilter::Trivia);
         }
         TriviaParser::EndOfInput => {}
     };
@@ -275,7 +275,7 @@ fn check_trivia_parser(analysis: &mut Analysis, parser: &TriviaParser, enablemen
 fn check_trivia(analysis: &mut Analysis, item: &TriviaItem, enablement: &VersionSet) {
     let TriviaItem { name, scanner } = item;
 
-    check_scanner(analysis, Some(name), &scanner, &enablement);
+    check_scanner(analysis, Some(name), scanner, enablement);
 }
 
 fn check_keyword(analysis: &mut Analysis, item: &KeywordItem, enablement: &VersionSet) {
@@ -289,7 +289,7 @@ fn check_keyword(analysis: &mut Analysis, item: &KeywordItem, enablement: &Versi
         analysis,
         Some(name),
         identifier,
-        &enablement,
+        enablement,
         ReferenceFilter::Tokens,
     );
 
@@ -300,7 +300,7 @@ fn check_keyword(analysis: &mut Analysis, item: &KeywordItem, enablement: &Versi
             value: _,
         } = &**definition;
 
-        let _ = update_enablement(analysis, &enablement, &enabled);
+        let _ = update_enablement(analysis, enablement, enabled);
 
         if let Some(reserved) = reserved {
             check_version_specifier(analysis, reserved);
@@ -314,9 +314,9 @@ fn check_token(analysis: &mut Analysis, item: &TokenItem, enablement: &VersionSe
     for definition in definitions {
         let TokenDefinition { enabled, scanner } = &**definition;
 
-        let enablement = update_enablement(analysis, &enablement, &enabled);
+        let enablement = update_enablement(analysis, enablement, enabled);
 
-        check_scanner(analysis, Some(name), &scanner, &enablement);
+        check_scanner(analysis, Some(name), scanner, &enablement);
     }
 }
 
@@ -327,7 +327,7 @@ fn check_fragment(analysis: &mut Analysis, item: &FragmentItem, enablement: &Ver
         scanner,
     } = item;
 
-    let enablement = update_enablement(analysis, &enablement, &enabled);
+    let enablement = update_enablement(analysis, enablement, enabled);
 
     check_scanner(analysis, Some(name), scanner, &enablement);
 }
@@ -341,13 +341,13 @@ fn check_scanner(
     match scanner {
         Scanner::Sequence { scanners } | Scanner::Choice { scanners } => {
             for scanner in scanners {
-                check_scanner(analysis, source, scanner, &enablement);
+                check_scanner(analysis, source, scanner, enablement);
             }
         }
         Scanner::Optional { scanner }
         | Scanner::ZeroOrMore { scanner }
         | Scanner::OneOrMore { scanner } => {
-            check_scanner(analysis, source, scanner, &enablement);
+            check_scanner(analysis, source, scanner, enablement);
         }
         Scanner::Not { chars: _ }
         | Scanner::Range {
@@ -361,8 +361,8 @@ fn check_scanner(
             scanner,
             not_followed_by,
         } => {
-            check_scanner(analysis, source, scanner, &enablement);
-            check_scanner(analysis, source, not_followed_by, &enablement);
+            check_scanner(analysis, source, scanner, enablement);
+            check_scanner(analysis, source, not_followed_by, enablement);
         }
         Scanner::Fragment { reference } => {
             check_reference(
@@ -478,11 +478,11 @@ fn update_enablement(
     let mut new_enablement = VersionSet::new();
     analysis.add_specifier(&mut new_enablement, new_specifier);
 
-    let not_defined_in = new_enablement.difference(&existing_enablement);
+    let not_defined_in = new_enablement.difference(existing_enablement);
     if !not_defined_in.is_empty() {
         analysis
             .errors
-            .add(new_specifier, &Errors::EnabledTooWide(&existing_enablement));
+            .add(new_specifier, &Errors::EnabledTooWide(existing_enablement));
     }
 
     return new_enablement;

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/adapter.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/adapter.rs
@@ -9,7 +9,7 @@ pub struct ParseAdapter;
 
 impl ParseAdapter {
     pub fn parse(input: TokenStream) -> Result<ParseOutput> {
-        return syn::parse2(input).map_err(|error| Error::from_syn(error));
+        return syn::parse2(input).map_err(Error::from_syn);
     }
 }
 

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
@@ -102,10 +102,8 @@ impl ParseHelpers {
     ) -> Result<T> {
         let span = input.span();
         match Self::syn::<Ident>(&input) {
-            Ok(key) if key.to_string() == name => key,
-            _ => {
-                return Error::fatal(&span, &Errors::ExpectedField(name));
-            }
+            Ok(key) if key == name => {}
+            _ => return Error::fatal(&span, &Errors::ExpectedField(name)),
         };
 
         Self::syn::<Token![=]>(&input)?;

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
@@ -31,10 +31,10 @@ impl ParseHelpers {
             let mut result = Vec::new();
 
             while !inner_input.is_empty() {
-                result.push(ParseInputTokens::parse_named_value(&inner_input, errors)?);
+                result.push(ParseInputTokens::parse_named_value(inner_input, errors)?);
 
                 if !inner_input.is_empty() {
-                    let comma = Self::syn::<Token![,]>(&inner_input)?;
+                    let comma = Self::syn::<Token![,]>(inner_input)?;
 
                     if inner_input.is_empty() {
                         errors.add(&comma, &Errors::TrailingComma);
@@ -62,14 +62,14 @@ impl ParseHelpers {
             let mut result = IndexMap::new();
 
             while !inner_input.is_empty() {
-                let key = ParseInputTokens::parse_named_value(&inner_input, errors)?;
+                let key = ParseInputTokens::parse_named_value(inner_input, errors)?;
 
-                Self::syn::<Token![=]>(&inner_input)?;
+                Self::syn::<Token![=]>(inner_input)?;
 
-                let value = ParseInputTokens::parse_named_value(&inner_input, errors)?;
+                let value = ParseInputTokens::parse_named_value(inner_input, errors)?;
 
                 if !inner_input.is_empty() {
-                    let comma = Self::syn::<Token![,]>(&inner_input)?;
+                    let comma = Self::syn::<Token![,]>(inner_input)?;
 
                     if inner_input.is_empty() {
                         errors.add(&comma, &Errors::TrailingComma);
@@ -101,17 +101,17 @@ impl ParseHelpers {
         errors: &mut ErrorsCollection,
     ) -> Result<T> {
         let span = input.span();
-        match Self::syn::<Ident>(&input) {
+        match Self::syn::<Ident>(input) {
             Ok(key) if key == name => {}
             _ => return Error::fatal(&span, &Errors::ExpectedField(name)),
         };
 
-        Self::syn::<Token![=]>(&input)?;
+        Self::syn::<Token![=]>(input)?;
 
-        let value = ParseInputTokens::parse_named_value(&input, errors)?;
+        let value = ParseInputTokens::parse_named_value(input, errors)?;
 
         if !input.is_empty() {
-            let comma = Self::syn::<Token![,]>(&input)?;
+            let comma = Self::syn::<Token![,]>(input)?;
 
             if input.is_empty() {
                 errors.add(&comma, &Errors::TrailingComma);

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/implementations.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/implementations.rs
@@ -85,7 +85,7 @@ impl<T: ParseInputTokens> ParseInputTokens for Option<T> {
 
     fn parse_field(name: &str, input: ParseStream, errors: &mut ErrorsCollection) -> Result<Self> {
         match ParseHelpers::syn::<Ident>(&input.fork()) {
-            Ok(key) if key.to_string() == name => {
+            Ok(key) if key == name => {
                 return Ok(Some(ParseHelpers::field(name, input, errors)?));
             }
             _ => {

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/implementations.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/implementations.rs
@@ -152,7 +152,7 @@ impl ParseInputTokens for usize {
 
         return literal
             .base10_parse::<usize>()
-            .map_err(|error| Error::from_syn(error));
+            .map_err(Error::from_syn);
     }
 }
 

--- a/crates/codegen/language/definition/src/internals/write_output_tokens/implementations.rs
+++ b/crates/codegen/language/definition/src/internals/write_output_tokens/implementations.rs
@@ -40,7 +40,7 @@ impl WriteOutputTokens for char {
 
 impl WriteOutputTokens for Identifier {
     fn write_output_tokens(&self) -> TokenStream {
-        let value = Literal::string(&self);
+        let value = Literal::string(self);
 
         return quote! {
             #value.into()

--- a/crates/codegen/language/definition/src/utils/versions.rs
+++ b/crates/codegen/language/definition/src/utils/versions.rs
@@ -3,14 +3,14 @@ use std::{fmt::Display, mem::swap, ops::Range};
 
 const MAX_VERSION: Version = Version::new(u64::MAX, u64::MAX, u64::MAX);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct VersionSet {
     ranges: Vec<Range<Version>>,
 }
 
 impl VersionSet {
     pub fn new() -> Self {
-        return Self { ranges: vec![] };
+        return Self::default();
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/codegen/language/definition/src/utils/versions.rs
+++ b/crates/codegen/language/definition/src/utils/versions.rs
@@ -24,7 +24,7 @@ impl VersionSet {
     pub fn add_version_range(&mut self, from: &Version, till: &Version) {
         let mut from = from.to_owned();
         let mut till = till.to_owned();
-        assert_eq!(from < till, true, "Invalid range: '{from}..{till}'");
+        assert!(from < till, "Invalid range: '{from}..{till}'");
 
         self.ranges.retain_mut(|range| {
             if till < range.start {

--- a/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
@@ -50,7 +50,7 @@ fn derive_enum(name: &Ident, variants: &[Variant]) -> TokenStream {
         let variant_name = variant_id.to_string();
 
         if let Some(fields) = &variant.fields {
-            let fields_return = derive_fields_return(quote!(Self::#variant_id), &fields);
+            let fields_return = derive_fields_return(quote!(Self::#variant_id), fields);
 
             return quote! {
                 #variant_name => {

--- a/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
@@ -74,7 +74,7 @@ fn derive_enum(name: &Ident, variants: &[Variant]) -> TokenStream {
         "Expected a variant: {}",
         variants
             .iter()
-            .map(|variant| format!("'{}'", variant.name.to_string()))
+            .map(|variant| format!("'{}'", variant.name))
             .collect_vec()
             .join(" or ")
     ));

--- a/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
@@ -30,7 +30,7 @@ fn derive_struct(name: &Ident, fields: &[Field]) -> TokenStream {
                 errors: &mut crate::internals::ErrorsCollection,
             ) -> crate::internals::Result<Self> {
                 let name = crate::internals::ParseHelpers::syn::<syn::Ident>(input)?;
-                if name.to_string() != #name_string {
+                if name != #name_string {
                     return crate::internals::Error::fatal(&name, &#unexpected_type_error);
                 }
 

--- a/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
@@ -10,7 +10,7 @@ pub fn parse_input_tokens(item: &Item) -> TokenStream {
     };
 }
 
-fn derive_struct(name: &Ident, fields: &Vec<Field>) -> TokenStream {
+fn derive_struct(name: &Ident, fields: &[Field]) -> TokenStream {
     let name_string = Literal::string(&name.to_string());
     let unexpected_type_error = Literal::string(&format!("Expected type: {name}"));
 
@@ -44,7 +44,7 @@ fn derive_struct(name: &Ident, fields: &Vec<Field>) -> TokenStream {
     };
 }
 
-fn derive_enum(name: &Ident, variants: &Vec<Variant>) -> TokenStream {
+fn derive_enum(name: &Ident, variants: &[Variant]) -> TokenStream {
     let match_arms = variants.iter().map(|variant| {
         let variant_id = &variant.name;
         let variant_name = variant_id.to_string();
@@ -98,10 +98,10 @@ fn derive_enum(name: &Ident, variants: &Vec<Variant>) -> TokenStream {
     };
 }
 
-fn derive_fields_return(type_name: TokenStream, fields: &Vec<Field>) -> TokenStream {
+fn derive_fields_return(type_name: TokenStream, fields: &[Field]) -> TokenStream {
     // When there is only one field, we omit the `key = ` part.
     // This way, we can just write `Foo(Bar)` instead of `Foo(key = Bar)`.
-    let assignments = if let [single_field] = &fields[..] {
+    let assignments = if let [single_field] = fields {
         let name = &single_field.name;
         quote!(
             #name: crate::internals::ParseInputTokens::parse_value(&input, errors)?

--- a/crates/codegen/language/internal_macros/src/derive/write_output_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/write_output_tokens.rs
@@ -18,7 +18,7 @@ pub fn write_output_tokens(item: &Item) -> TokenStream {
     };
 }
 
-fn derive_struct(name: &Ident, fields: &Vec<Field>) -> TokenStream {
+fn derive_struct(name: &Ident, fields: &[Field]) -> TokenStream {
     let keys = fields.iter().map(|field| &field.name).collect_vec();
 
     return quote! {
@@ -32,7 +32,7 @@ fn derive_struct(name: &Ident, fields: &Vec<Field>) -> TokenStream {
     };
 }
 
-fn derive_enum(name: &Ident, variants: &Vec<Variant>) -> TokenStream {
+fn derive_enum(name: &Ident, variants: &[Variant]) -> TokenStream {
     let match_arms = variants.iter().map(|variant| {
         let variant_name = &variant.name;
 

--- a/crates/codegen/language/internal_macros/src/lib.rs
+++ b/crates/codegen/language/internal_macros/src/lib.rs
@@ -40,7 +40,7 @@ fn derive_internals_aux(
     let output = run_derivers(input_items)?;
     input_items.push(syn::Item::Verbatim(output));
 
-    return Ok(input_mod.into_token_stream().into());
+    return Ok(input_mod.into_token_stream());
 }
 
 fn run_derivers(input_items: &[syn::Item]) -> Result<proc_macro2::TokenStream> {

--- a/crates/codegen/language/internal_macros/src/lib.rs
+++ b/crates/codegen/language/internal_macros/src/lib.rs
@@ -43,7 +43,7 @@ fn derive_internals_aux(
     return Ok(input_mod.into_token_stream().into());
 }
 
-fn run_derivers(input_items: &Vec<syn::Item>) -> Result<proc_macro2::TokenStream> {
+fn run_derivers(input_items: &[syn::Item]) -> Result<proc_macro2::TokenStream> {
     let model = Model::from_syn(input_items)?;
 
     let spanned = model.items().map(derive::spanned);

--- a/crates/codegen/language/internal_macros/src/model/mod.rs
+++ b/crates/codegen/language/internal_macros/src/model/mod.rs
@@ -58,7 +58,7 @@ impl Item {
             variants: input
                 .variants
                 .iter()
-                .map(|variant| Variant::from_syn(variant))
+                .map(Variant::from_syn)
                 .try_collect()?,
         });
     }

--- a/crates/codegen/language/internal_macros/src/model/mod.rs
+++ b/crates/codegen/language/internal_macros/src/model/mod.rs
@@ -11,7 +11,7 @@ impl Model {
         return self.items.iter();
     }
 
-    pub fn from_syn(input: &Vec<syn::Item>) -> Result<Self> {
+    pub fn from_syn(input: &[syn::Item]) -> Result<Self> {
         let items = input
             .iter()
             .filter_map(|item| match &item {

--- a/crates/codegen/language/tests/src/pass/tiny_language.rs
+++ b/crates/codegen/language/tests/src/pass/tiny_language.rs
@@ -71,8 +71,7 @@ fn definition() {
                                                 items: ["Bar".into()].into()
                                             }
                                         }
-                                    )
-                                        .into(),
+                                    ),
                                     (
                                         "baz".into(),
                                         Field::Required {
@@ -80,8 +79,7 @@ fn definition() {
                                                 items: ["Baz".into()].into()
                                             }
                                         }
-                                    )
-                                        .into(),
+                                    ),
                                     (
                                         "baz_again".into(),
                                         Field::Required {
@@ -90,7 +88,6 @@ fn definition() {
                                             }
                                         }
                                     )
-                                        .into()
                                 ]
                                 .into()
                             }

--- a/crates/codegen/parser/generator/src/code_generator.rs
+++ b/crates/codegen/parser/generator/src/code_generator.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     mem,
-    path::PathBuf,
+    path::Path,
 };
 
 use anyhow::Result;
@@ -57,7 +57,7 @@ struct ScannerContext {
 }
 
 impl CodeGenerator {
-    pub fn write_source(output_dir: &PathBuf, grammar: &Grammar) -> Result<()> {
+    pub fn write_source(output_dir: &Path, grammar: &Grammar) -> Result<()> {
         let mut code = Self::default();
         grammar.accept_visitor(&mut code);
         let code = &code;

--- a/crates/codegen/parser/generator/src/parser_definition.rs
+++ b/crates/codegen/parser/generator/src/parser_definition.rs
@@ -286,7 +286,7 @@ impl VersionQualityRangeVecExtensions for Vec<VersionQualityRange> {
     fn disambiguating_name_suffix(&self) -> String {
         let mut suffix = String::new();
         for vqr in self {
-            suffix.push_str("_");
+            suffix.push('_');
             suffix.push_str(&vqr.quality.to_string().to_lowercase());
             suffix.push_str("_from_");
             suffix.push_str(&vqr.from.to_string().replace('.', "_"));

--- a/crates/codegen/parser/generator/src/scanner_definition.rs
+++ b/crates/codegen/parser/generator/src/scanner_definition.rs
@@ -113,7 +113,7 @@ impl ScannerDefinitionNodeExtensions for ScannerDefinitionNode {
             }
 
             ScannerDefinitionNode::CharRange(from, to) => {
-                quote! { scan_char_range!(input, #from, #to) }
+                quote! { scan_char_range!(input, #from..=#to) }
             }
 
             ScannerDefinitionNode::Literal(string) => {

--- a/crates/codegen/parser/generator/src/scanner_definition.rs
+++ b/crates/codegen/parser/generator/src/scanner_definition.rs
@@ -108,7 +108,7 @@ impl ScannerDefinitionNodeExtensions for ScannerDefinitionNode {
                         quote! { scan_chars!(input, #(#chars),*) }
                     })
                     .collect::<Vec<_>>();
-                scanners.extend(non_literal_scanners.into_iter());
+                scanners.extend(non_literal_scanners);
                 quote! { scan_choice!(input, #(#scanners),*) }
             }
 

--- a/crates/codegen/parser/generator/src/trie.rs
+++ b/crates/codegen/parser/generator/src/trie.rs
@@ -23,10 +23,9 @@ impl Trie {
     }
 
     pub fn insert(&mut self, key: &str, payload: ScannerDefinitionRef) {
-        let chars = key.chars().collect::<Vec<_>>();
         let mut node = self;
-        for i in 0..chars.len() {
-            node = node.subtries.entry(chars[i]).or_insert_with(Self::new);
+        for char in key.chars() {
+            node = node.subtries.entry(char).or_insert_with(Self::new);
         }
         node.payload = Some(payload);
         node.key = Some(key.to_string());

--- a/crates/codegen/parser/runtime/src/support/parser_function.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_function.rs
@@ -96,10 +96,10 @@ where
                     let parse_tree = cst::Node::Rule(topmost_rule);
                     // Sanity check: Make sure that succesful parse is equivalent to not having any SKIPPED nodes
                     debug_assert_eq!(
-                        errors.len() > 0,
+                        errors.is_empty(),
                         parse_tree
                             .cursor_with_offset(TextIndex::ZERO)
-                            .any(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_some())
+                            .all(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_none())
                     );
 
                     ParseOutput { parse_tree, errors }

--- a/crates/codegen/parser/runtime/src/support/parser_function.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_function.rs
@@ -57,7 +57,7 @@ where
                 };
 
                 let topmost_rule = match &nodes[..] {
-                    [cst::Node::Rule(rule)] => Rc::clone(&rule),
+                    [cst::Node::Rule(rule)] => Rc::clone(rule),
                     [_] => unreachable!(
                         "(Incomplete)Match at the top level of a parser is not a Rule node"
                     ),

--- a/crates/codegen/parser/runtime/src/support/parser_result.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_result.rs
@@ -119,9 +119,9 @@ pub enum PrattElement {
 }
 
 impl PrattElement {
-    pub fn to_nodes(self) -> Vec<cst::Node> {
+    pub fn into_nodes(self) -> Vec<cst::Node> {
         match self {
-            Self::Expression { nodes } => nodes.clone(),
+            Self::Expression { nodes } => nodes,
             Self::Binary { kind, nodes, .. }
             | Self::Prefix { kind, nodes, .. }
             | Self::Postfix { kind, nodes, .. } => {

--- a/crates/codegen/parser/runtime/src/support/parser_result.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_result.rs
@@ -40,17 +40,14 @@ impl ParserResult {
     }
 
     pub fn is_match(&self) -> bool {
-        match self {
-            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_)
+        )
     }
 
     pub fn is_no_match(&self) -> bool {
-        match self {
-            ParserResult::NoMatch(_) => true,
-            _ => false,
-        }
+        matches!(self, ParserResult::NoMatch(_))
     }
 
     pub fn with_kind(self, new_kind: RuleKind) -> ParserResult {

--- a/crates/codegen/parser/runtime/src/support/scanner_macros.rs
+++ b/crates/codegen/parser/runtime/src/support/scanner_macros.rs
@@ -29,9 +29,10 @@ macro_rules! scan_none_of {
 
 #[allow(unused_macros)]
 macro_rules! scan_char_range {
-    ($stream:ident, $from:literal , $to:literal) => {
+    ($stream:ident, $from:literal..=$to:literal) => {
         if let Some(c) = $stream.next() {
-            if $from <= c && c <= $to {
+            #[allow(clippy::manual_is_ascii_check)]
+            if ($from..=$to).contains(&c) {
                 true
             } else {
                 $stream.undo();

--- a/crates/codegen/parser/runtime/src/support/separated_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/separated_helper.rs
@@ -86,10 +86,10 @@ impl SeparatedHelper {
                     }
                 }
                 ParserResult::NoMatch(no_match) => {
-                    if accum.len() > 0 {
-                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
-                    } else {
+                    if accum.is_empty() {
                         return ParserResult::no_match(no_match.expected_tokens);
+                    } else {
+                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
                     }
                 }
 

--- a/crates/codegen/parser/runtime/src/support/sequence_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/sequence_helper.rs
@@ -47,7 +47,7 @@ impl SequenceHelper {
 
                 // If the accumulated result is valid, but empty (e.g. we accepted an empty optional)
                 // just take the next result
-                (ParserResult::Match(running), next @ _) if running.nodes.is_empty() => {
+                (ParserResult::Match(running), next) if running.nodes.is_empty() => {
                     self.result = State::Running(next);
                 }
                 // Keep accepting or convert into PrattOperatorMatch

--- a/crates/codegen/parser/runtime/src/support/sequence_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/sequence_helper.rs
@@ -94,7 +94,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
@@ -104,7 +104,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/codegen/parser/runtime/src/support/sequence_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/sequence_helper.rs
@@ -95,7 +95,7 @@ impl SequenceHelper {
                         std::mem::take(&mut cur.elements)
                             .into_iter()
                             .flat_map(|pratt| pratt.to_nodes())
-                            .chain(next.nodes.into_iter())
+                            .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
@@ -43,6 +43,7 @@ pub enum RuleKind {
 
 impl RuleKind {
     pub fn is_trivia(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match self {
             {%- for variant in code.trivia_kinds -%}
                 Self::{{ variant }} => true,

--- a/crates/codegen/schema/src/compiler.rs
+++ b/crates/codegen/schema/src/compiler.rs
@@ -114,7 +114,7 @@ fn load_topic(
     for path in [&notes_path, &productions_path] {
         if !path.exists() {
             let range = Position::new(0, 0, 0)..Position::new(usize::MAX, usize::MAX, usize::MAX);
-            let message = format!("Topic file not found.");
+            let message = "Topic file not found.".to_string();
 
             return Err(InfraErrors::single(path.to_owned(), range, message));
         }

--- a/crates/codegen/schema/src/compiler.rs
+++ b/crates/codegen/schema/src/compiler.rs
@@ -98,7 +98,7 @@ fn load_sections(
         });
     }
 
-    return errors.to_result().map(|_| results);
+    return errors.into_result().map(|_| results);
 }
 
 fn load_topic(

--- a/crates/codegen/schema/src/validation/rules/definitions/keywords/collector.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/keywords/collector.rs
@@ -99,7 +99,7 @@ impl KeywordsCollector {
             ScannerDefinition::Choice(scanners) => {
                 let mut variations = Vec::new();
                 for scanner in scanners {
-                    variations.extend(Self::collect_variations(&scanner)?);
+                    variations.extend(Self::collect_variations(scanner)?);
                 }
 
                 return Some(variations);

--- a/crates/codegen/schema/src/validation/rules/definitions/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/mod.rs
@@ -23,5 +23,5 @@ pub fn run(language: &LanguageDefinitionRef) -> Result<()> {
     Productions::validate(language, &mut reporter);
     Versions::validate(language, &mut reporter);
 
-    return reporter.to_result();
+    return reporter.into_result();
 }

--- a/crates/codegen/schema/src/validation/rules/definitions/productions/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/productions/mod.rs
@@ -28,10 +28,10 @@ impl Visitor for Productions {
         for name in required_productions {
             if let Some(production) = self.language.productions.get(name) {
                 if production.inlined {
-                    reporter.report(&location, Errors::RequiredCannotBeInlined(name.to_owned()));
+                    reporter.report(location, Errors::RequiredCannotBeInlined(name.to_owned()));
                 }
             } else {
-                reporter.report(&location, Errors::MissingRequired(name.to_owned()));
+                reporter.report(location, Errors::MissingRequired(name.to_owned()));
             }
         }
 

--- a/crates/codegen/schema/src/validation/rules/definitions/versions/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/definitions/versions/mod.rs
@@ -22,7 +22,7 @@ impl Versions {
 impl Visitor for Versions {
     fn visit_manifest(&mut self, location: &LocationRef, reporter: &mut Reporter) -> bool {
         if self.language.versions.is_empty() {
-            reporter.report(&location, Errors::Empty);
+            reporter.report(location, Errors::Empty);
             return false;
         }
 
@@ -31,7 +31,7 @@ impl Visitor for Versions {
             let next = &window[1];
 
             if current >= next {
-                reporter.report(&location, Errors::NotSorted(current.to_owned()));
+                reporter.report(location, Errors::NotSorted(current.to_owned()));
                 return false;
             }
         }
@@ -51,7 +51,7 @@ impl Visitor for Versions {
         };
 
         if versions.is_empty() {
-            reporter.report(&location, Errors::Empty);
+            reporter.report(location, Errors::Empty);
             return false;
         }
 
@@ -60,7 +60,7 @@ impl Visitor for Versions {
             let next = window[1];
 
             if current >= next {
-                reporter.report(&location, Errors::NotSorted(current.to_owned()));
+                reporter.report(location, Errors::NotSorted(current.to_owned()));
                 return false;
             }
         }

--- a/crates/codegen/schema/src/validation/rules/lints/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/lints/mod.rs
@@ -17,5 +17,5 @@ pub fn run(language: &LanguageDefinitionRef) -> Result<()> {
     ChildrenCount::validate(language, &mut reporter);
     ConsistentShape::validate(language, &mut reporter);
 
-    return reporter.to_result();
+    return reporter.into_result();
 }

--- a/crates/codegen/schema/src/validation/rules/references/metadata.rs
+++ b/crates/codegen/schema/src/validation/rules/references/metadata.rs
@@ -100,7 +100,7 @@ impl Metadata {
             let references = &self.productions.get(production_name).unwrap().references;
             for reference in references {
                 if !visited.contains(reference) {
-                    queue.push(&reference);
+                    queue.push(reference);
                 }
             }
         }

--- a/crates/codegen/schema/src/validation/rules/references/mod.rs
+++ b/crates/codegen/schema/src/validation/rules/references/mod.rs
@@ -22,5 +22,5 @@ pub fn run(language: &LanguageDefinitionRef) -> Result<()> {
     metadata.validate_not_used(language, &mut reporter);
     metadata.validate_not_reachable(language, &mut reporter);
 
-    return reporter.to_result();
+    return reporter.into_result();
 }

--- a/crates/codegen/schema/src/validation/rules/references/validator.rs
+++ b/crates/codegen/schema/src/validation/rules/references/validator.rs
@@ -62,7 +62,7 @@ impl Visitor for Validator<'_> {
     ) -> bool {
         if let ScannerDefinition::Reference(reference) = &scanner.definition {
             self.validate_reference(
-                &reference,
+                reference,
                 ReferenceKind::ScannerToScanner,
                 location,
                 reporter,
@@ -161,7 +161,7 @@ impl Validator<'_> {
 
         if !self.metadata.is_defined_over(reference_name, version_set) {
             reporter.report(
-                &location,
+                location,
                 Errors::ReferenceVersionNotDefined(
                     reference_name.to_owned(),
                     version_set.to_owned(),
@@ -198,7 +198,7 @@ impl Validator<'_> {
         };
 
         self.metadata
-            .add_reference(&production.name, &version_set, reference_name);
+            .add_reference(&production.name, version_set, reference_name);
     }
 }
 

--- a/crates/codegen/schema/src/validation/rules/references/validator.rs
+++ b/crates/codegen/schema/src/validation/rules/references/validator.rs
@@ -172,11 +172,10 @@ impl Validator<'_> {
 
         match validation_kind {
             ReferenceKind::ParserToAnything => {
-                if matches!(reference.definition, ProductionDefinition::Scanner { .. }) {
-                    if reference.inlined {
-                        reporter
-                            .report(location, Errors::CannotBeInlined(reference_name.to_owned()));
-                    }
+                if reference.inlined
+                    && matches!(reference.definition, ProductionDefinition::Scanner { .. })
+                {
+                    reporter.report(location, Errors::CannotBeInlined(reference_name.to_owned()));
                 }
             }
             ReferenceKind::ParserToScanner => {

--- a/crates/codegen/schema/src/validation/visitors/reporter.rs
+++ b/crates/codegen/schema/src/validation/visitors/reporter.rs
@@ -21,7 +21,7 @@ impl Reporter {
         self.errors.push((location.to_owned(), error.to_string()));
     }
 
-    pub fn to_result(self) -> Result<()> {
+    pub fn into_result(self) -> Result<()> {
         let mut errors = InfraErrors::new();
         let mut cst_cache = HashMap::<PathBuf, NodeRef>::new();
 
@@ -50,6 +50,6 @@ impl Reporter {
             errors.push(file_path, range, message);
         }
 
-        return errors.to_result();
+        return errors.into_result();
     }
 }

--- a/crates/codegen/schema/src/validation/visitors/reporter.rs
+++ b/crates/codegen/schema/src/validation/visitors/reporter.rs
@@ -32,7 +32,7 @@ impl Reporter {
                 let source = file_path.read_to_string().unwrap();
 
                 return Parser::run_parser(&file_path, &source)
-                    .expect(&format!("File cannot be parsed: {file_path:?}"));
+                    .unwrap_or_else(|_| panic!("File cannot be parsed: {file_path:?}"));
             });
 
             let mut current_node = cst.as_ref();

--- a/crates/codegen/schema/src/yaml/cst.rs
+++ b/crates/codegen/schema/src/yaml/cst.rs
@@ -41,7 +41,7 @@ impl Node {
         return match self {
             Node::Array { nodes, .. } => nodes
                 .get(index)
-                .expect(&format!("Expected array to have index '{index}'.")),
+                .unwrap_or_else(|| panic!("Expected array to have index '{index}'.")),
             _ => unreachable!("Expected an array."),
         };
     }
@@ -51,7 +51,7 @@ impl Node {
             Node::Object { fields, .. } => {
                 &fields
                     .get(field)
-                    .expect(&format!("Expected object to have field '{field}'."))
+                    .unwrap_or_else(|| panic!("Expected object to have field '{field}'."))
                     .value
             }
             _ => unreachable!("Expected an object."),

--- a/crates/codegen/spec/src/grammar.rs
+++ b/crates/codegen/spec/src/grammar.rs
@@ -32,7 +32,7 @@ pub fn generate_supported_versions_page(language: &LanguageDefinition) -> Naviga
     return NavigationEntry::Page {
         title: "Supported Versions".to_owned(),
         path: "supported-versions".to_owned(),
-        contents: page.to_string(),
+        contents: page.into_string(),
     };
 }
 
@@ -88,5 +88,5 @@ fn generate_grammar_page(
         }
     }
 
-    return page.to_string();
+    return page.into_string();
 }

--- a/crates/codegen/spec/src/lib.rs
+++ b/crates/codegen/spec/src/lib.rs
@@ -37,7 +37,7 @@ impl SpecGeneratorExtensions for LanguageDefinitionRef {
     fn generate_spec(&self, output_dir: &Path) -> Result<()> {
         let mut codegen = Codegen::write_only()?;
 
-        let snippets = Snippets::new(&self, output_dir);
+        let snippets = Snippets::new(self, output_dir);
         snippets.write_files(&mut codegen)?;
 
         let root_entry = NavigationEntry::Directory {

--- a/crates/codegen/spec/src/markdown.rs
+++ b/crates/codegen/spec/src/markdown.rs
@@ -11,7 +11,7 @@ impl MarkdownWriter {
         return Self { w: String::new() };
     }
 
-    pub fn to_string(self) -> String {
+    pub fn into_string(self) -> String {
         return self.w;
     }
 

--- a/crates/codegen/spec/src/navigation.rs
+++ b/crates/codegen/spec/src/navigation.rs
@@ -39,8 +39,8 @@ impl NavigationEntry {
                     index_page.write_list_link(child.title(), &child.nav_path());
                 }
 
-                codegen.write_file(current_dir.join("NAV.md"), nav_page.to_string())?;
-                codegen.write_file(current_dir.join("index.md"), index_page.to_string())?;
+                codegen.write_file(current_dir.join("NAV.md"), nav_page.into_string())?;
+                codegen.write_file(current_dir.join("index.md"), index_page.into_string())?;
             }
             NavigationEntry::Page { contents, .. } => {
                 codegen.write_file(current_dir.join("index.md"), contents)?;

--- a/crates/codegen/spec/src/reference.rs
+++ b/crates/codegen/spec/src/reference.rs
@@ -48,5 +48,5 @@ fn generate_topic_page(
             .join(LanguageTopic::NOTES_FILE_NAME),
     );
 
-    return page.to_string();
+    return page.into_string();
 }

--- a/crates/codegen/spec/src/snippets.rs
+++ b/crates/codegen/spec/src/snippets.rs
@@ -34,8 +34,8 @@ impl Snippets {
             };
 
             for version in versions {
-                if let Some(snippet_path) = self.get_snippet_path(production, &version) {
-                    let snippet = self.get_snippet(production, &version).unwrap_or_default();
+                if let Some(snippet_path) = self.get_snippet_path(production, version) {
+                    let snippet = self.get_snippet(production, version).unwrap_or_default();
                     codegen.write_file(snippet_path, snippet)?
                 };
             }

--- a/crates/codegen/spec/src/snippets.rs
+++ b/crates/codegen/spec/src/snippets.rs
@@ -113,7 +113,7 @@ impl Snippets {
             snippet.write_code_block(language, class, &id, ebnf);
         }
 
-        return Some(snippet.to_string());
+        return Some(snippet.into_string());
     }
 
     fn locate_production(&self, name: &str) -> (&LanguageSection, &LanguageTopic) {

--- a/crates/codegen/testing/src/cst_output.rs
+++ b/crates/codegen/testing/src/cst_output.rs
@@ -62,7 +62,7 @@ fn collect_parser_tests(data_dir: &Path) -> Result<BTreeMap<String, BTreeSet<Str
             [parser_name, test_name, "input.sol"] => {
                 let parser_tests = parser_tests
                     .entry(parser_name.to_string())
-                    .or_insert_with(|| BTreeSet::new());
+                    .or_insert_with(BTreeSet::new);
 
                 parser_tests.insert(test_name.to_string());
             }

--- a/crates/infra/cli/src/commands/publish/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/publish/cargo/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use infra_utils::{cargo::CargoWorkspace, commands::Command, github::GitHub};
 
-const USER_FACING_CRATE: &'static str = "slang_solidity";
+const USER_FACING_CRATE: &str = "slang_solidity";
 
 pub fn publish_cargo() -> Result<()> {
     let local_version = CargoWorkspace::local_version()?;

--- a/crates/infra/cli/src/commands/publish/github_release/mod.rs
+++ b/crates/infra/cli/src/commands/publish/github_release/mod.rs
@@ -45,7 +45,7 @@ fn extract_latest_changelogs(
     // Asser that first block contains title '# changelog'
     assert_eq!(
         all_blocks.next().unwrap(),
-        Block::Header(vec![Span::Text(format!("changelog"))], 1),
+        Block::Header(vec![Span::Text("changelog".to_string())], 1),
     );
 
     // H2 for current_version: '## 1.2.3'

--- a/crates/infra/cli/src/toolchains/napi/compiler.rs
+++ b/crates/infra/cli/src/toolchains/napi/compiler.rs
@@ -146,7 +146,7 @@ fn compile_root_package(node_binary: Option<&Path>) -> Result<()> {
     return Ok(());
 }
 
-fn compile_platform_packages(node_binaries: &Vec<PathBuf>) -> Result<()> {
+fn compile_platform_packages(node_binaries: &[PathBuf]) -> Result<()> {
     for platform_dir in NapiResolver::platforms_dir().collect_children()? {
         let platform = platform_dir.unwrap_name();
         let package_kind = NapiPackageKind::Platform(platform.to_owned());

--- a/crates/infra/cli/src/toolchains/napi/resolver.rs
+++ b/crates/infra/cli/src/toolchains/napi/resolver.rs
@@ -33,7 +33,7 @@ impl NapiResolver {
             .join("target/napi")
             .join(match target {
                 BuildTarget::Debug => "debug",
-                BuildTarget::ReleaseTarget(target) => &target,
+                BuildTarget::ReleaseTarget(target) => target,
             });
     }
 

--- a/crates/infra/cli/src/utils.rs
+++ b/crates/infra/cli/src/utils.rs
@@ -9,8 +9,8 @@ use terminal_size::terminal_size;
 pub trait OrderedCommand: Clone + Ord + PartialEq + ValueEnum {
     fn execute(&self) -> Result<()>;
 
-    fn execute_in_order(commands: &Vec<Self>) -> Result<()> {
-        let mut commands = commands.clone();
+    fn execute_in_order(commands: &[Self]) -> Result<()> {
+        let mut commands = commands.to_owned();
 
         if commands.is_empty() {
             // Execute all commands if none are provided:

--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -31,7 +31,7 @@ impl CargoWorkspace {
 
         return Command::new("cargo")
             .args(["install", crate_name])
-            .property("--version", &version)
+            .property("--version", version)
             .run();
     }
 

--- a/crates/infra/utils/src/codegen/common/file_system.rs
+++ b/crates/infra/utils/src/codegen/common/file_system.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub fn delete_file(file_path: &Path) -> Result<()> {
-    return std::fs::remove_file(&file_path)
+    return std::fs::remove_file(file_path)
         .with_context(|| format!("Failed to delete source file: {file_path:?}"));
 }
 
@@ -16,7 +16,7 @@ pub fn write_file(file_path: &Path, contents: &str) -> Result<()> {
     std::fs::create_dir_all(file_path.unwrap_parent())
         .with_context(|| format!("Cannot create parent directory of: {file_path:?}"))?;
 
-    let formatted = format_source_file(file_path, &contents)?;
+    let formatted = format_source_file(file_path, contents)?;
 
     // To respect Cargo incrementability, don't touch the file if it is already up to date.
     if file_path.exists() && formatted == file_path.read_to_string()? {
@@ -31,7 +31,7 @@ pub fn write_file(file_path: &Path, contents: &str) -> Result<()> {
 }
 
 pub fn verify_file(file_path: &Path, contents: &str) -> Result<()> {
-    let formatted = format_source_file(file_path, &contents)?;
+    let formatted = format_source_file(file_path, contents)?;
 
     if !file_path.exists() {
         bail!("Generated file does not exist: {file_path:?}");

--- a/crates/infra/utils/src/codegen/common/formatting.rs
+++ b/crates/infra/utils/src/codegen/common/formatting.rs
@@ -56,7 +56,7 @@ fn generate_header(file_path: &Path) -> String {
         "This file is generated automatically by infrastructure scripts. Please don't edit by hand.";
 
     return match get_extension(file_path) {
-        "json" => format!(""),
+        "json" => "".to_string(),
         "html" | "md" => format!("<!-- {warning_line} -->"),
         "js" | "rs" | "ts" => format!("// {warning_line}"),
         "yml" | "zsh-completions" => format!("# {warning_line}"),

--- a/crates/infra/utils/src/commands/mod.rs
+++ b/crates/infra/utils/src/commands/mod.rs
@@ -217,8 +217,8 @@ impl Display for Command {
         parts.push(self.name.to_owned());
 
         for arg in &self.args {
-            let delimiter = if arg.contains(" ") {
-                if arg.contains("\"") {
+            let delimiter = if arg.contains(' ') {
+                if arg.contains('"') {
                     "'"
                 } else {
                     "\""

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -37,7 +37,7 @@ impl InfraErrors {
         self.contents.extend(other.contents);
     }
 
-    pub fn to_result(self) -> Result<()> {
+    pub fn into_result(self) -> Result<()> {
         if self.contents.is_empty() {
             return Ok(());
         } else {

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -114,13 +114,12 @@ impl ErrorDescriptor {
     fn write_problem_matcher(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(
             f,
-            "slang-problem-matcher:{file}:{line}:{column}-{end_line}:{end_column}: {severity}: {message}",
+            "slang-problem-matcher:{file}:{line}:{column}-{end_line}:{end_column}: error: {message}",
             file = self.file_path.unwrap_str(),
             line = self.range.start.line,
             column = self.range.start.column,
             end_line = self.range.end.line,
             end_column = self.range.end.column,
-            severity = "error",
             message = self.message,
         )?;
 

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -5,14 +5,14 @@ use anyhow::{bail, Result};
 use ariadne::{Color, Label, Report, ReportKind, Source};
 
 #[allow(clippy::len_without_is_empty)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct InfraErrors {
     contents: Vec<ErrorDescriptor>,
 }
 
 impl InfraErrors {
     pub fn new() -> Self {
-        return Self { contents: vec![] };
+        return Self::default();
     }
 
     pub fn len(&self) -> usize {

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -4,6 +4,7 @@ use crate::paths::PathExtensions;
 use anyhow::{bail, Result};
 use ariadne::{Color, Label, Report, ReportKind, Source};
 
+#[allow(clippy::len_without_is_empty)]
 #[derive(Debug)]
 pub struct InfraErrors {
     contents: Vec<ErrorDescriptor>,

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -69,7 +69,7 @@ impl std::fmt::Display for ErrorDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if var("VSCODE_PROBLEM_MATCHER").is_ok() {
             self.write_problem_matcher(f)?;
-            writeln!(f, "")?;
+            writeln!(f)?;
         }
 
         self.write_ariadne_report(f)?;

--- a/crates/infra/utils/src/github/mod.rs
+++ b/crates/infra/utils/src/github/mod.rs
@@ -53,7 +53,7 @@ impl GitHub {
 
         // tag_name is in the form 'v1.2.3', so remove the 'v' prefix before parsing the version:
         let version = tag_name
-            .strip_prefix("v")
+            .strip_prefix('v')
             .with_context(|| format!("Cannot extract version out of tag: {tag_name:#?}"))?;
 
         return Ok(Version::parse(version)?);

--- a/crates/infra/utils/src/paths/walker.rs
+++ b/crates/infra/utils/src/paths/walker.rs
@@ -37,7 +37,7 @@ impl FileWalker {
             // Since we allow hidden (dot) files below, we need to explicitly ignore the .git directory:
             builder.add("!.git/")?;
 
-            for glob in globs.as_ref() {
+            for glob in globs {
                 builder.add(glob.as_ref())?;
             }
 

--- a/crates/solidity/inputs/language/build.rs
+++ b/crates/solidity/inputs/language/build.rs
@@ -36,7 +36,7 @@ fn write_binary(language: &LanguageDefinitionRef, bin_file_path: &Path) -> Resul
     bson::to_document(&language)?.to_writer(&mut buffer)?;
 
     if bin_file_path.exists() {
-        let existing_buffer = std::fs::read(&bin_file_path)?;
+        let existing_buffer = std::fs::read(bin_file_path)?;
 
         if buffer == existing_buffer {
             // Don't overwrite, in order not to trigger a rebuild by Cargo:
@@ -46,7 +46,7 @@ fn write_binary(language: &LanguageDefinitionRef, bin_file_path: &Path) -> Resul
 
     std::fs::create_dir_all(bin_file_path.unwrap_parent())?;
 
-    std::fs::write(&bin_file_path, &buffer)?;
+    std::fs::write(bin_file_path, &buffer)?;
 
     return Ok(());
 }

--- a/crates/solidity/inputs/language/src/lib.rs
+++ b/crates/solidity/inputs/language/src/lib.rs
@@ -21,7 +21,7 @@ pub trait SolidityLanguageExtensions {
 }
 
 // Set by the build script.
-static LANGUAGE_DEFINITION_BIN: &'static str = env!("COMPILED_SOLIDITY_LANGUAGE_DEFINITION_BIN");
+static LANGUAGE_DEFINITION_BIN: &str = env!("COMPILED_SOLIDITY_LANGUAGE_DEFINITION_BIN");
 
 impl SolidityLanguageExtensions for LanguageDefinition {
     fn load_solidity() -> Result<LanguageDefinitionRef> {

--- a/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
@@ -328,6 +328,7 @@ pub enum RuleKind {
 
 impl RuleKind {
     pub fn is_trivia(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match self {
             Self::EndOfFileTrivia => true,
             Self::LeadingTrivia => true,

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -5373,9 +5373,9 @@ impl Language {
     fn ascii_character_without_double_quote_or_backslash(&self, input: &mut ParserContext) -> bool {
         scan_choice!(
             input,
-            scan_char_range!(input, ' ', '!'),
-            scan_char_range!(input, '#', '['),
-            scan_char_range!(input, ']', '~')
+            scan_char_range!(input, ' '..='!'),
+            scan_char_range!(input, '#'..='['),
+            scan_char_range!(input, ']'..='~')
         )
     }
 
@@ -5383,9 +5383,9 @@ impl Language {
     fn ascii_character_without_single_quote_or_backslash(&self, input: &mut ParserContext) -> bool {
         scan_choice!(
             input,
-            scan_char_range!(input, ' ', '&'),
-            scan_char_range!(input, '(', '['),
-            scan_char_range!(input, ']', '~')
+            scan_char_range!(input, ' '..='&'),
+            scan_char_range!(input, '('..='['),
+            scan_char_range!(input, ']'..='~')
         )
     }
 
@@ -5423,7 +5423,7 @@ impl Language {
 
     #[allow(unused_assignments, unused_parens)]
     fn decimal_digit(&self, input: &mut ParserContext) -> bool {
-        scan_char_range!(input, '0', '9')
+        scan_char_range!(input, '0'..='9')
     }
 
     #[allow(unused_assignments, unused_parens)]
@@ -5599,9 +5599,9 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     fn fixed_type_size(&self, input: &mut ParserContext) -> bool {
         scan_sequence!(
-            scan_one_or_more!(input, scan_char_range!(input, '0', '9')),
+            scan_one_or_more!(input, scan_char_range!(input, '0'..='9')),
             scan_chars!(input, 'x'),
-            scan_one_or_more!(input, scan_char_range!(input, '0', '9'))
+            scan_one_or_more!(input, scan_char_range!(input, '0'..='9'))
         )
     }
 
@@ -5619,8 +5619,8 @@ impl Language {
         scan_choice!(
             input,
             self.decimal_digit(input),
-            scan_char_range!(input, 'A', 'F'),
-            scan_char_range!(input, 'a', 'f')
+            scan_char_range!(input, 'A'..='F'),
+            scan_char_range!(input, 'a'..='f')
         )
     }
 
@@ -5686,7 +5686,7 @@ impl Language {
         scan_choice!(
             input,
             self.identifier_start(input),
-            scan_char_range!(input, '0', '9')
+            scan_char_range!(input, '0'..='9')
         )
     }
 
@@ -5696,8 +5696,8 @@ impl Language {
             input,
             scan_chars!(input, '_'),
             scan_chars!(input, '$'),
-            scan_char_range!(input, 'A', 'Z'),
-            scan_char_range!(input, 'a', 'z')
+            scan_char_range!(input, 'A'..='Z'),
+            scan_char_range!(input, 'a'..='z')
         )
     }
 
@@ -5876,7 +5876,7 @@ impl Language {
                 scan_chars!(input, 'x'),
                 scan_chars!(input, 'X'),
                 scan_chars!(input, '*'),
-                scan_char_range!(input, '0', '9')
+                scan_char_range!(input, '0'..='9')
             )
         )
     }
@@ -5897,7 +5897,7 @@ impl Language {
                 input,
                 scan_chars!(input, '0'),
                 scan_sequence!(
-                    scan_char_range!(input, '1', '9'),
+                    scan_char_range!(input, '1'..='9'),
                     scan_zero_or_more!(input, self.decimal_digit(input))
                 )
             ),

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
@@ -59,7 +59,7 @@ where
                 };
 
                 let topmost_rule = match &nodes[..] {
-                    [cst::Node::Rule(rule)] => Rc::clone(&rule),
+                    [cst::Node::Rule(rule)] => Rc::clone(rule),
                     [_] => unreachable!(
                         "(Incomplete)Match at the top level of a parser is not a Rule node"
                     ),

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
@@ -98,10 +98,10 @@ where
                     let parse_tree = cst::Node::Rule(topmost_rule);
                     // Sanity check: Make sure that succesful parse is equivalent to not having any SKIPPED nodes
                     debug_assert_eq!(
-                        errors.len() > 0,
+                        errors.is_empty(),
                         parse_tree
                             .cursor_with_offset(TextIndex::ZERO)
-                            .any(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_some())
+                            .all(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_none())
                     );
 
                     ParseOutput { parse_tree, errors }

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
@@ -42,17 +42,14 @@ impl ParserResult {
     }
 
     pub fn is_match(&self) -> bool {
-        match self {
-            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_)
+        )
     }
 
     pub fn is_no_match(&self) -> bool {
-        match self {
-            ParserResult::NoMatch(_) => true,
-            _ => false,
-        }
+        matches!(self, ParserResult::NoMatch(_))
     }
 
     pub fn with_kind(self, new_kind: RuleKind) -> ParserResult {

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
@@ -121,9 +121,9 @@ pub enum PrattElement {
 }
 
 impl PrattElement {
-    pub fn to_nodes(self) -> Vec<cst::Node> {
+    pub fn into_nodes(self) -> Vec<cst::Node> {
         match self {
-            Self::Expression { nodes } => nodes.clone(),
+            Self::Expression { nodes } => nodes,
             Self::Binary { kind, nodes, .. }
             | Self::Prefix { kind, nodes, .. }
             | Self::Postfix { kind, nodes, .. } => {

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/scanner_macros.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/scanner_macros.rs
@@ -31,9 +31,10 @@ macro_rules! scan_none_of {
 
 #[allow(unused_macros)]
 macro_rules! scan_char_range {
-    ($stream:ident, $from:literal , $to:literal) => {
+    ($stream:ident, $from:literal..=$to:literal) => {
         if let Some(c) = $stream.next() {
-            if $from <= c && c <= $to {
+            #[allow(clippy::manual_is_ascii_check)]
+            if ($from..=$to).contains(&c) {
                 true
             } else {
                 $stream.undo();

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/separated_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/separated_helper.rs
@@ -88,10 +88,10 @@ impl SeparatedHelper {
                     }
                 }
                 ParserResult::NoMatch(no_match) => {
-                    if accum.len() > 0 {
-                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
-                    } else {
+                    if accum.is_empty() {
                         return ParserResult::no_match(no_match.expected_tokens);
+                    } else {
+                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
                     }
                 }
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
@@ -49,7 +49,7 @@ impl SequenceHelper {
 
                 // If the accumulated result is valid, but empty (e.g. we accepted an empty optional)
                 // just take the next result
-                (ParserResult::Match(running), next @ _) if running.nodes.is_empty() => {
+                (ParserResult::Match(running), next) if running.nodes.is_empty() => {
                     self.result = State::Running(next);
                 }
                 // Keep accepting or convert into PrattOperatorMatch

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
@@ -97,7 +97,7 @@ impl SequenceHelper {
                         std::mem::take(&mut cur.elements)
                             .into_iter()
                             .flat_map(|pratt| pratt.to_nodes())
-                            .chain(next.nodes.into_iter())
+                            .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
@@ -96,7 +96,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
@@ -106,7 +106,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/solidity/outputs/cargo/crate/src/main.rs
+++ b/crates/solidity/outputs/cargo/crate/src/main.rs
@@ -20,7 +20,7 @@ mod supress_api_dependencies {
 #[derive(ClapParser, Debug)]
 #[command(next_line_help = true)]
 #[command(author, about)]
-struct CLI {
+struct Cli {
     #[command(subcommand)]
     command: Commands,
 }
@@ -43,7 +43,7 @@ enum Commands {
 }
 
 fn main() -> Result<()> {
-    return match CLI::parse().command {
+    return match Cli::parse().command {
         Commands::Parse {
             file_path,
             version,
@@ -83,5 +83,5 @@ fn execute_parse_command(file_path_string: String, version: Version, json: bool)
 #[test]
 fn verify_clap_cli() {
     // Catches problems earlier in the development cycle:
-    <CLI as clap::CommandFactory>::command().debug_assert();
+    <Cli as clap::CommandFactory>::command().debug_assert();
 }

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
@@ -32,7 +32,7 @@ pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
 
     for version in VERSION_BREAKS {
         let production_kind = ProductionKind::from_str(parser_name)
-            .expect(format!("No such parser: {parser_name}").as_str());
+            .unwrap_or_else(|_| panic!("No such parser: {parser_name}"));
 
         let output = Language::new(version.clone())?.parse(production_kind, &source);
 

--- a/crates/solidity/outputs/cargo/tests/src/doc_examples/cursor_api.rs
+++ b/crates/solidity/outputs/cargo/tests/src/doc_examples/cursor_api.rs
@@ -117,6 +117,7 @@ fn cursor_api_using_iter_combinators() -> Result<()> {
 }
 
 #[test]
+#[allow(clippy::redundant_pattern_matching)]
 fn cursor_as_iter() -> Result<()> {
     let language = Language::new(Version::parse("0.8.0")?)?;
     let parse_output = language.parse(ProductionKind::ContractDefinition, "contract Foo {}");

--- a/crates/solidity/outputs/cargo/tests/src/versions/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/versions/mod.rs
@@ -5,7 +5,7 @@ use slang_solidity::language::Language;
 fn list_supported_versions() {
     let versions = Language::SUPPORTED_VERSIONS;
 
-    assert_eq!(false, versions.is_empty());
-    assert_eq!(false, versions.contains(&Version::parse("0.0.0").unwrap()));
-    assert_eq!(true, versions.contains(&Version::parse("0.4.11").unwrap()));
+    assert!(!versions.is_empty());
+    assert!(!versions.contains(&Version::new(0, 0, 0)));
+    assert!(versions.contains(&Version::new(0, 4, 11)));
 }

--- a/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
@@ -328,6 +328,7 @@ pub enum RuleKind {
 
 impl RuleKind {
     pub fn is_trivia(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match self {
             Self::EndOfFileTrivia => true,
             Self::LeadingTrivia => true,

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -5373,9 +5373,9 @@ impl Language {
     fn ascii_character_without_double_quote_or_backslash(&self, input: &mut ParserContext) -> bool {
         scan_choice!(
             input,
-            scan_char_range!(input, ' ', '!'),
-            scan_char_range!(input, '#', '['),
-            scan_char_range!(input, ']', '~')
+            scan_char_range!(input, ' '..='!'),
+            scan_char_range!(input, '#'..='['),
+            scan_char_range!(input, ']'..='~')
         )
     }
 
@@ -5383,9 +5383,9 @@ impl Language {
     fn ascii_character_without_single_quote_or_backslash(&self, input: &mut ParserContext) -> bool {
         scan_choice!(
             input,
-            scan_char_range!(input, ' ', '&'),
-            scan_char_range!(input, '(', '['),
-            scan_char_range!(input, ']', '~')
+            scan_char_range!(input, ' '..='&'),
+            scan_char_range!(input, '('..='['),
+            scan_char_range!(input, ']'..='~')
         )
     }
 
@@ -5423,7 +5423,7 @@ impl Language {
 
     #[allow(unused_assignments, unused_parens)]
     fn decimal_digit(&self, input: &mut ParserContext) -> bool {
-        scan_char_range!(input, '0', '9')
+        scan_char_range!(input, '0'..='9')
     }
 
     #[allow(unused_assignments, unused_parens)]
@@ -5599,9 +5599,9 @@ impl Language {
     #[allow(unused_assignments, unused_parens)]
     fn fixed_type_size(&self, input: &mut ParserContext) -> bool {
         scan_sequence!(
-            scan_one_or_more!(input, scan_char_range!(input, '0', '9')),
+            scan_one_or_more!(input, scan_char_range!(input, '0'..='9')),
             scan_chars!(input, 'x'),
-            scan_one_or_more!(input, scan_char_range!(input, '0', '9'))
+            scan_one_or_more!(input, scan_char_range!(input, '0'..='9'))
         )
     }
 
@@ -5619,8 +5619,8 @@ impl Language {
         scan_choice!(
             input,
             self.decimal_digit(input),
-            scan_char_range!(input, 'A', 'F'),
-            scan_char_range!(input, 'a', 'f')
+            scan_char_range!(input, 'A'..='F'),
+            scan_char_range!(input, 'a'..='f')
         )
     }
 
@@ -5686,7 +5686,7 @@ impl Language {
         scan_choice!(
             input,
             self.identifier_start(input),
-            scan_char_range!(input, '0', '9')
+            scan_char_range!(input, '0'..='9')
         )
     }
 
@@ -5696,8 +5696,8 @@ impl Language {
             input,
             scan_chars!(input, '_'),
             scan_chars!(input, '$'),
-            scan_char_range!(input, 'A', 'Z'),
-            scan_char_range!(input, 'a', 'z')
+            scan_char_range!(input, 'A'..='Z'),
+            scan_char_range!(input, 'a'..='z')
         )
     }
 
@@ -5876,7 +5876,7 @@ impl Language {
                 scan_chars!(input, 'x'),
                 scan_chars!(input, 'X'),
                 scan_chars!(input, '*'),
-                scan_char_range!(input, '0', '9')
+                scan_char_range!(input, '0'..='9')
             )
         )
     }
@@ -5897,7 +5897,7 @@ impl Language {
                 input,
                 scan_chars!(input, '0'),
                 scan_sequence!(
-                    scan_char_range!(input, '1', '9'),
+                    scan_char_range!(input, '1'..='9'),
                     scan_zero_or_more!(input, self.decimal_digit(input))
                 )
             ),

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
@@ -59,7 +59,7 @@ where
                 };
 
                 let topmost_rule = match &nodes[..] {
-                    [cst::Node::Rule(rule)] => Rc::clone(&rule),
+                    [cst::Node::Rule(rule)] => Rc::clone(rule),
                     [_] => unreachable!(
                         "(Incomplete)Match at the top level of a parser is not a Rule node"
                     ),

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
@@ -98,10 +98,10 @@ where
                     let parse_tree = cst::Node::Rule(topmost_rule);
                     // Sanity check: Make sure that succesful parse is equivalent to not having any SKIPPED nodes
                     debug_assert_eq!(
-                        errors.len() > 0,
+                        errors.is_empty(),
                         parse_tree
                             .cursor_with_offset(TextIndex::ZERO)
-                            .any(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_some())
+                            .all(|x| x.as_token_with_kind(&[TokenKind::SKIPPED]).is_none())
                     );
 
                     ParseOutput { parse_tree, errors }

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
@@ -42,17 +42,14 @@ impl ParserResult {
     }
 
     pub fn is_match(&self) -> bool {
-        match self {
-            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ParserResult::Match(_) | ParserResult::PrattOperatorMatch(_)
+        )
     }
 
     pub fn is_no_match(&self) -> bool {
-        match self {
-            ParserResult::NoMatch(_) => true,
-            _ => false,
-        }
+        matches!(self, ParserResult::NoMatch(_))
     }
 
     pub fn with_kind(self, new_kind: RuleKind) -> ParserResult {

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
@@ -121,9 +121,9 @@ pub enum PrattElement {
 }
 
 impl PrattElement {
-    pub fn to_nodes(self) -> Vec<cst::Node> {
+    pub fn into_nodes(self) -> Vec<cst::Node> {
         match self {
-            Self::Expression { nodes } => nodes.clone(),
+            Self::Expression { nodes } => nodes,
             Self::Binary { kind, nodes, .. }
             | Self::Prefix { kind, nodes, .. }
             | Self::Postfix { kind, nodes, .. } => {

--- a/crates/solidity/outputs/npm/crate/src/generated/support/scanner_macros.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/scanner_macros.rs
@@ -31,9 +31,10 @@ macro_rules! scan_none_of {
 
 #[allow(unused_macros)]
 macro_rules! scan_char_range {
-    ($stream:ident, $from:literal , $to:literal) => {
+    ($stream:ident, $from:literal..=$to:literal) => {
         if let Some(c) = $stream.next() {
-            if $from <= c && c <= $to {
+            #[allow(clippy::manual_is_ascii_check)]
+            if ($from..=$to).contains(&c) {
                 true
             } else {
                 $stream.undo();

--- a/crates/solidity/outputs/npm/crate/src/generated/support/separated_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/separated_helper.rs
@@ -88,10 +88,10 @@ impl SeparatedHelper {
                     }
                 }
                 ParserResult::NoMatch(no_match) => {
-                    if accum.len() > 0 {
-                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
-                    } else {
+                    if accum.is_empty() {
                         return ParserResult::no_match(no_match.expected_tokens);
+                    } else {
+                        return ParserResult::incomplete_match(accum, no_match.expected_tokens);
                     }
                 }
 

--- a/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
@@ -49,7 +49,7 @@ impl SequenceHelper {
 
                 // If the accumulated result is valid, but empty (e.g. we accepted an empty optional)
                 // just take the next result
-                (ParserResult::Match(running), next @ _) if running.nodes.is_empty() => {
+                (ParserResult::Match(running), next) if running.nodes.is_empty() => {
                     self.result = State::Running(next);
                 }
                 // Keep accepting or convert into PrattOperatorMatch

--- a/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
@@ -97,7 +97,7 @@ impl SequenceHelper {
                         std::mem::take(&mut cur.elements)
                             .into_iter()
                             .flat_map(|pratt| pratt.to_nodes())
-                            .chain(next.nodes.into_iter())
+                            .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
@@ -96,7 +96,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .chain(next.nodes)
                             .collect(),
                         next.expected_tokens,
@@ -106,7 +106,7 @@ impl SequenceHelper {
                     self.result = State::Running(ParserResult::incomplete_match(
                         std::mem::take(&mut cur.elements)
                             .into_iter()
-                            .flat_map(|pratt| pratt.to_nodes())
+                            .flat_map(|pratt| pratt.into_nodes())
                             .collect(),
                         next.expected_tokens,
                     ));

--- a/crates/solidity/testing/sanctuary/src/datasets/mod.rs
+++ b/crates/solidity/testing/sanctuary/src/datasets/mod.rs
@@ -57,8 +57,7 @@ pub fn get_all_datasets() -> Result<Vec<impl Dataset>> {
                     "sanctuary-polygon",
                     Url::parse("https://github.com/tintinweb/smart-contract-sanctuary-polygon")?,
                 ),
-            ]
-            .into_iter(),
+            ],
         );
     }
 

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -97,7 +97,7 @@ fn process_source_file(
         let language = Language::new(version.to_owned())?;
         let output = language.parse(ProductionKind::SourceUnit, source);
 
-        reporter.report_test_result(source_id, source, &version, &output);
+        reporter.report_test_result(source_id, source, version, &output);
     }
 
     return Ok(());

--- a/crates/solidity/testing/sanctuary/src/reporting.rs
+++ b/crates/solidity/testing/sanctuary/src/reporting.rs
@@ -62,7 +62,7 @@ impl Reporter {
         self.total_tests.fetch_add(1, Ordering::Relaxed);
 
         let errors = output.errors();
-        if errors.len() == 0 {
+        if errors.is_empty() {
             return;
         }
 

--- a/crates/solidity/testing/solc/src/keywords/mod.rs
+++ b/crates/solidity/testing/solc/src/keywords/mod.rs
@@ -228,7 +228,7 @@ impl TestCase {
                     return false;
                 }
 
-                println!("");
+                println!();
                 println!(
                     "Invoking solc failed:\n{error}\n\nInput:\n{input}",
                     input = serde_json::to_string_pretty(&input).unwrap(),

--- a/crates/solidity/testing/solc/src/keywords/mod.rs
+++ b/crates/solidity/testing/solc/src/keywords/mod.rs
@@ -81,7 +81,7 @@ fn generate_test_cases(language: &Language) -> Vec<TestCase> {
                             "Duplicate variation: {variation}"
                         );
 
-                        test_cases.push(TestCase::new(language, item, &definition, variation));
+                        test_cases.push(TestCase::new(language, item, definition, variation));
                     }
                 }
             }

--- a/crates/solidity/testing/solc/src/utils/binaries.rs
+++ b/crates/solidity/testing/solc/src/utils/binaries.rs
@@ -6,7 +6,7 @@ use infra_utils::{cargo::CargoWorkspace, commands::Command};
 use rayon::prelude::{ParallelBridge, ParallelIterator};
 use semver::Version;
 use serde::Deserialize;
-use std::{collections::HashMap, os::unix::prelude::PermissionsExt, path::PathBuf};
+use std::{collections::HashMap, os::unix::prelude::PermissionsExt, path::PathBuf, path::Path};
 use url::Url;
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ impl Binary {
     }
 }
 
-fn fetch_releases(mirror_url: &Url, binaries_dir: &PathBuf) -> HashMap<Version, String> {
+fn fetch_releases(mirror_url: &Url, binaries_dir: &Path) -> HashMap<Version, String> {
     #[derive(Deserialize)]
     struct MirrorList {
         releases: HashMap<Version, String>,
@@ -84,7 +84,7 @@ fn fetch_releases(mirror_url: &Url, binaries_dir: &PathBuf) -> HashMap<Version, 
     return list.releases;
 }
 
-fn download_file(url: Url, path: &PathBuf) {
+fn download_file(url: Url, path: &Path) {
     let bytes = reqwest::blocking::get(url).unwrap().bytes().unwrap();
 
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
+++ b/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
@@ -69,7 +69,7 @@ fn write_source<W: Write>(w: &mut W, source: &str) -> Result<()> {
 }
 
 fn write_errors<W: Write>(w: &mut W, errors: &Vec<String>) -> Result<()> {
-    if errors.len() == 0 {
+    if errors.is_empty() {
         writeln!(w, "Errors: []")?;
         return Ok(());
     }

--- a/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
+++ b/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
@@ -134,7 +134,7 @@ fn write_node<W: Write>(
 
         (preview.to_owned(), range_string)
     } else {
-        let preview = render_source_preview(source, &range)?;
+        let preview = render_source_preview(source, range)?;
 
         if node.children().is_empty() {
             // "foo" # 1..2

--- a/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
+++ b/crates/solidity/testing/utils/src/cst_snapshots/mod.rs
@@ -179,17 +179,17 @@ pub fn render_source_preview(source: &str, range: &TextRange) -> Result<String> 
 
     // Escape line breaks:
     let contents = contents
-        .replace("\t", "\\t")
-        .replace("\r", "\\r")
-        .replace("\n", "\\n");
+        .replace('\t', "\\t")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n");
 
     // Surround by quotes for use in yaml:
     let contents = {
-        if contents.contains("\"") {
-            let contents = contents.replace("'", "''");
+        if contents.contains('"') {
+            let contents = contents.replace('\'', "''");
             format!("'{contents}'")
         } else {
-            let contents = contents.replace("\"", "\\\"");
+            let contents = contents.replace('"', "\\\"");
             format!("\"{contents}\"")
         }
     };


### PR DESCRIPTION
Part of #155 

These should all be more or less obvious, maybe with the exception of:
- `comparison_chain` - in this case it might be more noise than it's worth, I'm fine with silencing it here, instead
- `single_char_pattern` - in our case we do less `"`-escaping, so that's good enough for me (but I know it might be considered uncontroversial)
- `clippy::upper_case_acronyms` - this helps follow the Rust naming convention (`CLI` -> `Cli`, which I'm strongly in favour; it's not a SCREAMING_CASE_CONSTANT)

Some select lints are explicitly allowed on a case-by-case basis here but in general are worthwhile to be linted against, e.g. `enum_variant_names` or `manual_range_contains`.

The only ones left now are:
- `needless_return`, which we will have *many* instances of and I'd like to have a separate PR for that (but I'm *strongly* in favour, as I find it to be one of the signature aspects of Rust)
- `should_implement_trait` - needs to be silenced in one case for `#[napi] fn clone`, but `ParserContext::next` might or might not implement the `Iterator`, I'm not sure yet, so I'd like to defer it for now.