### PR TITLE
Bump actions/upload-pages-artifact patch ver to 1.0.8

### DIFF
--- a/.github/workflows/_jobs_github_pages.yml
+++ b/.github/workflows/_jobs_github_pages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: "actions/configure-pages@v3.0.5"
 
       - name: "Upload artifacts"
-        uses: "actions/upload-pages-artifact@v1.0.7"
+        uses: "actions/upload-pages-artifact@v1.0.8"
         with:
           path: "documentation/target/site" # _SLANG_MKDOCS_DOCUMENTATION_SITE_DIR_ (keep in sync)
 


### PR DESCRIPTION
This changes the internally used action of upload-artifact from `@main` to `@v3`. Because v4 has been recently published, which introduces quite a few performance improvements but may be in some cases incompatible with prior artifact creation workflow, we stick with the v3 that we know works.

This should fix our broken https://github.com/NomicFoundation/slang/deployments/github-pages pipeline.

Changes: https://github.com/actions/upload-pages-artifact/compare/v1.0.7...v1.0.8

Note: There was 1.0.9 published with a change that's been reverted in 1.0.10, so we might as well upgrade to 1.0.10; the only change was the back-and-forth fix (breaking change; introduced in 2.0.0) and docs change. We might upgrade to 2.0.0 but we'd need to verify if the breaking change of not running `chmod` affects us:

https://github.com/actions/upload-pages-artifact/pull/69/files