### PR TITLE
fix changeset publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "access": "public",
   "baseBranch": "main",
-  "changelog": ["@changesets/changelog-github", { "repo": "NomicFoundation/slang" }]
+  "changelog": ["./custom-changelog-generator.js", { "repo": "NomicFoundation/slang" }],
+  "fixed": [["@nomicfoundation/slang", "@nomicfoundation/slang-*"]]
 }

--- a/.changeset/custom-changelog-generator.js
+++ b/.changeset/custom-changelog-generator.js
@@ -1,0 +1,14 @@
+const { default: original } = require("@changesets/changelog-github");
+
+module.exports = {
+  getDependencyReleaseLine: (changesets, dependenciesUpdated, options) => {
+    // We don't want to embed NAPI dependency updates (always synced):
+    dependenciesUpdated = [];
+
+    return original.getDependencyReleaseLine(changesets, dependenciesUpdated, options);
+  },
+
+  getReleaseLine: (changeset, type, options) => {
+    return original.getReleaseLine(changeset, type, options);
+  },
+};

--- a/crates/infra/cli/src/commands/publish/changesets/mod.rs
+++ b/crates/infra/cli/src/commands/publish/changesets/mod.rs
@@ -3,7 +3,7 @@ use infra_utils::cargo::CargoWorkspace;
 use infra_utils::commands::Command;
 use infra_utils::paths::{FileWalker, PathExtensions};
 
-use crate::toolchains::napi::{NapiCli, NapiConfig, NapiResolver};
+use crate::toolchains::napi::{NapiConfig, NapiResolver};
 
 /// This repository versions and releases all its artifacts together, generating the same changelog.
 /// Unfortunately, changesets does not support combining changelogs from multiple packages into one.
@@ -43,10 +43,6 @@ pub fn publish_changesets() -> Result<()> {
         println!("No version changes. Skipping.");
         return Ok(());
     }
-
-    // Update platform-specific packages:
-
-    NapiCli::prepublish(resolver)?;
 
     // Format the updated package files:
 

--- a/crates/infra/cli/src/toolchains/napi/cli.rs
+++ b/crates/infra/cli/src/toolchains/napi/cli.rs
@@ -99,21 +99,4 @@ impl NapiCli {
             node_binary,
         })
     }
-
-    pub fn prepublish(resolver: NapiResolver) -> Result<()> {
-        let package_dir = resolver.main_package_dir();
-        let platforms_dir = resolver.platforms_dir();
-
-        // Note: NAPI expects all arguments to be relative to the current directory.
-        let package_dir = package_dir.strip_repo_root()?;
-        let platforms_dir = platforms_dir.strip_repo_root()?;
-
-        return Command::new("napi")
-            .arg("prepublish")
-            .flag("--skip-gh-release")
-            .property("--config", package_dir.join("package.json").unwrap_str())
-            .property("--prefix", platforms_dir.unwrap_str())
-            .env("npm_config_dry_run", "true")
-            .run();
-    }
 }


### PR DESCRIPTION
#957 introduced a bug in the release infra that `napi` CLI was still trying to update `optionalDependencies` not `dependencies`. This PR fixes it by adding all packages as a "fixed" set in changesets, so that they are always updated together, and thus we no longer need to run `napi prepublish`:

https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md