### PR TITLE
remove `allow_empty` from DSL v2

### DIFF
--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -114,7 +114,6 @@ fn check_repeated(analysis: &mut Analysis, item: &SpannedRepeatedItem, enablemen
     let SpannedRepeatedItem {
         name,
         repeated,
-        allow_empty: _,
         enabled,
     } = item;
 
@@ -134,7 +133,6 @@ fn check_separated(analysis: &mut Analysis, item: &SpannedSeparatedItem, enablem
         name,
         separated,
         separator,
-        allow_empty: _,
         enabled,
     } = item;
 

--- a/crates/codegen/language/definition/src/model/non_terminals/repeated.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/repeated.rs
@@ -9,6 +9,4 @@ pub struct RepeatedItem {
     pub repeated: Identifier,
 
     pub enabled: Option<VersionSpecifier>,
-
-    pub allow_empty: Option<bool>,
 }

--- a/crates/codegen/language/definition/src/model/non_terminals/separated.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/separated.rs
@@ -10,6 +10,4 @@ pub struct SeparatedItem {
     pub separator: Identifier,
 
     pub enabled: Option<VersionSpecifier>,
-
-    pub allow_empty: Option<bool>,
 }

--- a/crates/solidity/inputs/language/src/grammar.rs
+++ b/crates/solidity/inputs/language/src/grammar.rs
@@ -711,27 +711,14 @@ fn resolve_choice(item: model::EnumItem, ctx: &mut ResolveCtx) -> ParserDefiniti
 fn resolve_repeated(item: model::RepeatedItem, ctx: &mut ResolveCtx) -> ParserDefinitionNode {
     let body = Box::new(resolve_grammar_element(&item.repeated, ctx).into_parser_def_node());
 
-    let repeated = if item.allow_empty.unwrap_or(false) {
-        ParserDefinitionNode::ZeroOrMore
-    } else {
-        ParserDefinitionNode::OneOrMore
-    };
-
-    repeated(body).versioned(item.enabled)
+    ParserDefinitionNode::OneOrMore(body).versioned(item.enabled)
 }
 
 fn resolve_separated(item: model::SeparatedItem, ctx: &mut ResolveCtx) -> ParserDefinitionNode {
     let body = resolve_grammar_element(&item.separated, ctx).into_parser_def_node();
     let separator = resolve_grammar_element(&item.separator, ctx).into_parser_def_node();
 
-    let separated_by = ParserDefinitionNode::SeparatedBy(Box::new(body), Box::new(separator))
-        .versioned(item.enabled);
-
-    if item.allow_empty.unwrap_or(false) {
-        ParserDefinitionNode::Optional(Box::new(separated_by))
-    } else {
-        separated_by
-    }
+    ParserDefinitionNode::SeparatedBy(Box::new(body), Box::new(separator)).versioned(item.enabled)
 }
 
 fn resolve_precedence(


### PR DESCRIPTION
It was already removed from grammar. We don't want to emit useless parents. Their references should be optional instead.