### PR TITLE
disable cargo extra logs in CI

### DIFF
--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -145,7 +145,5 @@ impl CargoWorkspaceCommands for Command {
                 .unwrap(),
             ),
         )
-        // Print extra logs when build cache is invalidated:
-        .env("CARGO_LOG", "cargo::core::compiler::fingerprint=info")
     }
 }


### PR DESCRIPTION
cargo prints additional stack traces for each failed fingerprint, even internal non-user-facing errors, which makes it impossible to read test failures in CI ([example](https://github.com/NomicFoundation/slang/actions/runs/11616362259/job/32349137165?pr=1138)):

```log
2024-10-31T17:03:16.0479664Z    0.346629058s  INFO prepare_target{force=false package_id=infra_utils v0.18.3 (/workspaces/slang/crates/infra/utils) target="infra_utils"}: cargo::core::compiler::fingerprint: fingerprint error for infra_utils v0.18.3 (/workspaces/slang/crates/infra/utils)/Doc { deps: false, json: false }/TargetInner { name_inferred: true, ..: lib_target("infra_utils", ["lib"], "/workspaces/slang/crates/infra/utils/src/lib.rs", Edition2021) }
2024-10-31T17:03:16.0484532Z    0.346646862s  INFO prepare_target{force=false package_id=infra_utils v0.18.3 (/workspaces/slang/crates/infra/utils) target="infra_utils"}: cargo::core::compiler::fingerprint:     err: failed to read `/workspaces/slang/target/debug/.fingerprint/infra_utils-d0df7643d0fa78fa/doc-lib-infra_utils`
2024-10-31T17:03:16.0486177Z 
2024-10-31T17:03:16.0486266Z Caused by:
2024-10-31T17:03:16.0486541Z     No such file or directory (os error 2)
2024-10-31T17:03:16.0486801Z 
2024-10-31T17:03:16.0486889Z Stack backtrace:
2024-10-31T17:03:16.0487273Z    0: cargo_util::paths::read_bytes
2024-10-31T17:03:16.0487603Z    1: cargo_util::paths::read
2024-10-31T17:03:16.0488013Z    2: cargo::core::compiler::fingerprint::_compare_old_fingerprint
2024-10-31T17:03:16.0488514Z    3: cargo::core::compiler::fingerprint::prepare_target
2024-10-31T17:03:16.0488915Z    4: cargo::core::compiler::compile
2024-10-31T17:03:16.0489331Z    5: <cargo::core::compiler::build_runner::BuildRunner>::compile
2024-10-31T17:03:16.0489772Z    6: cargo::ops::cargo_compile::compile_ws
2024-10-31T17:03:16.0490132Z    7: cargo::ops::cargo_compile::compile
2024-10-31T17:03:16.0490464Z    8: cargo::ops::cargo_doc::doc
2024-10-31T17:03:16.0490762Z    9: cargo::commands::doc::exec
2024-10-31T17:03:16.0491144Z   10: <cargo::cli::Exec>::exec
2024-10-31T17:03:16.0491432Z   11: cargo::main
2024-10-31T17:03:16.0491869Z   12: std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>
2024-10-31T17:03:16.0492361Z   13: std::rt::lang_start::<()>::{closure#0}
2024-10-31T17:03:16.0492893Z   14: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
2024-10-31T17:03:16.0493796Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:284:13
2024-10-31T17:03:16.0494707Z   15: std::panicking::try::do_call
2024-10-31T17:03:16.0495235Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
2024-10-31T17:03:16.0495766Z   16: std::panicking::try
2024-10-31T17:03:16.0496248Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
2024-10-31T17:03:16.0496786Z   17: std::panic::catch_unwind
2024-10-31T17:03:16.0497279Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
2024-10-31T17:03:16.0497831Z   18: std::rt::lang_start_internal::{{closure}}
2024-10-31T17:03:16.0498370Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:48
2024-10-31T17:03:16.0498890Z   19: std::panicking::try::do_call
2024-10-31T17:03:16.0499403Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
2024-10-31T17:03:16.0499934Z   20: std::panicking::try
2024-10-31T17:03:16.0500417Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
2024-10-31T17:03:16.0500949Z   21: std::panic::catch_unwind
2024-10-31T17:03:16.0501426Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
2024-10-31T17:03:16.0501944Z   22: std::rt::lang_start_internal
2024-10-31T17:03:16.0502429Z              at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:20
2024-10-31T17:03:16.0502915Z   23: main
2024-10-31T17:03:16.0503143Z   24: __libc_start_call_main
2024-10-31T17:03:16.0503760Z              at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
2024-10-31T17:03:16.0504158Z   25: __libc_start_main_impl
2024-10-31T17:03:16.0504557Z              at ./csu/../csu/libc-start.c:392:3
2024-10-31T17:03:16.0504895Z   26: <unknown>
```