### PR TITLE
use nextest for running cargo tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ ariadne = { version = "0.2.0" }
 bencher_cli = { git = "https://github.com/bencherdev/bencher", branch = "main" }
 cargo-edit = { version = "0.12.3" }
 cargo-emit = { version = "0.2.1" }
+cargo-nextest = { version = "0.9.72" }
 cargo-xwin = { version = "0.14.2" }
 cargo-zigbuild = { version = "0.18.3" }
 clap = { version = "4.5.13", features = ["derive", "wrap_help"] }

--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::cargo::CargoWorkspace;
+use infra_utils::cargo::CargoWorkspaceCommands;
+use infra_utils::commands::Command;
 use infra_utils::terminal::Terminal;
 use strum::IntoEnumIterator;
 
@@ -47,18 +48,24 @@ impl OrderedCommand for CheckCommand {
 
 fn check_cargo() -> Result<()> {
     // 'cargo clippy' will run both 'cargo check', and 'clippy' lints:
-    CargoWorkspace::get_command("clippy")?
+    Command::new("cargo")
+        .arg("clippy")
+        .flag("--workspace")
+        .flag("--all-features")
         .flag("--all-targets")
+        .flag("--no-deps")
+        .add_build_rustflags()
         .run()
 }
 
 fn check_rustdoc() -> Result<()> {
-    CargoWorkspace::get_command("doc")?
+    Command::new("cargo")
+        .arg("doc")
+        .flag("--workspace")
+        .flag("--all-features")
         .flag("--no-deps")
         .flag("--document-private-items")
-        .flag("--lib")
-        .flag("--bins")
-        .flag("--examples")
+        .add_build_rustflags()
         .run()
 }
 

--- a/crates/infra/cli/src/commands/test/mod.rs
+++ b/crates/infra/cli/src/commands/test/mod.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::cargo::CargoWorkspace;
+use infra_utils::cargo::{CargoWorkspace, CargoWorkspaceCommands};
 use infra_utils::commands::Command;
-use infra_utils::github::GitHub;
 use infra_utils::terminal::Terminal;
 
 use crate::utils::{ClapExtensions, OrderedCommand};
@@ -39,13 +38,18 @@ impl OrderedCommand for TestCommand {
 }
 
 fn test_cargo() -> Result<()> {
-    let mut command = CargoWorkspace::get_command("test")?.flag("--quiet");
+    CargoWorkspace::install_binary("cargo-nextest")?;
 
-    if GitHub::is_running_in_ci() {
-        command = command.flag("--no-fail-fast");
-    }
-
-    command.run()
+    Command::new("cargo")
+        .args(["nextest", "run"])
+        .flag("--workspace")
+        .flag("--all-features")
+        .flag("--lib")
+        .flag("--bins")
+        .flag("--examples")
+        .flag("--no-fail-fast")
+        .add_build_rustflags()
+        .run()
 }
 
 fn test_npm() -> Result<()> {

--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -109,45 +109,48 @@ impl CargoWorkspace {
             .arg(new_version.to_string())
             .run()
     }
+}
 
-    pub fn get_command(subcommand: impl AsRef<str>) -> Result<Command> {
-        let subcommand = subcommand.as_ref();
+pub trait CargoWorkspaceCommands {
+    #[must_use]
+    fn add_build_rustflags(self) -> Self;
+}
 
-        let mut command = Command::new("cargo")
-            .arg(subcommand)
-            .flag("--workspace")
-            .flag("--all-features");
-
-        if GitHub::is_running_in_ci() {
-            // Using `$RUSTFLAGS' or '--' overrides any rustflags from `.cargo/config.toml'.
-            // Using this syntax instead, as it is concatenated with the existing flags:
-            command = command.property(
-                "--config",
-                format!(
-                    "build.rustflags = {rustflags}",
-                    rustflags = serde_json::to_string(&[
-                        // Deny any warnings in CI:
-                        "-Dwarnings",
-                        // Lint against leftover `dbg/todo!` macros in CI:
-                        "-Wclippy::dbg_macro",
-                        "-Wclippy::todo"
-                    ])?,
-                ),
-            );
-            // Rustdoc requires specifying RUSTDOCFLAGS, instead:
-            // See <https://github.com/rust-lang/cargo/issues/8424#issuecomment-1070988443>.
-            command = command.property(
-                "--config",
-                format!(
-                    "build.rustdocflags = {rustdocflags}",
-                    rustdocflags = serde_json::to_string(&[
-                        // Deny any warnings in CI:
-                        "-Dwarnings"
-                    ])?,
-                ),
-            );
+impl CargoWorkspaceCommands for Command {
+    fn add_build_rustflags(self) -> Self {
+        if !GitHub::is_running_in_ci() {
+            // Nothing to add locally:
+            return self;
         }
 
-        Ok(command)
+        // Using `$RUSTFLAGS' or '--' overrides any rustflags from `.cargo/config.toml'.
+        // Using this syntax instead, as it is concatenated with the existing flags:
+        self.property(
+            "--config",
+            format!(
+                "build.rustflags = {rustflags}",
+                rustflags = serde_json::to_string(&[
+                    // Deny any warnings in CI:
+                    "-Dwarnings",
+                    // Lint against leftover `dbg/todo!` macros in CI:
+                    "-Wclippy::dbg_macro",
+                    "-Wclippy::todo"
+                ])
+                .unwrap(),
+            ),
+        )
+        // Rustdoc requires specifying RUSTDOCFLAGS, instead:
+        // See <https://github.com/rust-lang/cargo/issues/8424#issuecomment-1070988443>.
+        .property(
+            "--config",
+            format!(
+                "build.rustdocflags = {rustdocflags}",
+                rustdocflags = serde_json::to_string(&[
+                    // Deny any warnings in CI:
+                    "-Dwarnings"
+                ])
+                .unwrap(),
+            ),
+        )
     }
 }


### PR DESCRIPTION
Makes it easier to debug failures in CI, as failures are grouped at the end, across all crates.