### PR TITLE
refactor: Move grammar parser constructor to codegen_grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,8 @@ dependencies = [
 name = "codegen_grammar"
 version = "0.13.0"
 dependencies = [
+ "codegen_language_definition",
+ "indexmap 1.9.3",
  "semver",
  "strum_macros",
 ]
@@ -2080,14 +2082,11 @@ dependencies = [
  "anyhow",
  "bson",
  "cargo-emit",
- "codegen_grammar",
  "codegen_language_definition",
  "codegen_language_macros",
  "codegen_schema",
- "indexmap 1.9.3",
  "infra_utils",
  "semver",
- "strum_macros",
 ]
 
 [[package]]

--- a/crates/codegen/grammar/Cargo.toml
+++ b/crates/codegen/grammar/Cargo.toml
@@ -6,5 +6,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+codegen_language_definition = { workspace = true }
+indexmap = { workspace = true }
 semver = { workspace = true }
 strum_macros = { workspace = true }

--- a/crates/codegen/grammar/src/constructor.rs
+++ b/crates/codegen/grammar/src/constructor.rs
@@ -6,15 +6,16 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Deref;
 use std::rc::Rc;
 
-use codegen_grammar::{
+use codegen_language_definition::model::{self, FieldsErrorRecovery, Identifier, Item};
+use indexmap::IndexMap;
+
+use crate::{
     Grammar, GrammarElement, KeywordScannerDefinition, KeywordScannerDefinitionNode,
     KeywordScannerDefinitionVersionedNode, Named, ParserDefinition, ParserDefinitionNode,
     PrecedenceOperatorModel, PrecedenceParserDefinition, PrecedenceParserDefinitionNode,
     ScannerDefinition, ScannerDefinitionNode, TriviaParserDefinition, VersionQuality,
     VersionQualityRange,
 };
-use codegen_language_definition::model::{self, FieldsErrorRecovery, Identifier, Item};
-use indexmap::IndexMap;
 
 /// Materializes the DSL v2 model ([`model::Language`]) into [`Grammar`].
 pub trait GrammarConstructorDslV2 {
@@ -143,7 +144,7 @@ impl KeywordScannerDefinition for NamedKeywordScanner {
         self.name
     }
 
-    fn definitions(&self) -> &[codegen_grammar::KeywordScannerDefinitionVersionedNode] {
+    fn definitions(&self) -> &[KeywordScannerDefinitionVersionedNode] {
         &self.defs
     }
 

--- a/crates/codegen/grammar/src/lib.rs
+++ b/crates/codegen/grammar/src/lib.rs
@@ -1,3 +1,4 @@
+mod constructor;
 mod grammar;
 mod parser_definition;
 mod precedence_parser_definition;
@@ -5,6 +6,7 @@ mod scanner_definition;
 mod version_quality;
 mod visitor;
 
+pub use constructor::GrammarConstructorDslV2;
 pub use grammar::*;
 pub use parser_definition::*;
 pub use precedence_parser_definition::*;

--- a/crates/codegen/language/definition/src/model/terminals/trivia.rs
+++ b/crates/codegen/language/definition/src/model/terminals/trivia.rs
@@ -10,7 +10,6 @@ pub enum TriviaParser {
     Choice { parsers: Vec<TriviaParser> },
 
     Optional { parser: Box<TriviaParser> },
-    // TODO(#638): Remove this, once we adapt the DSL v1 codegen model to the new v2 definition.
     OneOrMore { parser: Box<TriviaParser> },
     ZeroOrMore { parser: Box<TriviaParser> },
 

--- a/crates/solidity/inputs/language/Cargo.toml
+++ b/crates/solidity/inputs/language/Cargo.toml
@@ -16,10 +16,7 @@ infra_utils = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bson = { workspace = true }
-codegen_grammar = { workspace = true }
 codegen_language_definition = { workspace = true }
 codegen_language_macros = { workspace = true }
 codegen_schema = { workspace = true }
-indexmap = { workspace = true }
 semver = { workspace = true }
-strum_macros = { workspace = true }

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -3,8 +3,6 @@ pub use solidity::SolidityDefinition;
 codegen_language_macros::compile!(Language(
     name = Solidity,
     root_item = SourceUnit,
-    // TODO(#638): For now this is on par with the DSL v1 definition to minimize the fallout.
-    // We should replace this with the new definition from #629.
     leading_trivia = OneOrMore(Choice([
         Trivia(Whitespace),
         Trivia(EndOfLine),

--- a/crates/solidity/inputs/language/src/lib.rs
+++ b/crates/solidity/inputs/language/src/lib.rs
@@ -7,12 +7,10 @@
 //! Call the [`SolidityLanguageExtensions::load_solidity`] method to load the precompiled language definition.
 
 mod definition;
-mod grammar;
 
 use anyhow::Result;
 use codegen_schema::types::{LanguageDefinition, LanguageDefinitionRef};
 pub use definition::SolidityDefinition;
-pub use grammar::GrammarConstructorDslV2;
 
 pub trait SolidityLanguageExtensions {
     /// Loads the precompiled Solidity language definition.

--- a/crates/solidity/outputs/cargo/crate/build.rs
+++ b/crates/solidity/outputs/cargo/crate/build.rs
@@ -2,10 +2,10 @@
 //! It is removed when publishing to crates.io.
 
 use anyhow::Result;
-use codegen_grammar::Grammar;
+use codegen_grammar::{Grammar, GrammarConstructorDslV2};
 use codegen_parser_generator::{AstModel, RustGenerator};
 use infra_utils::cargo::CargoWorkspace;
-use solidity_language::{GrammarConstructorDslV2, SolidityDefinition};
+use solidity_language::SolidityDefinition;
 
 fn main() -> Result<()> {
     let language = SolidityDefinition::create();


### PR DESCRIPTION
Follow-up to #650

Nothing ground-breaking, just cleaning up the language definition crate and moving the grammar construction to be a part of the crate responsible for the codegen/parser logic itself.
