### PR TITLE
Add final Clippy lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,6 +15,9 @@ rustflags = [
 	"-Welided_lifetimes_in_paths",
 	"-Wunused_extern_crates",
 	"-Wexplicit_outlives_requirements",
+	# Cargo
+	"-Wclippy::cargo",                   # Warn about Cargo.toml issues, except...
+	"-Aclippy::multiple_crate_versions", # Not possible to deduplicate, should be done periodically ourselves
 	# 📎 Lints that are enabled (warn/deny) by default
 	"-Wclippy::all",
 	# Restriction (optional, neutral lints)

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,4 +30,8 @@ rustflags = [
 	"-Aclippy::module_name_repetitions",            # It seems we prefer it this way; we'd need to discuss that
 	"-Aclippy::must_use_candidate",                 # Overzealous, we'd have to `[must_use]` a lot of things
 	"-Aclippy::redundant_closure_for_method_calls", # Not always clearer, let's not pepper `allow`s whenever needed
+	# Nursery
+	"-Wclippy::collection_is_never_read", # Lint against collections not used after creation
+	"-Wclippy::equatable_if_let",         # Prefer regular `==` checks over Yoda `if let $pat = $value`
+	"-Wclippy::useless_let_if_seq",       # Use idiomatic direct assignment of `let $val = if $cond { .. } else { ..};`
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,8 @@ lto = true
 rustflags = [
 	# rustc additional warnings:
 	"-Wunused_crate_dependencies",
+	"-Wunused_lifetimes",
+	"-Wunused_tuple_struct_fields", # Will be uplifed into `dead_code` (warn-by-default) with https://github.com/rust-lang/rust/pull/118297
 	# Rust 2018 idioms that are not yet warn-by-default:
 	"-Welided_lifetimes_in_paths",
 	"-Wunused_extern_crates",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,11 +15,11 @@ rustflags = [
 	"-Welided_lifetimes_in_paths",
 	"-Wunused_extern_crates",
 	"-Wexplicit_outlives_requirements",
+	# 📎 Lints that are enabled (warn/deny) by default
+	"-Wclippy::all",
 	# Cargo
 	"-Wclippy::cargo",                   # Warn about Cargo.toml issues, except...
 	"-Aclippy::multiple_crate_versions", # Not possible to deduplicate, should be done periodically ourselves
-	# 📎 Lints that are enabled (warn/deny) by default
-	"-Wclippy::all",
 	# Restriction (optional, neutral lints)
 	"-Wclippy::exit",                            # Prefer not `process::exit`ing directly
 	"-Wclippy::rest_pat_in_fully_bound_structs", # Prefer not to use `..` in fully bound structs

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,6 +12,7 @@ rustflags = [
 	# rustc additional warnings:
 	"-Wunused_crate_dependencies",
 	"-Wunused_lifetimes",
+	"-Wunused_macro_rules",
 	"-Wunused_tuple_struct_fields", # Will be uplifed into `dead_code` (warn-by-default) with https://github.com/rust-lang/rust/pull/118297
 	"-Wmeta_variable_misuse",
 	# Rust 2018 idioms that are not yet warn-by-default:

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,7 @@ rustflags = [
 	"-Wunused_crate_dependencies",
 	"-Wunused_lifetimes",
 	"-Wunused_tuple_struct_fields", # Will be uplifed into `dead_code` (warn-by-default) with https://github.com/rust-lang/rust/pull/118297
+	"-Wmeta_variable_misuse",
 	# Rust 2018 idioms that are not yet warn-by-default:
 	"-Welided_lifetimes_in_paths",
 	"-Wunused_extern_crates",

--- a/crates/codegen/parser/runtime/src/support/context.rs
+++ b/crates/codegen/parser/runtime/src/support/context.rs
@@ -120,14 +120,14 @@ pub(crate) struct DelimiterGuard<'a, 's> {
     closing_delim: TokenKind,
 }
 
-impl<'a, 's> Drop for DelimiterGuard<'a, 's> {
+impl Drop for DelimiterGuard<'_, '_> {
     fn drop(&mut self) {
         let popped = self.input.closing_delimiters.pop();
         debug_assert_eq!(popped, Some(self.closing_delim));
     }
 }
 
-impl<'a, 's> DelimiterGuard<'a, 's> {
+impl<'s> DelimiterGuard<'_, 's> {
     pub(crate) fn ctx(&mut self) -> &mut ParserContext<'s> {
         self.input
     }

--- a/crates/codegen/parser/runtime/src/support/precedence_helper.rs
+++ b/crates/codegen/parser/runtime/src/support/precedence_helper.rs
@@ -224,14 +224,10 @@ impl PrecedenceHelper {
 
                 // 3. Until we have a single expression.
 
-                if pratt_elements.len() != 1 {
-                    unreachable!("Expected a single element: {:#?}", pratt_elements)
-                }
-
-                if let Expression { nodes } = pratt_elements.pop().unwrap() {
-                    ParserResult::r#match(nodes, vec![])
-                } else {
-                    unreachable!("Expected an expression: {:#?}", pratt_elements)
+                match <[_; 1]>::try_from(pratt_elements) {
+                    Ok([Expression { nodes }]) => ParserResult::r#match(nodes, vec![]),
+                    Ok([head]) => unreachable!("Expected an expression: {:#?}", head),
+                    Err(elems) => unreachable!("Expected a single element: {:#?}", elems),
                 }
             }
 

--- a/crates/codegen/parser/runtime/src/support/scanner_macros.rs
+++ b/crates/codegen/parser/runtime/src/support/scanner_macros.rs
@@ -1,7 +1,7 @@
 #[allow(unused_macros)]
 macro_rules! scan_chars {
     ($stream:ident, $($char:literal),+) => {
-        if $( $stream.next() == Some($char) )&&* {
+        if $( $stream.next() == Some($char) )&&+ {
             true
         } else {
             $stream.undo();
@@ -14,7 +14,7 @@ macro_rules! scan_chars {
 macro_rules! scan_none_of {
     ($stream:ident, $($char:literal),+) => {
         if let Some(c) = $stream.next() {
-            if $(c != $char)&&* {
+            if $(c != $char)&&+ {
                 true
             } else {
                 $stream.undo();

--- a/crates/codegen/schema/src/json_schema.rs
+++ b/crates/codegen/schema/src/json_schema.rs
@@ -51,10 +51,8 @@ fn relax_schema(value: Value) -> Value {
                     .into_iter()
                     .filter_map(|(key, value)| {
                         // Remove `additionalProperties: false`
-                        if key == "additionalProperties" {
-                            if let Value::Bool(false) = value {
-                                return None;
-                            }
+                        if key == "additionalProperties" && value == Value::Bool(false) {
+                            return None;
                         }
 
                         // Replace `oneOf` and `allOf` with `anyOf`

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/context.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/context.rs
@@ -122,14 +122,14 @@ pub(crate) struct DelimiterGuard<'a, 's> {
     closing_delim: TokenKind,
 }
 
-impl<'a, 's> Drop for DelimiterGuard<'a, 's> {
+impl Drop for DelimiterGuard<'_, '_> {
     fn drop(&mut self) {
         let popped = self.input.closing_delimiters.pop();
         debug_assert_eq!(popped, Some(self.closing_delim));
     }
 }
 
-impl<'a, 's> DelimiterGuard<'a, 's> {
+impl<'s> DelimiterGuard<'_, 's> {
     pub(crate) fn ctx(&mut self) -> &mut ParserContext<'s> {
         self.input
     }

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/precedence_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/precedence_helper.rs
@@ -226,14 +226,10 @@ impl PrecedenceHelper {
 
                 // 3. Until we have a single expression.
 
-                if pratt_elements.len() != 1 {
-                    unreachable!("Expected a single element: {:#?}", pratt_elements)
-                }
-
-                if let Expression { nodes } = pratt_elements.pop().unwrap() {
-                    ParserResult::r#match(nodes, vec![])
-                } else {
-                    unreachable!("Expected an expression: {:#?}", pratt_elements)
+                match <[_; 1]>::try_from(pratt_elements) {
+                    Ok([Expression { nodes }]) => ParserResult::r#match(nodes, vec![]),
+                    Ok([head]) => unreachable!("Expected an expression: {:#?}", head),
+                    Err(elems) => unreachable!("Expected a single element: {:#?}", elems),
                 }
             }
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/support/scanner_macros.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/support/scanner_macros.rs
@@ -3,7 +3,7 @@
 #[allow(unused_macros)]
 macro_rules! scan_chars {
     ($stream:ident, $($char:literal),+) => {
-        if $( $stream.next() == Some($char) )&&* {
+        if $( $stream.next() == Some($char) )&&+ {
             true
         } else {
             $stream.undo();
@@ -16,7 +16,7 @@ macro_rules! scan_chars {
 macro_rules! scan_none_of {
     ($stream:ident, $($char:literal),+) => {
         if let Some(c) = $stream.next() {
-            if $(c != $char)&&* {
+            if $(c != $char)&&+ {
                 true
             } else {
                 $stream.undo();

--- a/crates/solidity/outputs/npm/crate/src/generated/support/context.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/context.rs
@@ -122,14 +122,14 @@ pub(crate) struct DelimiterGuard<'a, 's> {
     closing_delim: TokenKind,
 }
 
-impl<'a, 's> Drop for DelimiterGuard<'a, 's> {
+impl Drop for DelimiterGuard<'_, '_> {
     fn drop(&mut self) {
         let popped = self.input.closing_delimiters.pop();
         debug_assert_eq!(popped, Some(self.closing_delim));
     }
 }
 
-impl<'a, 's> DelimiterGuard<'a, 's> {
+impl<'s> DelimiterGuard<'_, 's> {
     pub(crate) fn ctx(&mut self) -> &mut ParserContext<'s> {
         self.input
     }

--- a/crates/solidity/outputs/npm/crate/src/generated/support/precedence_helper.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/precedence_helper.rs
@@ -226,14 +226,10 @@ impl PrecedenceHelper {
 
                 // 3. Until we have a single expression.
 
-                if pratt_elements.len() != 1 {
-                    unreachable!("Expected a single element: {:#?}", pratt_elements)
-                }
-
-                if let Expression { nodes } = pratt_elements.pop().unwrap() {
-                    ParserResult::r#match(nodes, vec![])
-                } else {
-                    unreachable!("Expected an expression: {:#?}", pratt_elements)
+                match <[_; 1]>::try_from(pratt_elements) {
+                    Ok([Expression { nodes }]) => ParserResult::r#match(nodes, vec![]),
+                    Ok([head]) => unreachable!("Expected an expression: {:#?}", head),
+                    Err(elems) => unreachable!("Expected a single element: {:#?}", elems),
                 }
             }
 

--- a/crates/solidity/outputs/npm/crate/src/generated/support/scanner_macros.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/support/scanner_macros.rs
@@ -3,7 +3,7 @@
 #[allow(unused_macros)]
 macro_rules! scan_chars {
     ($stream:ident, $($char:literal),+) => {
-        if $( $stream.next() == Some($char) )&&* {
+        if $( $stream.next() == Some($char) )&&+ {
             true
         } else {
             $stream.undo();
@@ -16,7 +16,7 @@ macro_rules! scan_chars {
 macro_rules! scan_none_of {
     ($stream:ident, $($char:literal),+) => {
         if let Some(c) = $stream.next() {
-            if $(c != $char)&&* {
+            if $(c != $char)&&+ {
                 true
             } else {
                 $stream.undo();


### PR DESCRIPTION
Final Clippy part of #155

## Lints

From the additional lint list mentioned by @OmarTawfik:
- Cargo - added everything, except the duplicate packages lint, as this is not fixable and we should strive to periodically do that ourselves. In any case, it's not something we should lint against and deny in CI
- Restriction:
  - `clippy::same_name_method` - sounds useful but std traits are covered already by `should_implement_trait` and this fires on wrapper functions/traits; only 4 occurences in our codebase are intentional wrappers
  - `clippy::allow_attributes_without_reason` - requires a nightly rustc feature
  - `clippy::self_named_module_files` - forcing `mod.rs` onto users seems backwards, as that's one of the key issues addressed for Rust 2018 in terms of module/file path ergonomics, see https://dev-doc.rust-lang.org/stable/edition-guide/rust-2018/path-changes.html#no-more-modrs for more context
  - `clippy::format_push_string` - alternative proposed is fallible, whereas the "offending" code is infallible, not enough value IMO
  - `clippy::str_to_string` - will be better fixed with `implicit_clone` once we bump Rust to 1.7{3,4} with a new Clippy that has less false positives
  - `clippy::wildcard_enum_match_arm` - we already have `match_wildcard_for_single_variants` + can have more false positives
- Nursery:
  - `clippy::use_self` - unstable, false positives
  - `clippy::collection_is_never_read` ✅ added
  - `clippy::equatable_if_let` ✅ added
  - `clippy::useless_let_if_seq` ✅ added
  
  
## Panicking
  The remaining items from #155 are about panicking in N-API-exposed crate.

Unfortunately, there is no way to guarantee or more broadly verify that certain code paths don't panic, as `rustc` only compiles a single crate at a time and panicking is not encoded in the type system. We could brainstorm how we can make this more resilient on the Rust side but that requires more data (maybe we could plug in Sentry for the Rust side of VSCode extension?) and a more careful thinking rather than trying to tackle this as part of the "Lint Rust code" item.