### PR TITLE
use jest projects to run tests

### DIFF
--- a/crates/infra/cli/src/commands/test/mod.rs
+++ b/crates/infra/cli/src/commands/test/mod.rs
@@ -49,9 +49,5 @@ fn test_cargo() -> Result<()> {
 }
 
 fn test_npm() -> Result<()> {
-    Command::new("npm")
-        .args(["run", "test"])
-        .flag("--workspaces")
-        .flag("--if-present")
-        .run()
+    Command::new("jest").run()
 }

--- a/crates/solidity/outputs/npm/tests/jest.config.ts
+++ b/crates/solidity/outputs/npm/tests/jest.config.ts
@@ -15,7 +15,6 @@ const config: Config = {
 
   cacheDirectory: "<rootDir>/target/jest/cache",
   slowTestThreshold: 5,
-  verbose: true,
 
   clearMocks: true,
   resetMocks: true,

--- a/crates/solidity/outputs/npm/tests/package.json
+++ b/crates/solidity/outputs/npm/tests/package.json
@@ -6,8 +6,5 @@
     "jest": "29.7.0",
     "ts-jest": "29.1.5",
     "ts-node": "10.9.2"
-  },
-  "scripts": {
-    "test": "jest"
   }
 }

--- a/crates/testlang/outputs/npm/tests/jest.config.ts
+++ b/crates/testlang/outputs/npm/tests/jest.config.ts
@@ -15,7 +15,6 @@ const config: Config = {
 
   cacheDirectory: "<rootDir>/target/jest/cache",
   slowTestThreshold: 5,
-  verbose: true,
 
   clearMocks: true,
   resetMocks: true,

--- a/crates/testlang/outputs/npm/tests/package.json
+++ b/crates/testlang/outputs/npm/tests/package.json
@@ -6,8 +6,5 @@
     "jest": "29.7.0",
     "ts-jest": "29.1.5",
     "ts-node": "10.9.2"
-  },
-  "scripts": {
-    "test": "jest"
   }
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  projects: [
+    // List all directories with package-level "jest.config.ts" files:
+    "<rootDir>/crates/solidity/outputs/npm/tests/",
+    "<rootDir>/crates/testlang/outputs/npm/tests/",
+  ],
+};
+
+export default config;


### PR DESCRIPTION
this makes failures in terminal/CI much more readable, and file names/errors contain the full paths.