### PR TITLE
refactor: Use collect_breaking_versions from v2 directly in PG

### DIFF
--- a/crates/codegen/language/definition/src/model/manifest.rs
+++ b/crates/codegen/language/definition/src/model/manifest.rs
@@ -36,27 +36,15 @@ impl Language {
     }
 
     /// Collects all versions that change the language grammar in a breaking way.
+    ///
+    /// Includes the first supported version.
     pub fn collect_breaking_versions(&self) -> BTreeSet<Version> {
         let first = self.versions.first().unwrap().clone();
         let mut res = BTreeSet::from_iter([first]);
 
         let mut add_spec = |spec: &Option<VersionSpecifier>| {
-            let Some(spec) = spec else {
-                return;
-            };
-
-            match spec.clone() {
-                VersionSpecifier::Never => (),
-                VersionSpecifier::From { from } => {
-                    res.insert(from);
-                }
-                VersionSpecifier::Till { till } => {
-                    res.insert(till);
-                }
-                VersionSpecifier::Range { from, till } => {
-                    res.insert(from);
-                    res.insert(till);
-                }
+            if let Some(spec) = spec {
+                res.extend(spec.versions().cloned());
             }
         };
 

--- a/crates/codegen/runtime/cargo/src/runtime/language.rs.jinja2
+++ b/crates/codegen/runtime/cargo/src/runtime/language.rs.jinja2
@@ -30,7 +30,10 @@ use crate::parser_support::{
 #[cfg_attr(feature = "slang_napi_interfaces", napi(namespace = "language"))]
 pub struct Language {
     {%- if not rendering_in_stubs -%}
-        {%- for version in model.parser.referenced_versions -%}
+        {%- for version in model.breaking_versions -%}
+            {% if loop.first %} {# The first supported version may not be referenced by the items #}
+            #[allow(dead_code)]
+            {% endif %}
             pub(crate) version_is_at_least_{{ version | replace(from=".", to="_") }}: bool,
         {%- endfor -%}
     {%- endif -%}
@@ -68,7 +71,7 @@ impl Language {
         if Self::SUPPORTED_VERSIONS.binary_search(&version).is_ok() {
             Ok(Self {
                 {%- if not rendering_in_stubs -%}
-                    {%- for version in model.parser.referenced_versions %}
+                    {%- for version in model.breaking_versions %}
                         version_is_at_least_{{ version | replace(from=".", to="_") }}: Version::new({{ version | split(pat=".") | join(sep=", ") }}) <= version,
                     {%- endfor -%}
                 {%- endif -%}

--- a/crates/codegen/runtime/generator/src/model.rs
+++ b/crates/codegen/runtime/generator/src/model.rs
@@ -13,6 +13,7 @@ use crate::parser::ParserModel;
 pub struct RuntimeModel {
     /// Defines the `Language::SUPPORTED_VERSIONS` field.
     all_versions: BTreeSet<Version>,
+    breaking_versions: BTreeSet<Version>,
     parser: ParserModel,
     ast: AstModel,
     kinds: KindsModel,
@@ -22,6 +23,7 @@ impl RuntimeModel {
     pub fn from_language(language: &Rc<Language>) -> Self {
         Self {
             all_versions: language.versions.iter().cloned().collect(),
+            breaking_versions: language.collect_breaking_versions(),
             ast: AstModel::create(language),
             parser: ParserModel::from_language(language),
             kinds: KindsModel::create(language),

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/generated/language.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/generated/language.rs
@@ -31,6 +31,8 @@ use crate::parser_support::{
 #[derive(Debug)]
 #[cfg_attr(feature = "slang_napi_interfaces", napi(namespace = "language"))]
 pub struct Language {
+    #[allow(dead_code)]
+    pub(crate) version_is_at_least_0_4_11: bool,
     pub(crate) version_is_at_least_0_4_12: bool,
     pub(crate) version_is_at_least_0_4_14: bool,
     pub(crate) version_is_at_least_0_4_16: bool,
@@ -171,6 +173,7 @@ impl Language {
     pub fn new(version: Version) -> std::result::Result<Self, Error> {
         if Self::SUPPORTED_VERSIONS.binary_search(&version).is_ok() {
             Ok(Self {
+                version_is_at_least_0_4_11: Version::new(0, 4, 11) <= version,
                 version_is_at_least_0_4_12: Version::new(0, 4, 12) <= version,
                 version_is_at_least_0_4_14: Version::new(0, 4, 14) <= version,
                 version_is_at_least_0_4_16: Version::new(0, 4, 16) <= version,

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/generated/language.rs
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/generated/language.rs
@@ -31,6 +31,7 @@ use crate::parser_support::{
 #[derive(Debug)]
 #[cfg_attr(feature = "slang_napi_interfaces", napi(namespace = "language"))]
 pub struct Language {
+    #[allow(dead_code)]
     pub(crate) version_is_at_least_1_0_0: bool,
     pub(crate) version: Version,
 }


### PR DESCRIPTION
Part of #638 

Follow-up to #991

Pretty straightforward: instead of visiting the previously built v1 definition structure, we defer to `Language::collect_breaking_changes` as the definitions overlap - the breaking changes are defined as versions in which the syntax items may be evaluated differently, which means that these are exactly the versions that will be referenced for the conditional syntax item evaluation in the parser/lexer.