### PR TITLE
fix typos in user guide

### DIFF
--- a/crates/solidity/outputs/npm/tests/src/doc-examples/using-the-cursor.ts
+++ b/crates/solidity/outputs/npm/tests/src/doc-examples/using-the-cursor.ts
@@ -46,10 +46,10 @@ test("using the cursor", async () => {
     const cursor = parseOutput.createTreeCursor();
 
     while (cursor.goToNextRuleWithKind(RuleKind.ContractDefinition)) {
-      const childCursopr = cursor.spawn();
-      assert(childCursopr.goToNextTokenWithKind(TokenKind.Identifier));
+      const childCursor = cursor.spawn();
+      assert(childCursor.goToNextTokenWithKind(TokenKind.Identifier));
 
-      const tokenNode = childCursopr.node();
+      const tokenNode = childCursor.node();
       assert(tokenNode instanceof TokenNode);
       contracts.push(tokenNode.text);
     }

--- a/documentation/public/user-guide/concepts.md
+++ b/documentation/public/user-guide/concepts.md
@@ -31,7 +31,7 @@ tokens (lexical analysis), which then in turn is _parsed_ into the CST.
 The resulting CST is a regular tree data structure that you can visit.
 The tree nodes are represented by the `Node` structure, which can be one of two kinds:
 
--   `RuleNode` (aka _non-terminals_) represent sub-trees, containing a a vector of other `Node` children.
+-   `RuleNode` (aka _non-terminals_) represent sub-trees, containing a vector of other `Node` children.
 -   `TokenNode` (aka _terminals_) are leaves and represent a lexical token (i.e. an identifier, keyword, punctuation) in the source.
 
 ## CST Cursors


### PR DESCRIPTION
Fixes some typos in the documentation.