### PR TITLE
fix `npm ci` check

### DIFF
--- a/crates/infra/cli/src/commands/setup/npm/mod.rs
+++ b/crates/infra/cli/src/commands/setup/npm/mod.rs
@@ -4,7 +4,7 @@ use infra_utils::github::GitHub;
 
 pub fn setup_npm() -> Result<()> {
     if GitHub::is_running_in_ci() {
-        Command::new("npm").arg("install").flag("--ci").run()
+        Command::new("npm").arg("ci").run()
     } else {
         Command::new("npm").arg("install").run()
     }


### PR DESCRIPTION
as `npm install --ci` doesn't fail if lock files are out of date.