### PR TITLE
enable dependabot updates

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -17,6 +17,7 @@
     "napi",
     "nomic",
     "nomicfoundation",
+    "rustup",
     "struct",
     "structs",
     "tera",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Please see the documentation for all configuration options:
+#
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[cargo] "
+    groups:
+      non-major-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[npm] "
+    groups:
+      non-major-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[github-actions] "
+    groups:
+      non-major-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[pip] "
+    groups:
+      non-major-dependencies:
+        update-types:
+          - "minor"
+          - "patch"

--- a/documentation/public/internals/development.md
+++ b/documentation/public/internals/development.md
@@ -21,3 +21,10 @@ You can access all such commands (from the hermit environment) by just running t
 ## Versioning and Publishing
 
 We manage versioning through [changesets](https://github.com/changesets/changesets). Each pull request can describe what user facing changes it is introducing, and include this information as a "changeset" markdown file along with source changes. These changeset files are analyzed and used to create another pull request to bump the repository version and update dependencies. Once the version bump is merged, artifacts are built and released to all registries.
+
+## Managing Dependencies
+
+Our `$REPO_ROOT/.github/dependabot.yml` config runs automatic updates to our dependencies on a weekly basis. This handles `github-actions`, `npm`, `cargo`, and `pip` packages. However, two kinds of dependencies still need to be updated manually for now:
+
+1. Rust toolchains: `$RUST_STABLE_VERSION` and `$RUST_NIGHTLY_VERSION` defined in `hermit.hcl` and updated via `rustup install`.
+2. Hermit binaries defined in `$REPO_ROOT/bin/XXX.pkg`, and updated via `hermit install`.


### PR DESCRIPTION
- add `.github/dependabot.yml` to configure dependabot for `npm`, `cargo`, `pip`, and `github-actions`.
- group `minor` and `patch` version updates in a single PR (per package manager), while leaving `major` updates to be published in separate PRs (as they might need more explicit review/testing).
- I set all updates to run once weekly (typically on Monday morning) for now. They can also be run manually from GitHub UI as needed.

closes #25