### PR TITLE
fix infra failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,13 @@
       "onAutoForward": "openPreview"
     }
   },
+  "containerEnv": {
+    // A lot of dependencies/packages (specifically python) assume certain
+    // environment variables are set, and will fail otherwise.
+    // Here we set some defaults if the developer environment doesn't have them:
+    "LANG": "${localEnv:LANG:en_US.UTF-8}", // default language/locale
+    "TZ": "${localEnv:TZ:UTC}" // default timezone
+  },
   "customizations": {
     "vscode": {
       // __SLANG_VSCODE_EXTENSIONS_RECOMMENDATIONS__ (keep in sync)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: "ci"
 
 on:
-  # Run when invoked from other workflows:
-  workflow_call: {}
-
   # Run using manual triggers from GitHub UI:
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}
@@ -11,7 +8,7 @@ on:
   # Run on every pull request:
   pull_request: {}
 
-  # Run on pushes to any branch except 'main', which is handled by the 'publish' workflow:
+  # Run on pushes to any branch except 'main', as we use a merge queue, and test PRs individually before merging them:
   push:
     branches-ignore:
       - "main"
@@ -24,6 +21,11 @@ concurrency:
 jobs:
   ci:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
+
+    # Due to the "on" events above, this workflow will run on every push to any branch, and on every PR.
+    # This means that if a PR is created from a branch in the main repo, the CI jobs will run twice.
+    # This condition deduplicats it, so that it either runs on a push (to main repo or forks) or on a PR (from forks only).
+    if: "${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'NomicFoundation/slang') }}"
 
     steps:
       - name: "Checkout Repository"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ci:
-    # Only run on the main repo (not forks), and only on the 'main' branch:
-    if: "${{ github.repository == 'NomicFoundation/slang' && github.ref_name == 'main' }}"
-    uses: "./.github/workflows/ci.yml"
-
   publish:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
-    needs: "ci"
+
+    # Only run on the main repo (not forks), and only on the 'main' branch:
+    if: "${{ github.repository == 'NomicFoundation/slang' && github.ref_name == 'main' }}"
 
     permissions:
       contents: "write" # to create new branches and releases

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -3,9 +3,6 @@ env = {
   "PATH": "${HERMIT_ENV}/scripts/bin:${PATH}",
   "REPO_ROOT": "${HERMIT_ENV}",
 
-  // Python:
-  "LANG": "en_US.UTF-8",
-
   // Rust:
   "RUST_BACKTRACE": "full",
   "RUST_STABLE_VERSION": "1.79.0", // __RUST_STABLE_VERSION_MARKER__ (keep in sync)


### PR DESCRIPTION
This fixes a few issues discovered today:

- The python env bug, which bit us a few times already: #1006 a few months ago, and [more recently today](https://github.com/NomicFoundation/slang/actions/runs/10487528897/job/29049166673).
- Deduplicate CI jobs that trigger twice on PRs from branches in the main repo.
- Deduplicate `ci/ci` and `deploy/ci` jobs that cancel each other on when merging to `main` ([most recent failure](https://github.com/NomicFoundation/slang/actions/runs/10487528897/job/29048073333)).