### PR TITLE
remove version tag from wit definitions

### DIFF
--- a/crates/codegen/runtime/cargo/src/runtime/wit/interface/_world.wit.jinja2
+++ b/crates/codegen/runtime/cargo/src/runtime/wit/interface/_world.wit.jinja2
@@ -1,4 +1,4 @@
-package nomic-foundation:slang@{{ model.slang_version }};
+package nomic-foundation:slang;
 
 world slang {
     export cst;

--- a/crates/codegen/runtime/cargo/src/runtime/wit/interface/generated/_world.wit
+++ b/crates/codegen/runtime/cargo/src/runtime/wit/interface/generated/_world.wit
@@ -1,6 +1,6 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-package nomic-foundation:slang@0.0.0;
+package nomic-foundation:slang;
 
 world slang {
     export cst;

--- a/crates/solidity/outputs/cargo/slang_solidity/src/generated/wit/interface/generated/_world.wit
+++ b/crates/solidity/outputs/cargo/slang_solidity/src/generated/wit/interface/generated/_world.wit
@@ -1,6 +1,6 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-package nomic-foundation:slang@0.16.0;
+package nomic-foundation:slang;
 
 world slang {
     export cst;

--- a/crates/testlang/outputs/cargo/slang_testlang/src/generated/wit/interface/generated/_world.wit
+++ b/crates/testlang/outputs/cargo/slang_testlang/src/generated/wit/interface/generated/_world.wit
@@ -1,6 +1,6 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-package nomic-foundation:slang@0.16.0;
+package nomic-foundation:slang;
 
 world slang {
     export cst;


### PR DESCRIPTION
It failed the [recent version update](https://github.com/NomicFoundation/slang/actions/runs/10561509832/job/29257403873). Let's remove it for now, as it is not used anywhere, and will only be consumed in a later PR under the NPM package.