### PR TITLE
Don't panic when recovery-unwinding during Pratt-parsing

### DIFF
--- a/crates/codegen/parser/runtime/src/parser_support/repetition_helper.rs
+++ b/crates/codegen/parser/runtime/src/parser_support/repetition_helper.rs
@@ -1,5 +1,5 @@
 use crate::parser_support::context::ParserContext;
-use crate::parser_support::parser_result::{IncompleteMatch, NoMatch, ParserResult};
+use crate::parser_support::parser_result::{IncompleteMatch, NoMatch, ParserResult, PrattElement};
 
 pub struct RepetitionHelper<const MIN_COUNT: usize>;
 
@@ -67,12 +67,23 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
                 (
                     ParserResult::PrattOperatorMatch(_),
-                    ParserResult::IncompleteMatch(_)
-                    | ParserResult::NoMatch(_)
-                    | ParserResult::SkippedUntil(_),
+                    ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_),
                 ) => {
                     input.rewind(save);
                     return accum;
+                }
+
+                (
+                    ParserResult::PrattOperatorMatch(pratt),
+                    ParserResult::SkippedUntil(mut skipped),
+                ) => {
+                    skipped.nodes = std::mem::take(&mut pratt.elements)
+                        .into_iter()
+                        .flat_map(PrattElement::into_nodes)
+                        .chain(skipped.nodes)
+                        .collect();
+
+                    return ParserResult::SkippedUntil(skipped);
                 }
 
                 (ParserResult::Match(running), ParserResult::SkippedUntil(mut skipped)) => {

--- a/crates/codegen/parser/runtime/src/parser_support/repetition_helper.rs
+++ b/crates/codegen/parser/runtime/src/parser_support/repetition_helper.rs
@@ -67,7 +67,9 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
                 (
                     ParserResult::PrattOperatorMatch(_),
-                    ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_),
+                    ParserResult::IncompleteMatch(_)
+                    | ParserResult::NoMatch(_)
+                    | ParserResult::SkippedUntil(_),
                 ) => {
                     input.rewind(save);
                     return accum;
@@ -78,10 +80,6 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
                     skipped.nodes = std::mem::take(&mut running.nodes);
 
                     return ParserResult::SkippedUntil(skipped);
-                }
-
-                (ParserResult::PrattOperatorMatch(..), ParserResult::SkippedUntil(_)) => {
-                    unreachable!("We don't do recovery when reducing the Pratt matches")
                 }
 
                 (

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser_support/repetition_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser_support/repetition_helper.rs
@@ -69,7 +69,9 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
 
                 (
                     ParserResult::PrattOperatorMatch(_),
-                    ParserResult::IncompleteMatch(_) | ParserResult::NoMatch(_),
+                    ParserResult::IncompleteMatch(_)
+                    | ParserResult::NoMatch(_)
+                    | ParserResult::SkippedUntil(_),
                 ) => {
                     input.rewind(save);
                     return accum;
@@ -80,10 +82,6 @@ impl<const MIN_COUNT: usize> RepetitionHelper<MIN_COUNT> {
                     skipped.nodes = std::mem::take(&mut running.nodes);
 
                     return ParserResult::SkippedUntil(skipped);
-                }
-
-                (ParserResult::PrattOperatorMatch(..), ParserResult::SkippedUntil(_)) => {
-                    unreachable!("We don't do recovery when reducing the Pratt matches")
                 }
 
                 (

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Block.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/generated/Block.rs
@@ -5,6 +5,11 @@ use anyhow::Result;
 use crate::cst_output::runner::run;
 
 #[test]
+fn postfix_recovery_regression() -> Result<()> {
+    run("Block", "postfix_recovery_regression")
+}
+
+#[test]
 fn unchecked() -> Result<()> {
     run("Block", "unchecked")
 }

--- a/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/generated/0.4.11-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/generated/0.4.11-failure.yml
@@ -1,0 +1,42 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ // Make sure we don't panic when encountering an unwinding close brace in a precedence parser │ 0..93
+  2  │                                                                                               │ 94..94
+  3  │ {                                                                                             │ 95..96
+  4  │     a.b('                                                                                     │ 97..106
+  5  │         }');                                                                                  │ 107..119
+  6  │ }                                                                                             │ 120..121
+
+Errors: # 1 total
+  - >
+    Error: Expected Semicolon.
+       ╭─[crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/input.sol:4:8]
+       │
+     4 │ ╭─▶     a.b('
+     5 │ ├─▶         }');
+       │ │                  
+       │ ╰────────────────── Error occurred here.
+    ───╯
+
+Tree:
+  - (Block): # "// Make sure we don't panic when encountering an u..." (0..122)
+      - (LeadingTrivia): # "// Make sure we don't panic when encountering an u..." (0..95)
+          - (SingleLineComment): "// Make sure we don't panic when encountering an u..." # (0..93)
+          - (EndOfLine): "\n" # (93..94)
+          - (EndOfLine): "\n" # (94..95)
+      - (open_brace꞉ OpenBrace): "{" # (95..96)
+      - (TrailingTrivia) ► (EndOfLine): "\n" # (96..97)
+      - (statements꞉ Statements): # "    a.b('\n        }');\n" (97..120)
+          - (item꞉ Statement) ► (variant꞉ ExpressionStatement): # "    a.b('\n        }');\n" (97..120)
+              - (expression꞉ Expression) ► (variant꞉ MemberAccessExpression): # "    a.b" (97..104)
+                  - (operand꞉ Expression): # "    a" (97..102)
+                      - (LeadingTrivia) ► (Whitespace): "    " # (97..101)
+                      - (variant꞉ Identifier): "a" # (101..102)
+                  - (period꞉ Period): "." # (102..103)
+                  - (member꞉ MemberAccess) ► (variant꞉ Identifier): "b" # (103..104)
+              - (SKIPPED): "('\n        }')" # (104..118)
+              - (semicolon꞉ Semicolon): ";" # (118..119)
+              - (TrailingTrivia) ► (EndOfLine): "\n" # (119..120)
+      - (close_brace꞉ CloseBrace): "}" # (120..121)
+      - (TrailingTrivia) ► (EndOfLine): "\n" # (121..122)

--- a/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/generated/0.5.0-failure.yml
+++ b/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/generated/0.5.0-failure.yml
@@ -10,7 +10,7 @@ Source: >
 
 Errors: # 1 total
   - >
-    Error: Expected Identifier or MemoryKeyword or StorageKeyword.
+    Error: Expected CallDataKeyword or Identifier or MemoryKeyword or StorageKeyword.
        ╭─[crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/input.sol:4:8]
        │
      4 │ ╭─▶     a.b('

--- a/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/input.sol
+++ b/crates/solidity/testing/snapshots/cst_output/Block/postfix_recovery_regression/input.sol
@@ -1,0 +1,6 @@
+// Make sure we don't panic when encountering an unwinding close brace in a precedence parser
+
+{
+    a.b('
+        }');
+}


### PR DESCRIPTION
Fixes #788

Thanks @OmarTawfik for finding it!

I didn't think we would encounter this use case; for now, we flatten accumulated Pratt-parsed nodes and continue unwinding.

This might not be the optimal strategy, i.e. in the regression test it would be better to ignore the Skipped and rely on "skip unrecognized input" logic to handle it (this would give us correct `MemberAccessExpression` rather than `TypeName`) but we should be more consistent here and continue unwinding if we encounter the unwinding SkippedUntil ourselves; we can tweak recovery later.