### PR TITLE
Add debugging facilities to RuleNode/TokenNode exposed via N-API

### DIFF
--- a/.changeset/pink-bats-lie.md
+++ b/.changeset/pink-bats-lie.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+Changed the cst.NodeType in TS to use more descriptive string values rather than 0/1 integers

--- a/.changeset/warm-maps-give.md
+++ b/.changeset/warm-maps-give.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+Add RuleNode/TokenNode::toJSON() in the TypeScript API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "napi-derive",
  "nom",
  "serde",
+ "serde_json",
  "strum",
  "strum_macros",
 ]
@@ -1798,6 +1799,7 @@ dependencies = [
  "nom",
  "semver",
  "serde",
+ "serde_json",
  "slang_solidity",
  "strum",
  "strum_macros",
@@ -1832,6 +1834,7 @@ dependencies = [
  "nom",
  "semver",
  "serde",
+ "serde_json",
  "slang_testlang",
  "strum",
  "strum_macros",

--- a/crates/codegen/parser/runtime/Cargo.toml
+++ b/crates/codegen/parser/runtime/Cargo.toml
@@ -13,6 +13,7 @@ napi = { workspace = true, optional = true }
 napi-derive = { workspace = true, optional = true }
 nom = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 
@@ -20,7 +21,7 @@ strum_macros = { workspace = true }
 # i.e `slang_solidity_node_addon`.
 [features]
 default = ["slang_napi_interfaces"]
-slang_napi_interfaces = ["dep:napi", "dep:napi-derive"]
+slang_napi_interfaces = ["dep:napi", "dep:napi-derive", "dep:serde_json"]
 
 [lints]
 workspace = true

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -68,6 +68,14 @@ impl RuleNode {
             .into()
     }
 
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
+    }
+
     #[napi(catch_unwind)]
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
@@ -132,6 +140,14 @@ impl TokenNode {
     #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
+    }
+
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
     }
 
     #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -70,8 +70,6 @@ impl RuleNode {
 
     #[napi(catch_unwind, js_name = "toJSON")]
     /// Serialize the token node to JSON.
-    ///
-    /// This method is intended for debugging purposes and may not be stable.
     pub fn to_json(&self) -> String {
         serde_json::to_string(&self.0).unwrap()
     }
@@ -82,7 +80,7 @@ impl RuleNode {
     }
 
     // Expose the children as a hidden (non-enumerable, don't generate type definition)
-    // property that's eagerly evaluated (getter) in the debugger context.
+    // property that's eagerly evaluated (getter) for an inspected parent object in the debugger context.
     #[napi(
         enumerable = false,
         configurable = false,

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -72,6 +72,33 @@ impl RuleNode {
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
     }
+
+    // Expose the children as a hidden (non-enumerable, don't generate type definition)
+    // property that's eagerly evaluated (getter) in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
+        skip_typescript
+    )]
+    pub fn __children(&self, env: Env) -> Vec<JsObject> {
+        Self::children(self, env)
+    }
+
+    // Similarly, expose the eagerly evaluated unparsed text in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__text",
+        skip_typescript
+    )]
+    pub fn __text(&self) -> String {
+        self.unparse()
+    }
 }
 
 #[napi(namespace = "cst")]

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -102,7 +102,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
         Self::children(self)
@@ -115,7 +116,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__text",
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __text(&self) -> String {
         self.unparse()

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -104,8 +104,8 @@ impl RuleNode {
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
         skip_typescript
     )]
-    pub fn __children(&self, env: Env) -> Vec<JsObject> {
-        Self::children(self, env)
+    pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
+        Self::children(self)
     }
 
     // Similarly, expose the eagerly evaluated unparsed text in the debugger context.

--- a/crates/codegen/parser/runtime/src/napi_interface/cst.rs
+++ b/crates/codegen/parser/runtime/src/napi_interface/cst.rs
@@ -9,7 +9,7 @@ use crate::napi_interface::{
     RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode, TokenKind,
 };
 
-#[napi(namespace = "cst")]
+#[napi(namespace = "cst", string_enum)]
 pub enum NodeType {
     Rule,
     Token,

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -70,6 +70,14 @@ impl RuleNode {
             .into()
     }
 
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
+    }
+
     #[napi(catch_unwind)]
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
@@ -134,6 +142,14 @@ impl TokenNode {
     #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
+    }
+
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
     }
 
     #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -72,8 +72,6 @@ impl RuleNode {
 
     #[napi(catch_unwind, js_name = "toJSON")]
     /// Serialize the token node to JSON.
-    ///
-    /// This method is intended for debugging purposes and may not be stable.
     pub fn to_json(&self) -> String {
         serde_json::to_string(&self.0).unwrap()
     }
@@ -84,7 +82,7 @@ impl RuleNode {
     }
 
     // Expose the children as a hidden (non-enumerable, don't generate type definition)
-    // property that's eagerly evaluated (getter) in the debugger context.
+    // property that's eagerly evaluated (getter) for an inspected parent object in the debugger context.
     #[napi(
         enumerable = false,
         configurable = false,

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -106,8 +106,8 @@ impl RuleNode {
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
         skip_typescript
     )]
-    pub fn __children(&self, env: Env) -> Vec<JsObject> {
-        Self::children(self, env)
+    pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
+        Self::children(self)
     }
 
     // Similarly, expose the eagerly evaluated unparsed text in the debugger context.

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -74,6 +74,33 @@ impl RuleNode {
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
     }
+
+    // Expose the children as a hidden (non-enumerable, don't generate type definition)
+    // property that's eagerly evaluated (getter) in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
+        skip_typescript
+    )]
+    pub fn __children(&self, env: Env) -> Vec<JsObject> {
+        Self::children(self, env)
+    }
+
+    // Similarly, expose the eagerly evaluated unparsed text in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__text",
+        skip_typescript
+    )]
+    pub fn __text(&self) -> String {
+        self.unparse()
+    }
 }
 
 #[napi(namespace = "cst")]

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -11,7 +11,7 @@ use crate::napi_interface::{
     RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode, TokenKind,
 };
 
-#[napi(namespace = "cst")]
+#[napi(namespace = "cst", string_enum)]
 pub enum NodeType {
     Rule,
     Token,

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/napi_interface/cst.rs
@@ -104,7 +104,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
         Self::children(self)
@@ -117,7 +118,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__text",
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __text(&self) -> String {
         self.unparse()

--- a/crates/solidity/outputs/cargo/slang_solidity_node_addon/Cargo.toml
+++ b/crates/solidity/outputs/cargo/slang_solidity_node_addon/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib"]
 default = ["slang_napi_interfaces"]
 slang_napi_interfaces = [
   # This enables '#[napi]' attributes on the Rust types imported via [lib.path] above.
+  "dep:serde_json",
 ]
 
 [build-dependencies]
@@ -43,6 +44,7 @@ napi-derive = { workspace = true }
 nom = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/solidity/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.d.ts
@@ -737,8 +737,8 @@ export namespace ast_internal {
 }
 export namespace cst {
   export enum NodeType {
-    Rule = 0,
-    Token = 1,
+    Rule = "Rule",
+    Token = "Token",
   }
   export class RuleNode {
     get type(): NodeType.Rule;

--- a/crates/solidity/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.d.ts
@@ -746,6 +746,12 @@ export namespace cst {
     get textLength(): text_index.TextIndex;
     children(): Array<cst.Node>;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
+    /**
+     * Serialize the token node to JSON.
+     *
+     * This method is intended for debugging purposes and may not be stable.
+     */
+    toJSON(): string;
     unparse(): string;
   }
   export class TokenNode {
@@ -753,6 +759,12 @@ export namespace cst {
     get kind(): kinds.TokenKind;
     get textLength(): text_index.TextIndex;
     get text(): string;
+    /**
+     * Serialize the token node to JSON.
+     *
+     * This method is intended for debugging purposes and may not be stable.
+     */
+    toJSON(): string;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
   }
 }

--- a/crates/solidity/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.d.ts
@@ -746,11 +746,7 @@ export namespace cst {
     get textLength(): text_index.TextIndex;
     children(): Array<cst.Node>;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
-    /**
-     * Serialize the token node to JSON.
-     *
-     * This method is intended for debugging purposes and may not be stable.
-     */
+    /** Serialize the token node to JSON. */
     toJSON(): string;
     unparse(): string;
   }

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -70,6 +70,14 @@ impl RuleNode {
             .into()
     }
 
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
+    }
+
     #[napi(catch_unwind)]
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
@@ -134,6 +142,14 @@ impl TokenNode {
     #[napi(getter, catch_unwind)]
     pub fn text(&self) -> String {
         self.0.text.clone()
+    }
+
+    #[napi(catch_unwind, js_name = "toJSON")]
+    /// Serialize the token node to JSON.
+    ///
+    /// This method is intended for debugging purposes and may not be stable.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.0).unwrap()
     }
 
     #[napi(ts_return_type = "cursor.Cursor", catch_unwind)]

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -72,8 +72,6 @@ impl RuleNode {
 
     #[napi(catch_unwind, js_name = "toJSON")]
     /// Serialize the token node to JSON.
-    ///
-    /// This method is intended for debugging purposes and may not be stable.
     pub fn to_json(&self) -> String {
         serde_json::to_string(&self.0).unwrap()
     }
@@ -84,7 +82,7 @@ impl RuleNode {
     }
 
     // Expose the children as a hidden (non-enumerable, don't generate type definition)
-    // property that's eagerly evaluated (getter) in the debugger context.
+    // property that's eagerly evaluated (getter) for an inspected parent object in the debugger context.
     #[napi(
         enumerable = false,
         configurable = false,

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -106,8 +106,8 @@ impl RuleNode {
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
         skip_typescript
     )]
-    pub fn __children(&self, env: Env) -> Vec<JsObject> {
-        Self::children(self, env)
+    pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
+        Self::children(self)
     }
 
     // Similarly, expose the eagerly evaluated unparsed text in the debugger context.

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -74,6 +74,33 @@ impl RuleNode {
     pub fn unparse(&self) -> String {
         self.0.clone().unparse()
     }
+
+    // Expose the children as a hidden (non-enumerable, don't generate type definition)
+    // property that's eagerly evaluated (getter) in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
+        skip_typescript
+    )]
+    pub fn __children(&self, env: Env) -> Vec<JsObject> {
+        Self::children(self, env)
+    }
+
+    // Similarly, expose the eagerly evaluated unparsed text in the debugger context.
+    #[napi(
+        enumerable = false,
+        configurable = false,
+        writable = false,
+        getter,
+        js_name = "__text",
+        skip_typescript
+    )]
+    pub fn __text(&self) -> String {
+        self.unparse()
+    }
 }
 
 #[napi(namespace = "cst")]

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -11,7 +11,7 @@ use crate::napi_interface::{
     RuleKind, RustNode, RustRuleNode, RustTextIndex, RustTokenNode, TokenKind,
 };
 
-#[napi(namespace = "cst")]
+#[napi(namespace = "cst", string_enum)]
 pub enum NodeType {
     Rule,
     Token,

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/napi_interface/cst.rs
@@ -104,7 +104,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__children", // Needed; otherwise, the property name would shadow `children`.
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __children(&self) -> Vec<Either<RuleNode, TokenNode>> {
         Self::children(self)
@@ -117,7 +118,8 @@ impl RuleNode {
         writable = false,
         getter,
         js_name = "__text",
-        skip_typescript
+        skip_typescript,
+        catch_unwind
     )]
     pub fn __text(&self) -> String {
         self.unparse()

--- a/crates/testlang/outputs/cargo/slang_testlang_node_addon/Cargo.toml
+++ b/crates/testlang/outputs/cargo/slang_testlang_node_addon/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib"]
 default = ["slang_napi_interfaces"]
 slang_napi_interfaces = [
   # This enables '#[napi]' attributes on the Rust types imported via [lib.path] above.
+  "dep:serde_json",
 ]
 
 [build-dependencies]
@@ -43,6 +44,7 @@ napi-derive = { workspace = true }
 nom = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/testlang/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/testlang/outputs/npm/package/src/generated/index.d.ts
@@ -78,8 +78,8 @@ export namespace ast_internal {
 }
 export namespace cst {
   export enum NodeType {
-    Rule = 0,
-    Token = 1,
+    Rule = "Rule",
+    Token = "Token",
   }
   export class RuleNode {
     get type(): NodeType.Rule;

--- a/crates/testlang/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/testlang/outputs/npm/package/src/generated/index.d.ts
@@ -87,6 +87,12 @@ export namespace cst {
     get textLength(): text_index.TextIndex;
     children(): Array<cst.Node>;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
+    /**
+     * Serialize the token node to JSON.
+     *
+     * This method is intended for debugging purposes and may not be stable.
+     */
+    toJSON(): string;
     unparse(): string;
   }
   export class TokenNode {
@@ -94,6 +100,12 @@ export namespace cst {
     get kind(): kinds.TokenKind;
     get textLength(): text_index.TextIndex;
     get text(): string;
+    /**
+     * Serialize the token node to JSON.
+     *
+     * This method is intended for debugging purposes and may not be stable.
+     */
+    toJSON(): string;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
   }
 }

--- a/crates/testlang/outputs/npm/package/src/generated/index.d.ts
+++ b/crates/testlang/outputs/npm/package/src/generated/index.d.ts
@@ -87,11 +87,7 @@ export namespace cst {
     get textLength(): text_index.TextIndex;
     children(): Array<cst.Node>;
     createCursor(textOffset: text_index.TextIndex): cursor.Cursor;
-    /**
-     * Serialize the token node to JSON.
-     *
-     * This method is intended for debugging purposes and may not be stable.
-     */
+    /** Serialize the token node to JSON. */
     toJSON(): string;
     unparse(): string;
   }


### PR DESCRIPTION
Closes #466 

## JSON serialization
Adds the `toJSON` method to the RuleNode/TokenNode classes with the comment stating that it's unstable and for debugging purposes only. I explicitly didn't type it (it's a string) as I didn't want to publicly encode any assumptions about the shape of the data.

We can discuss further what we want to explore as part of having pure data external interface (JSON) for Slang, whether that's exporting or importing JSON, but I'd consider this a separate issue as it requires more thought and design; the original issue, from what I understand, was primarily about improving the debugging/inspection experience.

## Debugger
Adds hidden getter properties that is only eagerly evaluated by debugger; since it's a getter function, it shouldn't add overhead to the runtime but I have to admit, I didn't double-check that with numbers. It adds both `__children` and `__text`, allowing to quickly explore the tree structure recursively and also the enclosing text scope of the node:

### vscode-js-debug (built-in to VS Code)
![image](https://github.com/NomicFoundation/slang/assets/3093213/193702fa-02b6-4853-9dcd-8af58469cf23)
### Chrome DevTools for Node
![image](https://github.com/NomicFoundation/slang/assets/3093213/a7b81836-ad7e-495c-aded-ebcc48f3bb6b)
