### PR TITLE
Remove remaining mentions of #638 in the code

### DIFF
--- a/crates/codegen/language/definition/src/model/terminals/trivia.rs
+++ b/crates/codegen/language/definition/src/model/terminals/trivia.rs
@@ -10,7 +10,6 @@ pub enum TriviaParser {
     Choice { parsers: Vec<TriviaParser> },
 
     Optional { parser: Box<TriviaParser> },
-    // TODO(#638): Remove this, once we adapt the DSL v1 codegen model to the new v2 definition.
     OneOrMore { parser: Box<TriviaParser> },
     ZeroOrMore { parser: Box<TriviaParser> },
 

--- a/crates/codegen/runtime/generator/src/parser/grammar.rs
+++ b/crates/codegen/runtime/generator/src/parser/grammar.rs
@@ -1,8 +1,4 @@
-//! Definitions of the [`GrammarElement`]s and the grammar itself ([`Grammar`]).
-
-// TODO(#638): This is a leftover module from the original DSLv1 implementation.
-// We should remove it and replace the grammar construction in the super `parser`
-// module with the one from the new DSLv2 in the `constructor` module.
+//! Definitions of the [`GrammarElement`]s and the grammar itself ([`Grammar`]) used by the parser generator.
 
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -5,8 +5,8 @@ codegen_language_macros::compile!(Language(
     documentation_dir = "crates/solidity/inputs/language/docs",
     binding_rules_file = "crates/solidity/inputs/language/bindings/rules.msgb",
     root_item = SourceUnit,
-    // TODO(#638): For now this is on par with the DSL v1 definition to minimize the fallout.
-    // We should replace this with the new definition from #629.
+    // TODO(#1020): Define the end-of-file trivia explicitly rather than
+    // implicitly reusing the leading trivia in the generater parser code.
     leading_trivia = OneOrMore(Choice([
         Trivia(Whitespace),
         Trivia(EndOfLine),


### PR DESCRIPTION
Closes #638 

The trivia item from #638 is now separately tracked in #1020.