### PR TITLE
re-enable `ci` workflow on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   # Run on every pull request:
   pull_request: {}
 
+  # Run on pushes to any branch even 'main', as it is used to refresh the CI cache from scratch, so that it doesn't grow indefinitely:
+  push: {}
+
 # In the event that there is a new push to the ref, cancel any running jobs because they are now obsolete, wasting resources.
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}-${{ github.event_name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,6 @@ on:
   # Run on every pull request:
   pull_request: {}
 
-  # Run on pushes to any branch except 'main', as we use a merge queue, and test PRs individually before merging them:
-  push:
-    branches-ignore:
-      - "main"
-
 # In the event that there is a new push to the ref, cancel any running jobs because they are now obsolete, wasting resources.
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}-${{ github.event_name }}"


### PR DESCRIPTION
It is used to update the cache with a fresh copy, and prevent it from getting bigger over time.