### PR TITLE
turn on `clippy::wildcard_imports`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,8 +7,12 @@ lto = true
 
 [build]
 rustflags = [
+	# rustc additional warnings:
 	"--warn",
 	"unused_crate_dependencies",
+	# clippy additional warnings:
+	"--warn",
+	"clippy::wildcard_imports",
 	# This is a list of allowed Clippy rules for the purposes of gradual migration.
 	# See https://github.com/NomicFoundation/slang/pull/626
 	"-A",

--- a/crates/codegen/grammar/src/grammar.rs
+++ b/crates/codegen/grammar/src/grammar.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeSet, HashMap};
 
 use semver::Version;
 
-use super::*;
+use super::{
+    GrammarVisitor, ParserDefinitionRef, PrecedenceParserDefinitionRef, ScannerDefinitionRef,
+    TriviaParserDefinitionRef, Visitable,
+};
 
 pub struct Grammar {
     pub name: String,

--- a/crates/codegen/grammar/src/parser_definition.rs
+++ b/crates/codegen/grammar/src/parser_definition.rs
@@ -1,7 +1,10 @@
 use std::fmt::Debug;
 use std::rc::Rc;
 
-use super::*;
+use super::{
+    GrammarVisitor, PrecedenceParserDefinitionRef, ScannerDefinitionRef, VersionQualityRange,
+    Visitable,
+};
 
 pub trait ParserDefinition: Debug {
     fn name(&self) -> &'static str;

--- a/crates/codegen/grammar/src/precedence_parser_definition.rs
+++ b/crates/codegen/grammar/src/precedence_parser_definition.rs
@@ -1,7 +1,9 @@
 use std::fmt::Debug;
 use std::rc::Rc;
 
-use super::*;
+use super::{
+    GrammarVisitor, ParserDefinitionNode, ParserDefinitionRef, VersionQualityRange, Visitable,
+};
 
 pub trait PrecedenceParserDefinition: Debug {
     fn name(&self) -> &'static str;

--- a/crates/codegen/grammar/src/scanner_definition.rs
+++ b/crates/codegen/grammar/src/scanner_definition.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::rc::Rc;
 
-use super::*;
+use super::{GrammarVisitor, VersionQualityRange, Visitable};
 
 pub trait ScannerDefinition: Debug {
     fn name(&self) -> &'static str;

--- a/crates/codegen/grammar/src/visitor.rs
+++ b/crates/codegen/grammar/src/visitor.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    Grammar, ParserDefinitionNode, ParserDefinitionRef, PrecedenceParserDefinitionNode,
+    PrecedenceParserDefinitionRef, ScannerDefinitionNode, ScannerDefinitionRef,
+    TriviaParserDefinitionRef,
+};
 
 pub trait GrammarVisitor {
     fn grammar_enter(&mut self, _grammar: &Grammar) {}

--- a/crates/codegen/parser/runtime/src/cst.rs
+++ b/crates/codegen/parser/runtime/src/cst.rs
@@ -2,7 +2,11 @@ use std::rc::Rc;
 
 use serde::Serialize;
 
-use super::{cursor::Cursor, kinds::*, text_index::TextIndex};
+use super::{
+    cursor::Cursor,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RuleNode {

--- a/crates/codegen/parser/runtime/src/cursor.rs
+++ b/crates/codegen/parser/runtime/src/cursor.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use super::{
     cst::{Node, RuleNode},
-    kinds::*,
+    kinds::{RuleKind, TokenKind},
     text_index::{TextIndex, TextRange},
 };
 

--- a/crates/codegen/parser/runtime/src/kinds.rs
+++ b/crates/codegen/parser/runtime/src/kinds.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use {
+    napi::bindgen_prelude::{FromNapiValue, ToNapiValue},
+    napi_derive::napi,
+};
 
 #[derive(
     Debug,

--- a/crates/codegen/parser/runtime/src/napi/napi_cst.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cst.rs
@@ -1,11 +1,17 @@
 use std::rc::Rc;
 
 use {
-    napi::{bindgen_prelude::*, JsObject, NapiValue},
+    napi::{
+        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        JsObject, NapiValue,
+    },
     napi_derive::napi,
 };
 
-use super::*;
+use super::{
+    napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
+    TokenKind,
+};
 use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 

--- a/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
@@ -1,11 +1,11 @@
 use {
-    napi::{bindgen_prelude::*, JsObject},
+    napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
-use super::*;
-use napi_cst::*;
-use napi_text_index::*;
+use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
@@ -1,7 +1,7 @@
 use napi_derive::napi;
 
-use super::*;
-use napi_text_index::*;
+use super::{napi_text_index, RustParseError};
+use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
@@ -1,7 +1,7 @@
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use {napi::bindgen_prelude::Env, napi_derive::napi};
 
-use super::*;
-use napi_cst::*;
+use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
+use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/codegen/parser/runtime/src/napi/napi_text_index.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_text_index.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 
-use super::*;
+use super::{RustTextIndex, RustTextRange};
 
 #[napi(object, namespace = "text_index")]
 #[derive(Copy, Clone)]

--- a/crates/codegen/parser/runtime/src/support/mod.rs
+++ b/crates/codegen/parser/runtime/src/support/mod.rs
@@ -1,13 +1,13 @@
-pub mod choice_helper;
-pub mod context;
-pub mod optional_helper;
-pub mod parser_function;
-pub mod parser_result;
-pub mod precedence_helper;
-pub mod recovery;
-pub mod repetition_helper;
-pub mod separated_helper;
-pub mod sequence_helper;
+mod choice_helper;
+mod context;
+mod optional_helper;
+mod parser_function;
+mod parser_result;
+mod precedence_helper;
+mod recovery;
+mod repetition_helper;
+mod separated_helper;
+mod sequence_helper;
 
 #[macro_use]
 pub mod scanner_macros;
@@ -18,7 +18,7 @@ pub use optional_helper::OptionalHelper;
 pub use parser_function::ParserFunction;
 pub use parser_result::ParserResult;
 pub use precedence_helper::PrecedenceHelper;
-pub use recovery::*;
+pub use recovery::RecoverFromNoMatch;
 pub use repetition_helper::{OneOrMoreHelper, ZeroOrMoreHelper};
 pub use separated_helper::SeparatedHelper;
 pub use sequence_helper::SequenceHelper;

--- a/crates/codegen/parser/runtime/src/support/parser_function.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_function.rs
@@ -6,7 +6,7 @@ use super::{
         text_index::TextIndex,
     },
     context::ParserContext,
-    parser_result::*,
+    parser_result::{IncompleteMatch, Match, ParserResult, SkippedUntil},
 };
 
 pub trait ParserFunction<L>

--- a/crates/codegen/parser/runtime/src/support/parser_result.rs
+++ b/crates/codegen/parser/runtime/src/support/parser_result.rs
@@ -1,4 +1,8 @@
-use super::super::{cst, kinds::*, text_index::TextIndex};
+use super::super::{
+    cst,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ParserResult {

--- a/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
@@ -92,7 +92,7 @@ pub trait IsLexicalContext {
 
 #[allow(non_snake_case)]
 pub mod LexicalContextType {
-    use super::*;
+    use super::{IsLexicalContext, LexicalContext};
 
     {%- for context in code.scanner_contexts %}
         pub struct {{ context.name }} {}

--- a/crates/codegen/parser/runtime/src/templates/language.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/templates/language.rs.jinja2
@@ -7,7 +7,10 @@ use super::{
     kinds::{RuleKind, TokenKind, ProductionKind, IsLexicalContext, LexicalContextType},
     lexer::Lexer,
     parse_output::ParseOutput,
-    support::*,
+    support::{
+        ChoiceHelper, OneOrMoreHelper, OptionalHelper, ParserContext, ParserFunction, ParserResult,
+        PrecedenceHelper, RecoverFromNoMatch, SeparatedHelper, SequenceHelper, ZeroOrMoreHelper,
+    },
 };
 
 pub use super::kinds::LexicalContext;

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst.rs
@@ -4,7 +4,11 @@ use std::rc::Rc;
 
 use serde::Serialize;
 
-use super::{cursor::Cursor, kinds::*, text_index::TextIndex};
+use super::{
+    cursor::Cursor,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RuleNode {

--- a/crates/solidity/outputs/cargo/crate/src/generated/cursor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cursor.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use super::{
     cst::{Node, RuleNode},
-    kinds::*,
+    kinds::{RuleKind, TokenKind},
     text_index::{TextIndex, TextRange},
 };
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
@@ -682,7 +682,7 @@ pub trait IsLexicalContext {
 
 #[allow(non_snake_case)]
 pub mod LexicalContextType {
-    use super::*;
+    use super::{IsLexicalContext, LexicalContext};
     pub struct Default {}
     impl IsLexicalContext for Default {
         fn value() -> LexicalContext {

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -9,7 +9,10 @@ use super::{
     kinds::{IsLexicalContext, LexicalContextType, ProductionKind, RuleKind, TokenKind},
     lexer::Lexer,
     parse_output::ParseOutput,
-    support::*,
+    support::{
+        ChoiceHelper, OneOrMoreHelper, OptionalHelper, ParserContext, ParserFunction, ParserResult,
+        PrecedenceHelper, RecoverFromNoMatch, SeparatedHelper, SequenceHelper, ZeroOrMoreHelper,
+    },
 };
 
 pub use super::kinds::LexicalContext;

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
@@ -3,11 +3,17 @@
 use std::rc::Rc;
 
 use {
-    napi::{bindgen_prelude::*, JsObject, NapiValue},
+    napi::{
+        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        JsObject, NapiValue,
+    },
     napi_derive::napi,
 };
 
-use super::*;
+use super::{
+    napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
+    TokenKind,
+};
 use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
@@ -1,13 +1,13 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 use {
-    napi::{bindgen_prelude::*, JsObject},
+    napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
-use super::*;
-use napi_cst::*;
-use napi_text_index::*;
+use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
@@ -2,8 +2,8 @@
 
 use napi_derive::napi;
 
-use super::*;
-use napi_text_index::*;
+use super::{napi_text_index, RustParseError};
+use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
@@ -1,9 +1,9 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use {napi::bindgen_prelude::Env, napi_derive::napi};
 
-use super::*;
-use napi_cst::*;
+use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
+use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_text_index.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_text_index.rs
@@ -2,7 +2,7 @@
 
 use napi_derive::napi;
 
-use super::*;
+use super::{RustTextIndex, RustTextRange};
 
 #[napi(object, namespace = "text_index")]
 #[derive(Copy, Clone)]

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/mod.rs
@@ -1,15 +1,15 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-pub mod choice_helper;
-pub mod context;
-pub mod optional_helper;
-pub mod parser_function;
-pub mod parser_result;
-pub mod precedence_helper;
-pub mod recovery;
-pub mod repetition_helper;
-pub mod separated_helper;
-pub mod sequence_helper;
+mod choice_helper;
+mod context;
+mod optional_helper;
+mod parser_function;
+mod parser_result;
+mod precedence_helper;
+mod recovery;
+mod repetition_helper;
+mod separated_helper;
+mod sequence_helper;
 
 #[macro_use]
 pub mod scanner_macros;
@@ -20,7 +20,7 @@ pub use optional_helper::OptionalHelper;
 pub use parser_function::ParserFunction;
 pub use parser_result::ParserResult;
 pub use precedence_helper::PrecedenceHelper;
-pub use recovery::*;
+pub use recovery::RecoverFromNoMatch;
 pub use repetition_helper::{OneOrMoreHelper, ZeroOrMoreHelper};
 pub use separated_helper::SeparatedHelper;
 pub use sequence_helper::SequenceHelper;

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_function.rs
@@ -8,7 +8,7 @@ use super::{
         text_index::TextIndex,
     },
     context::ParserContext,
-    parser_result::*,
+    parser_result::{IncompleteMatch, Match, ParserResult, SkippedUntil},
 };
 
 pub trait ParserFunction<L>

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/parser_result.rs
@@ -1,6 +1,10 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use super::super::{cst, kinds::*, text_index::TextIndex};
+use super::super::{
+    cst,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ParserResult {

--- a/crates/solidity/outputs/npm/crate/src/generated/cst.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/cst.rs
@@ -4,7 +4,11 @@ use std::rc::Rc;
 
 use serde::Serialize;
 
-use super::{cursor::Cursor, kinds::*, text_index::TextIndex};
+use super::{
+    cursor::Cursor,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RuleNode {

--- a/crates/solidity/outputs/npm/crate/src/generated/cursor.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/cursor.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use super::{
     cst::{Node, RuleNode},
-    kinds::*,
+    kinds::{RuleKind, TokenKind},
     text_index::{TextIndex, TextRange},
 };
 

--- a/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
@@ -682,7 +682,7 @@ pub trait IsLexicalContext {
 
 #[allow(non_snake_case)]
 pub mod LexicalContextType {
-    use super::*;
+    use super::{IsLexicalContext, LexicalContext};
     pub struct Default {}
     impl IsLexicalContext for Default {
         fn value() -> LexicalContext {

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -9,7 +9,10 @@ use super::{
     kinds::{IsLexicalContext, LexicalContextType, ProductionKind, RuleKind, TokenKind},
     lexer::Lexer,
     parse_output::ParseOutput,
-    support::*,
+    support::{
+        ChoiceHelper, OneOrMoreHelper, OptionalHelper, ParserContext, ParserFunction, ParserResult,
+        PrecedenceHelper, RecoverFromNoMatch, SeparatedHelper, SequenceHelper, ZeroOrMoreHelper,
+    },
 };
 
 pub use super::kinds::LexicalContext;

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
@@ -3,11 +3,17 @@
 use std::rc::Rc;
 
 use {
-    napi::{bindgen_prelude::*, JsObject, NapiValue},
+    napi::{
+        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        JsObject, NapiValue,
+    },
     napi_derive::napi,
 };
 
-use super::*;
+use super::{
+    napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
+    TokenKind,
+};
 use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
@@ -1,13 +1,13 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 use {
-    napi::{bindgen_prelude::*, JsObject},
+    napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
-use super::*;
-use napi_cst::*;
-use napi_text_index::*;
+use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
@@ -2,8 +2,8 @@
 
 use napi_derive::napi;
 
-use super::*;
-use napi_text_index::*;
+use super::{napi_text_index, RustParseError};
+use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
@@ -1,9 +1,9 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use {napi::bindgen_prelude::Env, napi_derive::napi};
 
-use super::*;
-use napi_cst::*;
+use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
+use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_text_index.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_text_index.rs
@@ -2,7 +2,7 @@
 
 use napi_derive::napi;
 
-use super::*;
+use super::{RustTextIndex, RustTextRange};
 
 #[napi(object, namespace = "text_index")]
 #[derive(Copy, Clone)]

--- a/crates/solidity/outputs/npm/crate/src/generated/support/mod.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/mod.rs
@@ -1,15 +1,15 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-pub mod choice_helper;
-pub mod context;
-pub mod optional_helper;
-pub mod parser_function;
-pub mod parser_result;
-pub mod precedence_helper;
-pub mod recovery;
-pub mod repetition_helper;
-pub mod separated_helper;
-pub mod sequence_helper;
+mod choice_helper;
+mod context;
+mod optional_helper;
+mod parser_function;
+mod parser_result;
+mod precedence_helper;
+mod recovery;
+mod repetition_helper;
+mod separated_helper;
+mod sequence_helper;
 
 #[macro_use]
 pub mod scanner_macros;
@@ -20,7 +20,7 @@ pub use optional_helper::OptionalHelper;
 pub use parser_function::ParserFunction;
 pub use parser_result::ParserResult;
 pub use precedence_helper::PrecedenceHelper;
-pub use recovery::*;
+pub use recovery::RecoverFromNoMatch;
 pub use repetition_helper::{OneOrMoreHelper, ZeroOrMoreHelper};
 pub use separated_helper::SeparatedHelper;
 pub use sequence_helper::SequenceHelper;

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_function.rs
@@ -8,7 +8,7 @@ use super::{
         text_index::TextIndex,
     },
     context::ParserContext,
-    parser_result::*,
+    parser_result::{IncompleteMatch, Match, ParserResult, SkippedUntil},
 };
 
 pub trait ParserFunction<L>

--- a/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/parser_result.rs
@@ -1,6 +1,10 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use super::super::{cst, kinds::*, text_index::TextIndex};
+use super::super::{
+    cst,
+    kinds::{RuleKind, TokenKind},
+    text_index::TextIndex,
+};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ParserResult {


### PR DESCRIPTION
cc @Xanewok for context: https://github.com/NomicFoundation/slang/pull/680#discussion_r1412727532

This works well on `use foo::*` and allows automatic fixing/replacing. But it doesn't work on `pub use foo::*`. I looked into doing that manually, but realized that for public re-exports, it is actually much more work to do/maintain than the readability benefits it offers, especially when items have different visibility, and there are generated items.

Taking `non_terminals/mod.rs`, I think the below list is a lot of noise, and requires manual work every time we add/remove something. I suggest allowing `pub use foo::*` for these reasons, and use it as appropriate.

```rust
pub use enum_::{EnumItem, EnumVariant};
pub use field::{Field, FieldDelimiters, FieldKind, FieldsErrorRecovery};
pub use precedence::{PrecedenceExpression, PrecedenceItem, PrecedenceOperator, PrimaryExpression};
pub use repeated::RepeatedItem;
pub use separated::SeparatedItem;
pub use struct_::StructItem;

pub(crate) use enum_::{SpannedEnumItem, SpannedEnumVariant};
pub(crate) use field::{
    SpannedField, SpannedFieldDelimiters, SpannedFieldKind, SpannedFieldsErrorRecovery,
};
pub(crate) use precedence::{
    SpannedPrecedenceExpression, SpannedPrecedenceItem, SpannedPrecedenceOperator,
    SpannedPrimaryExpression,
};
pub(crate) use repeated::SpannedRepeatedItem;
pub(crate) use separated::SpannedSeparatedItem;
pub(crate) use struct_::SpannedStructItem;
```