### PR TITLE
remove slack notification workflows

### DIFF
--- a/.github/workflows/review-requested-slack-notification.yml
+++ b/.github/workflows/review-requested-slack-notification.yml
@@ -1,9 +1,0 @@
-name: "PR review requested Slack notification"
-on:
-  pull_request_target:
-    types:
-      - "review_requested"
-jobs:
-  requested:
-    uses: "NomicFoundation/github-actions-workflows/.github/workflows/review-requested-slack-notification.yml@main"
-    secrets: "inherit"

--- a/.github/workflows/review-submitted-slack-notification.yml
+++ b/.github/workflows/review-submitted-slack-notification.yml
@@ -1,9 +1,0 @@
-name: "PR reviewed Slack notification"
-on:
-  pull_request_review:
-    types:
-      - "submitted"
-jobs:
-  reviewed:
-    uses: "NomicFoundation/github-actions-workflows/.github/workflows/review-submitted-slack-notification.yml@main"
-    secrets: "inherit"


### PR DESCRIPTION
As the feature is now natively supported by GitHub via real-time reminders:

- https://github.com/settings/reminders

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/cdaa4baa-c890-49a5-900f-606518429f5a">
