### PR TITLE
fix: Print infra command title/group to stderr

### DIFF
--- a/crates/infra/utils/src/github/mod.rs
+++ b/crates/infra/utils/src/github/mod.rs
@@ -22,19 +22,19 @@ impl GitHub {
         let title = title.as_ref();
 
         if Self::is_running_in_ci() {
-            println!("::group::{title}");
+            eprintln!("::group::{title}");
         } else {
-            println!();
-            println!("{title}");
-            println!();
+            eprintln!();
+            eprintln!("{title}");
+            eprintln!();
         }
 
         let result = operation();
 
         if Self::is_running_in_ci() {
-            println!("::endgroup::");
+            eprintln!("::endgroup::");
         } else {
-            println!();
+            eprintln!();
         }
 
         result


### PR DESCRIPTION
Otherwise, this pollutes the output and we can't use the `infra` wrapper reliably to pipe the the command output like the `slang_solidity parse --json`, which would lead to malformed JSON.