### PR TITLE
unblock release pipeline

### DIFF
--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -40,13 +40,15 @@ impl OrderedCommand for CheckCommand {
         match self {
             CheckCommand::Cargo => check_cargo(),
             CheckCommand::Rustdoc => check_rustdoc(),
-            CheckCommand::Npm => check_npm(),
+            CheckCommand::Npm => check_npm()?,
             CheckCommand::Mkdocs => check_mkdocs(),
-        }
+        };
+
+        Ok(())
     }
 }
 
-fn check_cargo() -> Result<()> {
+fn check_cargo() {
     // 'cargo clippy' will run both 'cargo check', and 'clippy' lints:
     Command::new("cargo")
         .arg("clippy")
@@ -55,10 +57,10 @@ fn check_cargo() -> Result<()> {
         .flag("--all-targets")
         .flag("--no-deps")
         .add_build_rustflags()
-        .run()
+        .run();
 }
 
-fn check_rustdoc() -> Result<()> {
+fn check_rustdoc() {
     Command::new("cargo")
         .arg("doc")
         .flag("--workspace")
@@ -66,7 +68,7 @@ fn check_rustdoc() -> Result<()> {
         .flag("--no-deps")
         .flag("--document-private-items")
         .add_build_rustflags()
-        .run()
+        .run();
 }
 
 fn check_npm() -> Result<()> {
@@ -77,6 +79,6 @@ fn check_npm() -> Result<()> {
     Ok(())
 }
 
-fn check_mkdocs() -> Result<()> {
-    Mkdocs::check()
+fn check_mkdocs() {
+    Mkdocs::check();
 }

--- a/crates/infra/cli/src/commands/completions/mod.rs
+++ b/crates/infra/cli/src/commands/completions/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use clap_complete::Generator;
 
@@ -11,13 +10,10 @@ pub struct CompletionController {
 }
 
 impl CompletionController {
-    #[allow(clippy::unnecessary_wraps)] // for consistency with other commands
-    pub fn execute(&self) -> Result<()> {
+    pub fn execute(&self) {
         let mut command = crate::commands::Cli::command();
         command.build(); // Required to generate completions
 
         self.shell.generate(&command, &mut std::io::stdout());
-
-        Ok(())
     }
 }

--- a/crates/infra/cli/src/commands/mod.rs
+++ b/crates/infra/cli/src/commands/mod.rs
@@ -71,16 +71,18 @@ impl Cli {
 impl AppCommand {
     pub fn execute(&self) -> Result<()> {
         match self {
-            AppCommand::Setup(controller) => controller.execute(),
-            AppCommand::Check(controller) => controller.execute(),
-            AppCommand::Test(controller) => controller.execute(),
-            AppCommand::Lint(controller) => controller.execute(),
-            AppCommand::Ci(controller) => controller.execute(),
+            AppCommand::Setup(controller) => controller.execute()?,
+            AppCommand::Check(controller) => controller.execute()?,
+            AppCommand::Test(controller) => controller.execute()?,
+            AppCommand::Lint(controller) => controller.execute()?,
+            AppCommand::Ci(controller) => controller.execute()?,
             AppCommand::Run(controller) => controller.execute(),
-            AppCommand::Watch(controller) => controller.execute(),
-            AppCommand::Perf(controller) => controller.execute(),
-            AppCommand::Publish(controller) => controller.execute(),
+            AppCommand::Watch(controller) => controller.execute()?,
+            AppCommand::Perf(controller) => controller.execute()?,
+            AppCommand::Publish(controller) => controller.execute()?,
             AppCommand::Completions(controller) => controller.execute(),
-        }
+        };
+
+        Ok(())
     }
 }

--- a/crates/infra/cli/src/commands/perf/mod.rs
+++ b/crates/infra/cli/src/commands/perf/mod.rs
@@ -32,7 +32,7 @@ impl PerfController {
                 // Bencher supports multiple languages/frameworks: https://bencher.dev/docs/explanation/adapters/
                 // We currently only have one benchmark suite (Rust/iai), but we can add more here in the future.
 
-                run_iai_bench("solidity_testing_perf", "iai")?;
+                run_iai_bench("solidity_testing_perf", "iai");
             }
         };
 
@@ -62,10 +62,11 @@ fn install_perf_tools() -> Result<()> {
     Ok(())
 }
 
-fn run_iai_bench(package_name: &str, bench_name: &str) -> Result<()> {
-    if std::env::var("BENCHER_API_TOKEN").is_err() {
-        bail!("BENCHER_API_TOKEN is not set. Please set it to your Bencher API token: https://bencher.dev/console");
-    }
+fn run_iai_bench(package_name: &str, bench_name: &str) {
+    assert!(
+        std::env::var("BENCHER_API_TOKEN").is_ok(),
+        "BENCHER_API_TOKEN is not set. Please set it to your Bencher API token: https://bencher.dev/console",
+    );
 
     let cargo_command = format!("cargo bench --package {package_name} --bench {bench_name}");
 
@@ -81,7 +82,7 @@ fn run_iai_bench(package_name: &str, bench_name: &str) -> Result<()> {
         .property("--adapter", "rust_iai_callgrind")
         .property("--testbed", testbed)
         .arg(cargo_command)
-        .run()?;
+        .run();
 
     let reports_dir = Path::repo_path("target/iai")
         .join(package_name)
@@ -97,6 +98,4 @@ Reports/Logs: {reports_dir:?}
 - DHAT traces (dhat.*.out) can be viewed using the [dhat/dh_view.html] tool from the Valgrind release [https://valgrind.org/downloads/].
 
 ");
-
-    Ok(())
 }

--- a/crates/infra/cli/src/commands/publish/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/publish/cargo/mod.rs
@@ -50,7 +50,7 @@ impl CargoController {
         changeset.commit_changes()?;
 
         for crate_name in &changed_crates {
-            run_cargo_publish(crate_name, self.dry_run)?;
+            run_cargo_publish(crate_name, self.dry_run);
         }
 
         changeset.revert_changes()?;
@@ -109,11 +109,11 @@ fn strip_publish_markers(cargo_toml_path: &Path) -> Result<bool> {
 
 fn update_cargo_lock(changeset: &mut TemporaryChangeset) -> Result<()> {
     let cargo_lock_path = Path::repo_path("Cargo.lock");
-    let old_contents = std::fs::read_to_string(&cargo_lock_path)?;
+    let old_contents = cargo_lock_path.read_to_string()?;
 
-    Command::new("cargo").arg("check").run()?;
+    Command::new("cargo").arg("check").run();
 
-    let new_contents = std::fs::read_to_string(&cargo_lock_path)?;
+    let new_contents = cargo_lock_path.read_to_string()?;
 
     if new_contents != old_contents {
         changeset.expect_change(&cargo_lock_path);
@@ -122,7 +122,7 @@ fn update_cargo_lock(changeset: &mut TemporaryChangeset) -> Result<()> {
     Ok(())
 }
 
-fn run_cargo_publish(crate_name: &str, dry_run: DryRun) -> Result<()> {
+fn run_cargo_publish(crate_name: &str, dry_run: DryRun) {
     let mut command = Command::new("cargo")
         .arg("publish")
         .property("--package", crate_name)
@@ -132,5 +132,5 @@ fn run_cargo_publish(crate_name: &str, dry_run: DryRun) -> Result<()> {
         command = command.flag("--dry-run");
     }
 
-    command.run()
+    command.run();
 }

--- a/crates/infra/cli/src/commands/publish/changesets/mod.rs
+++ b/crates/infra/cli/src/commands/publish/changesets/mod.rs
@@ -41,7 +41,7 @@ impl ChangesetsController {
         // 2) Update the CHANGELOG.md file for the NPM package.
         // 3) Bump the version in its package.json accordingly.
 
-        Command::new("changeset").arg("version").run()?;
+        Command::new("changeset").arg("version").run();
 
         let updated_version = NapiConfig::local_version(&package_dir)?;
         println!("Updated version: {updated_version}");
@@ -56,14 +56,14 @@ impl ChangesetsController {
         let package_dir = resolver.main_package_dir();
         Command::new("prettier")
             .property("--write", package_dir.unwrap_str())
-            .run()?;
+            .run();
 
         // Update NPM lock file:
 
         Command::new("npm")
             .arg("install")
             .flag("--package-lock-only")
-            .run()?;
+            .run();
 
         // Update Cargo workspace:
 
@@ -75,7 +75,7 @@ impl ChangesetsController {
         Command::new("cargo")
             .arg("update")
             .flag("--workspace")
-            .run()?;
+            .run();
 
         // Update other CHANGELOG files:
 
@@ -92,7 +92,7 @@ impl ChangesetsController {
             .args(["stash", "push"])
             .flag("--include-untracked")
             .property("--message", "applied changesets")
-            .run()?;
+            .run();
 
         println!();
         println!("Source files are now updated with the new version, and stored in a 'git stash'.");

--- a/crates/infra/cli/src/commands/publish/mkdocs/mod.rs
+++ b/crates/infra/cli/src/commands/publish/mkdocs/mod.rs
@@ -24,7 +24,9 @@ impl MkdocsController {
     pub fn execute(&self) -> Result<()> {
         match self.target {
             PublishTarget::MainBranch => Mkdocs::publish_main_branch(self.dry_run),
-            PublishTarget::LatestRelease => Mkdocs::publish_latest_release(self.dry_run),
-        }
+            PublishTarget::LatestRelease => Mkdocs::publish_latest_release(self.dry_run)?,
+        };
+
+        Ok(())
     }
 }

--- a/crates/infra/cli/src/commands/publish/npm/mod.rs
+++ b/crates/infra/cli/src/commands/publish/npm/mod.rs
@@ -70,5 +70,7 @@ fn publish_package(
         command = command.flag("--dry-run");
     }
 
-    command.run()
+    command.run();
+
+    Ok(())
 }

--- a/crates/infra/cli/src/commands/run/mod.rs
+++ b/crates/infra/cli/src/commands/run/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use infra_utils::commands::Command;
 use infra_utils::terminal::Terminal;
@@ -33,7 +32,7 @@ enum BinaryName {
 }
 
 impl RunController {
-    pub fn execute(&self) -> Result<()> {
+    pub fn execute(&self) {
         let bin = self.bin.clap_name();
 
         Terminal::step(format!("run {bin}"));
@@ -48,6 +47,6 @@ impl RunController {
             .property("--bin", bin)
             .arg("--")
             .args(&self.args)
-            .run()
+            .run();
     }
 }

--- a/crates/infra/cli/src/commands/setup/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/setup/cargo/mod.rs
@@ -1,8 +1,7 @@
-use anyhow::Result;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 
-pub fn setup_cargo() -> Result<()> {
+pub fn setup_cargo() {
     // The bootstrap bash script defined in '$REPO_ROOT/scripts/_common.sh'
     // installs the 'minimal' profile of the '$RUST_STABLE_VERSION' toolchain.
     // This includes the following components:
@@ -13,46 +12,41 @@ pub fn setup_cargo() -> Result<()> {
     //
     // Which are enough to run infra scripts.
     // But we need these additional optional components for local development:
-    rustup_add_components(env!("RUST_STABLE_VERSION"), ["clippy"])?;
+    rustup_add_components(env!("RUST_STABLE_VERSION"), ["clippy"]);
     if !GitHub::is_running_in_ci() {
         rustup_add_components(
             env!("RUST_STABLE_VERSION"),
             ["rust-analyzer", "rust-docs", "rust-src"],
-        )?;
+        );
     }
 
     // Additionally, we also need 'rustfmt nightly', as we use experimental options.
     // So let's install the '$RUST_NIGHTLY_VERSION' toolchain along with the 'rustfmt' component.
-    rustup_install_toolchain(env!("RUST_NIGHTLY_VERSION"))?;
-    rustup_add_components(env!("RUST_NIGHTLY_VERSION"), ["rustfmt"])?;
+    rustup_install_toolchain(env!("RUST_NIGHTLY_VERSION"));
+    rustup_add_components(env!("RUST_NIGHTLY_VERSION"), ["rustfmt"]);
 
     // Make sure we have the latest dependencies:
-    run_cargo_fetch()?;
-
-    Ok(())
+    run_cargo_fetch();
 }
 
-fn rustup_install_toolchain(toolchain: &str) -> Result<()> {
+fn rustup_install_toolchain(toolchain: &str) {
     Command::new("rustup")
         .arg("install")
         .flag("--no-self-update")
         .property("--profile", "minimal")
         .arg(toolchain)
-        .run()
+        .run();
 }
 
-fn rustup_add_components(
-    toolchain: &str,
-    components: impl IntoIterator<Item = impl Into<String>>,
-) -> Result<()> {
+fn rustup_add_components(toolchain: &str, components: impl IntoIterator<Item = impl Into<String>>) {
     Command::new("rustup")
         .args(["component", "add"])
         .property("--toolchain", toolchain)
         .args(components)
-        .run()
+        .run();
 }
 
-fn run_cargo_fetch() -> Result<()> {
+fn run_cargo_fetch() {
     let mut command = Command::new("cargo").arg("fetch");
 
     if GitHub::is_running_in_ci() {
@@ -61,5 +55,5 @@ fn run_cargo_fetch() -> Result<()> {
         command = command.flag("--locked");
     }
 
-    command.run()
+    command.run();
 }

--- a/crates/infra/cli/src/commands/setup/git/mod.rs
+++ b/crates/infra/cli/src/commands/setup/git/mod.rs
@@ -1,22 +1,19 @@
-use anyhow::Result;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 
-pub fn setup_git() -> Result<()> {
+pub fn setup_git() {
     if !GitHub::is_running_in_ci() {
         println!("No need to modify local dev environments.");
-        return Ok(());
+        return;
     }
 
     Command::new("git")
         .arg("config")
         .property("user.name", "github-actions")
-        .run()?;
+        .run();
 
     Command::new("git")
         .arg("config")
         .property("user.email", "github-actions@users.noreply.github.com")
-        .run()?;
-
-    Ok(())
+        .run();
 }

--- a/crates/infra/cli/src/commands/setup/mod.rs
+++ b/crates/infra/cli/src/commands/setup/mod.rs
@@ -49,8 +49,10 @@ impl OrderedCommand for SetupCommand {
             SetupCommand::Git => setup_git(),
             SetupCommand::Cargo => setup_cargo(),
             SetupCommand::Npm => setup_npm(),
-            SetupCommand::Pipenv => setup_pipenv(),
-            SetupCommand::ShellCompletions => setup_shell_completions(),
-        }
+            SetupCommand::Pipenv => setup_pipenv()?,
+            SetupCommand::ShellCompletions => setup_shell_completions()?,
+        };
+
+        Ok(())
     }
 }

--- a/crates/infra/cli/src/commands/setup/npm/mod.rs
+++ b/crates/infra/cli/src/commands/setup/npm/mod.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 
-pub fn setup_npm() -> Result<()> {
+pub fn setup_npm() {
     if GitHub::is_running_in_ci() {
-        Command::new("npm").arg("ci").run()
+        Command::new("npm").arg("ci").run();
     } else {
-        Command::new("npm").arg("install").run()
+        Command::new("npm").arg("install").run();
     }
 }

--- a/crates/infra/cli/src/commands/test/mod.rs
+++ b/crates/infra/cli/src/commands/test/mod.rs
@@ -31,9 +31,11 @@ impl OrderedCommand for TestCommand {
         Terminal::step(format!("test {name}", name = self.clap_name()));
 
         match self {
-            TestCommand::Cargo => test_cargo(),
+            TestCommand::Cargo => test_cargo()?,
             TestCommand::Npm => test_npm(),
-        }
+        };
+
+        Ok(())
     }
 }
 
@@ -49,9 +51,11 @@ fn test_cargo() -> Result<()> {
         .flag("--examples")
         .flag("--no-fail-fast")
         .add_build_rustflags()
-        .run()
+        .run();
+
+    Ok(())
 }
 
-fn test_npm() -> Result<()> {
-    Command::new("jest").run()
+fn test_npm() {
+    Command::new("jest").run();
 }

--- a/crates/infra/cli/src/commands/watch/mod.rs
+++ b/crates/infra/cli/src/commands/watch/mod.rs
@@ -27,11 +27,9 @@ impl OrderedCommand for WatchCommand {
         Terminal::step(format!("watch {name}", name = self.clap_name()));
 
         match self {
-            WatchCommand::Mkdocs => watch_mkdocs(),
-        }
-    }
-}
+            WatchCommand::Mkdocs => Mkdocs::watch(),
+        };
 
-fn watch_mkdocs() -> Result<()> {
-    Mkdocs::watch()
+        Ok(())
+    }
 }

--- a/crates/infra/cli/src/toolchains/mkdocs/mod.rs
+++ b/crates/infra/cli/src/toolchains/mkdocs/mod.rs
@@ -11,11 +11,11 @@ use crate::utils::DryRun;
 pub struct Mkdocs;
 
 impl Mkdocs {
-    pub fn check() -> Result<()> {
-        mkdocs().arg("build").flag("--clean").flag("--strict").run()
+    pub fn check() {
+        mkdocs().arg("build").flag("--clean").flag("--strict").run();
     }
 
-    pub fn watch() -> Result<()> {
+    pub fn watch() {
         // _MKDOCS_WATCH_PORT_ | keep in sync with the port number defined in "$REPO_ROOT/.devcontainer/devcontainer.json"
         const PORT: usize = 5353;
 
@@ -24,11 +24,11 @@ impl Mkdocs {
             .flag("--clean")
             .flag("--watch-theme")
             .property("--dev-addr", format!("localhost:{PORT}"))
-            .run()
+            .run();
     }
 
-    pub fn publish_main_branch(dry_run: DryRun) -> Result<()> {
-        fetch_latest_remote()?;
+    pub fn publish_main_branch(dry_run: DryRun) {
+        fetch_latest_remote();
 
         let mut command = mike().args(["deploy", "main"]);
 
@@ -36,15 +36,15 @@ impl Mkdocs {
             command = command.flag("--push");
         }
 
-        command.run()
+        command.run();
     }
 
     pub fn publish_latest_release(dry_run: DryRun) -> Result<()> {
-        fetch_latest_remote()?;
+        fetch_latest_remote();
 
         let version = CargoWorkspace::local_version()?.to_string();
 
-        if mike().args(["list", &version]).run().is_ok() {
+        if mike().args(["list", &version]).evaluate().is_ok() {
             println!("Version '{version}' is already published.");
             return Ok(());
         }
@@ -57,15 +57,17 @@ impl Mkdocs {
             command = command.flag("--push");
         }
 
-        command.run()
+        command.run();
+
+        Ok(())
     }
 }
 
-fn fetch_latest_remote() -> Result<()> {
+fn fetch_latest_remote() {
     Command::new("git")
         .args(["fetch", "origin", "gh-pages"])
         .property("--depth", "1")
-        .run()
+        .run();
 }
 
 fn mkdocs() -> Command {

--- a/crates/infra/cli/src/toolchains/napi/cli.rs
+++ b/crates/infra/cli/src/toolchains/napi/cli.rs
@@ -60,7 +60,7 @@ impl NapiCli {
             }
         };
 
-        command.run()?;
+        command.run();
 
         glibc::ensure_correct_glibc_for_vscode(resolver, output_dir, target)?;
 

--- a/crates/infra/cli/src/toolchains/napi/compiler.rs
+++ b/crates/infra/cli/src/toolchains/napi/compiler.rs
@@ -62,7 +62,7 @@ fn compile_all_targets(resolver: NapiResolver) -> Result<Vec<PathBuf>> {
     Command::new("rustup")
         .args(["target", "add"])
         .args(&targets)
-        .run()?;
+        .run();
 
     // Needed for cross-compiling windows targets:
     CargoWorkspace::install_binary("cargo-xwin")?;
@@ -127,7 +127,7 @@ fn compile_root_package(resolver: NapiResolver, node_binary: Option<&Path>) -> R
         .property("--outDir", output_dir.unwrap_str())
         .property("--declaration", "true")
         .property("--noEmit", "false")
-        .run()?;
+        .run();
 
     for file_name in &["package.json", "CHANGELOG.md", "LICENSE", "README.md"] {
         let source = package_dir.join(file_name);

--- a/crates/infra/cli/src/toolchains/napi/glibc.rs
+++ b/crates/infra/cli/src/toolchains/napi/glibc.rs
@@ -109,7 +109,7 @@ pub fn ensure_correct_glibc_for_vscode(
             .flag("--release")
             .property("--target", format!("{target_triple}.{target_glibc}"))
             .property("--target-dir", zigbuild_output.path().to_string_lossy())
-            .run()?;
+            .run();
 
         // Overwrite the existing artifact with the cross-compiled one.
         let zigbuild_output = zigbuild_output.into_path();

--- a/crates/infra/cli/src/toolchains/pipenv/mod.rs
+++ b/crates/infra/cli/src/toolchains/pipenv/mod.rs
@@ -24,7 +24,7 @@ impl PipEnv {
         Command::new("pip3")
             .arg("install")
             .arg(format!("pipenv{version}"))
-            .run()?;
+            .run();
 
         let mut command = Command::new("python3")
             .property("-m", "pipenv")
@@ -34,7 +34,7 @@ impl PipEnv {
             command = command.flag("--deploy");
         }
 
-        command.run()?;
+        command.run();
 
         Ok(())
     }

--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -44,7 +44,9 @@ impl CargoWorkspace {
                 .property("--rev", rev),
         };
 
-        command.run()
+        command.run();
+
+        Ok(())
     }
 
     pub fn is_running_inside_build_scripts() -> bool {
@@ -107,7 +109,9 @@ impl CargoWorkspace {
             .arg("set-version")
             .flag("--workspace")
             .arg(new_version.to_string())
-            .run()
+            .run();
+
+        Ok(())
     }
 }
 

--- a/crates/infra/utils/src/git/mod.rs
+++ b/crates/infra/utils/src/git/mod.rs
@@ -52,19 +52,19 @@ impl TemporaryChangeset {
         Command::new("git")
             .arg("checkout")
             .property("-b", &self.head_branch)
-            .run()?;
+            .run();
 
         Command::new("git")
             .arg("add")
             .args(local_changes.iter().map(|path| path.unwrap_str()))
-            .run()?;
+            .run();
 
-        Command::new("git").arg("diff").flag("--cached").run()?;
+        Command::new("git").arg("diff").flag("--cached").run();
 
         Command::new("git")
             .arg("commit")
             .property("--message", &self.message)
-            .run()?;
+            .run();
 
         Ok(())
     }
@@ -80,12 +80,12 @@ impl TemporaryChangeset {
         Command::new("git")
             .arg("checkout")
             .arg(&self.base_branch)
-            .run()?;
+            .run();
 
         Command::new("git")
             .arg("branch")
             .property("-D", &self.head_branch)
-            .run()?;
+            .run();
 
         Ok(())
     }

--- a/crates/infra/utils/src/github/mod.rs
+++ b/crates/infra/utils/src/github/mod.rs
@@ -1,7 +1,7 @@
 use std::env::var;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Ok, Result};
 use semver::Version;
 use serde::Deserialize;
 
@@ -67,10 +67,12 @@ impl GitHub {
         std::fs::create_dir_all(notes_file.unwrap_parent())?;
         notes_file.write_string(notes)?;
 
-        return Command::new("gh")
+        Command::new("gh")
             .args(["release", "create", tag_name.as_ref()])
             .property("--title", tag_name.as_ref())
             .property("--notes-file", notes_file.unwrap_str())
             .run();
+
+        Ok(())
     }
 }

--- a/crates/solidity/testing/sanctuary/src/datasets.rs
+++ b/crates/solidity/testing/sanctuary/src/datasets.rs
@@ -61,13 +61,13 @@ impl DataSet {
         &self.directories
     }
 
-    pub fn checkout_directory(&self, directory: &str) -> Result<&Vec<SourceFile>> {
+    pub fn checkout_directory(&self, directory: &str) -> &Vec<SourceFile> {
         // Make sure to reset any local changes, in case some were made during local development/debugging:
         Command::new("git")
             .arg("reset")
             .flag("--hard")
             .current_dir(&self.repo_dir)
-            .run()?;
+            .run();
 
         let relative_path = format!("contracts/{network}/{directory}", network = self.network);
 
@@ -75,9 +75,9 @@ impl DataSet {
             .arg("sparse-checkout")
             .property("set", relative_path)
             .current_dir(&self.repo_dir)
-            .run()?;
+            .run();
 
-        Ok(&self.directories[directory])
+        &self.directories[directory]
     }
 }
 
@@ -94,25 +94,22 @@ fn clone_repository(chain: &Chain) -> Result<PathBuf> {
             .property("--depth", "1")
             .property("--filter", "blob:none")
             .flag("--no-checkout")
-            .run()?;
+            .run();
     }
 
     Command::new("git")
         .arg("sparse-checkout")
         .property("set", "--cone")
         .current_dir(&repo_dir)
-        .run()?;
+        .run();
 
     Command::new("git")
         .arg("checkout")
         .arg("origin/HEAD")
         .current_dir(&repo_dir)
-        .run()?;
+        .run();
 
-    Command::new("git")
-        .arg("pull")
-        .current_dir(&repo_dir)
-        .run()?;
+    Command::new("git").arg("pull").current_dir(&repo_dir).run();
 
     Ok(repo_dir)
 }

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     for directory in directories {
         Terminal::step(format!("testing directory '{directory}'"));
 
-        let files = dataset.checkout_directory(directory)?;
+        let files = dataset.checkout_directory(directory);
 
         events.start_directory(files.len());
 


### PR DESCRIPTION
Release pipeline is [currently failing](https://github.com/NomicFoundation/slang/actions/runs/10281343571/job/28451407526) due to a tiny bug in `Command::run()`, where it returns a `Result<()>` even though it is panicking on error. This PR fixes that, and fixes all callsites to not expect a result.

Just a mechanical find/replace. The only functional change (the bug fix) is in `crates/infra/cli/src/toolchains/mkdocs/mod.rs` to use `Command::evaluate()` instead to check for the sub-process result.