### PR TITLE
fixup: Silence unused warnings on non-GNU systems in glibc.rs

### DIFF
--- a/crates/infra/cli/src/toolchains/napi/cli.rs
+++ b/crates/infra/cli/src/toolchains/napi/cli.rs
@@ -62,7 +62,6 @@ impl NapiCli {
 
         command.run()?;
 
-        #[cfg(target_env = "gnu")]
         glibc::ensure_correct_glibc_for_vscode(resolver, output_dir, target)?;
 
         let mut source_files = vec![];


### PR DESCRIPTION
Fixes warnings on non-GNU systems introduced with #909 

Instead of doing the conditional compilation for the remaining items that are only used for this check, the routines will be compiled in on the other systems for simplicity but only used inside a host GNU system.

The alternative is to pepper `#[cfg(target_env = "gnu")]` everywhere but IMO it'd hurt readability and we're talking about the `infra` CLI, should is only executed as part of the local development, so this should be an acceptable trade-off.

This was not caught in the CI as we only use a GNU host there, so naturally all of the code was compiled in.

Tested with `infra ci` and `infra publish npm --dry-run` on macOS and a Linux GNU.