### PR TITLE
fix `RUST_BACKTRACE` casing

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -8,7 +8,7 @@ env = {
   "LANG": "en_US.UTF-8",
 
   // Rust:
-  "RUST_BACKTRACE": "FULL",
+  "RUST_BACKTRACE": "full",
   "RUST_STABLE_VERSION": "1.72.0", // Keep in sync with other "RUST_STABLE_VERSION" references
   "RUST_NIGHTLY_VERSION": "nightly-2023-12-01", // Keep in sync with other "RUST_NIGHTLY_VERSION" references
   "RUSTC_WRAPPER": "${HERMIT_ENV}/bin/sccache",


### PR DESCRIPTION
Turns out the matching is case sensitive. This enables panic traces for `build.rs` failures:

https://github.com/rust-lang/rust/blob/920e0051cf7b80e7ea00c4fadc482e8b70f2e81b/library/std/src/sys_common/backtrace.rs#L137-L143