### PR TITLE
fix cargo workspace publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.15.0"
+version = "0.15.0"      # Should be kept in sync with the internal dependencies table below
 rust-version = "1.76.0" # __RUST_STABLE_VERSION_MARKER__ (keep in sync)
 edition = "2021"
 publish = false
@@ -46,45 +46,46 @@ members = [
 #
 # Internal
 #
-codegen_ebnf = { path = "crates/codegen/ebnf" }
-codegen_language_definition = { path = "crates/codegen/language/definition" }
-codegen_language_internal_macros = { path = "crates/codegen/language/internal_macros" }
-codegen_language_macros = { path = "crates/codegen/language/macros" }
-codegen_language_tests = { path = "crates/codegen/language/tests" }
-codegen_runtime_cargo = { path = "crates/codegen/runtime/cargo" }
-codegen_runtime_generator = { path = "crates/codegen/runtime/generator" }
-codegen_runtime_node_addon = { path = "crates/codegen/runtime/node_addon" }
-codegen_runtime_npm = { path = "crates/codegen/runtime/npm" }
-codegen_spec = { path = "crates/codegen/spec" }
-codegen_testing = { path = "crates/codegen/testing" }
+codegen_ebnf = { path = "crates/codegen/ebnf", version = "0.15.0" }
+codegen_language_definition = { path = "crates/codegen/language/definition", version = "0.15.0" }
+codegen_language_internal_macros = { path = "crates/codegen/language/internal_macros", version = "0.15.0" }
+codegen_language_macros = { path = "crates/codegen/language/macros", version = "0.15.0" }
+codegen_language_tests = { path = "crates/codegen/language/tests", version = "0.15.0" }
+codegen_runtime_cargo = { path = "crates/codegen/runtime/cargo", version = "0.15.0" }
+codegen_runtime_generator = { path = "crates/codegen/runtime/generator", version = "0.15.0" }
+codegen_runtime_node_addon = { path = "crates/codegen/runtime/node_addon", version = "0.15.0" }
+codegen_runtime_npm = { path = "crates/codegen/runtime/npm", version = "0.15.0" }
+codegen_spec = { path = "crates/codegen/spec", version = "0.15.0" }
+codegen_testing = { path = "crates/codegen/testing", version = "0.15.0" }
 
-infra_cli = { path = "crates/infra/cli" }
-infra_utils = { path = "crates/infra/utils" }
+infra_cli = { path = "crates/infra/cli", version = "0.15.0" }
+infra_utils = { path = "crates/infra/utils", version = "0.15.0" }
 
-metaslang_graph_builder = { path = "crates/metaslang/graph_builder" }
-metaslang_cst = { path = "crates/metaslang/cst" }
+metaslang_graph_builder = { path = "crates/metaslang/graph_builder", version = "0.15.0" }
+metaslang_cst = { path = "crates/metaslang/cst", version = "0.15.0" }
 
-slang_solidity = { path = "crates/solidity/outputs/cargo/slang_solidity" }
-slang_solidity_node_addon = { path = "crates/solidity/outputs/cargo/slang_solidity_node_addon" }
-solidity_cargo_tests = { path = "crates/solidity/outputs/cargo/tests" }
-solidity_language = { path = "crates/solidity/inputs/language" }
-solidity_npm_package = { path = "crates/solidity/outputs/npm/package" }
-solidity_spec = { path = "crates/solidity/outputs/spec" }
-solidity_testing_sanctuary = { path = "crates/solidity/testing/sanctuary" }
-solidity_testing_snapshots = { path = "crates/solidity/testing/snapshots" }
-solidity_testing_solc = { path = "crates/solidity/testing/solc" }
+slang_solidity = { path = "crates/solidity/outputs/cargo/slang_solidity", version = "0.15.0" }
+slang_solidity_node_addon = { path = "crates/solidity/outputs/cargo/slang_solidity_node_addon", version = "0.15.0" }
+solidity_cargo_tests = { path = "crates/solidity/outputs/cargo/tests", version = "0.15.0" }
+solidity_language = { path = "crates/solidity/inputs/language", version = "0.15.0" }
+solidity_npm_package = { path = "crates/solidity/outputs/npm/package", version = "0.15.0" }
+solidity_spec = { path = "crates/solidity/outputs/spec", version = "0.15.0" }
+solidity_testing_sanctuary = { path = "crates/solidity/testing/sanctuary", version = "0.15.0" }
+solidity_testing_snapshots = { path = "crates/solidity/testing/snapshots", version = "0.15.0" }
+solidity_testing_solc = { path = "crates/solidity/testing/solc", version = "0.15.0" }
 
-slang_testlang = { path = "crates/testlang/outputs/cargo/slang_testlang" }
-slang_testlang_node_addon = { path = "crates/testlang/outputs/cargo/slang_testlang_node_addon" }
-testlang_cargo_tests = { path = "crates/testlang/outputs/cargo/tests" }
-testlang_language = { path = "crates/testlang/inputs/language" }
-testlang_npm_package = { path = "crates/testlang/outputs/npm/package" }
+slang_testlang = { path = "crates/testlang/outputs/cargo/slang_testlang", version = "0.15.0" }
+slang_testlang_node_addon = { path = "crates/testlang/outputs/cargo/slang_testlang_node_addon", version = "0.15.0" }
+testlang_cargo_tests = { path = "crates/testlang/outputs/cargo/tests", version = "0.15.0" }
+testlang_language = { path = "crates/testlang/inputs/language", version = "0.15.0" }
+testlang_npm_package = { path = "crates/testlang/outputs/npm/package", version = "0.15.0" }
 
 #
 # External
 #
 anyhow = { version = "1.0.86", features = ["backtrace", "std"] }
 ariadne = { version = "0.2.0" }
+cargo-edit = { version = "0.12.3" }
 cargo-emit = { version = "0.2.1" }
 cargo-xwin = { version = "0.14.2" }
 cargo-zigbuild = { version = "0.18.3" }

--- a/crates/infra/cli/src/commands/publish/changesets/mod.rs
+++ b/crates/infra/cli/src/commands/publish/changesets/mod.rs
@@ -61,7 +61,7 @@ pub fn publish_changesets() -> Result<()> {
     // Update Cargo workspace:
 
     println!("Updating Cargo workspace version.");
-    CargoWorkspace::update_version(&package_version, &updated_version)?;
+    CargoWorkspace::update_version(&updated_version)?;
 
     // Update Cargo lock file:
 


### PR DESCRIPTION
Currently our publishing pipeline is failing to publish workspace crates that have internal dependencies:
https://github.com/NomicFoundation/slang/actions/runs/9468852124/job/26088399371

```log
error: all dependencies must have a version specified when publishing.
  dependency `metaslang_cst` does not specify a version
```

This is a known bug/limitation of `cargo publish`: https://github.com/rust-lang/cargo/issues/11133

To get around this, I'm explicitly adding versions to all internal dependencies, and switching our versioning workflow to use `cargo set-version` to update all of them when creating the changesets PR.