### PR TITLE
add `#[napi(catch_unwind)]` everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,12 +1184,12 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.13.2"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede2d12cd6fce44da537a4be1f5510c73be2506c2e32dfaaafd1f36968f3a0e"
+checksum = "1133249c46e92da921bafc8aba4912bf84d6c475f7625183772ed2d0844dc3a7"
 dependencies = [
  "bitflags 2.3.3",
  "ctor",
@@ -1291,15 +1291,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
+checksum = "d4b4532cf86bfef556348ac65e561e3123879f0e7566cca6d43a6ff5326f13df"
 
 [[package]]
 name = "napi-derive"
-version = "2.13.0"
+version = "2.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1c6a8fa84d549aa8708fcd062372bf8ec6e849de39016ab921067d21bde367"
+checksum = "2b0c0743f6a3f29c20851b8377f01d485a837e2bfa57dd56d519ab7ed98ae2af"
 dependencies = [
  "cfg-if",
  "convert_case",
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bbc7c69168d06a848f925ec5f0e0997f98e8c8d4f2cc30157f0da51c009e17"
+checksum = "4869e4d80615fdab57dffe38c36a5bc62fae37352a00a35ee7aca1cea41b1bb3"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166b5ef52a3ab5575047a9fe8d4a030cdd0f63c96f071cd6907674453b07bae3"
+checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,9 @@ indicatif = { version = "0.17.3" }
 Inflector = { version = "0.11.4" }
 itertools = { version = "0.10.5" }
 markdown = { version = "0.3.0" }
-napi = { version = "2.13.1", features = ["compat-mode", "napi8", "serde-json"] }
-napi-build = { version = "2.0.1" }
-napi-derive = { version = "2.13.0" }
+napi = { version = "2.14.1", features = ["compat-mode", "napi8", "serde-json"] }
+napi-build = { version = "2.1.0" }
+napi-derive = { version = "2.14.3" }
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 proc-macro2 = { version = "1.0.53" }
 quote = { version = "1.0.26" }

--- a/crates/codegen/parser/runtime/src/kinds.rs
+++ b/crates/codegen/parser/runtime/src/kinds.rs
@@ -1,8 +1,5 @@
 #[cfg(feature = "slang_napi_interfaces")]
-use {
-    napi::bindgen_prelude::{FromNapiValue, ToNapiValue},
-    napi_derive::napi,
-};
+use napi_derive::napi;
 
 #[derive(
     Debug,

--- a/crates/codegen/parser/runtime/src/napi/napi_cst.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cst.rs
@@ -4,7 +4,7 @@ use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 use {
     napi::{
-        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        bindgen_prelude::{Env, ToNapiValue},
         JsObject, NapiValue,
     },
     napi_derive::napi,
@@ -29,12 +29,17 @@ pub struct TokenNode(Rc<RustTokenNode>);
 
 #[napi(namespace = "cst")]
 impl RuleNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Rule")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Rule",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Rule
     }
 
-    #[napi(getter, ts_return_type = "kinds.RuleKind")]
+    #[napi(getter, ts_return_type = "kinds.RuleKind", catch_unwind)]
     pub fn kind(&self) -> RuleKind {
         self.0.kind
     }
@@ -42,13 +47,14 @@ impl RuleNode {
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         (&self.0.text_len).into()
     }
 
-    #[napi(ts_return_type = "Array<cst.Node>")]
+    #[napi(ts_return_type = "Array<cst.Node>", catch_unwind)]
     pub fn children(&self, env: Env) -> Vec<JsObject> {
         self.0
             .children
@@ -57,7 +63,7 @@ impl RuleNode {
             .collect()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,
@@ -70,31 +76,38 @@ impl RuleNode {
 
 #[napi(namespace = "cst")]
 impl TokenNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Token")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Token",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Token
     }
 
-    #[napi(getter, ts_return_type = "kinds.TokenKind")]
+    #[napi(getter, ts_return_type = "kinds.TokenKind", catch_unwind)]
     pub fn kind(&self) -> TokenKind {
         self.0.kind
     }
+
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         let text_len: RustTextIndex = (&self.0.text).into();
         (&text_len).into()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,

--- a/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_cursor.rs
@@ -27,54 +27,54 @@ impl Cursor {
         Self(Box::new(cursor))
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn reset(&mut self) {
         self.0.reset();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn complete(&mut self) {
         self.0.complete();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     #[allow(clippy::should_implement_trait)] // These are meant to be explicitly exposed to NAPI
     pub fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn spawn(&self) -> Self {
         Self::new(self.0.spawn())
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_completed(&self) -> bool {
         self.0.is_completed()
     }
 
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
         self.0.node().to_js(&env)
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextIndex")]
+    #[napi(getter, ts_return_type = "text_index.TextIndex", catch_unwind)]
     pub fn text_offset(&self) -> TextIndex {
         (&self.0.text_offset()).into()
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         (&self.0.text_range()).into()
     }
 
     #[allow(clippy::cast_possible_truncation)] // Cursor depth can't reasonably be larger than u32
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn depth(&self) -> u32 {
         self.0.depth() as u32
     }
 
-    #[napi(ts_return_type = "Array<cst.RuleNode>")]
+    #[napi(ts_return_type = "Array<cst.RuleNode>", catch_unwind)]
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
@@ -82,57 +82,57 @@ impl Cursor {
             .collect()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next(&mut self) -> bool {
         self.0.go_to_next()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_non_descendent(&mut self) -> bool {
         self.0.go_to_next_non_descendent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous(&mut self) -> bool {
         self.0.go_to_previous()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_parent(&mut self) -> bool {
         self.0.go_to_parent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_first_child(&mut self) -> bool {
         self.0.go_to_first_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_last_child(&mut self) -> bool {
         self.0.go_to_last_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_nth_child(&mut self, child_number: u32) -> bool {
         self.0.go_to_nth_child(child_number as usize)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_sibling(&mut self) -> bool {
         self.0.go_to_next_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous_sibling(&mut self) -> bool {
         self.0.go_to_previous_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token(&mut self) -> bool {
         self.0.go_to_next_token()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.TokenKind>")] kinds: Vec<TokenKind>,
@@ -140,12 +140,12 @@ impl Cursor {
         self.0.go_to_next_token_with_kinds(&kinds)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule(&mut self) -> bool {
         self.0.go_to_next_rule()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.RuleKind>")] kinds: Vec<RuleKind>,

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_error.rs
@@ -18,16 +18,12 @@ impl From<RustParseError> for ParseError {
 
 #[napi(namespace = "parse_error")]
 impl ParseError {
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         self.0.text_range().into()
     }
 
-    pub fn tokens_that_would_have_allowed_more_progress(&self) -> Vec<String> {
-        self.0.tokens_that_would_have_allowed_more_progress()
-    }
-
-    #[napi(namespace = "parse_error")]
+    #[napi(catch_unwind)]
     pub fn to_error_report(&self, source_id: String, source: String, with_color: bool) -> String {
         self.0.to_error_report(&source_id, &source, with_color)
     }

--- a/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
+++ b/crates/codegen/parser/runtime/src/napi/napi_parse_output.rs
@@ -14,23 +14,23 @@ impl From<RustParseOutput> for ParseOutput {
 
 #[napi(namespace = "parse_output")]
 impl ParseOutput {
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
         self.0.tree().to_js(&env)
     }
 
-    #[napi(ts_return_type = "Array<parse_error.ParseError>")]
+    #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]
     pub fn errors(&self) -> Vec<napi_parse_error::ParseError> {
         self.0.errors().iter().map(|x| x.clone().into()).collect()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_valid(&self) -> bool {
         self.0.is_valid()
     }
 
     /// Creates a cursor that starts at the root of the parse tree.
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_tree_cursor(&self) -> napi_cursor::Cursor {
         self.0.create_tree_cursor().into()
     }

--- a/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/templates/kinds.rs.jinja2
@@ -1,5 +1,5 @@
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
 
 #[derive(
     Debug,

--- a/crates/codegen/parser/runtime/src/templates/language.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/templates/language.rs.jinja2
@@ -2,7 +2,7 @@
 #![allow(clippy::if_not_else, clippy::too_many_lines, clippy::unused_self, clippy::struct_excessive_bools, clippy::similar_names)]
 
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
 
 use semver::Version;
 
@@ -199,26 +199,31 @@ impl Language {
 
     #[napi(constructor)]
     pub fn new_napi(version: String) -> std::result::Result<Self, napi::Error> {
+        // IMPORTANT:
+        // Make sure this does NOT panic.
+        // '#[napi(catch_unwind)]' is not supported on constructors yet.
+        // More Info: https://github.com/napi-rs/napi-rs/issues/1852
+
         let version = Version::parse(&version).map_err(|_| Error::InvalidSemanticVersion(version))?;
         Self::new(version).map_err(|e| e.into())
     }
 
-    #[napi(getter, js_name = "version")]
+    #[napi(getter, js_name = "version", catch_unwind)]
     pub fn version_napi(&self) -> String {
         self.version.to_string()
     }
 
-    #[napi(js_name = "supportedVersions")]
+    #[napi(js_name = "supportedVersions", catch_unwind)]
     pub fn supported_versions_napi() -> Vec<String> {
         return Self::SUPPORTED_VERSIONS.iter().map(|v| v.to_string()).collect();
     }
 
-    #[napi(js_name = "scan", ts_return_type = "kinds.TokenKind | null")]
+    #[napi(js_name = "scan", ts_return_type = "kinds.TokenKind | null", catch_unwind)]
     pub fn scan_napi(&self, lexical_context: LexicalContext, input: String) -> Option<TokenKind> {
         self.scan(lexical_context, input.as_str())
     }
 
-    #[napi(js_name = "parse", ts_return_type = "parse_output.ParseOutput")]
+    #[napi(js_name = "parse", ts_return_type = "parse_output.ParseOutput", catch_unwind)]
     pub fn parse_napi(
         &self,
         #[napi(ts_arg_type = "kinds.RuleKind")] kind: RuleKind,

--- a/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/kinds.rs
@@ -1,7 +1,7 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
 
 #[derive(
     Debug,

--- a/crates/solidity/outputs/cargo/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/language.rs
@@ -9,9 +9,9 @@
     clippy::similar_names
 )]
 
-use semver::Version;
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
+use semver::Version;
 
 pub use super::kinds::LexicalContext;
 #[cfg(feature = "slang_napi_interfaces")]
@@ -9750,17 +9750,22 @@ impl Lexer for Language {
 impl Language {
     #[napi(constructor)]
     pub fn new_napi(version: String) -> std::result::Result<Self, napi::Error> {
+        // IMPORTANT:
+        // Make sure this does NOT panic.
+        // '#[napi(catch_unwind)]' is not supported on constructors yet.
+        // More Info: https://github.com/napi-rs/napi-rs/issues/1852
+
         let version =
             Version::parse(&version).map_err(|_| Error::InvalidSemanticVersion(version))?;
         Self::new(version).map_err(|e| e.into())
     }
 
-    #[napi(getter, js_name = "version")]
+    #[napi(getter, js_name = "version", catch_unwind)]
     pub fn version_napi(&self) -> String {
         self.version.to_string()
     }
 
-    #[napi(js_name = "supportedVersions")]
+    #[napi(js_name = "supportedVersions", catch_unwind)]
     pub fn supported_versions_napi() -> Vec<String> {
         return Self::SUPPORTED_VERSIONS
             .iter()
@@ -9768,12 +9773,20 @@ impl Language {
             .collect();
     }
 
-    #[napi(js_name = "scan", ts_return_type = "kinds.TokenKind | null")]
+    #[napi(
+        js_name = "scan",
+        ts_return_type = "kinds.TokenKind | null",
+        catch_unwind
+    )]
     pub fn scan_napi(&self, lexical_context: LexicalContext, input: String) -> Option<TokenKind> {
         self.scan(lexical_context, input.as_str())
     }
 
-    #[napi(js_name = "parse", ts_return_type = "parse_output.ParseOutput")]
+    #[napi(
+        js_name = "parse",
+        ts_return_type = "parse_output.ParseOutput",
+        catch_unwind
+    )]
     pub fn parse_napi(
         &self,
         #[napi(ts_arg_type = "kinds.RuleKind")] kind: RuleKind,

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cst.rs
@@ -6,7 +6,7 @@ use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 use {
     napi::{
-        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        bindgen_prelude::{Env, ToNapiValue},
         JsObject, NapiValue,
     },
     napi_derive::napi,
@@ -31,12 +31,17 @@ pub struct TokenNode(Rc<RustTokenNode>);
 
 #[napi(namespace = "cst")]
 impl RuleNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Rule")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Rule",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Rule
     }
 
-    #[napi(getter, ts_return_type = "kinds.RuleKind")]
+    #[napi(getter, ts_return_type = "kinds.RuleKind", catch_unwind)]
     pub fn kind(&self) -> RuleKind {
         self.0.kind
     }
@@ -44,13 +49,14 @@ impl RuleNode {
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         (&self.0.text_len).into()
     }
 
-    #[napi(ts_return_type = "Array<cst.Node>")]
+    #[napi(ts_return_type = "Array<cst.Node>", catch_unwind)]
     pub fn children(&self, env: Env) -> Vec<JsObject> {
         self.0
             .children
@@ -59,7 +65,7 @@ impl RuleNode {
             .collect()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,
@@ -72,31 +78,38 @@ impl RuleNode {
 
 #[napi(namespace = "cst")]
 impl TokenNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Token")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Token",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Token
     }
 
-    #[napi(getter, ts_return_type = "kinds.TokenKind")]
+    #[napi(getter, ts_return_type = "kinds.TokenKind", catch_unwind)]
     pub fn kind(&self) -> TokenKind {
         self.0.kind
     }
+
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         let text_len: RustTextIndex = (&self.0.text).into();
         (&text_len).into()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_cursor.rs
@@ -29,54 +29,54 @@ impl Cursor {
         Self(Box::new(cursor))
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn reset(&mut self) {
         self.0.reset();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn complete(&mut self) {
         self.0.complete();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     #[allow(clippy::should_implement_trait)] // These are meant to be explicitly exposed to NAPI
     pub fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn spawn(&self) -> Self {
         Self::new(self.0.spawn())
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_completed(&self) -> bool {
         self.0.is_completed()
     }
 
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
         self.0.node().to_js(&env)
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextIndex")]
+    #[napi(getter, ts_return_type = "text_index.TextIndex", catch_unwind)]
     pub fn text_offset(&self) -> TextIndex {
         (&self.0.text_offset()).into()
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         (&self.0.text_range()).into()
     }
 
     #[allow(clippy::cast_possible_truncation)] // Cursor depth can't reasonably be larger than u32
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn depth(&self) -> u32 {
         self.0.depth() as u32
     }
 
-    #[napi(ts_return_type = "Array<cst.RuleNode>")]
+    #[napi(ts_return_type = "Array<cst.RuleNode>", catch_unwind)]
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
@@ -84,57 +84,57 @@ impl Cursor {
             .collect()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next(&mut self) -> bool {
         self.0.go_to_next()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_non_descendent(&mut self) -> bool {
         self.0.go_to_next_non_descendent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous(&mut self) -> bool {
         self.0.go_to_previous()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_parent(&mut self) -> bool {
         self.0.go_to_parent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_first_child(&mut self) -> bool {
         self.0.go_to_first_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_last_child(&mut self) -> bool {
         self.0.go_to_last_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_nth_child(&mut self, child_number: u32) -> bool {
         self.0.go_to_nth_child(child_number as usize)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_sibling(&mut self) -> bool {
         self.0.go_to_next_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous_sibling(&mut self) -> bool {
         self.0.go_to_previous_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token(&mut self) -> bool {
         self.0.go_to_next_token()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.TokenKind>")] kinds: Vec<TokenKind>,
@@ -142,12 +142,12 @@ impl Cursor {
         self.0.go_to_next_token_with_kinds(&kinds)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule(&mut self) -> bool {
         self.0.go_to_next_rule()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.RuleKind>")] kinds: Vec<RuleKind>,

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_error.rs
@@ -20,16 +20,12 @@ impl From<RustParseError> for ParseError {
 
 #[napi(namespace = "parse_error")]
 impl ParseError {
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         self.0.text_range().into()
     }
 
-    pub fn tokens_that_would_have_allowed_more_progress(&self) -> Vec<String> {
-        self.0.tokens_that_would_have_allowed_more_progress()
-    }
-
-    #[napi(namespace = "parse_error")]
+    #[napi(catch_unwind)]
     pub fn to_error_report(&self, source_id: String, source: String, with_color: bool) -> String {
         self.0.to_error_report(&source_id, &source, with_color)
     }

--- a/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/napi/napi_parse_output.rs
@@ -16,23 +16,23 @@ impl From<RustParseOutput> for ParseOutput {
 
 #[napi(namespace = "parse_output")]
 impl ParseOutput {
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
         self.0.tree().to_js(&env)
     }
 
-    #[napi(ts_return_type = "Array<parse_error.ParseError>")]
+    #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]
     pub fn errors(&self) -> Vec<napi_parse_error::ParseError> {
         self.0.errors().iter().map(|x| x.clone().into()).collect()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_valid(&self) -> bool {
         self.0.is_valid()
     }
 
     /// Creates a cursor that starts at the root of the parse tree.
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_tree_cursor(&self) -> napi_cursor::Cursor {
         self.0.create_tree_cursor().into()
     }

--- a/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/kinds.rs
@@ -1,7 +1,7 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
 
 #[derive(
     Debug,

--- a/crates/solidity/outputs/npm/crate/src/generated/language.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/language.rs
@@ -9,9 +9,9 @@
     clippy::similar_names
 )]
 
-use semver::Version;
 #[cfg(feature = "slang_napi_interfaces")]
-use {napi::bindgen_prelude::*, napi_derive::napi};
+use napi_derive::napi;
+use semver::Version;
 
 pub use super::kinds::LexicalContext;
 #[cfg(feature = "slang_napi_interfaces")]
@@ -9750,17 +9750,22 @@ impl Lexer for Language {
 impl Language {
     #[napi(constructor)]
     pub fn new_napi(version: String) -> std::result::Result<Self, napi::Error> {
+        // IMPORTANT:
+        // Make sure this does NOT panic.
+        // '#[napi(catch_unwind)]' is not supported on constructors yet.
+        // More Info: https://github.com/napi-rs/napi-rs/issues/1852
+
         let version =
             Version::parse(&version).map_err(|_| Error::InvalidSemanticVersion(version))?;
         Self::new(version).map_err(|e| e.into())
     }
 
-    #[napi(getter, js_name = "version")]
+    #[napi(getter, js_name = "version", catch_unwind)]
     pub fn version_napi(&self) -> String {
         self.version.to_string()
     }
 
-    #[napi(js_name = "supportedVersions")]
+    #[napi(js_name = "supportedVersions", catch_unwind)]
     pub fn supported_versions_napi() -> Vec<String> {
         return Self::SUPPORTED_VERSIONS
             .iter()
@@ -9768,12 +9773,20 @@ impl Language {
             .collect();
     }
 
-    #[napi(js_name = "scan", ts_return_type = "kinds.TokenKind | null")]
+    #[napi(
+        js_name = "scan",
+        ts_return_type = "kinds.TokenKind | null",
+        catch_unwind
+    )]
     pub fn scan_napi(&self, lexical_context: LexicalContext, input: String) -> Option<TokenKind> {
         self.scan(lexical_context, input.as_str())
     }
 
-    #[napi(js_name = "parse", ts_return_type = "parse_output.ParseOutput")]
+    #[napi(
+        js_name = "parse",
+        ts_return_type = "parse_output.ParseOutput",
+        catch_unwind
+    )]
     pub fn parse_napi(
         &self,
         #[napi(ts_arg_type = "kinds.RuleKind")] kind: RuleKind,

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cst.rs
@@ -6,7 +6,7 @@ use napi_cursor::Cursor;
 use napi_text_index::TextIndex;
 use {
     napi::{
-        bindgen_prelude::{Env, FromNapiValue, ToNapiValue},
+        bindgen_prelude::{Env, ToNapiValue},
         JsObject, NapiValue,
     },
     napi_derive::napi,
@@ -31,12 +31,17 @@ pub struct TokenNode(Rc<RustTokenNode>);
 
 #[napi(namespace = "cst")]
 impl RuleNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Rule")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Rule",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Rule
     }
 
-    #[napi(getter, ts_return_type = "kinds.RuleKind")]
+    #[napi(getter, ts_return_type = "kinds.RuleKind", catch_unwind)]
     pub fn kind(&self) -> RuleKind {
         self.0.kind
     }
@@ -44,13 +49,14 @@ impl RuleNode {
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         (&self.0.text_len).into()
     }
 
-    #[napi(ts_return_type = "Array<cst.Node>")]
+    #[napi(ts_return_type = "Array<cst.Node>", catch_unwind)]
     pub fn children(&self, env: Env) -> Vec<JsObject> {
         self.0
             .children
@@ -59,7 +65,7 @@ impl RuleNode {
             .collect()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,
@@ -72,31 +78,38 @@ impl RuleNode {
 
 #[napi(namespace = "cst")]
 impl TokenNode {
-    #[napi(getter, js_name = "type", ts_return_type = "NodeType.Token")]
+    #[napi(
+        getter,
+        js_name = "type",
+        ts_return_type = "NodeType.Token",
+        catch_unwind
+    )]
     pub fn tipe(&self) -> NodeType {
         NodeType::Token
     }
 
-    #[napi(getter, ts_return_type = "kinds.TokenKind")]
+    #[napi(getter, ts_return_type = "kinds.TokenKind", catch_unwind)]
     pub fn kind(&self) -> TokenKind {
         self.0.kind
     }
+
     #[napi(
         getter,
         js_name = "textLength",
-        ts_return_type = "text_index.TextIndex"
+        ts_return_type = "text_index.TextIndex",
+        catch_unwind
     )]
     pub fn text_len(&self) -> TextIndex {
         let text_len: RustTextIndex = (&self.0.text).into();
         (&text_len).into()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
     }
 
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_cursor(
         &self,
         #[napi(ts_arg_type = "text_index.TextIndex")] text_offset: TextIndex,

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_cursor.rs
@@ -29,54 +29,54 @@ impl Cursor {
         Self(Box::new(cursor))
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn reset(&mut self) {
         self.0.reset();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn complete(&mut self) {
         self.0.complete();
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     #[allow(clippy::should_implement_trait)] // These are meant to be explicitly exposed to NAPI
     pub fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn spawn(&self) -> Self {
         Self::new(self.0.spawn())
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_completed(&self) -> bool {
         self.0.is_completed()
     }
 
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
         self.0.node().to_js(&env)
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextIndex")]
+    #[napi(getter, ts_return_type = "text_index.TextIndex", catch_unwind)]
     pub fn text_offset(&self) -> TextIndex {
         (&self.0.text_offset()).into()
     }
 
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         (&self.0.text_range()).into()
     }
 
     #[allow(clippy::cast_possible_truncation)] // Cursor depth can't reasonably be larger than u32
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn depth(&self) -> u32 {
         self.0.depth() as u32
     }
 
-    #[napi(ts_return_type = "Array<cst.RuleNode>")]
+    #[napi(ts_return_type = "Array<cst.RuleNode>", catch_unwind)]
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
@@ -84,57 +84,57 @@ impl Cursor {
             .collect()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next(&mut self) -> bool {
         self.0.go_to_next()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_non_descendent(&mut self) -> bool {
         self.0.go_to_next_non_descendent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous(&mut self) -> bool {
         self.0.go_to_previous()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_parent(&mut self) -> bool {
         self.0.go_to_parent()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_first_child(&mut self) -> bool {
         self.0.go_to_first_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_last_child(&mut self) -> bool {
         self.0.go_to_last_child()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_nth_child(&mut self, child_number: u32) -> bool {
         self.0.go_to_nth_child(child_number as usize)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_sibling(&mut self) -> bool {
         self.0.go_to_next_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_previous_sibling(&mut self) -> bool {
         self.0.go_to_previous_sibling()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token(&mut self) -> bool {
         self.0.go_to_next_token()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_token_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.TokenKind>")] kinds: Vec<TokenKind>,
@@ -142,12 +142,12 @@ impl Cursor {
         self.0.go_to_next_token_with_kinds(&kinds)
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule(&mut self) -> bool {
         self.0.go_to_next_rule()
     }
 
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn go_to_next_rule_with_kinds(
         &mut self,
         #[napi(ts_arg_type = "Array<kinds.RuleKind>")] kinds: Vec<RuleKind>,

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_error.rs
@@ -20,16 +20,12 @@ impl From<RustParseError> for ParseError {
 
 #[napi(namespace = "parse_error")]
 impl ParseError {
-    #[napi(getter, ts_return_type = "text_index.TextRange")]
+    #[napi(getter, ts_return_type = "text_index.TextRange", catch_unwind)]
     pub fn text_range(&self) -> TextRange {
         self.0.text_range().into()
     }
 
-    pub fn tokens_that_would_have_allowed_more_progress(&self) -> Vec<String> {
-        self.0.tokens_that_would_have_allowed_more_progress()
-    }
-
-    #[napi(namespace = "parse_error")]
+    #[napi(catch_unwind)]
     pub fn to_error_report(&self, source_id: String, source: String, with_color: bool) -> String {
         self.0.to_error_report(&source_id, &source, with_color)
     }

--- a/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
+++ b/crates/solidity/outputs/npm/crate/src/generated/napi/napi_parse_output.rs
@@ -16,23 +16,23 @@ impl From<RustParseOutput> for ParseOutput {
 
 #[napi(namespace = "parse_output")]
 impl ParseOutput {
-    #[napi(ts_return_type = "cst.Node")]
+    #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
         self.0.tree().to_js(&env)
     }
 
-    #[napi(ts_return_type = "Array<parse_error.ParseError>")]
+    #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]
     pub fn errors(&self) -> Vec<napi_parse_error::ParseError> {
         self.0.errors().iter().map(|x| x.clone().into()).collect()
     }
 
-    #[napi(getter)]
+    #[napi(getter, catch_unwind)]
     pub fn is_valid(&self) -> bool {
         self.0.is_valid()
     }
 
     /// Creates a cursor that starts at the root of the parse tree.
-    #[napi(ts_return_type = "cursor.Cursor")]
+    #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]
     pub fn create_tree_cursor(&self) -> napi_cursor::Cursor {
         self.0.create_tree_cursor().into()
     }


### PR DESCRIPTION
this makes sure Rust panics are converted to JS exceptions, so that we don't crash the NodeJS process.