### PR TITLE
remove toThrowError from tests

### DIFF
--- a/crates/testlang/outputs/npm/tests/src/tests/ast.ts
+++ b/crates/testlang/outputs/npm/tests/src/tests/ast.ts
@@ -109,9 +109,7 @@ test("throws an exception on initializing the wrong type", () => {
   const cst = parseOutput.tree();
   expectNonterminal(cst, NonterminalKind.Tree);
 
-  expect(() => new SourceUnit(cst)).toThrowError(
-    "SourceUnit can only be initialized with a CST node of the same kind.",
-  );
+  expect(() => new SourceUnit(cst)).toThrow("SourceUnit can only be initialized with a CST node of the same kind.");
 });
 
 test("throws an exception on on using an incorrect/incomplete CST node", () => {
@@ -134,7 +132,7 @@ test("throws an exception on on using an incorrect/incomplete CST node", () => {
   const tree = new Tree(cst);
   expectNonterminal(tree.cst, NonterminalKind.Tree);
 
-  expect(() => tree.node).toThrowError(
+  expect(() => tree.node).toThrow(
     "Unexpected SKIPPED terminal at index '1'. Creating AST types from incorrect/incomplete CST nodes is not supported yet.",
   );
 });

--- a/crates/testlang/outputs/npm/tests/src/tests/errors.ts
+++ b/crates/testlang/outputs/npm/tests/src/tests/errors.ts
@@ -17,9 +17,9 @@ test("render error reports", () => {
 });
 
 test("invalid semantic version", () => {
-  expect(() => new Language("foo_bar")).toThrowError("Invalid semantic version 'foo_bar'.");
+  expect(() => new Language("foo_bar")).toThrow("Invalid semantic version 'foo_bar'.");
 });
 
 test("unsupported language version", () => {
-  expect(() => new Language("0.0.0")).toThrowError("Unsupported language version '0.0.0'.");
+  expect(() => new Language("0.0.0")).toThrow("Unsupported language version '0.0.0'.");
 });


### PR DESCRIPTION
It was deprecated, showing errors during local development.

Updating with the newer alternative.