### PR TITLE
Fix query engine `OneOrMoreMatcher` to skip over in-between trivia

### DIFF
--- a/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
+++ b/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
@@ -268,6 +268,31 @@ fn test_one_or_more() {
 }
 
 #[test]
+fn test_one_or_more_anonymous() {
+    run_query_test(
+        &common_test_tree(),
+        "[TreeNode (@x [_])+ .]",
+        query_matches! {
+            {x: ["A", "B", "C", "DE"]}
+            {x: ["B", "C", "DE"]}
+            {x: ["C", "DE"]}
+            {x: ["DE"]}
+        },
+    );
+}
+
+#[test]
+fn test_one_or_more_anonymous_both_adjacent() {
+    run_query_test(
+        &common_test_tree(),
+        "[TreeNode . (@x [_])+ .]",
+        query_matches! {
+            {x: ["A", "B", "C", "DE"]}
+        },
+    );
+}
+
+#[test]
 fn test_zero_or_more() {
     run_query_test(
         &common_test_tree(),
@@ -337,6 +362,17 @@ fn test_adjacency_at_end_skips_trivia() {
         "[TreeNodeChild @x [DelimitedIdentifier] .]",
         query_matches! {
             {x: ["E"]}
+        },
+    );
+}
+
+#[test]
+fn test_one_or_more_anonymous_both_adjacent_with_trivia() {
+    run_query_test(
+        &common_test_tree_with_trivia(),
+        "[TreeNodeChild . @children [_]+ .]",
+        query_matches! {
+            {children: ["D", "E"]}
         },
     );
 }

--- a/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
+++ b/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
@@ -293,6 +293,17 @@ fn test_one_or_more_anonymous_both_adjacent() {
 }
 
 #[test]
+fn test_one_or_more_anonymous_both_adjacent_with_trivia() {
+    run_query_test(
+        &common_test_tree_with_trivia(),
+        "[TreeNodeChild . @children [_]+ .]",
+        query_matches! {
+            {children: ["D", "E"]}
+        },
+    );
+}
+
+#[test]
 fn test_zero_or_more() {
     run_query_test(
         &common_test_tree(),
@@ -362,17 +373,6 @@ fn test_adjacency_at_end_skips_trivia() {
         "[TreeNodeChild @x [DelimitedIdentifier] .]",
         query_matches! {
             {x: ["E"]}
-        },
-    );
-}
-
-#[test]
-fn test_one_or_more_anonymous_both_adjacent_with_trivia() {
-    run_query_test(
-        &common_test_tree_with_trivia(),
-        "[TreeNodeChild . @children [_]+ .]",
-        query_matches! {
-            {children: ["D", "E"]}
         },
     );
 }


### PR DESCRIPTION
The `OneOrMoreMatcher` would stop matching whenever it encountered a trivia item in a sequence. Since the parser may arbitrarily insert trivia items anywhere, this meant that the matched results would be incomplete.

This was found with this query from the Solidity bindings rules:

```
@specifier [InheritanceSpecifier [InheritanceTypes . @parents [_]+ .]]
```

Depending on the formatting of the parsed code, the parser would generate the children of `InheritanceTypes` with interleaved trivia items, eg. newlines if the inherited contracts/interfaces are enumerated in separate lines. Because `[_]+` would stop on the first trivia, the overall query would never match.
