### PR TITLE
Refactor `BuiltInLabel` to avoid duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "quote",
  "semver",
  "serde",
+ "strum",
  "strum_macros",
  "syn",
  "thiserror",
@@ -413,7 +414,7 @@ dependencies = [
  "quote",
  "semver",
  "serde",
- "strum_macros",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,6 @@ dependencies = [
  "codegen_language_definition",
  "derive-new",
  "indexmap",
- "strum_macros",
 ]
 
 [[package]]

--- a/crates/codegen/ebnf/Cargo.toml
+++ b/crates/codegen/ebnf/Cargo.toml
@@ -11,7 +11,6 @@ codegen_language_definition = { workspace = true }
 derive-new = { workspace = true }
 indexmap = { workspace = true }
 Inflector = { workspace = true }
-strum_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/codegen/ebnf/src/builder.rs
+++ b/crates/codegen/ebnf/src/builder.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use codegen_language_definition::model::{
-    EnumItem, EnumVariant, Field, FragmentItem, Identifier, Item, KeywordDefinition, KeywordItem,
-    KeywordValue, Language, OperatorModel, PrecedenceExpression, PrecedenceItem,
+    BuiltInLabel, EnumItem, EnumVariant, Field, FragmentItem, Identifier, Item, KeywordDefinition,
+    KeywordItem, KeywordValue, Language, OperatorModel, PrecedenceExpression, PrecedenceItem,
     PrecedenceOperator, PrimaryExpression, RepeatedItem, Scanner, SeparatedItem, StructItem,
     TokenDefinition, TokenItem, TriviaItem, VersionSpecifier,
 };
@@ -10,21 +10,6 @@ use indexmap::IndexMap;
 use inflector::Inflector;
 
 use crate::model::{Definition, DefinitionKind, Entry, Expression, Value};
-
-#[allow(dead_code)]
-#[derive(strum_macros::AsRefStr)]
-#[strum(serialize_all = "snake_case")]
-enum BuiltInLabel {
-    // _SLANG_INTERNAL_RESERVED_NODE_LABELS_ (keep in sync)
-    Item,
-    Variant,
-    Separator,
-    Operand,
-    LeftOperand,
-    RightOperand,
-    LeadingTrivia,
-    TrailingTrivia,
-}
 
 pub struct Builder {
     section_index: usize,

--- a/crates/codegen/language/definition/Cargo.toml
+++ b/crates/codegen/language/definition/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
+strum = { workspace = true }
 strum_macros = { workspace = true }
 syn = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/codegen/language/definition/src/model/manifest.rs
+++ b/crates/codegen/language/definition/src/model/manifest.rs
@@ -139,3 +139,16 @@ pub struct Topic {
 
     pub items: Vec<Item>,
 }
+
+#[derive(strum_macros::AsRefStr, strum_macros::EnumIter)]
+#[strum(serialize_all = "snake_case")]
+pub enum BuiltInLabel {
+    Item,
+    Variant,
+    Separator,
+    Operand,
+    LeftOperand,
+    RightOperand,
+    LeadingTrivia,
+    TrailingTrivia,
+}

--- a/crates/codegen/language/definition/src/model/manifest.rs
+++ b/crates/codegen/language/definition/src/model/manifest.rs
@@ -140,7 +140,7 @@ pub struct Topic {
     pub items: Vec<Item>,
 }
 
-#[derive(strum_macros::AsRefStr, strum_macros::EnumIter)]
+#[derive(strum_macros::AsRefStr, strum_macros::EnumIter, strum_macros::VariantNames)]
 #[strum(serialize_all = "snake_case")]
 pub enum BuiltInLabel {
     Item,

--- a/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
+++ b/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
@@ -49,7 +49,7 @@ impl metaslang_cst::NonterminalKind for NonterminalKind {}
 #[cfg_attr(not(feature = "slang_napi_interfaces"), derive(Clone, Copy))]
 pub enum EdgeLabel {
     // Built-in:
-    {% for label in model.builtin_labels -%}
+    {% for label in model.kinds.built_in_labels -%}
         {{ label | pascal_case }},
     {%- endfor %}
 

--- a/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
+++ b/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
@@ -49,7 +49,7 @@ impl metaslang_cst::NonterminalKind for NonterminalKind {}
 #[cfg_attr(not(feature = "slang_napi_interfaces"), derive(Clone, Copy))]
 pub enum EdgeLabel {
     // Built-in:
-    {% for label in builtin_labels -%}
+    {% for label in model.builtin_labels -%}
         {{ label | pascal_case }},
     {%- endfor %}
 

--- a/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
+++ b/crates/codegen/runtime/cargo/src/runtime/kinds.rs.jinja2
@@ -49,15 +49,9 @@ impl metaslang_cst::NonterminalKind for NonterminalKind {}
 #[cfg_attr(not(feature = "slang_napi_interfaces"), derive(Clone, Copy))]
 pub enum EdgeLabel {
     // Built-in:
-    {# _SLANG_INTERNAL_RESERVED_NODE_LABELS_ (keep in sync) #}
-    Item,
-    Variant,
-    Separator,
-    Operand,
-    LeftOperand,
-    RightOperand,
-    LeadingTrivia,
-    TrailingTrivia,
+    {% for label in builtin_labels -%}
+        {{ label | pascal_case }},
+    {%- endfor %}
 
     // Generated:
     {% if rendering_in_stubs -%}

--- a/crates/codegen/runtime/generator/Cargo.toml
+++ b/crates/codegen/runtime/generator/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
-strum_macros = { workspace = true }
+strum = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/codegen/runtime/generator/src/kinds.rs
+++ b/crates/codegen/runtime/generator/src/kinds.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeSet;
 
-use codegen_language_definition::model::{self, Identifier, Item};
+use codegen_language_definition::model::{self, BuiltInLabel, Identifier, Item};
 use serde::Serialize;
+use strum::VariantNames;
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 pub struct KindsModel {
     /// Defines the `NonterminalKind` enum variants.
     nonterminal_kinds: BTreeSet<Identifier>,
@@ -13,8 +14,23 @@ pub struct KindsModel {
     trivia_scanner_names: BTreeSet<Identifier>,
     /// Defines `EdgeLabel` enum variants.
     labels: BTreeSet<Identifier>,
+    /// Built-in labels for edges
+    built_in_labels: &'static [&'static str],
     // Defines the `LexicalContext(Type)` enum and type-level variants.
     lexical_contexts: BTreeSet<Identifier>,
+}
+
+impl Default for KindsModel {
+    fn default() -> Self {
+        Self {
+            nonterminal_kinds: Default::default(),
+            terminal_kinds: Default::default(),
+            trivia_scanner_names: Default::default(),
+            labels: Default::default(),
+            built_in_labels: BuiltInLabel::VARIANTS,
+            lexical_contexts: Default::default(),
+        }
+    }
 }
 
 impl KindsModel {
@@ -93,6 +109,7 @@ impl KindsModel {
             trivia_scanner_names,
             labels,
             lexical_contexts,
+            ..Self::default()
         }
     }
 }

--- a/crates/codegen/runtime/generator/src/kinds.rs
+++ b/crates/codegen/runtime/generator/src/kinds.rs
@@ -23,12 +23,12 @@ pub struct KindsModel {
 impl Default for KindsModel {
     fn default() -> Self {
         Self {
-            nonterminal_kinds: Default::default(),
-            terminal_kinds: Default::default(),
-            trivia_scanner_names: Default::default(),
-            labels: Default::default(),
+            nonterminal_kinds: BTreeSet::default(),
+            terminal_kinds: BTreeSet::default(),
+            trivia_scanner_names: BTreeSet::default(),
+            labels: BTreeSet::default(),
             built_in_labels: BuiltInLabel::VARIANTS,
-            lexical_contexts: Default::default(),
+            lexical_contexts: BTreeSet::default(),
         }
     }
 }

--- a/crates/codegen/runtime/generator/src/lib.rs
+++ b/crates/codegen/runtime/generator/src/lib.rs
@@ -43,7 +43,7 @@ impl OutputLanguage {
     pub fn generate_stubs(&self) -> Result<()> {
         let model = ModelWrapper {
             rendering_in_stubs: true,
-            model: RuntimeModel::for_stubs(),
+            model: RuntimeModel::default(),
         };
 
         let mut templates = CodegenTemplates::new(self.source_dir()?)?;

--- a/crates/codegen/runtime/generator/src/lib.rs
+++ b/crates/codegen/runtime/generator/src/lib.rs
@@ -2,11 +2,10 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use anyhow::Result;
-use codegen_language_definition::model::{BuiltInLabel, Language};
+use codegen_language_definition::model::Language;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenTemplates;
 use serde::Serialize;
-use strum::IntoEnumIterator;
 
 use crate::model::RuntimeModel;
 
@@ -26,22 +25,14 @@ pub enum OutputLanguage {
 #[derive(Serialize)]
 struct ModelWrapper {
     rendering_in_stubs: bool,
-    model: Option<RuntimeModel>,
-    builtin_labels: Vec<String>,
-}
-
-fn builtin_labels() -> Vec<String> {
-    BuiltInLabel::iter()
-        .map(|label| label.as_ref().to_owned())
-        .collect()
+    model: RuntimeModel,
 }
 
 impl OutputLanguage {
     pub fn generate_runtime(&self, language: &Rc<Language>, output_dir: &Path) -> Result<()> {
         let model = ModelWrapper {
             rendering_in_stubs: false,
-            model: Some(RuntimeModel::from_language(language)),
-            builtin_labels: builtin_labels(),
+            model: RuntimeModel::from_language(language),
         };
 
         let mut templates = CodegenTemplates::new(self.source_dir()?)?;
@@ -52,8 +43,7 @@ impl OutputLanguage {
     pub fn generate_stubs(&self) -> Result<()> {
         let model = ModelWrapper {
             rendering_in_stubs: true,
-            model: None,
-            builtin_labels: builtin_labels(),
+            model: RuntimeModel::for_stubs(),
         };
 
         let mut templates = CodegenTemplates::new(self.source_dir()?)?;

--- a/crates/codegen/runtime/generator/src/lib.rs
+++ b/crates/codegen/runtime/generator/src/lib.rs
@@ -2,10 +2,11 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use anyhow::Result;
-use codegen_language_definition::model::Language;
+use codegen_language_definition::model::{BuiltInLabel, Language};
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenTemplates;
 use serde::Serialize;
+use strum::IntoEnumIterator;
 
 use crate::model::RuntimeModel;
 
@@ -26,6 +27,13 @@ pub enum OutputLanguage {
 struct ModelWrapper {
     rendering_in_stubs: bool,
     model: Option<RuntimeModel>,
+    builtin_labels: Vec<String>,
+}
+
+fn builtin_labels() -> Vec<String> {
+    BuiltInLabel::iter()
+        .map(|label| label.as_ref().to_owned())
+        .collect()
 }
 
 impl OutputLanguage {
@@ -33,6 +41,7 @@ impl OutputLanguage {
         let model = ModelWrapper {
             rendering_in_stubs: false,
             model: Some(RuntimeModel::from_language(language)),
+            builtin_labels: builtin_labels(),
         };
 
         let mut templates = CodegenTemplates::new(self.source_dir()?)?;
@@ -44,6 +53,7 @@ impl OutputLanguage {
         let model = ModelWrapper {
             rendering_in_stubs: true,
             model: None,
+            builtin_labels: builtin_labels(),
         };
 
         let mut templates = CodegenTemplates::new(self.source_dir()?)?;

--- a/crates/codegen/runtime/generator/src/model.rs
+++ b/crates/codegen/runtime/generator/src/model.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeSet;
 use std::rc::Rc;
 
-use codegen_language_definition::model::Language;
+use codegen_language_definition::model::{BuiltInLabel, Language};
 use semver::Version;
 use serde::Serialize;
+use strum::IntoEnumIterator;
 
 use crate::ast::AstModel;
 use crate::kinds::KindsModel;
@@ -16,6 +17,7 @@ pub struct RuntimeModel {
     parser: ParserModel,
     ast: AstModel,
     kinds: KindsModel,
+    builtin_labels: Vec<String>,
 }
 
 impl RuntimeModel {
@@ -25,6 +27,20 @@ impl RuntimeModel {
             ast: AstModel::create(language),
             parser: ParserModel::from_language(language),
             kinds: KindsModel::create(language),
+            builtin_labels: builtin_labels(),
         }
     }
+
+    pub fn for_stubs() -> Self {
+        Self {
+            builtin_labels: builtin_labels(),
+            ..Default::default()
+        }
+    }
+}
+
+fn builtin_labels() -> Vec<String> {
+    BuiltInLabel::iter()
+        .map(|label| label.as_ref().to_owned())
+        .collect()
 }

--- a/crates/codegen/runtime/generator/src/model.rs
+++ b/crates/codegen/runtime/generator/src/model.rs
@@ -1,10 +1,9 @@
 use std::collections::BTreeSet;
 use std::rc::Rc;
 
-use codegen_language_definition::model::{BuiltInLabel, Language};
+use codegen_language_definition::model::Language;
 use semver::Version;
 use serde::Serialize;
-use strum::IntoEnumIterator;
 
 use crate::ast::AstModel;
 use crate::kinds::KindsModel;
@@ -17,7 +16,6 @@ pub struct RuntimeModel {
     parser: ParserModel,
     ast: AstModel,
     kinds: KindsModel,
-    builtin_labels: Vec<String>,
 }
 
 impl RuntimeModel {
@@ -27,20 +25,6 @@ impl RuntimeModel {
             ast: AstModel::create(language),
             parser: ParserModel::from_language(language),
             kinds: KindsModel::create(language),
-            builtin_labels: builtin_labels(),
         }
     }
-
-    pub fn for_stubs() -> Self {
-        Self {
-            builtin_labels: builtin_labels(),
-            ..Default::default()
-        }
-    }
-}
-
-fn builtin_labels() -> Vec<String> {
-    BuiltInLabel::iter()
-        .map(|label| label.as_ref().to_owned())
-        .collect()
 }

--- a/crates/codegen/runtime/generator/src/parser/grammar/constructor.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar/constructor.rs
@@ -5,7 +5,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Deref;
 use std::rc::Rc;
 
-use codegen_language_definition::model::{self, FieldsErrorRecovery, Identifier, Item};
+use codegen_language_definition::model::{
+    self, BuiltInLabel, FieldsErrorRecovery, Identifier, Item,
+};
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 
@@ -791,21 +793,6 @@ trait LabeledExt<T> {
     fn anonymous(node: T) -> Self;
     fn with_ident_name(name: Identifier, node: T) -> Self;
     fn with_builtin_label(name: BuiltInLabel, node: T) -> Self;
-}
-
-#[allow(dead_code)]
-#[derive(strum_macros::AsRefStr)]
-#[strum(serialize_all = "snake_case")]
-enum BuiltInLabel {
-    // _SLANG_INTERNAL_RESERVED_NODE_LABELS_ (keep in sync)
-    Item,
-    Variant,
-    Separator,
-    Operand,
-    LeftOperand,
-    RightOperand,
-    LeadingTrivia,
-    TrailingTrivia,
 }
 
 impl<T> LabeledExt<T> for Labeled<T> {


### PR DESCRIPTION
Spin off of #976 

Moves the `BuiltInLabel` enum from the parser generator into the language definition and remove duplication in the `kinds` template.
