### PR TITLE
Add .envrc to allow direnv to pick up paths

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+PATH_add bin
+PATH_add scripts/bin

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
-PATH_add bin
-PATH_add scripts/bin
+source bin/activate-hermit

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+# Used by `direnv` to initialize the hermit environment: https://direnv.net/
+
 source bin/activate-hermit


### PR DESCRIPTION
This PR adds a `.envrc` file to the root of the project, that adds `./bin/` and `./scripts/bin` to `$PATH`. If you have direnv installed this makes `hermit` work and the `infra` script accessible.