### PR TITLE
pin github actions ref to commit SHA

### DIFF
--- a/.github/workflows/_jobs_ci.yml
+++ b/.github/workflows/_jobs_ci.yml
@@ -16,11 +16,11 @@ jobs:
       #
 
       - name: "Clone repository"
-        uses: "actions/checkout@v3.4.0"
+        uses: "actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f"
 
       - name: "Restore CI cache"
         if: "${{ github.ref_name != 'main' }}"
-        uses: "actions/cache/restore@v3.3.1"
+        uses: "actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
         with:
           key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"
           restore-keys: |
@@ -47,7 +47,7 @@ jobs:
       #
 
       - name: "Save cache"
-        uses: "actions/cache/save@v3.3.1"
+        uses: "actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
         with:
           key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"
           path: |

--- a/.github/workflows/_jobs_github_pages.yml
+++ b/.github/workflows/_jobs_github_pages.yml
@@ -23,10 +23,10 @@ jobs:
       #
 
       - name: "Clone repository"
-        uses: "actions/checkout@v3.4.0"
+        uses: "actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f"
 
       - name: "Restore CI cache"
-        uses: "actions/cache/restore@v3.3.1"
+        uses: "actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
         with:
           key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"
           restore-keys: |
@@ -46,13 +46,13 @@ jobs:
       - run: "scripts/bin/infra check mkdocs"
 
       - name: "Configure GitHub Pages"
-        uses: "actions/configure-pages@v3.0.5"
+        uses: "actions/configure-pages@7110e9e03ffb4a421945e5d0607007b8e9f1f52b"
 
       - name: "Upload artifacts"
-        uses: "actions/upload-pages-artifact@v1.0.8"
+        uses: "actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187"
         with:
           path: "documentation/target/site" # _SLANG_MKDOCS_DOCUMENTATION_SITE_DIR_ (keep in sync)
 
       - name: "Deploy to GitHub Pages"
         id: "deployment"
-        uses: "actions/deploy-pages@v2.0.0"
+        uses: "actions/deploy-pages@73e62e651178eeba977de2dc9f4c7645b3d01015"

--- a/.github/workflows/_jobs_publish.yml
+++ b/.github/workflows/_jobs_publish.yml
@@ -19,10 +19,10 @@ jobs:
       #
 
       - name: "Clone repository"
-        uses: "actions/checkout@v3.4.0"
+        uses: "actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f"
 
       - name: "Restore CI cache"
-        uses: "actions/cache/restore@v3.3.1"
+        uses: "actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
         with:
           key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"
           restore-keys: |
@@ -41,7 +41,7 @@ jobs:
       - run: "scripts/bin/infra setup npm"
 
       - id: "changesets"
-        uses: "changesets/action@v1.4.1"
+        uses: "changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a"
         with:
           title: "Bump Slang Version"
           commit: "Bump Slang Version"
@@ -66,10 +66,10 @@ jobs:
       #
 
       - name: "Clone repository"
-        uses: "actions/checkout@v3.4.0"
+        uses: "actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f"
 
       - name: "Restore CI cache"
-        uses: "actions/cache/restore@v3.3.1"
+        uses: "actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
         with:
           key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"
           restore-keys: |


### PR DESCRIPTION
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions