### PR TITLE
refactor: Use safe generated version `T::into_instance` by napi-rs

### DIFF
--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -118,7 +118,7 @@ impl TokenNode {
     }
 }
 
-pub trait ToJS {
+pub(crate) trait ToJS {
     fn to_js(&self, env: Env) -> JsObject;
 }
 

--- a/crates/codegen/parser/runtime/src/napi_interface/cursor.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cursor.rs
@@ -54,7 +54,7 @@ impl Cursor {
 
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
-        self.0.node().to_js(&env)
+        self.0.node().to_js(env)
     }
 
     #[napi(getter, ts_return_type = "kinds.NodeLabel", catch_unwind)]
@@ -82,7 +82,7 @@ impl Cursor {
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
-            .map(|rust_rule_node| rust_rule_node.to_js(&env))
+            .map(|rust_rule_node| rust_rule_node.to_js(env))
             .collect()
     }
 

--- a/crates/codegen/parser/runtime/src/napi_interface/parse_output.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/parse_output.rs
@@ -17,7 +17,7 @@ impl From<RustParseOutput> for ParseOutput {
 impl ParseOutput {
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
-        self.0.tree().to_js(&env)
+        self.0.tree().to_js(env)
     }
 
     #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]

--- a/crates/codegen/parser/runtime/src/napi_interface/templates/ast_selectors.rs.jinja2
+++ b/crates/codegen/parser/runtime/src/napi_interface/templates/ast_selectors.rs.jinja2
@@ -290,7 +290,7 @@ impl Selector {
                 }
                 node if filter(node) => {
                     self.index += 1;
-                    return Ok(Some(node.to_js(&self.env)));
+                    return Ok(Some(node.to_js(self.env)));
                 }
                 _ => {
                     break;

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/ast_selectors.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/ast_selectors.rs
@@ -3159,7 +3159,7 @@ impl Selector {
                 }
                 node if filter(node) => {
                     self.index += 1;
-                    return Ok(Some(node.to_js(&self.env)));
+                    return Ok(Some(node.to_js(self.env)));
                 }
                 _ => {
                     break;

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -120,7 +120,7 @@ impl TokenNode {
     }
 }
 
-pub trait ToJS {
+pub(crate) trait ToJS {
     fn to_js(&self, env: Env) -> JsObject;
 }
 

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -2,8 +2,8 @@
 
 use std::rc::Rc;
 
-use napi::bindgen_prelude::{Env, ToNapiValue};
-use napi::{JsObject, NapiValue};
+use napi::bindgen_prelude::Env;
+use napi::JsObject;
 use napi_derive::napi;
 
 use crate::napi_interface::cursor::Cursor;
@@ -56,7 +56,7 @@ impl RuleNode {
         self.0
             .children
             .iter()
-            .map(|child| child.to_js(&env))
+            .map(|child| child.to_js(env))
             .collect()
     }
 
@@ -121,28 +121,29 @@ impl TokenNode {
 }
 
 pub trait ToJS {
-    fn to_js(&self, env: &Env) -> JsObject;
+    fn to_js(&self, env: Env) -> JsObject;
 }
 
 impl ToJS for Rc<RustRuleNode> {
-    fn to_js(&self, env: &Env) -> JsObject {
-        let obj =
-            unsafe { <RuleNode as ToNapiValue>::to_napi_value(env.raw(), RuleNode(self.clone())) };
-        unsafe { JsObject::from_raw_unchecked(env.raw(), obj.unwrap()) }
+    fn to_js(&self, env: Env) -> JsObject {
+        RuleNode(self.clone())
+            .into_instance(env)
+            .expect("Class constructor to be defined by #[napi]")
+            .as_object(env)
     }
 }
 
 impl ToJS for Rc<RustTokenNode> {
-    fn to_js(&self, env: &Env) -> JsObject {
-        let obj = unsafe {
-            <TokenNode as ToNapiValue>::to_napi_value(env.raw(), TokenNode(self.clone()))
-        };
-        unsafe { JsObject::from_raw_unchecked(env.raw(), obj.unwrap()) }
+    fn to_js(&self, env: Env) -> JsObject {
+        TokenNode(self.clone())
+            .into_instance(env)
+            .expect("Class constructor to be defined by #[napi]")
+            .as_object(env)
     }
 }
 
 impl ToJS for RustNode {
-    fn to_js(&self, env: &Env) -> JsObject {
+    fn to_js(&self, env: Env) -> JsObject {
         match self {
             RustNode::Rule(rust_rule_node) => rust_rule_node.to_js(env),
             RustNode::Token(rust_token_node) => rust_token_node.to_js(env),

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cursor.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cursor.rs
@@ -56,7 +56,7 @@ impl Cursor {
 
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
-        self.0.node().to_js(&env)
+        self.0.node().to_js(env)
     }
 
     #[napi(getter, ts_return_type = "kinds.NodeLabel", catch_unwind)]
@@ -84,7 +84,7 @@ impl Cursor {
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
-            .map(|rust_rule_node| rust_rule_node.to_js(&env))
+            .map(|rust_rule_node| rust_rule_node.to_js(env))
             .collect()
     }
 

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/parse_output.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/parse_output.rs
@@ -19,7 +19,7 @@ impl From<RustParseOutput> for ParseOutput {
 impl ParseOutput {
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
-        self.0.tree().to_js(&env)
+        self.0.tree().to_js(env)
     }
 
     #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/ast_selectors.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/ast_selectors.rs
@@ -310,7 +310,7 @@ impl Selector {
                 }
                 node if filter(node) => {
                     self.index += 1;
-                    return Ok(Some(node.to_js(&self.env)));
+                    return Ok(Some(node.to_js(self.env)));
                 }
                 _ => {
                     break;

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -120,7 +120,7 @@ impl TokenNode {
     }
 }
 
-pub trait ToJS {
+pub(crate) trait ToJS {
     fn to_js(&self, env: Env) -> JsObject;
 }
 

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -2,8 +2,8 @@
 
 use std::rc::Rc;
 
-use napi::bindgen_prelude::{Env, ToNapiValue};
-use napi::{JsObject, NapiValue};
+use napi::bindgen_prelude::Env;
+use napi::JsObject;
 use napi_derive::napi;
 
 use crate::napi_interface::cursor::Cursor;
@@ -56,7 +56,7 @@ impl RuleNode {
         self.0
             .children
             .iter()
-            .map(|child| child.to_js(&env))
+            .map(|child| child.to_js(env))
             .collect()
     }
 
@@ -121,28 +121,29 @@ impl TokenNode {
 }
 
 pub trait ToJS {
-    fn to_js(&self, env: &Env) -> JsObject;
+    fn to_js(&self, env: Env) -> JsObject;
 }
 
 impl ToJS for Rc<RustRuleNode> {
-    fn to_js(&self, env: &Env) -> JsObject {
-        let obj =
-            unsafe { <RuleNode as ToNapiValue>::to_napi_value(env.raw(), RuleNode(self.clone())) };
-        unsafe { JsObject::from_raw_unchecked(env.raw(), obj.unwrap()) }
+    fn to_js(&self, env: Env) -> JsObject {
+        RuleNode(self.clone())
+            .into_instance(env)
+            .expect("Class constructor to be defined by #[napi]")
+            .as_object(env)
     }
 }
 
 impl ToJS for Rc<RustTokenNode> {
-    fn to_js(&self, env: &Env) -> JsObject {
-        let obj = unsafe {
-            <TokenNode as ToNapiValue>::to_napi_value(env.raw(), TokenNode(self.clone()))
-        };
-        unsafe { JsObject::from_raw_unchecked(env.raw(), obj.unwrap()) }
+    fn to_js(&self, env: Env) -> JsObject {
+        TokenNode(self.clone())
+            .into_instance(env)
+            .expect("Class constructor to be defined by #[napi]")
+            .as_object(env)
     }
 }
 
 impl ToJS for RustNode {
-    fn to_js(&self, env: &Env) -> JsObject {
+    fn to_js(&self, env: Env) -> JsObject {
         match self {
             RustNode::Rule(rust_rule_node) => rust_rule_node.to_js(env),
             RustNode::Token(rust_token_node) => rust_token_node.to_js(env),

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cursor.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cursor.rs
@@ -56,7 +56,7 @@ impl Cursor {
 
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn node(&self, env: Env) -> JsObject {
-        self.0.node().to_js(&env)
+        self.0.node().to_js(env)
     }
 
     #[napi(getter, ts_return_type = "kinds.NodeLabel", catch_unwind)]
@@ -84,7 +84,7 @@ impl Cursor {
     pub fn ancestors(&self, env: Env) -> Vec<JsObject> {
         self.0
             .ancestors()
-            .map(|rust_rule_node| rust_rule_node.to_js(&env))
+            .map(|rust_rule_node| rust_rule_node.to_js(env))
             .collect()
     }
 

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/parse_output.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/parse_output.rs
@@ -19,7 +19,7 @@ impl From<RustParseOutput> for ParseOutput {
 impl ParseOutput {
     #[napi(ts_return_type = "cst.Node", catch_unwind)]
     pub fn tree(&self, env: Env) -> napi::JsObject {
-        self.0.tree().to_js(&env)
+        self.0.tree().to_js(env)
     }
 
     #[napi(ts_return_type = "Array<parse_error.ParseError>", catch_unwind)]


### PR DESCRIPTION
Rather than hand-rolling it; The codegen uses exactly the same code but with the benefit of abstracting away the unsafe details, getting rid of the only instance of `unsafe` we use.

For reference:
- `ToNapiValue`/`into_instance`: https://github.com/napi-rs/napi-rs/blob/0550c56fcf8eeec61d2e5abfa00c92a990c34e25/crates/backend/src/codegen/struct.rs#L278-L330
- `JsObject::from_raw_unchecked`/`ClassInstance::as_object`: https://github.com/napi-rs/napi-rs/blob/0550c56fcf8eeec61d2e5abfa00c92a990c34e25/crates/napi/src/bindgen_runtime/js_values/class.rs#L25

Additionally, I changed `Env` to be passed by value since it's a `Copy` newtype wrapper around pointer (no double indirection) and makes the code a bit clearer: no need to additionally dereference with `*`in the related calls, since napi-rs API accepts it by value.