### PR TITLE
Import grouping

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-#
 # rustfmt nightly configuration options:
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
-#
+
+group_imports = "StdExternalCrate"

--- a/crates/codegen/language/definition/src/compiler/analysis/definitions.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/definitions.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::{
     compiler::{
         analysis::{Analysis, ItemMetadata},
@@ -6,7 +8,6 @@ use crate::{
     internals::Spanned,
     model::{Identifier, SpannedItem, SpannedVersionSpecifier},
 };
-use std::collections::HashSet;
 
 pub(crate) fn analyze_definitions(analysis: &mut Analysis) {
     collect_top_level_items(analysis);

--- a/crates/codegen/language/definition/src/compiler/analysis/mod.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/mod.rs
@@ -3,6 +3,11 @@ mod reachability;
 mod references;
 mod utils;
 
+use std::rc::Rc;
+
+use indexmap::IndexMap;
+use proc_macro2::Span;
+
 use crate::{
     compiler::analysis::{
         definitions::analyze_definitions, reachability::analyze_reachability,
@@ -12,9 +17,6 @@ use crate::{
     internals::{ErrorsCollection, ParseOutput, Spanned},
     model::{Identifier, SpannedItem, SpannedLanguage},
 };
-use indexmap::IndexMap;
-use proc_macro2::Span;
-use std::rc::Rc;
 
 pub(crate) struct Analysis {
     pub errors: ErrorsCollection,

--- a/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/reachability.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
+
 use crate::{
     compiler::{analysis::Analysis, version_set::VersionSet},
     model::{Identifier, SpannedTriviaParser},
 };
-use std::collections::HashSet;
 
 pub(crate) fn analyze_reachability(analysis: &mut Analysis) {
     check_unreachabable_items(analysis);

--- a/crates/codegen/language/definition/src/compiler/analysis/references.rs
+++ b/crates/codegen/language/definition/src/compiler/analysis/references.rs
@@ -1,3 +1,8 @@
+use std::fmt::Debug;
+
+use indexmap::IndexMap;
+use semver::Version;
+
 use crate::{
     compiler::{analysis::Analysis, version_set::VersionSet},
     internals::Spanned,
@@ -14,9 +19,6 @@ use crate::{
         SpannedVersionSpecifier,
     },
 };
-use indexmap::IndexMap;
-use semver::Version;
-use std::fmt::Debug;
 
 pub(crate) fn analyze_references(analysis: &mut Analysis) {
     let language = analysis.language.clone();

--- a/crates/codegen/language/definition/src/compiler/emitter.rs
+++ b/crates/codegen/language/definition/src/compiler/emitter.rs
@@ -1,7 +1,8 @@
-use crate::{compiler::analysis::Analysis, internals::WriteOutputTokens};
 use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+
+use crate::{compiler::analysis::Analysis, internals::WriteOutputTokens};
 
 pub(crate) struct LanguageEmitter;
 

--- a/crates/codegen/language/definition/src/compiler/mod.rs
+++ b/crates/codegen/language/definition/src/compiler/mod.rs
@@ -2,11 +2,12 @@ mod analysis;
 mod emitter;
 mod version_set;
 
+use proc_macro2::TokenStream;
+
 use crate::{
     compiler::{analysis::Analysis, emitter::LanguageEmitter},
     internals::ParseAdapter,
 };
-use proc_macro2::TokenStream;
 
 pub struct LanguageCompiler;
 

--- a/crates/codegen/language/definition/src/compiler/version_set.rs
+++ b/crates/codegen/language/definition/src/compiler/version_set.rs
@@ -1,5 +1,6 @@
-use semver::Version;
 use std::{fmt::Display, mem::swap, ops::Range};
+
+use semver::Version;
 
 const MAX_VERSION: Version = Version::new(u64::MAX, u64::MAX, u64::MAX);
 

--- a/crates/codegen/language/definition/src/internals/errors.rs
+++ b/crates/codegen/language/definition/src/internals/errors.rs
@@ -1,5 +1,6 @@
-use proc_macro2::{Span, TokenStream};
 use std::fmt::Display;
+
+use proc_macro2::{Span, TokenStream};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/adapter.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/adapter.rs
@@ -1,9 +1,10 @@
+use proc_macro2::TokenStream;
+use syn::parse::{Parse, ParseStream};
+
 use crate::{
     internals::{ErrorsCollection, ParseInputTokens, Result},
     model::SpannedLanguage,
 };
-use proc_macro2::TokenStream;
-use syn::parse::{Parse, ParseStream};
 
 pub(crate) struct ParseAdapter;
 

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/external_types.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/external_types.rs
@@ -1,11 +1,13 @@
-use crate::internals::{
-    parse_input_tokens::ParseHelpers, ErrorsCollection, ParseInputTokens, Result, Spanned,
-};
+use std::{fmt::Debug, rc::Rc};
+
 use indexmap::{IndexMap, IndexSet};
 use proc_macro2::Ident;
 use semver::Version;
-use std::{fmt::Debug, rc::Rc};
 use syn::{parse::ParseStream, LitBool, LitChar, LitStr};
+
+use crate::internals::{
+    parse_input_tokens::ParseHelpers, ErrorsCollection, ParseInputTokens, Result, Spanned,
+};
 
 impl ParseInputTokens for bool {
     fn parse_value(input: ParseStream<'_>, _: &mut ErrorsCollection) -> Result<Self> {

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/helpers.rs
@@ -1,8 +1,10 @@
-use crate::internals::{Error, ErrorsCollection, ParseInputTokens, Result, Spanned};
+use std::fmt::Debug;
+
 use indexmap::IndexMap;
 use proc_macro2::{extra::DelimSpan, Delimiter, Ident, TokenStream};
-use std::fmt::Debug;
 use syn::{braced, bracketed, parenthesized, parse::ParseStream, Token};
+
+use crate::internals::{Error, ErrorsCollection, ParseInputTokens, Result, Spanned};
 
 pub struct ParseHelpers;
 

--- a/crates/codegen/language/definition/src/internals/parse_input_tokens/mod.rs
+++ b/crates/codegen/language/definition/src/internals/parse_input_tokens/mod.rs
@@ -4,9 +4,9 @@ mod helpers;
 
 pub(crate) use adapter::*;
 pub(crate) use helpers::*;
+use syn::parse::ParseStream;
 
 use crate::internals::{ErrorsCollection, Result};
-use syn::parse::ParseStream;
 
 pub trait ParseInputTokens: Sized {
     /// Main parser entrypoint, and should be implemented by all types.

--- a/crates/codegen/language/definition/src/internals/spanned/mod.rs
+++ b/crates/codegen/language/definition/src/internals/spanned/mod.rs
@@ -1,7 +1,9 @@
-use crate::internals::{ErrorsCollection, ParseInputTokens, Result, WriteOutputTokens};
-use proc_macro2::{Span, TokenStream};
 use std::cmp::Ordering;
+
+use proc_macro2::{Span, TokenStream};
 use syn::parse::ParseStream;
+
+use crate::internals::{ErrorsCollection, ParseInputTokens, Result, WriteOutputTokens};
 
 #[derive(Clone, Debug)]
 pub struct Spanned<T> {

--- a/crates/codegen/language/definition/src/internals/write_output_tokens/external_types.rs
+++ b/crates/codegen/language/definition/src/internals/write_output_tokens/external_types.rs
@@ -1,9 +1,11 @@
-use crate::internals::WriteOutputTokens;
+use std::rc::Rc;
+
 use indexmap::{IndexMap, IndexSet};
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 use semver::Version;
-use std::rc::Rc;
+
+use crate::internals::WriteOutputTokens;
 
 impl WriteOutputTokens for bool {
     fn write_output_tokens(&self) -> TokenStream {

--- a/crates/codegen/language/definition/src/model/item.rs
+++ b/crates/codegen/language/definition/src/model/item.rs
@@ -1,10 +1,11 @@
+use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumDiscriminants;
+
 use crate::model::{
     EnumItem, FragmentItem, Identifier, KeywordItem, PrecedenceItem, RepeatedItem, SeparatedItem,
     StructItem, TokenItem, TriviaItem,
 };
-use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
-use serde::{Deserialize, Serialize};
-use strum_macros::EnumDiscriminants;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(EnumDiscriminants, ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/manifest.rs
+++ b/crates/codegen/language/definition/src/model/manifest.rs
@@ -1,9 +1,11 @@
-use crate::model::{Field, Identifier, Item, TriviaParser, VersionSpecifier};
+use std::{collections::BTreeSet, rc::Rc};
+
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use indexmap::IndexSet;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, rc::Rc};
+
+use crate::model::{Field, Identifier, Item, TriviaParser, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/enum_.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/enum_.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/field.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/field.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/precedence.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/precedence.rs
@@ -1,7 +1,8 @@
-use crate::model::{Field, FieldsErrorRecovery, Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Field, FieldsErrorRecovery, Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/repeated.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/repeated.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/separated.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/separated.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/non_terminals/struct_.rs
+++ b/crates/codegen/language/definition/src/model/non_terminals/struct_.rs
@@ -1,7 +1,8 @@
-use crate::model::{Field, FieldsErrorRecovery, Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Field, FieldsErrorRecovery, Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/terminals/fragment.rs
+++ b/crates/codegen/language/definition/src/model/terminals/fragment.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, Scanner, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, Scanner, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/terminals/keyword.rs
+++ b/crates/codegen/language/definition/src/model/terminals/keyword.rs
@@ -1,7 +1,8 @@
-use crate::model::{Identifier, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/terminals/scanner.rs
+++ b/crates/codegen/language/definition/src/model/terminals/scanner.rs
@@ -1,7 +1,8 @@
-use crate::model::Identifier;
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
+
+use crate::model::Identifier;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/terminals/token.rs
+++ b/crates/codegen/language/definition/src/model/terminals/token.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, Scanner, VersionSpecifier};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, Scanner, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/terminals/trivia.rs
+++ b/crates/codegen/language/definition/src/model/terminals/trivia.rs
@@ -1,6 +1,7 @@
-use crate::model::{Identifier, Scanner};
 use codegen_language_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
+
+use crate::model::{Identifier, Scanner};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(ParseInputTokens, WriteOutputTokens)]

--- a/crates/codegen/language/definition/src/model/utils/identifier.rs
+++ b/crates/codegen/language/definition/src/model/utils/identifier.rs
@@ -1,11 +1,13 @@
-use crate::internals::{
-    ErrorsCollection, ParseHelpers, ParseInputTokens, Result, WriteOutputTokens,
-};
+use std::ops::Deref;
+
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 use syn::{parse::ParseStream, Ident};
+
+use crate::internals::{
+    ErrorsCollection, ParseHelpers, ParseInputTokens, Result, WriteOutputTokens,
+};
 
 /// A wrapper type to make sure the DSL token is written as an identifier instead of a string literal.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/parse_input_tokens.rs
@@ -1,7 +1,8 @@
-use crate::input_model::{strip_spanned_prefix, InputField, InputItem, InputVariant};
 use itertools::Itertools;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
+
+use crate::input_model::{strip_spanned_prefix, InputField, InputItem, InputVariant};
 
 pub fn parse_input_tokens(item: InputItem) -> TokenStream {
     match item {

--- a/crates/codegen/language/internal_macros/src/derive/spanned.rs
+++ b/crates/codegen/language/internal_macros/src/derive/spanned.rs
@@ -1,7 +1,8 @@
-use crate::input_model::{add_spanned_prefix, InputField, InputItem, InputVariant};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{fold::Fold, parse_quote, Error, GenericArgument, Type};
+
+use crate::input_model::{add_spanned_prefix, InputField, InputItem, InputVariant};
 
 pub fn spanned(item: InputItem, spanned_derive_args: TokenStream) -> TokenStream {
     let derive_attribute = if spanned_derive_args.is_empty() {

--- a/crates/codegen/language/internal_macros/src/derive/write_output_tokens.rs
+++ b/crates/codegen/language/internal_macros/src/derive/write_output_tokens.rs
@@ -1,7 +1,8 @@
-use crate::input_model::{strip_spanned_prefix, InputField, InputItem, InputVariant};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+
+use crate::input_model::{strip_spanned_prefix, InputField, InputItem, InputVariant};
 
 pub fn write_output_tokens(item: InputItem) -> TokenStream {
     match item {

--- a/crates/codegen/language/internal_macros/src/input_model.rs
+++ b/crates/codegen/language/internal_macros/src/input_model.rs
@@ -1,6 +1,7 @@
+use std::fmt::Display;
+
 use itertools::Itertools;
 use quote::ToTokens;
-use std::fmt::Display;
 use syn::{
     parse::{Parse, ParseStream},
     Data, DeriveInput, Error, Fields, FieldsNamed, Ident, Result, Type, Variant,

--- a/crates/codegen/language/internal_macros/src/lib.rs
+++ b/crates/codegen/language/internal_macros/src/lib.rs
@@ -1,9 +1,10 @@
 mod derive;
 mod input_model;
 
-use crate::input_model::InputItem;
 use proc_macro::TokenStream;
 use quote::ToTokens;
+
+use crate::input_model::InputItem;
 
 #[proc_macro_attribute]
 pub fn derive_spanned_type(args: TokenStream, mut input: TokenStream) -> TokenStream {

--- a/crates/codegen/parser/generator/src/code_generator.rs
+++ b/crates/codegen/parser/generator/src/code_generator.rs
@@ -5,16 +5,15 @@ use std::{
 };
 
 use anyhow::Result;
-use infra_utils::{cargo::CargoWorkspace, codegen::Codegen};
-use quote::{format_ident, quote};
-use semver::Version;
-use serde::Serialize;
-
 use codegen_grammar::{
     Grammar, GrammarVisitor, ParserDefinitionNode, ParserDefinitionRef,
     PrecedenceParserDefinitionNode, PrecedenceParserDefinitionRef, ScannerDefinitionNode,
     ScannerDefinitionRef, TriviaParserDefinitionRef,
 };
+use infra_utils::{cargo::CargoWorkspace, codegen::Codegen};
+use quote::{format_ident, quote};
+use semver::Version;
+use serde::Serialize;
 
 use super::{
     parser_definition::ParserDefinitionExtensions,

--- a/crates/codegen/parser/generator/src/parser_definition.rs
+++ b/crates/codegen/parser/generator/src/parser_definition.rs
@@ -1,11 +1,10 @@
-use inflector::Inflector;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-
 use codegen_grammar::{
     ParserDefinitionNode, ParserDefinitionRef, TriviaParserDefinitionRef, VersionQuality,
     VersionQualityRange,
 };
+use inflector::Inflector;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
 pub trait ParserDefinitionExtensions {
     fn to_parser_code(&self) -> TokenStream;

--- a/crates/codegen/parser/generator/src/precedence_parser_definition.rs
+++ b/crates/codegen/parser/generator/src/precedence_parser_definition.rs
@@ -1,11 +1,10 @@
-use inflector::Inflector;
-use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
-
 use codegen_grammar::{
     PrecedenceOperatorModel, PrecedenceParserDefinitionNode, PrecedenceParserDefinitionRef,
     VersionQualityRange,
 };
+use inflector::Inflector;
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
 
 use super::parser_definition::{ParserDefinitionNodeExtensions, VersionQualityRangeVecExtensions};
 

--- a/crates/codegen/parser/runtime/src/napi/napi_cst.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cst.rs
@@ -1,5 +1,7 @@
 use std::rc::Rc;
 
+use napi_cursor::Cursor;
+use napi_text_index::TextIndex;
 use {
     napi::{
         bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
@@ -12,8 +14,6 @@ use super::{
     napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
     TokenKind,
 };
-use napi_cursor::Cursor;
-use napi_text_index::TextIndex;
 
 #[napi(object, namespace = "cst")]
 pub enum NodeType {

--- a/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
@@ -3,14 +3,14 @@
 // The functions are meant to be definitions for export, so they're not really used
 #![allow(clippy::return_self_not_must_use)]
 
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 use {
     napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
 use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
-use napi_cst::ToJS;
-use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
@@ -2,9 +2,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use napi_derive::napi;
+use napi_text_index::TextRange;
 
 use super::{napi_text_index, RustParseError};
-use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
@@ -1,7 +1,7 @@
+use napi_cst::ToJS;
 use {napi::bindgen_prelude::Env, napi_derive::napi};
 
 use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
-use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/codegen/parser/runtime/src/support/choice_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/choice_helper.rs
@@ -1,9 +1,8 @@
 use std::mem;
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
-
 use super::{context::Marker, ParserContext, ParserResult};
+use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
 
 /// Starting from a given position in the input, this helper will try to pick (and remember) a best match. Settles on
 /// a first full match if possible, otherwise on the best incomplete match.

--- a/crates/codegen/parser/runtime/src/support/context.rs
+++ b/crates/codegen/parser/runtime/src/support/context.rs
@@ -1,10 +1,9 @@
 use std::mem;
 use std::ops::Range;
 
+use super::super::text_index::TextIndex;
 use crate::kinds::TokenKind;
 use crate::parse_error::ParseError;
-
-use super::super::text_index::TextIndex;
 
 pub struct ParserContext<'s> {
     source: &'s str,

--- a/crates/codegen/parser/runtime/src/support/recovery.rs
+++ b/crates/codegen/parser/runtime/src/support/recovery.rs
@@ -1,12 +1,11 @@
+use super::parser_result::SkippedUntil;
+use super::ParserContext;
 use crate::cst;
 use crate::kinds::{IsLexicalContext, TokenKind};
 use crate::lexer::Lexer;
 use crate::parse_error::ParseError;
 use crate::support::ParserResult;
 use crate::text_index::{TextRange, TextRangeExtensions as _};
-
-use super::parser_result::SkippedUntil;
-use super::ParserContext;
 
 /// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
 #[derive(Clone, Copy)]

--- a/crates/codegen/parser/runtime/src/support/sequence_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/sequence_helper.rs
@@ -1,8 +1,7 @@
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind};
-
 use super::parser_result::{Match, ParserResult, PrattElement, SkippedUntil};
+use crate::{cst, kinds::TokenKind};
 
 /// Keeps accumulating parses sequentially until it hits an incomplete or no match.
 #[must_use]

--- a/crates/codegen/testing/src/cst_output.rs
+++ b/crates/codegen/testing/src/cst_output.rs
@@ -133,8 +133,9 @@ fn generate_unit_test_file(
 
     let contents = format!(
         "
-            use crate::cst_output::runner::run;
             use anyhow::Result;
+
+            use crate::cst_output::runner::run;
 
             {unit_tests}
         "

--- a/crates/infra/cli/src/commands/test/mod.rs
+++ b/crates/infra/cli/src/commands/test/mod.rs
@@ -1,7 +1,8 @@
-use crate::utils::{ClapExtensions, OrderedCommand, Terminal};
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use infra_utils::{cargo::CargoWorkspace, commands::Command, github::GitHub};
+
+use crate::utils::{ClapExtensions, OrderedCommand, Terminal};
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct TestController {

--- a/crates/infra/utils/src/codegen/mod.rs
+++ b/crates/infra/utils/src/codegen/mod.rs
@@ -2,12 +2,11 @@ mod common;
 mod read_write;
 mod write_only;
 
-pub use read_write::*;
-pub use write_only::*;
-
 use std::path::PathBuf;
 
 use anyhow::Result;
+pub use read_write::*;
+pub use write_only::*;
 
 pub struct Codegen;
 

--- a/crates/infra/utils/src/errors/mod.rs
+++ b/crates/infra/utils/src/errors/mod.rs
@@ -1,8 +1,9 @@
 use std::{env::var, path::PathBuf};
 
-use crate::paths::PathExtensions;
 use anyhow::{bail, Result};
 use ariadne::{Color, Label, Report, ReportKind, Source};
+
+use crate::paths::PathExtensions;
 
 #[derive(Debug, Default)]
 pub struct InfraErrors {

--- a/crates/solidity/inputs/language/src/lib.rs
+++ b/crates/solidity/inputs/language/src/lib.rs
@@ -9,11 +9,10 @@
 mod definition;
 mod grammar;
 
-pub use definition::SolidityDefinition;
-pub use grammar::GrammarConstructorDslV2;
-
 use anyhow::Result;
 use codegen_schema::types::{LanguageDefinition, LanguageDefinitionRef};
+pub use definition::SolidityDefinition;
+pub use grammar::GrammarConstructorDslV2;
 
 pub trait SolidityLanguageExtensions {
     /// Loads the precompiled Solidity language definition.

--- a/crates/solidity/outputs/cargo/build/src/main.rs
+++ b/crates/solidity/outputs/cargo/build/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use cargo_emit::rerun_if_changed;
-
 use codegen_grammar::Grammar;
 use codegen_parser_generator::code_generator::CodeGenerator;
 use infra_utils::{cargo::CargoWorkspace, paths::PathExtensions};

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -9,11 +9,13 @@
     clippy::similar_names
 )]
 
+use semver::Version;
 #[cfg(feature = "slang_napi_interfaces")]
 use {napi::bindgen_prelude::*, napi_derive::napi};
 
-use semver::Version;
-
+pub use super::kinds::LexicalContext;
+#[cfg(feature = "slang_napi_interfaces")]
+use super::napi::napi_parse_output::ParseOutput as NAPIParseOutput;
 use super::{
     kinds::{IsLexicalContext, LexicalContextType, ProductionKind, RuleKind, TokenKind},
     lexer::Lexer,
@@ -23,11 +25,6 @@ use super::{
         PrecedenceHelper, RecoverFromNoMatch, SeparatedHelper, SequenceHelper, ZeroOrMoreHelper,
     },
 };
-
-pub use super::kinds::LexicalContext;
-
-#[cfg(feature = "slang_napi_interfaces")]
-use super::napi::napi_parse_output::ParseOutput as NAPIParseOutput;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "slang_napi_interfaces", napi(namespace = "language"))]

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
@@ -2,6 +2,8 @@
 
 use std::rc::Rc;
 
+use napi_cursor::Cursor;
+use napi_text_index::TextIndex;
 use {
     napi::{
         bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
@@ -14,8 +16,6 @@ use super::{
     napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
     TokenKind,
 };
-use napi_cursor::Cursor;
-use napi_text_index::TextIndex;
 
 #[napi(object, namespace = "cst")]
 pub enum NodeType {

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
@@ -5,14 +5,14 @@
 // The functions are meant to be definitions for export, so they're not really used
 #![allow(clippy::return_self_not_must_use)]
 
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 use {
     napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
 use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
-use napi_cst::ToJS;
-use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
@@ -4,9 +4,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use napi_derive::napi;
+use napi_text_index::TextRange;
 
 use super::{napi_text_index, RustParseError};
-use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
@@ -1,9 +1,9 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+use napi_cst::ToJS;
 use {napi::bindgen_prelude::Env, napi_derive::napi};
 
 use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
-use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/choice_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/choice_helper.rs
@@ -3,9 +3,8 @@
 use std::mem;
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
-
 use super::{context::Marker, ParserContext, ParserResult};
+use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
 
 /// Starting from a given position in the input, this helper will try to pick (and remember) a best match. Settles on
 /// a first full match if possible, otherwise on the best incomplete match.

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/context.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/context.rs
@@ -3,10 +3,9 @@
 use std::mem;
 use std::ops::Range;
 
+use super::super::text_index::TextIndex;
 use crate::kinds::TokenKind;
 use crate::parse_error::ParseError;
-
-use super::super::text_index::TextIndex;
 
 pub struct ParserContext<'s> {
     source: &'s str,

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/recovery.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/recovery.rs
@@ -1,14 +1,13 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+use super::parser_result::SkippedUntil;
+use super::ParserContext;
 use crate::cst;
 use crate::kinds::{IsLexicalContext, TokenKind};
 use crate::lexer::Lexer;
 use crate::parse_error::ParseError;
 use crate::support::ParserResult;
 use crate::text_index::{TextRange, TextRangeExtensions as _};
-
-use super::parser_result::SkippedUntil;
-use super::ParserContext;
 
 /// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
 #[derive(Clone, Copy)]

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/sequence_helper.rs
@@ -2,9 +2,8 @@
 
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind};
-
 use super::parser_result::{Match, ParserResult, PrattElement, SkippedUntil};
+use crate::{cst, kinds::TokenKind};
 
 /// Keeps accumulating parses sequentially until it hits an incomplete or no match.
 #[must_use]

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/AsciiStringLiterals.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/AsciiStringLiterals.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn multiple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/AssemblyStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/AssemblyStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn simple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Block.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Block.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn unchecked() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/BreakStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/BreakStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn error_recovery() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ConstantDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ConstantDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn int() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ConstructorDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ConstructorDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn simple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ContractDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ContractDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn abstract_contract() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ContractMembers.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ContractMembers.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn constructor() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/DecimalNumberExpression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/DecimalNumberExpression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn days_unit() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/DeleteStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/DeleteStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn delete_identifier() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/EnumDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/EnumDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn multiple_members() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ErrorDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ErrorDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn top_level() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/EventDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/EventDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn no_parens() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Expression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Expression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn _0() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/FallbackFunctionDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/FallbackFunctionDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn simple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/FunctionDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/FunctionDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn constant_state_mutability() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/HexNumberExpression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/HexNumberExpression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn hex_consecutive_underscores() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/HexStringLiterals.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/HexStringLiterals.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn all_separated_pairs() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ImportDirective.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ImportDirective.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn destructure_import_empty() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/InterfaceDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/InterfaceDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn sample_counter() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/MappingType.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/MappingType.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn named_both() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/NewExpression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/NewExpression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn array_1d() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/PragmaDirective.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/PragmaDirective.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn abi_coder() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ReceiveFunctionDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ReceiveFunctionDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn simple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ReturnStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ReturnStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn invalid_terminator() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/SourceUnit.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/SourceUnit.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn SafeMath() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Statements.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Statements.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn compound_tokens() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/StructDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/StructDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn no_members() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ThrowStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/ThrowStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn throw() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TryStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TryStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn try_catch() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TupleDeconstructionStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TupleDeconstructionStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn abi_decode_array_type() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TupleExpression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TupleExpression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn empty() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TypeName.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/TypeName.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn byte() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UnicodeStringLiterals.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UnicodeStringLiterals.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn multiple() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UserDefinedValueTypeDefinition.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UserDefinedValueTypeDefinition.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn bool() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UsingDeconstructionSymbol.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UsingDeconstructionSymbol.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn identifier_path() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UsingDirective.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/UsingDirective.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn destructure_empty() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/VariableDeclarationStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/VariableDeclarationStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn var() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/VersionPragma.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/VersionPragma.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn alternatives() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulBlock.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulBlock.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn function_def() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulExpression.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulExpression.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn decimal_literal() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulLeaveStatement.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/YulLeaveStatement.rs
@@ -1,7 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-use crate::cst_output::runner::run;
 use anyhow::Result;
+
+use crate::cst_output::runner::run;
 
 #[test]
 fn leave() -> Result<()> {

--- a/crates/solidity/outputs/cargo/tests/src/doc_examples/cursor_api.rs
+++ b/crates/solidity/outputs/cargo/tests/src/doc_examples/cursor_api.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use semver::Version;
-
 use slang_solidity::{
     kinds::{ProductionKind, RuleKind, TokenKind},
     language::Language,

--- a/crates/solidity/outputs/cargo/tests/src/doc_examples/simple_contract.rs
+++ b/crates/solidity/outputs/cargo/tests/src/doc_examples/simple_contract.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use semver::Version;
-
 use slang_solidity::{
     cst::Node,
     kinds::{ProductionKind, RuleKind, TokenKind},

--- a/crates/solidity/outputs/npm/build/src/main.rs
+++ b/crates/solidity/outputs/npm/build/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use cargo_emit::rerun_if_changed;
-
 use codegen_grammar::Grammar;
 use codegen_parser_generator::code_generator::CodeGenerator;
 use infra_utils::{cargo::CargoWorkspace, paths::PathExtensions};

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -9,11 +9,13 @@
     clippy::similar_names
 )]
 
+use semver::Version;
 #[cfg(feature = "slang_napi_interfaces")]
 use {napi::bindgen_prelude::*, napi_derive::napi};
 
-use semver::Version;
-
+pub use super::kinds::LexicalContext;
+#[cfg(feature = "slang_napi_interfaces")]
+use super::napi::napi_parse_output::ParseOutput as NAPIParseOutput;
 use super::{
     kinds::{IsLexicalContext, LexicalContextType, ProductionKind, RuleKind, TokenKind},
     lexer::Lexer,
@@ -23,11 +25,6 @@ use super::{
         PrecedenceHelper, RecoverFromNoMatch, SeparatedHelper, SequenceHelper, ZeroOrMoreHelper,
     },
 };
-
-pub use super::kinds::LexicalContext;
-
-#[cfg(feature = "slang_napi_interfaces")]
-use super::napi::napi_parse_output::ParseOutput as NAPIParseOutput;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "slang_napi_interfaces", napi(namespace = "language"))]

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
@@ -2,6 +2,8 @@
 
 use std::rc::Rc;
 
+use napi_cursor::Cursor;
+use napi_text_index::TextIndex;
 use {
     napi::{
         bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
@@ -14,8 +16,6 @@ use super::{
     napi_cursor, napi_text_index, RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode,
     TokenKind,
 };
-use napi_cursor::Cursor;
-use napi_text_index::TextIndex;
 
 #[napi(object, namespace = "cst")]
 pub enum NodeType {

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
@@ -5,14 +5,14 @@
 // The functions are meant to be definitions for export, so they're not really used
 #![allow(clippy::return_self_not_must_use)]
 
+use napi_cst::ToJS;
+use napi_text_index::{TextIndex, TextRange};
 use {
     napi::{bindgen_prelude::Env, JsObject},
     napi_derive::napi,
 };
 
 use super::{napi_cst, napi_text_index, RuleKind, RustCursor, TokenKind};
-use napi_cst::ToJS;
-use napi_text_index::{TextIndex, TextRange};
 
 #[napi(namespace = "cursor")]
 pub struct Cursor(Box<RustCursor>);

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
@@ -4,9 +4,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use napi_derive::napi;
+use napi_text_index::TextRange;
 
 use super::{napi_text_index, RustParseError};
-use napi_text_index::TextRange;
 
 #[napi(namespace = "parse_error")]
 #[derive(PartialEq, Clone)]

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
@@ -1,9 +1,9 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+use napi_cst::ToJS;
 use {napi::bindgen_prelude::Env, napi_derive::napi};
 
 use super::{napi_cst, napi_cursor, napi_parse_error, RustParseOutput};
-use napi_cst::ToJS;
 
 #[napi(namespace = "parse_output")]
 pub struct ParseOutput(RustParseOutput);

--- a/crates/solidity/outputs/npm/crate/src/generated/support/choice_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/choice_helper.rs
@@ -3,9 +3,8 @@
 use std::mem;
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
-
 use super::{context::Marker, ParserContext, ParserResult};
+use crate::{cst, kinds::TokenKind, parse_error::ParseError, text_index::TextIndex};
 
 /// Starting from a given position in the input, this helper will try to pick (and remember) a best match. Settles on
 /// a first full match if possible, otherwise on the best incomplete match.

--- a/crates/solidity/outputs/npm/crate/src/generated/support/context.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/context.rs
@@ -3,10 +3,9 @@
 use std::mem;
 use std::ops::Range;
 
+use super::super::text_index::TextIndex;
 use crate::kinds::TokenKind;
 use crate::parse_error::ParseError;
-
-use super::super::text_index::TextIndex;
 
 pub struct ParserContext<'s> {
     source: &'s str,

--- a/crates/solidity/outputs/npm/crate/src/generated/support/recovery.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/recovery.rs
@@ -1,14 +1,13 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+use super::parser_result::SkippedUntil;
+use super::ParserContext;
 use crate::cst;
 use crate::kinds::{IsLexicalContext, TokenKind};
 use crate::lexer::Lexer;
 use crate::parse_error::ParseError;
 use crate::support::ParserResult;
 use crate::text_index::{TextRange, TextRangeExtensions as _};
-
-use super::parser_result::SkippedUntil;
-use super::ParserContext;
 
 /// An explicit parameter for the [`ParserResult::recover_until_with_nested_delims`] method.
 #[derive(Clone, Copy)]

--- a/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/sequence_helper.rs
@@ -2,9 +2,8 @@
 
 use std::ops::ControlFlow;
 
-use crate::{cst, kinds::TokenKind};
-
 use super::parser_result::{Match, ParserResult, PrattElement, SkippedUntil};
+use crate::{cst, kinds::TokenKind};
 
 /// Keeps accumulating parses sequentially until it hits an incomplete or no match.
 #[must_use]

--- a/crates/solidity/testing/solc/src/keywords/mod.rs
+++ b/crates/solidity/testing/solc/src/keywords/mod.rs
@@ -1,11 +1,13 @@
-use crate::utils::{ApiInput, Binary, InputSource};
+use std::collections::HashSet;
+
 use anyhow::Result;
 use codegen_language_definition::model::{Item, KeywordDefinition, KeywordItem, Language};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use semver::Version;
 use solidity_language::SolidityDefinition;
-use std::collections::HashSet;
+
+use crate::utils::{ApiInput, Binary, InputSource};
 
 pub fn check_solidity_keywords() -> Result<()> {
     println!();

--- a/crates/solidity/testing/solc/src/main.rs
+++ b/crates/solidity/testing/solc/src/main.rs
@@ -1,9 +1,10 @@
 mod keywords;
 mod utils;
 
-use crate::keywords::check_solidity_keywords;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+
+use crate::keywords::check_solidity_keywords;
 
 #[derive(Debug, Parser)]
 pub struct CLI {

--- a/crates/solidity/testing/solc/src/utils/binaries.rs
+++ b/crates/solidity/testing/solc/src/utils/binaries.rs
@@ -1,4 +1,8 @@
-use crate::utils::{ApiInput, ApiOutput};
+use std::{
+    collections::HashMap, os::unix::prelude::PermissionsExt, path::Path, path::PathBuf,
+    time::Duration,
+};
+
 use anyhow::Result;
 use codegen_language_definition::model::Language;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -6,11 +10,9 @@ use infra_utils::{cargo::CargoWorkspace, commands::Command, paths::PathExtension
 use rayon::prelude::{ParallelBridge, ParallelIterator};
 use semver::Version;
 use serde::Deserialize;
-use std::{
-    collections::HashMap, os::unix::prelude::PermissionsExt, path::Path, path::PathBuf,
-    time::Duration,
-};
 use url::Url;
+
+use crate::utils::{ApiInput, ApiOutput};
 
 #[derive(Debug)]
 pub struct Binary {

--- a/crates/solidity/testing/solc/src/utils/json_api.rs
+++ b/crates/solidity/testing/solc/src/utils/json_api.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 #[derive(Debug, Serialize)]
 pub struct ApiInput {


### PR DESCRIPTION
Part of #155 

This is fairly standard practice - we group the imports in the `std` > external libraries > current crate categories, separated by newlines.

Some links:
- https://github.com/rust-lang/style-team/issues/24
- https://github.com/rust-lang/rustfmt/issues/1302
- https://www.reddit.com/r/rust/comments/wwbxhw/comment/ilkid50/