### PR TITLE
Disentangle grammar resolution and related PG code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "semver",
  "serde",
  "strum",
+ "strum_macros",
 ]
 
 [[package]]

--- a/crates/codegen/runtime/generator/Cargo.toml
+++ b/crates/codegen/runtime/generator/Cargo.toml
@@ -17,6 +17,7 @@ quote = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/codegen/runtime/generator/src/parser/grammar.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar.rs
@@ -9,14 +9,15 @@ use std::rc::Rc;
 
 use codegen_language_definition::model::{self, Identifier};
 
-pub mod constructor;
 pub mod parser_definition;
 pub mod precedence_parser_definition;
+pub mod resolver;
 pub mod scanner_definition;
 pub mod visitor;
 
 pub use parser_definition::*;
 pub use precedence_parser_definition::*;
+pub use resolver::ResolveCtx;
 pub use scanner_definition::*;
 pub use visitor::*;
 

--- a/crates/codegen/runtime/generator/src/parser/grammar.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar.rs
@@ -36,7 +36,7 @@ impl Grammar {
 }
 
 #[allow(clippy::enum_variant_names)] // this will be removed soon
-#[derive(Clone)]
+#[derive(Clone, strum_macros::EnumTryAs)]
 pub enum GrammarElement {
     ScannerDefinition(ScannerDefinitionRef),
     KeywordScannerDefinition(Rc<model::KeywordItem>),

--- a/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
@@ -274,7 +274,7 @@ fn resolve_grammar_element(ident: &Identifier, ctx: &mut ResolveCtx) -> GrammarE
                         .set(resolve_precedence(item.deref().clone(), &lex_ctx, ctx))
                         .unwrap();
                 }
-                _ => unreachable!("Only nonterminals can be resolved here"),
+                _ => unreachable!("{ident}: Only nonterminals can be resolved here"),
             };
 
             ctx.resolved.get(ident).cloned().unwrap()
@@ -291,7 +291,7 @@ fn resolve_grammar_element(ident: &Identifier, ctx: &mut ResolveCtx) -> GrammarE
                 Item::Token { item } => item as Rc<_>,
                 Item::Trivia { item } => item as Rc<_>,
                 Item::Fragment { item } => item as Rc<_>,
-                _ => unreachable!("Only terminals can be resolved here"),
+                _ => unreachable!("{ident}: Only terminals can be resolved here"),
             };
 
             let resolved = GrammarElement::ScannerDefinition(named_scanner);
@@ -502,7 +502,10 @@ fn resolve_precedence(
         })
         .collect();
     let primary_expression = Box::new(match primaries.len() {
-        0 => panic!("Precedence operator has no primary expressions"),
+        0 => panic!(
+            "Precedence operator {item} has no primary expressions",
+            item = item.name
+        ),
         _ => ParserDefinitionNode::Choice(Labeled::with_builtin_label(
             BuiltInLabel::Variant,
             primaries,

--- a/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
@@ -197,6 +197,11 @@ impl ResolveCtx {
 }
 
 impl Resolution {
+    /// Returns the resolved items.
+    pub fn items(&self) -> impl Iterator<Item = (&Identifier, &GrammarElement)> {
+        self.resolved.iter()
+    }
+
     /// Collects the already resolved item into a [`Grammar`].
     pub fn to_grammar(&self) -> Grammar {
         let resolved_items = self

--- a/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar/resolver.rs
@@ -165,8 +165,9 @@ impl ResolveCtx {
 }
 
 impl Resolution {
-    pub fn original(&self, name: &Identifier) -> &(Identifier, Item) {
-        &self.items[name]
+    /// Returns the lexical context in which the item was defined.
+    pub fn lex_ctx(&self, name: &Identifier) -> &Identifier {
+        &self.items[name].0
     }
 
     /// Returns the resolved items.

--- a/crates/codegen/runtime/generator/src/parser/mod.rs
+++ b/crates/codegen/runtime/generator/src/parser/mod.rs
@@ -122,7 +122,7 @@ impl ScannerContextCollector {
             .items()
             .filter_map(|(_, item)| item.try_as_keyword_scanner_definition_ref())
         {
-            let (lex_ctxt, _) = resolved.original(&kw_scanner_def.name);
+            let lex_ctxt = resolved.lex_ctx(&kw_scanner_def.name);
 
             self.scanner_contexts
                 .entry(lex_ctxt.clone())


### PR DESCRIPTION
Ticks the box in #638 (_Keyword trie inclusion should be reworked to not require synthetic rules over all keywords_)

This exposes the resolution step rather than treating it as an implementation detail and doesn't try to shoehorn the DSL v2 items to the old `Grammar` model as much that the PG was based on.

Moreover, this breaks up the existing grammar visitor and tries to collect or calculate more properties upfront directly from DSL v2 in order to be more explicit that they not need to depend on the collector state that tracked everything.

I didn't submit it initially because I felt I could polish it slightly further (see the `TODO` note) but since I'm focused on EDR now and this cleans up the last important box in #638 (the other one is simply reverting some rules for string literals), I think it's worth reviewing in the current state.