### PR TITLE
Implement binding rules for control statements

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -526,7 +526,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Statements
+;;; Expressions & declaration statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; In the general case for statements the structure is [Statement [StmtVariant]]
@@ -743,6 +743,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @error_ident.left -> @stmt.lexical_scope
 }
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Other statements
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@stmt [Statement [UncheckedBlock @block block: [Block]]] {
+  edge @block.lexical_scope -> @stmt.lexical_scope
+}
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -27,78 +27,6 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge export -> @source_unit.defs
 }
 
-;; Definition entities that can appear at the source unit level
-;; We define them individually to get better variable names when debugging
-;; For all of the following:
-;; - lexical_scope is the node that connect upwards for binding resolution
-;; - def provides the definition entry for the entity (aka. the name)
-;; - members is for internal use and it's where the nested definitions are found
-
-@contract [ContractDefinition] {
-  node @contract.lexical_scope
-  node @contract.def
-  node @contract.members
-  node @contract.type_members
-
-  edge @contract.lexical_scope -> @contract.members
-  edge @contract.lexical_scope -> @contract.type_members
-}
-
-@interface [InterfaceDefinition] {
-  node @interface.lexical_scope
-  node @interface.def
-  node @interface.members
-  node @interface.type_members
-
-  edge @interface.lexical_scope -> @interface.members
-  edge @interface.lexical_scope -> @interface.type_members
-}
-
-@library [LibraryDefinition] {
-  node @library.lexical_scope
-  node @library.def
-  node @library.members
-
-  edge @library.lexical_scope -> @library.members
-}
-
-@struct [StructDefinition] {
-  node @struct.lexical_scope
-  node @struct.def
-  node @struct.members
-}
-
-@enum [EnumDefinition] {
-  node @enum.lexical_scope
-  node @enum.def
-  node @enum.members
-}
-
-@function [FunctionDefinition] {
-  node @function.lexical_scope
-  node @function.def
-}
-
-@constant [ConstantDefinition] {
-  node @constant.lexical_scope
-  node @constant.def
-}
-
-@error [ErrorDefinition] {
-  node @error.lexical_scope
-  node @error.def
-}
-
-@value_type [UserDefinedValueTypeDefinition] {
-  node @value_type.lexical_scope
-  node @value_type.def
-}
-
-@event [EventDefinition] {
-  node @event.lexical_scope
-  node @event.def
-}
-
 ;; Top-level definitions...
 @source_unit [SourceUnit [SourceUnitMembers
     [SourceUnitMember @unit_member (
@@ -115,19 +43,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
     )]
 ]] {
   edge @unit_member.lexical_scope -> @source_unit.lexical_scope
-
-  ;; ... are available in the file's lexical scope
   edge @source_unit.lexical_scope -> @unit_member.def
-
-  ;; ... and are exported in the file
   edge @source_unit.defs -> @unit_member.def
 }
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Imports
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
+;; ... and imports
 @source_unit [SourceUnit [SourceUnitMembers
      [SourceUnitMember [ImportDirective
          [ImportClause @import (
@@ -142,6 +62,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
    edge @source_unit.lexical_scope -> @import.defs
 }
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Imports
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 [ImportClause [_ @path path: [StringLiteral]]] {
   ;; This node represents the imported file and the @path.import node is used by
   ;; all subsequent import rules
@@ -151,11 +76,9 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
       let resolved_path = (resolve-path FILE_PATH $1)
       attr (@path.import) push_symbol = resolved_path
     }
-    ;; TODO: if there are other cases possible, we should signal it as an error
   }
   edge @path.import -> ROOT_NODE
 }
-
 
 ;;; `import <URI>`
 @import [PathImport @path path: [StringLiteral] .] {
@@ -248,8 +171,18 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Named definitions (contracts, functions, libraries, etc.)
+;;; Contracts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@contract [ContractDefinition] {
+  node @contract.lexical_scope
+  node @contract.def
+  node @contract.members
+  node @contract.type_members
+
+  edge @contract.lexical_scope -> @contract.members
+  edge @contract.lexical_scope -> @contract.type_members
+}
 
 @contract [ContractDefinition @name name: [Identifier]] {
   node def
@@ -258,21 +191,64 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
   edge @contract.def -> def
 
+  ;; "instance" like access path
   node type_def
   attr (type_def) pop_symbol = "@typeof"
-
   node member
   attr (member) pop_symbol = "."
-
   edge def -> type_def
   edge type_def -> member
   edge member -> @contract.members
 
+  ;; "namespace" like access path
   node type_member
   attr (type_member) pop_symbol = "."
   edge def -> type_member
-
   edge type_member -> @contract.type_members
+}
+
+@contract [ContractDefinition [ContractMembers
+    [ContractMember @member (
+          [EnumDefinition]
+        | [StructDefinition]
+        | [EventDefinition]
+        | [ErrorDefinition]
+    )]
+]] {
+  edge @member.lexical_scope -> @contract.lexical_scope
+  edge @contract.type_members -> @member.def
+}
+
+@contract [ContractDefinition [ContractMembers
+    [ContractMember @member (
+          [FunctionDefinition]
+        | [StateVariableDefinition]
+    )]
+]] {
+  edge @member.lexical_scope -> @contract.lexical_scope
+  edge @contract.lexical_scope -> @member.def
+}
+
+@contract [ContractDefinition members: [ContractMembers
+    item: [ContractMember @function variant: [FunctionDefinition]]
+]] {
+  ;; Contract functions are also accessible for an instance of the contract
+  edge @contract.members -> @function.def
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Interfaces
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@interface [InterfaceDefinition] {
+  node @interface.lexical_scope
+  node @interface.def
+  node @interface.members
+  node @interface.type_members
+
+  edge @interface.lexical_scope -> @interface.members
+  edge @interface.lexical_scope -> @interface.type_members
 }
 
 @interface [InterfaceDefinition @name name: [Identifier]] {
@@ -282,21 +258,52 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
   edge @interface.def -> def
 
+  ;; "instance" like access path
   node type_def
   attr (type_def) pop_symbol = "@typeof"
-
   node member
   attr (member) pop_symbol = "."
-
   edge def -> type_def
   edge type_def -> member
   edge member -> @interface.members
 
+  ;; "namespace" like access path
   node type_member
   attr (type_member) pop_symbol = "."
   edge def -> type_member
-
   edge type_member -> @interface.type_members
+}
+
+@interface [InterfaceDefinition [InterfaceMembers
+    [ContractMember @member (
+          [EnumDefinition]
+        | [StructDefinition]
+        | [EventDefinition]
+        | [ErrorDefinition]
+    )]
+]] {
+  edge @member.lexical_scope -> @interface.lexical_scope
+  edge @interface.type_members -> @member.def
+}
+
+@interface [InterfaceDefinition members: [InterfaceMembers
+    item: [ContractMember @function variant: [FunctionDefinition]]
+]] {
+  edge @function.lexical_scope -> @interface.lexical_scope
+  edge @interface.members -> @function.def
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Libraries
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@library [LibraryDefinition] {
+  node @library.lexical_scope
+  node @library.def
+  node @library.members
+
+  edge @library.lexical_scope -> @library.members
 }
 
 @library [LibraryDefinition @name name: [Identifier]] {
@@ -313,12 +320,17 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge member -> @library.members
 }
 
-@function [FunctionDefinition name: [FunctionName @name [Identifier]]] {
-  node def
-  attr (def) node_definition = @name
-  attr (def) definiens_node = @function
-
-  edge @function.def -> def
+@library [LibraryDefinition [LibraryMembers
+    [ContractMember @member (
+          [FunctionDefinition]
+        | [EnumDefinition]
+        | [StructDefinition]
+        | [EventDefinition]
+        | [ErrorDefinition]
+    )]
+]] {
+  edge @member.lexical_scope -> @library.lexical_scope
+  edge @library.members -> @member.def
 }
 
 
@@ -335,11 +347,6 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   node @type_name.output
 }
 
-@id_path [IdentifierPath] {
-  node @id_path.left
-  node @id_path.right
-}
-
 @type_name [TypeName @id_path [IdentifierPath]] {
   ;; For an identifier path used as a type, the left-most element is the one
   ;; that connects to the parent lexical scope, because the name resolution
@@ -352,6 +359,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 ;; The identifier path constructs a path of nodes connected from right to left
+@id_path [IdentifierPath] {
+  node @id_path.left
+  node @id_path.right
+}
+
 [IdentifierPath @name [Identifier]] {
   node @name.ref
   attr (@name.ref) node_reference = @name
@@ -375,7 +387,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Functions
+;;; Function and parameter declarations
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 @param [Parameter] {
@@ -411,6 +423,19 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @params.defs -> @param.def
 }
 
+@function [FunctionDefinition] {
+  node @function.lexical_scope
+  node @function.def
+}
+
+@function [FunctionDefinition name: [FunctionName @name [Identifier]]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @function
+
+  edge @function.def -> def
+}
+
 @function [FunctionDefinition @params parameters: [ParametersDeclaration]] {
   edge @params.lexical_scope -> @function.lexical_scope
 
@@ -429,37 +454,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   attr (@function.lexical_scope -> @return_params.defs) precedence = 1
 }
 
-;; Connect function's lexical scope with the enclosing
-;; contract/interface/library, and make the function itself available in the
-;; enclosing contract/interface/library scope.
-;; NB. free-functions (ie. those defined at the file's level) are already
-;; covered above
-
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @function variant: [FunctionDefinition]]
-]] {
-  edge @function.lexical_scope -> @contract.lexical_scope
-  edge @contract.members -> @function.def
+;; Connect the function body's block lexical scope to the function
+@function [FunctionDefinition [FunctionBody @block [Block]]] {
+  edge @block.lexical_scope -> @function.lexical_scope
 }
-
-@interface [InterfaceDefinition members: [InterfaceMembers
-    item: [ContractMember @function variant: [FunctionDefinition]]
-]] {
-  edge @function.lexical_scope -> @interface.lexical_scope
-  edge @interface.members -> @function.def
-}
-
-@library [LibraryDefinition members: [LibraryMembers
-    item: [ContractMember @function variant: [FunctionDefinition]]
-]] {
-  edge @function.lexical_scope -> @library.lexical_scope
-  edge @library.members -> @function.def
-}
-
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Blocks
+;;; Blocks and generic statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 @block [Block] {
@@ -467,30 +469,10 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   node @block.defs
 }
 
-@stmt [Statement] {
-  node @stmt.lexical_scope
-  node @stmt.defs
-
-  if (version-matches ">= 0.5.0") {
-    ;; For Solidity >= 0.5.0, definitions are immediately available in the
-    ;; statement scope. For < 0.5.0 this is also true, but resolved through the
-    ;; enclosing block's lexical scope.
-    edge @stmt.lexical_scope -> @stmt.defs
-    attr (@stmt.lexical_scope -> @stmt.defs) precedence = 1
-  }
-}
-
 ;; The first statement in a block
 @block [Block [Statements . @stmt [Statement]]] {
   if (version-matches ">= 0.5.0") {
     edge @stmt.lexical_scope -> @block.lexical_scope
-  }
-}
-
-;; Two consecutive statements
-[Statements @left_stmt [Statement] . @right_stmt [Statement]] {
-  if (version-matches ">= 0.5.0") {
-    edge @right_stmt.lexical_scope -> @left_stmt.lexical_scope
   }
 }
 
@@ -509,6 +491,26 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
+;; Two consecutive statements
+[Statements @left_stmt [Statement] . @right_stmt [Statement]] {
+  if (version-matches ">= 0.5.0") {
+    edge @right_stmt.lexical_scope -> @left_stmt.lexical_scope
+  }
+}
+
+@stmt [Statement] {
+  node @stmt.lexical_scope
+  node @stmt.defs
+
+  if (version-matches ">= 0.5.0") {
+    ;; For Solidity >= 0.5.0, definitions are immediately available in the
+    ;; statement scope. For < 0.5.0 this is also true, but resolved through the
+    ;; enclosing block's lexical scope.
+    edge @stmt.lexical_scope -> @stmt.defs
+    attr (@stmt.lexical_scope -> @stmt.defs) precedence = 1
+  }
+}
+
 ;; Statements of type block
 @stmt [Statement @block variant: [Block]] {
   edge @block.lexical_scope -> @stmt.lexical_scope
@@ -519,33 +521,40 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
-;; Connect the function body's block lexical scope to the function
-@function [FunctionDefinition [FunctionBody @block [Block]]] {
-  edge @block.lexical_scope -> @function.lexical_scope
-}
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Expressions & declaration statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; In the general case for statements the structure is [Statement [StmtVariant]]
-;; and we will define the scoped nodes .lexical_scope and (possibly) .defs in
-;; the Statement CST node.
+;; In general for statements the structure is [Statement [StmtVariant]] and we
+;; will define the scoped nodes .lexical_scope and (possibly) .defs in the
+;; Statement CST node, skipping scoped nodes in the variant of the statement.
 ;;
-;; For expression statements, variable and tuple declarations we defined
-;; separately from the enclosing statement to be able to use them in for
+;; For expression statements, variable and tuple declarations we define them
+;; separately from the enclosing statement to be able to use them in `for`
 ;; initialization and condition clauses directly. Also, because we intend to
 ;; reuse them, all of them must have both a .lexical_scope and .defs scoped
-;; nodes.
+;; nodes (even though .defs doesn't make sense for ExpressionStatement)
+
+@stmt [Statement @expr_stmt [ExpressionStatement]] {
+  edge @expr_stmt.lexical_scope -> @stmt.lexical_scope
+}
 
 @expr_stmt [ExpressionStatement] {
   node @expr_stmt.lexical_scope
   node @expr_stmt.defs
 }
 
-@stmt [Statement @expr_stmt [ExpressionStatement]] {
-  edge @expr_stmt.lexical_scope -> @stmt.lexical_scope
+@expr_stmt [ExpressionStatement @expr [Expression]] {
+  edge @expr.lexical_scope -> @expr_stmt.lexical_scope
+}
+
+
+;;; Variable declaration statements
+
+@stmt [Statement @var_decl [VariableDeclarationStatement]] {
+  edge @var_decl.lexical_scope -> @stmt.lexical_scope
+  edge @stmt.defs -> @var_decl.defs
 }
 
 @var_decl [VariableDeclarationStatement] {
@@ -553,23 +562,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   node @var_decl.defs
 }
 
-@stmt [Statement @var_decl [VariableDeclarationStatement]] {
-  edge @var_decl.lexical_scope -> @stmt.lexical_scope
-  edge @stmt.defs -> @var_decl.defs
+@var_decl [VariableDeclarationStatement
+    value: [VariableDeclarationValue @expr [Expression]]
+] {
+  edge @expr.lexical_scope -> @var_decl.lexical_scope
 }
-
-@tuple_decon [TupleDeconstructionStatement] {
-  node @tuple_decon.lexical_scope
-  node @tuple_decon.defs
-}
-
-@stmt [Statement @tuple_decon [TupleDeconstructionStatement]] {
-  edge @tuple_decon.lexical_scope -> @stmt.lexical_scope
-  edge @stmt.defs -> @tuple_decon.defs
-}
-
-
-;;; Variable declaration and tuple deconstruction statements introduce new definitionns
 
 @var_decl [VariableDeclarationStatement
     [VariableDeclarationType @var_type [TypeName]]
@@ -587,6 +584,25 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
   edge def -> typeof
   edge typeof -> @var_type.output
+}
+
+
+;;; Tuple deconstruction statements
+
+@stmt [Statement @tuple_decon [TupleDeconstructionStatement]] {
+  edge @tuple_decon.lexical_scope -> @stmt.lexical_scope
+  edge @stmt.defs -> @tuple_decon.defs
+}
+
+@tuple_decon [TupleDeconstructionStatement] {
+  node @tuple_decon.lexical_scope
+  node @tuple_decon.defs
+}
+
+@tuple_decon [TupleDeconstructionStatement
+    @expr expression: [Expression]
+] {
+  edge @expr.lexical_scope -> @tuple_decon.lexical_scope
 }
 
 @tuple_decon [TupleDeconstructionStatement [TupleDeconstructionElements
@@ -632,6 +648,10 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 ;; If conditionals
 
+@stmt [Statement [IfStatement @condition condition: [Expression]]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
 @stmt [Statement [IfStatement @body body: [Statement]]] {
   edge @body.lexical_scope -> @stmt.lexical_scope
   if (version-matches "< 0.5.0") {
@@ -647,17 +667,6 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 ;; For loops
-
-@stmt [Statement [ForStatement @body body: [Statement]]] {
-  node @stmt.init_defs
-
-  edge @body.lexical_scope -> @stmt.lexical_scope
-  edge @body.lexical_scope -> @stmt.init_defs
-  if (version-matches "< 0.5.0") {
-    edge @stmt.defs -> @body.defs
-    edge @stmt.defs -> @stmt.init_defs
-  }
-}
 
 @stmt [Statement [ForStatement
     initialization: [ForStatementInitialization
@@ -677,7 +686,27 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @cond_stmt.lexical_scope -> @stmt.init_defs
 }
 
+@stmt [Statement [ForStatement @iter_expr iterator: [Expression]]] {
+  edge @iter_expr.lexical_scope -> @stmt.lexical_scope
+  edge @iter_expr.lexical_scope -> @stmt.init_defs
+}
+
+@stmt [Statement [ForStatement @body body: [Statement]]] {
+  node @stmt.init_defs
+
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  edge @body.lexical_scope -> @stmt.init_defs
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+    edge @stmt.defs -> @stmt.init_defs
+  }
+}
+
 ;; While loops
+
+@stmt [Statement [WhileStatement @condition condition: [Expression]]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
 
 @stmt [Statement [WhileStatement @body body: [Statement]]] {
   edge @body.lexical_scope -> @stmt.lexical_scope
@@ -695,10 +724,8 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
-;; Emit statements
-
-@stmt [Statement [EmitStatement @event_ident [IdentifierPath]]] {
-  edge @event_ident.left -> @stmt.lexical_scope
+@stmt [Statement [DoWhileStatement @condition condition: [Expression]]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
 }
 
 
@@ -707,6 +734,10 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;; Try-catch statements
+
+@stmt [Statement [TryStatement @expr expression: [Expression]]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
 
 @stmt [Statement [TryStatement @body body: [Block]]] {
   edge @body.lexical_scope -> @stmt.lexical_scope
@@ -743,11 +774,31 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @error_ident.left -> @stmt.lexical_scope
 }
 
+@stmt [Statement [RevertStatement @args [ArgumentsDeclaration]]] {
+  edge @args.lexical_scope -> @stmt.lexical_scope
+}
+
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Other statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; Return
+@stmt [Statement [ReturnStatement @expr [Expression]]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;;; Emit
+@stmt [Statement [EmitStatement
+    @event_ident [IdentifierPath]
+    @args [ArgumentsDeclaration]
+]] {
+  edge @event_ident.left -> @stmt.lexical_scope
+  edge @args.lexical_scope -> @stmt.lexical_scope
+}
+
+;;; Unchecked
 @stmt [Statement [UncheckedBlock @block block: [Block]]] {
   edge @block.lexical_scope -> @stmt.lexical_scope
 }
@@ -780,20 +831,22 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge typeof -> @type_name.output
 }
 
-;; NB. Even though the grammar allows it, state variables can only be declared
-;; inside contracts, and not interfaces or libraries. So, we will only bind
-;; contract state variables.
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @state_var variant: [StateVariableDefinition]]
-]] {
-  edge @state_var.lexical_scope -> @contract.lexical_scope
-  edge @contract.lexical_scope -> @state_var.def
+@state_var [StateVariableDefinition
+    value: [StateVariableDefinitionValue @expr [Expression]]
+] {
+  edge @expr.lexical_scope -> @state_var.lexical_scope
 }
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Enum definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@enum [EnumDefinition] {
+  node @enum.lexical_scope
+  node @enum.def
+  node @enum.members
+}
 
 @enum [EnumDefinition @name name: [Identifier]] {
   node def
@@ -819,32 +872,16 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @enum.members -> def
 }
 
-;; Make the enum available to the enclosing contract/interface/library.
-;; NB. top-level enums (ie. those defined at the file's level) are already
-;; covered above
-
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @enum variant: [EnumDefinition]]
-]] {
-  edge @contract.type_members -> @enum.def
-}
-
-@interface [InterfaceDefinition members: [InterfaceMembers
-    item: [ContractMember @enum variant: [EnumDefinition]]
-]] {
-  edge @interface.type_members -> @enum.def
-}
-
-@library [LibraryDefinition members: [LibraryMembers
-    item: [ContractMember @enum variant: [EnumDefinition]]
-]] {
-  edge @library.members -> @enum.def
-}
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Structure definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@struct [StructDefinition] {
+  node @struct.lexical_scope
+  node @struct.def
+  node @struct.members
+}
 
 @struct [StructDefinition @name name: [Identifier]] {
   node def
@@ -887,35 +924,15 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge typeof -> @type_name.output
 }
 
-;; Make the struct available to the enclosing contract/interface/library.
-;; NB. top-level enums (ie. those defined at the file's level) are already
-;; covered above
-
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @struct variant: [StructDefinition]]
-]] {
-  edge @struct.lexical_scope -> @contract.lexical_scope
-  edge @contract.type_members -> @struct.def
-}
-
-@interface [InterfaceDefinition members: [InterfaceMembers
-    item: [ContractMember @struct variant: [StructDefinition]]
-]] {
-  edge @struct.lexical_scope -> @interface.lexical_scope
-  edge @interface.type_members -> @struct.def
-}
-
-@library [LibraryDefinition members: [LibraryMembers
-    item: [ContractMember @struct variant: [StructDefinition]]
-]] {
-  edge @struct.lexical_scope -> @library.lexical_scope
-  edge @library.members -> @struct.def
-}
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Event definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@event [EventDefinition] {
+  node @event.lexical_scope
+  node @event.def
+}
 
 @event [EventDefinition @name name: [Identifier]] {
   node def
@@ -925,32 +942,15 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @event.def -> def
 }
 
-;; Make the event available to the enclosing contract/interface/library.
-;; NB. top-level events (ie. those defined at the file's level) are already
-;; covered above
-
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @event variant: [EventDefinition]]
-]] {
-  edge @contract.type_members -> @event.def
-}
-
-@interface [InterfaceDefinition members: [InterfaceMembers
-    item: [ContractMember @event variant: [EventDefinition]]
-]] {
-  edge @interface.type_members -> @event.def
-}
-
-@library [LibraryDefinition members: [LibraryMembers
-    item: [ContractMember @event variant: [EventDefinition]]
-]] {
-  edge @library.members -> @event.def
-}
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Error definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@error [ErrorDefinition] {
+  node @error.lexical_scope
+  node @error.def
+}
 
 @error [ErrorDefinition @name name: [Identifier]] {
   node def
@@ -960,26 +960,19 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @error.def -> def
 }
 
-;; Make the error available to the enclosing contract/interface/library.
-;; NB. top-level errors (ie. those defined at the file's level) are already
-;; covered above
 
-@contract [ContractDefinition members: [ContractMembers
-    item: [ContractMember @error variant: [ErrorDefinition]]
-]] {
-  edge @contract.type_members -> @error.def
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Other named definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@constant [ConstantDefinition] {
+  node @constant.lexical_scope
+  node @constant.def
 }
 
-@interface [InterfaceDefinition members: [InterfaceMembers
-    item: [ContractMember @error variant: [ErrorDefinition]]
-]] {
-  edge @interface.type_members -> @error.def
-}
-
-@library [LibraryDefinition members: [LibraryMembers
-    item: [ContractMember @error variant: [ErrorDefinition]]
-]] {
-  edge @library.members -> @error.def
+@value_type [UserDefinedValueTypeDefinition] {
+  node @value_type.lexical_scope
+  node @value_type.def
 }
 
 
@@ -998,71 +991,6 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @child.lexical_scope -> @expr.lexical_scope
 }
 
-;; Expressions statements
-@expr_stmt [ExpressionStatement @expr [Expression]] {
-  edge @expr.lexical_scope -> @expr_stmt.lexical_scope
-}
-
-;; Expressions used for variable declarations
-@var_decl [VariableDeclarationStatement
-    value: [VariableDeclarationValue @expr [Expression]]
-] {
-  edge @expr.lexical_scope -> @var_decl.lexical_scope
-}
-
-;; Expressions used for tuple deconstruction statements
-@tuple_decon [TupleDeconstructionStatement
-    @expr expression: [Expression]
-] {
-  edge @expr.lexical_scope -> @tuple_decon.lexical_scope
-}
-
-;; Expressions as if conditions
-@stmt [Statement [IfStatement @condition condition: [Expression]]] {
-  edge @condition.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Expressions in return statements
-@stmt [Statement [ReturnStatement @expr [Expression]]] {
-  edge @expr.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Expressions in for iterations
-@stmt [Statement [ForStatement
-    @iter_expr iterator: [Expression]
-]] {
-  edge @iter_expr.lexical_scope -> @stmt.lexical_scope
-  edge @iter_expr.lexical_scope -> @stmt.init_defs
-}
-
-;; Expressions in while conditions
-@stmt [Statement [WhileStatement
-    @condition condition: [Expression]
-]] {
-  edge @condition.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Expressions in do-while conditions
-@stmt [Statement [DoWhileStatement
-    @condition condition: [Expression]
-]] {
-  edge @condition.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Expressions in try statements
-@stmt [Statement [TryStatement
-    @expr expression: [Expression]
-]] {
-  edge @expr.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Expressions used for state variable declarations
-@state_var [StateVariableDefinition
-    value: [StateVariableDefinitionValue @expr [Expression]]
-] {
-  edge @expr.lexical_scope -> @state_var.lexical_scope
-}
-
 ;; Tuple expressions
 @tuple_expr [Expression [TupleExpression
     items: [TupleValues [TupleValue @expr [Expression]]]
@@ -1070,9 +998,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @expr.lexical_scope -> @tuple_expr.lexical_scope
 }
 
-
-;;; Identifier expressions
-
+;; Identifier expressions
 @expr [Expression @name variant: [Identifier]] {
   node ref
   attr (ref) node_reference = @name
@@ -1081,10 +1007,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @expr.output -> ref
 }
 
-
-;;; Member access expressions
-
-;; TODO: implement variant for `.address` member
+;; Member access expressions
 @expr [Expression [MemberAccessExpression
     @operand operand: [Expression]
     @name member: [Identifier]
@@ -1101,7 +1024,10 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @expr.output -> ref
 }
 
-;; TODO: implement `.output` link for other expression variants
+;; Type expressions
+@type_expr [Expression [TypeExpression @type [TypeName]]] {
+  edge @type.type_ref -> @type_expr.lexical_scope
+}
 
 
 ;;; Function call expressions
@@ -1123,9 +1049,6 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
   node ref
   attr (ref) node_reference = @name
-  ;; TODO: bind the named argument to the parameters definition of the function
-  ;; (is this possible given that function references are expressions?)
-  ;; Ditto for events emissions (where it should be possible for sure)
 }
 
 @args [ArgumentsDeclaration [NamedArgumentsDeclaration
@@ -1137,22 +1060,3 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 @funcall [Expression [FunctionCallExpression @args [ArgumentsDeclaration]]] {
   edge @args.lexical_scope -> @funcall.lexical_scope
 }
-
-;; Arguments to an event in an emit statement
-@stmt [Statement [EmitStatement @args [ArgumentsDeclaration]]] {
-  edge @args.lexical_scope -> @stmt.lexical_scope
-}
-
-;; Arguments to an error in a revert statement
-@stmt [Statement [RevertStatement @args [ArgumentsDeclaration]]] {
-  edge @args.lexical_scope -> @stmt.lexical_scope
-}
-
-
-;;; Type expressions
-
-@type_expr [Expression [TypeExpression @type [TypeName]]] {
-  edge @type.type_ref -> @type_expr.lexical_scope
-}
-
-

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -517,6 +517,25 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Control statements
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@stmt [Statement [IfStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
+}
+
+@stmt [Statement [IfStatement else_branch: [ElseBranch @else_body body: [Statement]]]] {
+  edge @else_body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @else_body.defs
+  }
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Declaration Statements introducing variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -751,7 +770,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 ;; Expressions as statements
-@stmt [Statement variant: [_ @expr [Expression]]] {
+@stmt [Statement variant: [ExpressionStatement @expr [Expression]]] {
   edge @expr.lexical_scope -> @stmt.lexical_scope
 }
 
@@ -759,6 +778,23 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 @stmt [Statement variant: [VariableDeclarationStatement
     value: [VariableDeclarationValue @expr [Expression]]
 ]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions used for tuple deconstruction statements
+@stmt [Statement [TupleDeconstructionStatement
+    @expr expression: [Expression]
+]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions as if conditions
+@stmt [Statement [IfStatement @condition condition: [Expression]]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in return statements
+@stmt [Statement [ReturnStatement @expr [Expression]]] {
   edge @expr.lexical_scope -> @stmt.lexical_scope
 }
 
@@ -849,3 +885,5 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 @type_expr [Expression [TypeExpression @type [TypeName]]] {
   edge @type.type_ref -> @type_expr.lexical_scope
 }
+
+

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -621,6 +621,8 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ;;; Control statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; If conditionals
+
 @stmt [Statement [IfStatement @body body: [Statement]]] {
   edge @body.lexical_scope -> @stmt.lexical_scope
   if (version-matches "< 0.5.0") {
@@ -635,9 +637,9 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
-@stmt [Statement [ForStatement
-    @body body: [Statement]
-]] {
+;; For loops
+
+@stmt [Statement [ForStatement @body body: [Statement]]] {
   node @stmt.init_defs
 
   edge @body.lexical_scope -> @stmt.lexical_scope
@@ -664,6 +666,24 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ]] {
   edge @cond_stmt.lexical_scope -> @stmt.lexical_scope
   edge @cond_stmt.lexical_scope -> @stmt.init_defs
+}
+
+;; While loops
+
+@stmt [Statement [WhileStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
+}
+
+;; Do-while loops
+
+@stmt [Statement [DoWhileStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
 }
 
 
@@ -877,6 +897,20 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ]] {
   edge @iter_expr.lexical_scope -> @stmt.lexical_scope
   edge @iter_expr.lexical_scope -> @stmt.init_defs
+}
+
+;; Expressions in while conditions
+@stmt [Statement [WhileStatement
+    @condition condition: [Expression]
+]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in do-while conditions
+@stmt [Statement [DoWhileStatement
+    @condition condition: [Expression]
+]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
 }
 
 ;; Expressions used for state variable declarations

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -246,6 +246,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge import -> @symbol.import
 }
 
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Named definitions (contracts, functions, libraries, etc.)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -400,24 +401,32 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge typeof -> @type_name.output
 }
 
-@function [FunctionDefinition parameters: [ParametersDeclaration
-    [Parameters @param item: [Parameter]]
-]] {
-  edge @param.lexical_scope -> @function.lexical_scope
+@params [ParametersDeclaration] {
+  node @params.lexical_scope
+  node @params.defs
+}
+
+@params [ParametersDeclaration [Parameters @param item: [Parameter]]] {
+  edge @param.lexical_scope -> @params.lexical_scope
+  edge @params.defs -> @param.def
+}
+
+@function [FunctionDefinition @params parameters: [ParametersDeclaration]] {
+  edge @params.lexical_scope -> @function.lexical_scope
 
   ;; Input parameters are available in the function scope
-  edge @function.lexical_scope -> @param.def
-  attr (@function.lexical_scope -> @param.def) precedence = 1
+  edge @function.lexical_scope -> @params.defs
+  attr (@function.lexical_scope -> @params.defs) precedence = 1
 }
 
 @function [FunctionDefinition returns: [ReturnsDeclaration
-    [ParametersDeclaration [Parameters @param item: [Parameter]]]
+    @return_params [ParametersDeclaration]
 ]] {
-  edge @param.lexical_scope -> @function.lexical_scope
+  edge @return_params.lexical_scope -> @function.lexical_scope
 
   ;; Return parameters are available in the function scope
-  edge @function.lexical_scope -> @param.def
-  attr (@function.lexical_scope -> @param.def) precedence = 1
+  edge @function.lexical_scope -> @return_params.defs
+  attr (@function.lexical_scope -> @return_params.defs) precedence = 1
 }
 
 ;; Connect function's lexical scope with the enclosing
@@ -694,6 +703,41 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Error handling
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Try-catch statements
+
+@stmt [Statement [TryStatement @body body: [Block]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+}
+
+@stmt [Statement [TryStatement
+    [ReturnsDeclaration @return_params [ParametersDeclaration]]
+    @body body: [Block]
+]] {
+  edge @return_params.lexical_scope -> @stmt.lexical_scope
+  edge @body.lexical_scope -> @return_params.defs
+  attr (@body.lexical_scope -> @return_params.defs) precedence = 1
+}
+
+@stmt [Statement [TryStatement [CatchClauses [CatchClause
+    @body body: [Block]
+]]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+}
+
+@stmt [Statement [TryStatement [CatchClauses [CatchClause
+    [CatchClauseError @catch_params parameters: [ParametersDeclaration]]
+    @body body: [Block]
+]]]] {
+  edge @catch_params.lexical_scope -> @stmt.lexical_scope
+  edge @body.lexical_scope -> @catch_params.defs
+  attr (@body.lexical_scope -> @catch_params.defs) precedence = 1
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; State Variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -865,8 +909,8 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @event.def -> def
 }
 
-;; Make the enum available to the enclosing contract/interface/library.
-;; NB. top-level enums (ie. those defined at the file's level) are already
+;; Make the event available to the enclosing contract/interface/library.
+;; NB. top-level events (ie. those defined at the file's level) are already
 ;; covered above
 
 @contract [ContractDefinition members: [ContractMembers
@@ -885,6 +929,41 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
     item: [ContractMember @event variant: [EventDefinition]]
 ]] {
   edge @library.members -> @event.def
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Error definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@error [ErrorDefinition @name name: [Identifier]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @error
+
+  edge @error.def -> def
+}
+
+;; Make the error available to the enclosing contract/interface/library.
+;; NB. top-level errors (ie. those defined at the file's level) are already
+;; covered above
+
+@contract [ContractDefinition members: [ContractMembers
+    item: [ContractMember @error variant: [ErrorDefinition]]
+]] {
+  edge @contract.type_members -> @error.def
+}
+
+@interface [InterfaceDefinition members: [InterfaceMembers
+    item: [ContractMember @error variant: [ErrorDefinition]]
+]] {
+  edge @interface.type_members -> @error.def
+}
+
+@library [LibraryDefinition members: [LibraryMembers
+    item: [ContractMember @error variant: [ErrorDefinition]]
+]] {
+  edge @library.members -> @error.def
 }
 
 
@@ -952,6 +1031,13 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
     @condition condition: [Expression]
 ]] {
   edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in try statements
+@stmt [Statement [TryStatement
+    @expr expression: [Expression]
+]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
 }
 
 ;; Expressions used for state variable declarations

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -686,6 +686,12 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
+;; Emit statements
+
+@stmt [Statement [EmitStatement @event_ident [IdentifierPath]]] {
+  edge @event_ident.left -> @stmt.lexical_scope
+}
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; State Variables
@@ -848,6 +854,41 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Event definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@event [EventDefinition @name name: [Identifier]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @event
+
+  edge @event.def -> def
+}
+
+;; Make the enum available to the enclosing contract/interface/library.
+;; NB. top-level enums (ie. those defined at the file's level) are already
+;; covered above
+
+@contract [ContractDefinition members: [ContractMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @contract.type_members -> @event.def
+}
+
+@interface [InterfaceDefinition members: [InterfaceMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @interface.type_members -> @event.def
+}
+
+@library [LibraryDefinition members: [LibraryMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @library.members -> @event.def
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Expressions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -982,6 +1023,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   attr (ref) node_reference = @name
   ;; TODO: bind the named argument to the parameters definition of the function
   ;; (is this possible given that function references are expressions?)
+  ;; Ditto for events emissions (where it should be possible for sure)
 }
 
 @args [ArgumentsDeclaration [NamedArgumentsDeclaration
@@ -992,6 +1034,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 @funcall [Expression [FunctionCallExpression @args [ArgumentsDeclaration]]] {
   edge @args.lexical_scope -> @funcall.lexical_scope
+}
+
+;; Arguments to an event in an emit statement
+@stmt [Statement [EmitStatement @args [ArgumentsDeclaration]]] {
+  edge @args.lexical_scope -> @stmt.lexical_scope
 }
 
 

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -517,6 +517,107 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Statements
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; In the general case for statements the structure is [Statement [StmtVariant]]
+;; and we will define the scoped nodes .lexical_scope and (possibly) .defs in
+;; the Statement CST node.
+;;
+;; For expression statements, variable and tuple declarations we defined
+;; separately from the enclosing statement to be able to use them in for
+;; initialization and condition clauses directly. Also, because we intend to
+;; reuse them, all of them must have both a .lexical_scope and .defs scoped
+;; nodes.
+
+@expr_stmt [ExpressionStatement] {
+  node @expr_stmt.lexical_scope
+  node @expr_stmt.defs
+}
+
+@stmt [Statement @expr_stmt [ExpressionStatement]] {
+  edge @expr_stmt.lexical_scope -> @stmt.lexical_scope
+}
+
+@var_decl [VariableDeclarationStatement] {
+  node @var_decl.lexical_scope
+  node @var_decl.defs
+}
+
+@stmt [Statement @var_decl [VariableDeclarationStatement]] {
+  edge @var_decl.lexical_scope -> @stmt.lexical_scope
+  edge @stmt.defs -> @var_decl.defs
+}
+
+@tuple_decon [TupleDeconstructionStatement] {
+  node @tuple_decon.lexical_scope
+  node @tuple_decon.defs
+}
+
+@stmt [Statement @tuple_decon [TupleDeconstructionStatement]] {
+  edge @tuple_decon.lexical_scope -> @stmt.lexical_scope
+  edge @stmt.defs -> @tuple_decon.defs
+}
+
+
+;;; Variable declaration and tuple deconstruction statements introduce new definitionns
+
+@var_decl [VariableDeclarationStatement
+    [VariableDeclarationType @var_type [TypeName]]
+    @name name: [Identifier]
+] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @var_decl
+
+  edge @var_decl.defs -> def
+  edge @var_type.type_ref -> @var_decl.lexical_scope
+
+  node typeof
+  attr (typeof) push_symbol = "@typeof"
+
+  edge def -> typeof
+  edge typeof -> @var_type.output
+}
+
+@tuple_decon [TupleDeconstructionStatement [TupleDeconstructionElements
+    [TupleDeconstructionElement
+        @tuple_member [TupleMember variant: [UntypedTupleMember
+            @name name: [Identifier]]
+        ]
+    ]
+]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @tuple_member
+
+  edge @tuple_decon.defs -> def
+}
+
+@tuple_decon [TupleDeconstructionStatement [TupleDeconstructionElements
+    [TupleDeconstructionElement
+        @tuple_member [TupleMember variant: [TypedTupleMember
+            @member_type type_name: [TypeName]
+            @name name: [Identifier]]
+        ]
+    ]
+]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @tuple_member
+
+  edge @tuple_decon.defs -> def
+  edge @member_type.type_ref -> @tuple_decon.lexical_scope
+
+  node typeof
+  attr (typeof) push_symbol = "@typeof"
+
+  edge def -> typeof
+  edge typeof -> @member_type.output
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Control statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -534,63 +635,35 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Declaration Statements introducing variables
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-@stmt [Statement @var_decl [VariableDeclarationStatement
-    [VariableDeclarationType @var_type [TypeName]]
-    @name name: [Identifier]
+@stmt [Statement [ForStatement
+    @body body: [Statement]
 ]] {
-  node def
-  attr (def) node_definition = @name
-  attr (def) definiens_node = @var_decl
+  node @stmt.init_defs
 
-  edge @stmt.defs -> def
-  edge @var_type.type_ref -> @stmt.lexical_scope
-
-  node typeof
-  attr (typeof) push_symbol = "@typeof"
-
-  edge def -> typeof
-  edge typeof -> @var_type.output
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  edge @body.lexical_scope -> @stmt.init_defs
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+    edge @stmt.defs -> @stmt.init_defs
+  }
 }
 
-@stmt [Statement [TupleDeconstructionStatement [TupleDeconstructionElements
-    [TupleDeconstructionElement
-        @tuple_member [TupleMember variant: [UntypedTupleMember
-            @name name: [Identifier]]
-        ]
+@stmt [Statement [ForStatement
+    initialization: [ForStatementInitialization
+        @init_stmt ([ExpressionStatement]
+                  | [VariableDeclarationStatement]
+                  | [TupleDeconstructionStatement])
     ]
-]]] {
-  node def
-  attr (def) node_definition = @name
-  attr (def) definiens_node = @tuple_member
-
-  edge @stmt.defs -> def
+]] {
+  edge @init_stmt.lexical_scope -> @stmt.lexical_scope
+  edge @stmt.init_defs -> @init_stmt.defs
 }
 
-@stmt [Statement [TupleDeconstructionStatement [TupleDeconstructionElements
-    [TupleDeconstructionElement
-        @tuple_member [TupleMember variant: [TypedTupleMember
-            @member_type type_name: [TypeName]
-            @name name: [Identifier]]
-        ]
-    ]
-]]] {
-  node def
-  attr (def) node_definition = @name
-  attr (def) definiens_node = @tuple_member
-
-  edge @stmt.defs -> def
-  edge @member_type.type_ref -> @stmt.lexical_scope
-
-  node typeof
-  attr (typeof) push_symbol = "@typeof"
-
-  edge def -> typeof
-  edge typeof -> @member_type.output
+@stmt [Statement [ForStatement
+    condition: [ForStatementCondition @cond_stmt [ExpressionStatement]]
+]] {
+  edge @cond_stmt.lexical_scope -> @stmt.lexical_scope
+  edge @cond_stmt.lexical_scope -> @stmt.init_defs
 }
 
 
@@ -769,23 +842,23 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @child.lexical_scope -> @expr.lexical_scope
 }
 
-;; Expressions as statements
-@stmt [Statement variant: [ExpressionStatement @expr [Expression]]] {
-  edge @expr.lexical_scope -> @stmt.lexical_scope
+;; Expressions statements
+@expr_stmt [ExpressionStatement @expr [Expression]] {
+  edge @expr.lexical_scope -> @expr_stmt.lexical_scope
 }
 
 ;; Expressions used for variable declarations
-@stmt [Statement variant: [VariableDeclarationStatement
+@var_decl [VariableDeclarationStatement
     value: [VariableDeclarationValue @expr [Expression]]
-]] {
-  edge @expr.lexical_scope -> @stmt.lexical_scope
+] {
+  edge @expr.lexical_scope -> @var_decl.lexical_scope
 }
 
 ;; Expressions used for tuple deconstruction statements
-@stmt [Statement [TupleDeconstructionStatement
+@tuple_decon [TupleDeconstructionStatement
     @expr expression: [Expression]
-]] {
-  edge @expr.lexical_scope -> @stmt.lexical_scope
+] {
+  edge @expr.lexical_scope -> @tuple_decon.lexical_scope
 }
 
 ;; Expressions as if conditions
@@ -796,6 +869,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ;; Expressions in return statements
 @stmt [Statement [ReturnStatement @expr [Expression]]] {
   edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in for iterations
+@stmt [Statement [ForStatement
+    @iter_expr iterator: [Expression]
+]] {
+  edge @iter_expr.lexical_scope -> @stmt.lexical_scope
+  edge @iter_expr.lexical_scope -> @stmt.init_defs
 }
 
 ;; Expressions used for state variable declarations

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -737,6 +737,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 
+;;; Revert statements
+
+@stmt [Statement [RevertStatement @error_ident [IdentifierPath]]] {
+  edge @error_ident.left -> @stmt.lexical_scope
+}
+
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; State Variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1124,6 +1132,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 ;; Arguments to an event in an emit statement
 @stmt [Statement [EmitStatement @args [ArgumentsDeclaration]]] {
+  edge @args.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Arguments to an error in a revert statement
+@stmt [Statement [RevertStatement @args [ArgumentsDeclaration]]] {
   edge @args.lexical_scope -> @stmt.lexical_scope
 }
 

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
@@ -626,6 +626,8 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ;;; Control statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; If conditionals
+
 @stmt [Statement [IfStatement @body body: [Statement]]] {
   edge @body.lexical_scope -> @stmt.lexical_scope
   if (version-matches "< 0.5.0") {
@@ -640,9 +642,9 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
-@stmt [Statement [ForStatement
-    @body body: [Statement]
-]] {
+;; For loops
+
+@stmt [Statement [ForStatement @body body: [Statement]]] {
   node @stmt.init_defs
 
   edge @body.lexical_scope -> @stmt.lexical_scope
@@ -669,6 +671,24 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ]] {
   edge @cond_stmt.lexical_scope -> @stmt.lexical_scope
   edge @cond_stmt.lexical_scope -> @stmt.init_defs
+}
+
+;; While loops
+
+@stmt [Statement [WhileStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
+}
+
+;; Do-while loops
+
+@stmt [Statement [DoWhileStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
 }
 
 
@@ -882,6 +902,20 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 ]] {
   edge @iter_expr.lexical_scope -> @stmt.lexical_scope
   edge @iter_expr.lexical_scope -> @stmt.init_defs
+}
+
+;; Expressions in while conditions
+@stmt [Statement [WhileStatement
+    @condition condition: [Expression]
+]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in do-while conditions
+@stmt [Statement [DoWhileStatement
+    @condition condition: [Expression]
+]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
 }
 
 ;; Expressions used for state variable declarations

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
@@ -742,6 +742,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 
+;;; Revert statements
+
+@stmt [Statement [RevertStatement @error_ident [IdentifierPath]]] {
+  edge @error_ident.left -> @stmt.lexical_scope
+}
+
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; State Variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1129,6 +1137,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 ;; Arguments to an event in an emit statement
 @stmt [Statement [EmitStatement @args [ArgumentsDeclaration]]] {
+  edge @args.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Arguments to an error in a revert statement
+@stmt [Statement [RevertStatement @args [ArgumentsDeclaration]]] {
   edge @args.lexical_scope -> @stmt.lexical_scope
 }
 

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
@@ -531,7 +531,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Statements
+;;; Expressions & declaration statements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; In the general case for statements the structure is [Statement [StmtVariant]]
@@ -748,6 +748,14 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   edge @error_ident.left -> @stmt.lexical_scope
 }
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Other statements
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@stmt [Statement [UncheckedBlock @block block: [Block]]] {
+  edge @block.lexical_scope -> @stmt.lexical_scope
+}
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
@@ -522,6 +522,25 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Control statements
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@stmt [Statement [IfStatement @body body: [Statement]]] {
+  edge @body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @body.defs
+  }
+}
+
+@stmt [Statement [IfStatement else_branch: [ElseBranch @else_body body: [Statement]]]] {
+  edge @else_body.lexical_scope -> @stmt.lexical_scope
+  if (version-matches "< 0.5.0") {
+    edge @stmt.defs -> @else_body.defs
+  }
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Declaration Statements introducing variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -756,7 +775,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 }
 
 ;; Expressions as statements
-@stmt [Statement variant: [_ @expr [Expression]]] {
+@stmt [Statement variant: [ExpressionStatement @expr [Expression]]] {
   edge @expr.lexical_scope -> @stmt.lexical_scope
 }
 
@@ -764,6 +783,23 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 @stmt [Statement variant: [VariableDeclarationStatement
     value: [VariableDeclarationValue @expr [Expression]]
 ]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions used for tuple deconstruction statements
+@stmt [Statement [TupleDeconstructionStatement
+    @expr expression: [Expression]
+]] {
+  edge @expr.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions as if conditions
+@stmt [Statement [IfStatement @condition condition: [Expression]]] {
+  edge @condition.lexical_scope -> @stmt.lexical_scope
+}
+
+;; Expressions in return statements
+@stmt [Statement [ReturnStatement @expr [Expression]]] {
   edge @expr.lexical_scope -> @stmt.lexical_scope
 }
 
@@ -854,5 +890,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 @type_expr [Expression [TypeExpression @type [TypeName]]] {
   edge @type.type_ref -> @type_expr.lexical_scope
 }
+
+
 
 "#####;

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/bindings/generated/binding_rules.rs
@@ -691,6 +691,12 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   }
 }
 
+;; Emit statements
+
+@stmt [Statement [EmitStatement @event_ident [IdentifierPath]]] {
+  edge @event_ident.left -> @stmt.lexical_scope
+}
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; State Variables
@@ -853,6 +859,41 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Event definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@event [EventDefinition @name name: [Identifier]] {
+  node def
+  attr (def) node_definition = @name
+  attr (def) definiens_node = @event
+
+  edge @event.def -> def
+}
+
+;; Make the enum available to the enclosing contract/interface/library.
+;; NB. top-level enums (ie. those defined at the file's level) are already
+;; covered above
+
+@contract [ContractDefinition members: [ContractMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @contract.type_members -> @event.def
+}
+
+@interface [InterfaceDefinition members: [InterfaceMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @interface.type_members -> @event.def
+}
+
+@library [LibraryDefinition members: [LibraryMembers
+    item: [ContractMember @event variant: [EventDefinition]]
+]] {
+  edge @library.members -> @event.def
+}
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Expressions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -987,6 +1028,7 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
   attr (ref) node_reference = @name
   ;; TODO: bind the named argument to the parameters definition of the function
   ;; (is this possible given that function references are expressions?)
+  ;; Ditto for events emissions (where it should be possible for sure)
 }
 
 @args [ArgumentsDeclaration [NamedArgumentsDeclaration
@@ -997,6 +1039,11 @@ attribute symbol_reference = symbol  => type = "push_symbol", symbol = symbol, i
 
 @funcall [Expression [FunctionCallExpression @args [ArgumentsDeclaration]]] {
   edge @args.lexical_scope -> @funcall.lexical_scope
+}
+
+;; Arguments to an event in an emit statement
+@stmt [Statement [EmitStatement @args [ArgumentsDeclaration]]] {
+  edge @args.lexical_scope -> @stmt.lexical_scope
 }
 
 

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/assertions.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/assertions.rs
@@ -368,8 +368,6 @@ fn check_reference_assertion(
     version: &Version,
     assertion: &ReferenceAssertion<'_>,
 ) -> Result<(), String> {
-    let resolution = find_and_resolve_reference(bindings, assertion)?;
-
     let ReferenceAssertion {
         id, version_req, ..
     } = assertion;
@@ -378,6 +376,18 @@ fn check_reference_assertion(
         version_req.matches(version)
     } else {
         true
+    };
+
+    let resolution = match find_and_resolve_reference(bindings, assertion) {
+        Ok(resolution) => resolution,
+        Err(err) => {
+            if version_matches {
+                return Err(err);
+            }
+            // the reference was not found, but that's ok if the assertion
+            // should not match for this version
+            None
+        }
     };
 
     match (version_matches, id) {

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/assertions.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/assertions.rs
@@ -283,6 +283,11 @@ fn search_asserted_node_backwards(mut cursor: Cursor, anchor_column: usize) -> O
             Ordering::Greater => continue,
             Ordering::Less => (),
         }
+        // Skip over empty nodes which the parser may insert to fulfill the
+        // grammar (eg. commonly an empty Statements node)
+        if cursor.text_range().is_empty() {
+            continue;
+        }
 
         // Node is not found, and probably the anchor is invalid
         break;

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -40,6 +40,11 @@ fn return_stmt() -> Result<()> {
 }
 
 #[test]
+fn try_stmt() -> Result<()> {
+    run("control", "try_stmt")
+}
+
+#[test]
 fn while_stmt() -> Result<()> {
     run("control", "while_stmt")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -1,0 +1,15 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+use anyhow::Result;
+
+use crate::bindings_assertions::runner::run;
+
+#[test]
+fn if_else() -> Result<()> {
+    run("control", "if_else")
+}
+
+#[test]
+fn return_stmt() -> Result<()> {
+    run("control", "return_stmt")
+}

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -50,6 +50,11 @@ fn try_stmt() -> Result<()> {
 }
 
 #[test]
+fn unchecked() -> Result<()> {
+    run("control", "unchecked")
+}
+
+#[test]
 fn while_stmt() -> Result<()> {
     run("control", "while_stmt")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -5,6 +5,11 @@ use anyhow::Result;
 use crate::bindings_assertions::runner::run;
 
 #[test]
+fn do_while() -> Result<()> {
+    run("control", "do_while")
+}
+
+#[test]
 fn for_empty_init_or_cond() -> Result<()> {
     run("control", "for_empty_init_or_cond")
 }
@@ -27,4 +32,9 @@ fn if_else() -> Result<()> {
 #[test]
 fn return_stmt() -> Result<()> {
     run("control", "return_stmt")
+}
+
+#[test]
+fn while_stmt() -> Result<()> {
+    run("control", "while_stmt")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -40,6 +40,11 @@ fn return_stmt() -> Result<()> {
 }
 
 #[test]
+fn revert_stmt() -> Result<()> {
+    run("control", "revert_stmt")
+}
+
+#[test]
 fn try_stmt() -> Result<()> {
     run("control", "try_stmt")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -5,6 +5,21 @@ use anyhow::Result;
 use crate::bindings_assertions::runner::run;
 
 #[test]
+fn for_empty_init_or_cond() -> Result<()> {
+    run("control", "for_empty_init_or_cond")
+}
+
+#[test]
+fn for_stmt() -> Result<()> {
+    run("control", "for_stmt")
+}
+
+#[test]
+fn for_tuple_decon() -> Result<()> {
+    run("control", "for_tuple_decon")
+}
+
+#[test]
 fn if_else() -> Result<()> {
     run("control", "if_else")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/control.rs
@@ -10,6 +10,11 @@ fn do_while() -> Result<()> {
 }
 
 #[test]
+fn emit_event() -> Result<()> {
+    run("control", "emit_event")
+}
+
+#[test]
 fn for_empty_init_or_cond() -> Result<()> {
     run("control", "for_empty_init_or_cond")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/generated/mod.rs
@@ -1,6 +1,7 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 mod contracts;
+mod control;
 mod enums;
 mod expressions;
 mod functions;

--- a/crates/solidity/outputs/cargo/tests/src/bindings_assertions/runner.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_assertions/runner.rs
@@ -33,6 +33,7 @@ fn check_assertions_with_version(version: &Version, contents: &str) -> Result<()
     let mut bindings =
         bindings::create_with_resolver(version.clone(), Arc::new(TestsPathResolver {}));
     let mut assertions = Assertions::new();
+    let mut skipped = 0;
 
     let parts = split_multi_file(contents);
 
@@ -50,7 +51,7 @@ fn check_assertions_with_version(version: &Version, contents: &str) -> Result<()
         }
 
         bindings.add_file(file_path, parse_output.create_tree_cursor());
-        collect_assertions_into(
+        skipped += collect_assertions_into(
             &mut assertions,
             parse_output.create_tree_cursor(),
             file_path,
@@ -63,7 +64,7 @@ fn check_assertions_with_version(version: &Version, contents: &str) -> Result<()
     match result {
         Ok(count) => {
             assert!(count > 0, "No assertions found with version {version}");
-            println!("Version {version}, {count} assertions OK");
+            println!("Version {version}, {count} assertions OK, {skipped} skipped");
         }
         Err(err) => {
             panic!("Failed bindings assertions in version {version}:\n{err}");

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
@@ -5,6 +5,36 @@ use anyhow::Result;
 use crate::bindings_output::runner::run;
 
 #[test]
+fn for_empty_clauses() -> Result<()> {
+    run("control", "for_empty_clauses")
+}
+
+#[test]
+fn for_empty_cond() -> Result<()> {
+    run("control", "for_empty_cond")
+}
+
+#[test]
+fn for_empty_init() -> Result<()> {
+    run("control", "for_empty_init")
+}
+
+#[test]
+fn for_expr_init() -> Result<()> {
+    run("control", "for_expr_init")
+}
+
+#[test]
+fn for_stmt() -> Result<()> {
+    run("control", "for_stmt")
+}
+
+#[test]
+fn for_tuple_init() -> Result<()> {
+    run("control", "for_tuple_init")
+}
+
+#[test]
 fn if_else() -> Result<()> {
     run("control", "if_else")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
@@ -45,6 +45,11 @@ fn if_else() -> Result<()> {
 }
 
 #[test]
+fn try_stmt() -> Result<()> {
+    run("control", "try_stmt")
+}
+
+#[test]
 fn while_stmt() -> Result<()> {
     run("control", "while_stmt")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
@@ -1,0 +1,10 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+use anyhow::Result;
+
+use crate::bindings_output::runner::run;
+
+#[test]
+fn if_else() -> Result<()> {
+    run("control", "if_else")
+}

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
@@ -5,6 +5,11 @@ use anyhow::Result;
 use crate::bindings_output::runner::run;
 
 #[test]
+fn emit_event() -> Result<()> {
+    run("control", "emit_event")
+}
+
+#[test]
 fn for_empty_clauses() -> Result<()> {
     run("control", "for_empty_clauses")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/control.rs
@@ -38,3 +38,8 @@ fn for_tuple_init() -> Result<()> {
 fn if_else() -> Result<()> {
     run("control", "if_else")
 }
+
+#[test]
+fn while_stmt() -> Result<()> {
+    run("control", "while_stmt")
+}

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/mod.rs
@@ -1,6 +1,7 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 mod contracts;
+mod control;
 mod enums;
 mod expressions;
 mod imports;

--- a/crates/solidity/testing/snapshots/bindings_assertions/contracts/visibility.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/contracts/visibility.sol
@@ -25,15 +25,13 @@ contract Second {
         //     ^ref:5
     }
     function get_first_choice() public returns (First.Choice) {
-        // Cannot access a member function through the contract type
         return First.get_choice();
         //     ^ref:1
-        //           ^ref:!
+        //           ^ref:!  -- cannot access a member function through the contract type
     }
     function other_choice() public returns (First.Choice) {
-        // Cannot access a state variable in another contract
         return First.choice;
         //     ^ref:1
-        //           ^ref:!
+        //           ^ref:!  -- cannot access a state variable in another contract
     }
 }

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/do_while.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/do_while.sol
@@ -1,0 +1,17 @@
+contract Test {
+    function test() public returns (int) {
+        int i = 1;
+        //  ^def:1
+        do {
+            int odd = i % 2;
+            //  ^def:2
+            //        ^ref:1
+            i *= 3;
+            //<ref:1
+        } while (i < 100);
+        //       ^ref:1
+        return odd;
+        //     ^ref:! (>= 0.5.0)
+        //     ^ref:2 (< 0.5.0)
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/emit_event.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/emit_event.sol
@@ -1,0 +1,23 @@
+contract Test {
+    event TestEvent(int id);
+    //    ^def:1
+
+    function test_emit() public {
+        int x = 1;
+        //  ^def:2
+
+        emit TestEvent(x);
+        //             ^ref:2 (>= 0.4.21)
+        //   ^ref:1 (>= 0.4.21)
+        emit Utils.Debug(x);
+        //               ^ref:2 (>= 0.4.21)
+        //         ^ref:4 (>= 0.4.21)
+        //   ^ref:3 (>= 0.4.21)
+    }
+}
+
+library Utils {
+    //  ^def:3
+    event Debug(int subject);
+    //    ^def:4
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/for_empty_init_or_cond.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/for_empty_init_or_cond.sol
@@ -1,0 +1,24 @@
+contract Test {
+    function empty_init() public {
+        int i = 1;
+        //  ^def:1
+        int x = 0;
+        //  ^def:2
+        for (; i < 10; i++) {
+            //         ^ref:1
+            // ^ref:1
+            x += i;
+            //<ref:2
+            //   ^ref:1
+        }
+    }
+
+    function empty_condition() public {
+        for (int i = 0;; i++) {
+            //   ^def:3
+            //           ^ref:3
+            if (i > 10) break;
+            //  ^ref:3
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/for_stmt.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/for_stmt.sol
@@ -1,0 +1,32 @@
+contract Test {
+    function simple_loop() public returns (int) {
+        int x = 1;
+        //  ^def:1
+        for (int i = 0; i < 10; i++) {
+            //   ^def:2
+            //          ^ref:2
+            //                  ^ref:2
+            x = x * 2;
+            //<ref:1
+            //  ^ref:1
+        }
+        return x + i;
+        //         ^ref:! (>= 0.5.0)
+        //         ^ref:2 (< 0.5.0)
+    }
+
+    function loop_with_outside_var() public {
+        int z;
+        //  ^def:3
+        int w = 0;
+        //  ^def:4
+        for ( z = 10; z > 0; w += z) {
+            //^ref:3
+            //        ^ref:3
+            //               ^ref:4
+            //                    ^ref:3
+            z--;
+            //<ref:3
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/for_tuple_decon.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/for_tuple_decon.sol
@@ -1,0 +1,17 @@
+contract Test {
+    function with_tuple_decon() public {
+        int a = 1;
+        //  ^def:1
+        for ((int i, int b) = (0, a); i < 10; ) {
+            //    ^def:2
+            //           ^def:3
+            //                    ^ref:1
+            //                        ^ref:2
+            b = a + b;
+            //<ref:3
+            //  ^ref:1
+            //      ^ref:3
+            a = b;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/if_else.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/if_else.sol
@@ -1,0 +1,28 @@
+contract Test {
+    function test() {
+        int x = 1;
+        //  ^def:1
+        int y = 2;
+        //  ^def:2
+        if (x > 1) {
+            //<ref:1
+            int z = 3;
+            //  ^def:3
+            y = x + 10;
+            //  ^ref:1
+            //<ref:2
+        } else {
+            int w = 4;
+            //  ^def:4
+            y = x + 20;
+            //  ^ref:1
+            //<ref:2
+        }
+        return y + z + w;
+        //             ^ref:! (>= 0.5.0)
+        //             ^ref:4 (< 0.5.0)
+        //         ^ref:! (>= 0.5.0)
+        //         ^ref:3 (< 0.5.0)
+        //     ^ref:2
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/return_stmt.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/return_stmt.sol
@@ -1,0 +1,8 @@
+contract Test {
+    function test() returns (int) {
+        int x = 1;
+        //  ^def:1
+        return x;
+        //     ^ref:1
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/revert_stmt.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/revert_stmt.sol
@@ -1,0 +1,24 @@
+contract Test {
+    error InvalidState();
+    //    ^def:1
+
+    function testRevert() public {
+        revert InvalidState();
+        //     ^ref:1 (>= 0.8.4)
+    }
+
+    function testOtherRevert() public {
+        int code = 10;
+        //  ^def:2
+        revert Utils.GenericError(code);
+        //                        ^ref:2 (>= 0.8.4)
+        //           ^ref:4 (>= 0.8.4)
+        //     ^ref:3 (>= 0.8.4)
+    }
+}
+
+library Utils {
+    //  ^def:3
+    error GenericError(int code);
+    //    ^def:4
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/try_stmt.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/try_stmt.sol
@@ -1,0 +1,28 @@
+interface DataFeed { function getData(address token) external returns (uint value); }
+
+contract FeedConsumer {
+    DataFeed feed;
+    //       ^def:1
+    uint errorCount;
+    //   ^def:2
+    function rate(address token) public returns (uint value, bool success) {
+        //                                                        ^def:5
+        //                                            ^def:4
+        //                ^def:3
+        try feed.getData(token) returns (uint v) {
+            //                                ^def:6
+            //           ^ref:3
+            //<ref:1
+            value = v;
+            //<ref:4
+            //      ^ref:6
+            success = true;
+            //<ref:5
+        } catch {
+            errorCount++;
+            //<ref:2
+
+            return (0, false);
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/unchecked.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/unchecked.sol
@@ -1,0 +1,12 @@
+contract Test {
+    function sub(uint a, uint b) public returns (uint) {
+        //                    ^def:2
+        //            ^def:1
+        uint c = a;
+        //       ^ref:1
+        //   ^def:3
+        unchecked { return c - b; }
+        //                     ^ref:2 (>= 0.8.0)
+        //                 ^ref:3 (>= 0.8.0)
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/control/while_stmt.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/control/while_stmt.sol
@@ -1,0 +1,17 @@
+contract Test {
+    function test() public returns (int) {
+        int i = 1;
+        //  ^def:1
+        while (i < 100) {
+            // ^ref:1
+            int odd = i % 2;
+            //  ^def:2
+            //        ^ref:1
+            i *= 3;
+            //<ref:1
+        }
+        return odd;
+        //     ^ref:! (>= 0.5.0)
+        //     ^ref:2 (< 0.5.0)
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_assertions/scoping/hoisting_scopes.sol
+++ b/crates/solidity/testing/snapshots/bindings_assertions/scoping/hoisting_scopes.sol
@@ -1,4 +1,3 @@
-// Before 0.5.0 Solidity hoists all variable definitions
 contract Foo {
   function bar() returns (int x) {
     //                        ^def:1

--- a/crates/solidity/testing/snapshots/bindings_output/control/emit_event/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/emit_event/generated/0.4.11-failure.txt
@@ -1,0 +1,33 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected Equal or Semicolon.
+   ╭─[input.sol:7:23]
+   │
+ 7 │         emit TestEvent(x);
+   │                       ─┬─  
+   │                        ╰─── Error occurred here.
+───╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     event TestEvent(int id);
+   │           ────┬────  
+   │               ╰────── def: 2
+   │ 
+ 4 │     function test_emit() public {
+   │              ────┬────  
+   │                  ╰────── def: 3
+ 5 │         int x = 1;
+   │             ┬  
+   │             ╰── def: 4
+   │ 
+ 7 │         emit TestEvent(x);
+   │         ──┬─ ────┬────  
+   │           ╰───────────── unresolved
+   │                  │      
+   │                  ╰────── def: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/emit_event/generated/0.4.21-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/emit_event/generated/0.4.21-success.txt
@@ -1,0 +1,25 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     event TestEvent(int id);
+   │           ────┬────  
+   │               ╰────── def: 2
+   │ 
+ 4 │     function test_emit() public {
+   │              ────┬────  
+   │                  ╰────── def: 3
+ 5 │         int x = 1;
+   │             ┬  
+   │             ╰── def: 4
+   │ 
+ 7 │         emit TestEvent(x);
+   │              ────┬──── ┬  
+   │                  ╰──────── ref: 2
+   │                        │  
+   │                        ╰── ref: 4
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/emit_event/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/emit_event/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    event TestEvent(int id);
+
+    function test_emit() public {
+        int x = 1;
+
+        emit TestEvent(x);
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_clauses/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_clauses/generated/0.4.11-success.txt
@@ -1,0 +1,22 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test() public {
+   │              ──┬─  
+   │                ╰─── def: 2
+ 3 │         int i = 1;
+   │             ┬  
+   │             ╰── def: 3
+   │ 
+ 5 │             if (i > 10) break;
+   │                 ┬  
+   │                 ╰── ref: 3
+ 6 │             i++;
+   │             ┬  
+   │             ╰── ref: 3
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_clauses/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_clauses/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test() public {
+        int i = 1;
+        for (;;) {
+            if (i > 10) break;
+            i++;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_cond/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_cond/generated/0.4.11-success.txt
@@ -1,0 +1,28 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test() public {
+   │              ──┬─  
+   │                ╰─── def: 2
+ 3 │         int x = 1;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         for (int i = 0;; i++) {
+   │                  ┬       ┬  
+   │                  ╰────────── def: 4
+   │                          │  
+   │                          ╰── ref: 4
+ 5 │             x = x * 2;
+   │             ┬   ┬  
+   │             ╰────── ref: 3
+   │                 │  
+   │                 ╰── ref: 3
+ 6 │             if (i > 10) break;
+   │                 ┬  
+   │                 ╰── ref: 4
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_cond/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_cond/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test() public {
+        int x = 1;
+        for (int i = 0;; i++) {
+            x = x * 2;
+            if (i > 10) break;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_init/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_init/generated/0.4.11-success.txt
@@ -1,0 +1,28 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test_for_empty_init() public {
+   │              ─────────┬─────────  
+   │                       ╰─────────── def: 2
+ 3 │         int i = 1;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         int x = 0;
+   │             ┬  
+   │             ╰── def: 4
+ 5 │         for (; i < 10; i++) {
+   │                ┬       ┬  
+   │                ╰────────── ref: 3
+   │                        │  
+   │                        ╰── ref: 3
+ 6 │             x += i;
+   │             ┬    ┬  
+   │             ╰─────── ref: 4
+   │                  │  
+   │                  ╰── ref: 3
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_empty_init/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_empty_init/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test_for_empty_init() public {
+        int i = 1;
+        int x = 0;
+        for (; i < 10; i++) {
+            x += i;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_expr_init/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_expr_init/generated/0.4.11-success.txt
@@ -1,0 +1,30 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test_non_decl_init() public {
+   │              ─────────┬────────  
+   │                       ╰────────── def: 2
+ 3 │         int z;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         int w = 0;
+   │             ┬  
+   │             ╰── def: 4
+ 5 │         for (z = 10; z > 0; w += z) {
+   │              ┬       ┬      ┬    ┬  
+   │              ╰────────────────────── ref: 3
+   │                      │      │    │  
+   │                      ╰────────────── ref: 3
+   │                             │    │  
+   │                             ╰─────── ref: 4
+   │                                  │  
+   │                                  ╰── ref: 3
+ 6 │             z--;
+   │             ┬  
+   │             ╰── ref: 3
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_expr_init/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_expr_init/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test_non_decl_init() public {
+        int z;
+        int w = 0;
+        for (z = 10; z > 0; w += z) {
+            z--;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_stmt/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_stmt/generated/0.4.11-success.txt
@@ -1,0 +1,41 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test() public {
+   │              ──┬─  
+   │                ╰─── def: 2
+ 3 │         int x = 1;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         int y = 0;
+   │             ┬  
+   │             ╰── def: 4
+ 5 │         for (int i = x - 1; i < 10 && x < 500; i++) {
+   │                  ┬   ┬      ┬         ┬        ┬  
+   │                  ╰──────────────────────────────── def: 5
+   │                      │      │         │        │  
+   │                      ╰──────────────────────────── ref: 3
+   │                             │         │        │  
+   │                             ╰───────────────────── ref: 5
+   │                                       │        │  
+   │                                       ╰─────────── ref: 3
+   │                                                │  
+   │                                                ╰── ref: 5
+ 6 │             x = x * 2;
+   │             ┬   ┬  
+   │             ╰────── ref: 3
+   │                 │  
+   │                 ╰── ref: 3
+ 7 │             y = y + i;
+   │             ┬   ┬   ┬  
+   │             ╰────────── ref: 4
+   │                 │   │  
+   │                 ╰────── ref: 4
+   │                     │  
+   │                     ╰── ref: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_stmt/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_stmt/input.sol
@@ -1,0 +1,10 @@
+contract Test {
+    function test() public {
+        int x = 1;
+        int y = 0;
+        for (int i = x - 1; i < 10 && x < 500; i++) {
+            x = x * 2;
+            y = y + i;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_tuple_init/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_tuple_init/generated/0.4.11-success.txt
@@ -1,0 +1,38 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test() public {
+   │              ──┬─  
+   │                ╰─── def: 2
+ 3 │         int b = 1;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         for ((int i, int a) = (0, b); i < 10; i++) {
+   │                   ┬      ┬        ┬   ┬       ┬  
+   │                   ╰────────────────────────────── def: 4
+   │                          │        │   │       │  
+   │                          ╰─────────────────────── def: 5
+   │                                   │   │       │  
+   │                                   ╰────────────── ref: 3
+   │                                       │       │  
+   │                                       ╰────────── ref: 4
+   │                                               │  
+   │                                               ╰── ref: 4
+ 5 │             b = a + b;
+   │             ┬   ┬   ┬  
+   │             ╰────────── ref: 3
+   │                 │   │  
+   │                 ╰────── ref: 5
+   │                     │  
+   │                     ╰── ref: 3
+ 6 │             a = b;
+   │             ┬   ┬  
+   │             ╰────── ref: 5
+   │                 │  
+   │                 ╰── ref: 3
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/for_tuple_init/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/for_tuple_init/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test() public {
+        int b = 1;
+        for ((int i, int a) = (0, b); i < 10; i++) {
+            b = a + b;
+            a = b;
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/if_else/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/if_else/generated/0.4.11-success.txt
@@ -1,0 +1,51 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── def: 1
+  2 │     function test() public returns (int) {
+    │              ──┬─  
+    │                ╰─── def: 2
+  3 │         int x = 1;
+    │             ┬  
+    │             ╰── def: 3
+  4 │         int y = 2;
+    │             ┬  
+    │             ╰── def: 4
+  5 │         if (x > 1) {
+    │             ┬  
+    │             ╰── ref: 3
+  6 │             int z = 3;
+    │                 ┬  
+    │                 ╰── def: 5
+  7 │             y = x + 10;
+    │             ┬   ┬  
+    │             ╰────── ref: 4
+    │                 │  
+    │                 ╰── ref: 3
+    │ 
+  9 │             int w = 4;
+    │                 ┬  
+    │                 ╰── def: 6
+ 10 │             y = x + 20;
+    │             ┬   ┬  
+    │             ╰────── ref: 4
+    │                 │  
+    │                 ╰── ref: 3
+    │ 
+ 12 │         int r = y + z + w;
+    │             ┬   ┬   ┬   ┬  
+    │             ╰────────────── def: 7
+    │                 │   │   │  
+    │                 ╰────────── ref: 4
+    │                     │   │  
+    │                     ╰────── ref: 5
+    │                         │  
+    │                         ╰── ref: 6
+ 13 │         return r;
+    │                ┬  
+    │                ╰── ref: 7
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/if_else/generated/0.5.0-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/if_else/generated/0.5.0-success.txt
@@ -1,0 +1,51 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── def: 1
+  2 │     function test() public returns (int) {
+    │              ──┬─  
+    │                ╰─── def: 2
+  3 │         int x = 1;
+    │             ┬  
+    │             ╰── def: 3
+  4 │         int y = 2;
+    │             ┬  
+    │             ╰── def: 4
+  5 │         if (x > 1) {
+    │             ┬  
+    │             ╰── ref: 3
+  6 │             int z = 3;
+    │                 ┬  
+    │                 ╰── def: 5
+  7 │             y = x + 10;
+    │             ┬   ┬  
+    │             ╰────── ref: 4
+    │                 │  
+    │                 ╰── ref: 3
+    │ 
+  9 │             int w = 4;
+    │                 ┬  
+    │                 ╰── def: 6
+ 10 │             y = x + 20;
+    │             ┬   ┬  
+    │             ╰────── ref: 4
+    │                 │  
+    │                 ╰── ref: 3
+    │ 
+ 12 │         int r = y + z + w;
+    │             ┬   ┬   ┬   ┬  
+    │             ╰────────────── def: 7
+    │                 │   │   │  
+    │                 ╰────────── ref: 4
+    │                     │   │  
+    │                     ╰────── unresolved
+    │                         │  
+    │                         ╰── unresolved
+ 13 │         return r;
+    │                ┬  
+    │                ╰── ref: 7
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/if_else/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/if_else/input.sol
@@ -1,0 +1,15 @@
+contract Test {
+    function test() public returns (int) {
+        int x = 1;
+        int y = 2;
+        if (x > 1) {
+            int z = 3;
+            y = x + 10;
+        } else {
+            int w = 4;
+            y = x + 20;
+        }
+        int r = y + z + w;
+        return r;
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.4.11-failure.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or ThrowKeyword or TrueKeyword or UfixedKeyword or UintKeyword or VarKeyword or WhileKeyword.
+    ╭─[input.sol:9:9]
+    │
+  9 │ ╭─▶         try feed.getData(token) returns (uint v) {
+    ┆ ┆   
+ 20 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ interface DataFeed { function getData(address token) external returns (uint value); }
+   │           ────┬───            ───┬───         ──┬──                         ──┬──  
+   │               ╰──────────────────────────────────────────────────────────────────── def: 1
+   │                                  │              │                             │    
+   │                                  ╰───────────────────────────────────────────────── def: 2
+   │                                                 │                             │    
+   │                                                 ╰────────────────────────────────── def: 3
+   │                                                                               │    
+   │                                                                               ╰──── def: 4
+   │ 
+ 3 │ contract FeedConsumer {
+   │          ──────┬─────  
+   │                ╰─────── def: 5
+ 4 │     DataFeed feed;
+   │     ────┬─── ──┬─  
+   │         ╰────────── ref: 1
+   │                │   
+   │                ╰─── def: 6
+ 5 │     uint errorCount;
+   │          ─────┬────  
+   │               ╰────── def: 7
+ 6 │     uint lastValue;
+   │          ────┬────  
+   │              ╰────── def: 8
+ 7 │     function rate(address token) public returns (uint value, bool success) {
+   │              ──┬─         ──┬──                       ──┬──       ───┬───  
+   │                ╰─────────────────────────────────────────────────────────── def: 9
+   │                             │                           │            │     
+   │                             ╰────────────────────────────────────────────── def: 10
+   │                                                         │            │     
+   │                                                         ╰────────────────── def: 11
+   │                                                                      │     
+   │                                                                      ╰───── def: 12
+ 8 │         string memory last_reason;
+   │                       ─────┬─────  
+   │                            ╰─────── def: 13
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.4.21-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.4.21-failure.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or ThrowKeyword or TrueKeyword or UfixedKeyword or UintKeyword or VarKeyword or WhileKeyword.
+    ╭─[input.sol:9:9]
+    │
+  9 │ ╭─▶         try feed.getData(token) returns (uint v) {
+    ┆ ┆   
+ 20 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ interface DataFeed { function getData(address token) external returns (uint value); }
+   │           ────┬───            ───┬───         ──┬──                         ──┬──  
+   │               ╰──────────────────────────────────────────────────────────────────── def: 1
+   │                                  │              │                             │    
+   │                                  ╰───────────────────────────────────────────────── def: 2
+   │                                                 │                             │    
+   │                                                 ╰────────────────────────────────── def: 3
+   │                                                                               │    
+   │                                                                               ╰──── def: 4
+   │ 
+ 3 │ contract FeedConsumer {
+   │          ──────┬─────  
+   │                ╰─────── def: 5
+ 4 │     DataFeed feed;
+   │     ────┬─── ──┬─  
+   │         ╰────────── ref: 1
+   │                │   
+   │                ╰─── def: 6
+ 5 │     uint errorCount;
+   │          ─────┬────  
+   │               ╰────── def: 7
+ 6 │     uint lastValue;
+   │          ────┬────  
+   │              ╰────── def: 8
+ 7 │     function rate(address token) public returns (uint value, bool success) {
+   │              ──┬─         ──┬──                       ──┬──       ───┬───  
+   │                ╰─────────────────────────────────────────────────────────── def: 9
+   │                             │                           │            │     
+   │                             ╰────────────────────────────────────────────── def: 10
+   │                                                         │            │     
+   │                                                         ╰────────────────── def: 11
+   │                                                                      │     
+   │                                                                      ╰───── def: 12
+ 8 │         string memory last_reason;
+   │                       ─────┬─────  
+   │                            ╰─────── def: 13
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.5.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.5.0-failure.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or TrueKeyword or UfixedKeyword or UintKeyword or WhileKeyword.
+    ╭─[input.sol:9:9]
+    │
+  9 │ ╭─▶         try feed.getData(token) returns (uint v) {
+    ┆ ┆   
+ 20 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ interface DataFeed { function getData(address token) external returns (uint value); }
+   │           ────┬───            ───┬───         ──┬──                         ──┬──  
+   │               ╰──────────────────────────────────────────────────────────────────── def: 1
+   │                                  │              │                             │    
+   │                                  ╰───────────────────────────────────────────────── def: 2
+   │                                                 │                             │    
+   │                                                 ╰────────────────────────────────── def: 3
+   │                                                                               │    
+   │                                                                               ╰──── def: 4
+   │ 
+ 3 │ contract FeedConsumer {
+   │          ──────┬─────  
+   │                ╰─────── def: 5
+ 4 │     DataFeed feed;
+   │     ────┬─── ──┬─  
+   │         ╰────────── ref: 1
+   │                │   
+   │                ╰─── def: 6
+ 5 │     uint errorCount;
+   │          ─────┬────  
+   │               ╰────── def: 7
+ 6 │     uint lastValue;
+   │          ────┬────  
+   │              ╰────── def: 8
+ 7 │     function rate(address token) public returns (uint value, bool success) {
+   │              ──┬─         ──┬──                       ──┬──       ───┬───  
+   │                ╰─────────────────────────────────────────────────────────── def: 9
+   │                             │                           │            │     
+   │                             ╰────────────────────────────────────────────── def: 10
+   │                                                         │            │     
+   │                                                         ╰────────────────── def: 11
+   │                                                                      │     
+   │                                                                      ╰───── def: 12
+ 8 │         string memory last_reason;
+   │                       ─────┬─────  
+   │                            ╰─────── def: 13
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.5.3-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.5.3-failure.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or TrueKeyword or TypeKeyword or UfixedKeyword or UintKeyword or WhileKeyword.
+    ╭─[input.sol:9:9]
+    │
+  9 │ ╭─▶         try feed.getData(token) returns (uint v) {
+    ┆ ┆   
+ 20 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ interface DataFeed { function getData(address token) external returns (uint value); }
+   │           ────┬───            ───┬───         ──┬──                         ──┬──  
+   │               ╰──────────────────────────────────────────────────────────────────── def: 1
+   │                                  │              │                             │    
+   │                                  ╰───────────────────────────────────────────────── def: 2
+   │                                                 │                             │    
+   │                                                 ╰────────────────────────────────── def: 3
+   │                                                                               │    
+   │                                                                               ╰──── def: 4
+   │ 
+ 3 │ contract FeedConsumer {
+   │          ──────┬─────  
+   │                ╰─────── def: 5
+ 4 │     DataFeed feed;
+   │     ────┬─── ──┬─  
+   │         ╰────────── ref: 1
+   │                │   
+   │                ╰─── def: 6
+ 5 │     uint errorCount;
+   │          ─────┬────  
+   │               ╰────── def: 7
+ 6 │     uint lastValue;
+   │          ────┬────  
+   │              ╰────── def: 8
+ 7 │     function rate(address token) public returns (uint value, bool success) {
+   │              ──┬─         ──┬──                       ──┬──       ───┬───  
+   │                ╰─────────────────────────────────────────────────────────── def: 9
+   │                             │                           │            │     
+   │                             ╰────────────────────────────────────────────── def: 10
+   │                                                         │            │     
+   │                                                         ╰────────────────── def: 11
+   │                                                                      │     
+   │                                                                      ╰───── def: 12
+ 8 │         string memory last_reason;
+   │                       ─────┬─────  
+   │                            ╰─────── def: 13
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.6.0-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/generated/0.6.0-success.txt
@@ -1,0 +1,74 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ interface DataFeed { function getData(address token) external returns (uint value); }
+    │           ────┬───            ───┬───         ──┬──                         ──┬──  
+    │               ╰──────────────────────────────────────────────────────────────────── def: 1
+    │                                  │              │                             │    
+    │                                  ╰───────────────────────────────────────────────── def: 2
+    │                                                 │                             │    
+    │                                                 ╰────────────────────────────────── def: 3
+    │                                                                               │    
+    │                                                                               ╰──── def: 4
+    │ 
+  3 │ contract FeedConsumer {
+    │          ──────┬─────  
+    │                ╰─────── def: 5
+  4 │     DataFeed feed;
+    │     ────┬─── ──┬─  
+    │         ╰────────── ref: 1
+    │                │   
+    │                ╰─── def: 6
+  5 │     uint errorCount;
+    │          ─────┬────  
+    │               ╰────── def: 7
+  6 │     uint lastValue;
+    │          ────┬────  
+    │              ╰────── def: 8
+  7 │     function rate(address token) public returns (uint value, bool success) {
+    │              ──┬─         ──┬──                       ──┬──       ───┬───  
+    │                ╰─────────────────────────────────────────────────────────── def: 9
+    │                             │                           │            │     
+    │                             ╰────────────────────────────────────────────── def: 10
+    │                                                         │            │     
+    │                                                         ╰────────────────── def: 11
+    │                                                                      │     
+    │                                                                      ╰───── def: 12
+  8 │         string memory last_reason;
+    │                       ─────┬─────  
+    │                            ╰─────── def: 13
+  9 │         try feed.getData(token) returns (uint v) {
+    │             ──┬─ ───┬─── ──┬──                ┬  
+    │               ╰────────────────────────────────── ref: 6
+    │                     │      │                  │  
+    │                     ╰──────────────────────────── ref: 2
+    │                            │                  │  
+    │                            ╰───────────────────── ref: 10
+    │                                               │  
+    │                                               ╰── def: 14
+ 10 │             lastValue = v;
+    │             ────┬────   ┬  
+    │                 ╰────────── ref: 8
+    │                         │  
+    │                         ╰── ref: 14
+ 11 │             return (v, true);
+    │                     ┬  
+    │                     ╰── ref: 14
+ 12 │         } catch Error(string memory reason) {
+    │                                     ───┬──  
+    │                                        ╰──── def: 15
+ 13 │             last_reason = reason;
+    │             ─────┬─────   ───┬──  
+    │                  ╰──────────────── ref: 13
+    │                              │    
+    │                              ╰──── ref: 15
+ 14 │             errorCount++;
+    │             ─────┬────  
+    │                  ╰────── ref: 7
+    │ 
+ 17 │             errorCount++;
+    │             ─────┬────  
+    │                  ╰────── ref: 7
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/try_stmt/input.sol
@@ -1,0 +1,21 @@
+interface DataFeed { function getData(address token) external returns (uint value); }
+
+contract FeedConsumer {
+    DataFeed feed;
+    uint errorCount;
+    uint lastValue;
+    function rate(address token) public returns (uint value, bool success) {
+        string memory last_reason;
+        try feed.getData(token) returns (uint v) {
+            lastValue = v;
+            return (v, true);
+        } catch Error(string memory reason) {
+            last_reason = reason;
+            errorCount++;
+            return (0, false);
+        } catch {
+            errorCount++;
+            return (0, false);
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/control/while_stmt/generated/0.4.11-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/control/while_stmt/generated/0.4.11-success.txt
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── def: 1
+ 2 │     function test() public {
+   │              ──┬─  
+   │                ╰─── def: 2
+ 3 │         int i = 1;
+   │             ┬  
+   │             ╰── def: 3
+ 4 │         while (i < 100) {
+   │                ┬  
+   │                ╰── ref: 3
+ 5 │             i *= 3;
+   │             ┬  
+   │             ╰── ref: 3
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/control/while_stmt/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/control/while_stmt/input.sol
@@ -1,0 +1,8 @@
+contract Test {
+    function test() public {
+        int i = 1;
+        while (i < 100) {
+            i *= 3;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support in the binding rules for:

- `if`/`else` statements
- `for` loops
- `while` and `do-while` loops
- `emit` statements and basic event definitions
- `try-catch` statements
- `revert` and basic error definitions
- `unchecked` blocks

It also includes a reorganization of the rules file to improve readability and maintainability. Previously we were attempting to maintain compatibility with strict evaluation mode which meant that nodes and edges needed to be defined in previous rules. But since to build the stack graph the lazy evaluation mode is used anyway, this restriction can be dropped.

The file is now organized more or less hierarchically, with all the rules affecting a node and its descendants grouped together.
