### PR TITLE
infra improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,7 @@ dependencies = [
  "infra_utils",
  "itertools 0.13.0",
  "markdown",
+ "rayon",
  "semver",
  "serde",
  "serde_json",

--- a/crates/codegen/ebnf/src/builder.rs
+++ b/crates/codegen/ebnf/src/builder.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use codegen_language_definition::model::{
-    BuiltInLabel, EnumItem, EnumVariant, Field, FragmentItem, Identifier, Item, KeywordDefinition,
-    KeywordItem, KeywordValue, Language, OperatorModel, PrecedenceExpression, PrecedenceItem,
-    PrecedenceOperator, PrimaryExpression, RepeatedItem, Scanner, SeparatedItem, StructItem,
-    TokenDefinition, TokenItem, TriviaItem, VersionSpecifier,
+    EnumItem, EnumVariant, Field, FragmentItem, Identifier, Item, KeywordDefinition, KeywordItem,
+    KeywordValue, Language, OperatorModel, PrecedenceExpression, PrecedenceItem,
+    PrecedenceOperator, PredefinedLabel, PrimaryExpression, RepeatedItem, Scanner, SeparatedItem,
+    StructItem, TokenDefinition, TokenItem, TriviaItem, VersionSpecifier,
 };
 use indexmap::IndexMap;
 use inflector::Inflector;
@@ -128,7 +128,7 @@ impl Builder {
 
         let variants = variants.iter().map(|EnumVariant { reference, enabled }| {
             Value::new(
-                Self::build_ref(Some(BuiltInLabel::Variant.as_ref()), reference),
+                Self::build_ref(Some(PredefinedLabel::Variant.as_ref()), reference),
                 Self::build_enabled_comment(enabled),
             )
         });
@@ -151,7 +151,7 @@ impl Builder {
 
         self.add_entry(name, Terminal::No, Inlined::No);
 
-        let label = BuiltInLabel::Item.as_ref();
+        let label = PredefinedLabel::Item.as_ref();
         let expression = if allow_empty.unwrap_or_default() {
             Expression::new_zero_or_more(Self::build_ref(Some(label), reference).into())
         } else {
@@ -178,11 +178,11 @@ impl Builder {
         self.add_entry(name, Terminal::No, Inlined::No);
 
         let mut expression = Expression::new_sequence(vec![
-            Self::build_ref(Some(BuiltInLabel::Item.as_ref()), reference),
+            Self::build_ref(Some(PredefinedLabel::Item.as_ref()), reference),
             Expression::new_zero_or_more(
                 Expression::new_sequence(vec![
-                    Self::build_ref(Some(BuiltInLabel::Separator.as_ref()), separator),
-                    Self::build_ref(Some(BuiltInLabel::Item.as_ref()), reference),
+                    Self::build_ref(Some(PredefinedLabel::Separator.as_ref()), separator),
+                    Self::build_ref(Some(PredefinedLabel::Item.as_ref()), reference),
                 ])
                 .into(),
             ),
@@ -216,7 +216,7 @@ impl Builder {
             let PrecedenceExpression { name, operators } = precedence_expression.as_ref();
 
             values.push(Value::new(
-                Self::build_ref(Some(BuiltInLabel::Variant.as_ref()), name),
+                Self::build_ref(Some(PredefinedLabel::Variant.as_ref()), name),
                 None,
             ));
 
@@ -231,7 +231,7 @@ impl Builder {
             let PrimaryExpression { reference, enabled } = primary_expression;
 
             values.push(Value::new(
-                Self::build_ref(Some(BuiltInLabel::Variant.as_ref()), reference),
+                Self::build_ref(Some(PredefinedLabel::Variant.as_ref()), reference),
                 Self::build_enabled_comment(enabled),
             ));
         }
@@ -265,7 +265,7 @@ impl Builder {
                 leading_comments.push("Prefix unary operator".to_string());
 
                 values.push(Value::new(
-                    Self::build_ref(Some(BuiltInLabel::Operand.as_ref()), base_name),
+                    Self::build_ref(Some(PredefinedLabel::Operand.as_ref()), base_name),
                     None,
                 ));
             }
@@ -275,7 +275,7 @@ impl Builder {
                 values.insert(
                     0,
                     Value::new(
-                        Self::build_ref(Some(BuiltInLabel::Operand.as_ref()), base_name),
+                        Self::build_ref(Some(PredefinedLabel::Operand.as_ref()), base_name),
                         None,
                     ),
                 );
@@ -286,12 +286,12 @@ impl Builder {
                 values.insert(
                     0,
                     Value::new(
-                        Self::build_ref(Some(BuiltInLabel::LeftOperand.as_ref()), base_name),
+                        Self::build_ref(Some(PredefinedLabel::LeftOperand.as_ref()), base_name),
                         None,
                     ),
                 );
                 values.push(Value::new(
-                    Self::build_ref(Some(BuiltInLabel::RightOperand.as_ref()), base_name),
+                    Self::build_ref(Some(PredefinedLabel::RightOperand.as_ref()), base_name),
                     None,
                 ));
             }
@@ -301,12 +301,12 @@ impl Builder {
                 values.insert(
                     0,
                     Value::new(
-                        Self::build_ref(Some(BuiltInLabel::LeftOperand.as_ref()), base_name),
+                        Self::build_ref(Some(PredefinedLabel::LeftOperand.as_ref()), base_name),
                         None,
                     ),
                 );
                 values.push(Value::new(
-                    Self::build_ref(Some(BuiltInLabel::RightOperand.as_ref()), base_name),
+                    Self::build_ref(Some(PredefinedLabel::RightOperand.as_ref()), base_name),
                     None,
                 ));
             }

--- a/crates/codegen/language/definition/src/model/manifest.rs
+++ b/crates/codegen/language/definition/src/model/manifest.rs
@@ -177,7 +177,7 @@ pub struct Topic {
     Clone, Copy, Debug, strum_macros::AsRefStr, strum_macros::EnumIter, strum_macros::VariantNames,
 )]
 #[strum(serialize_all = "snake_case")]
-pub enum BuiltInLabel {
+pub enum PredefinedLabel {
     Item,
     Variant,
     Separator,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/edge_label.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/edge_label.rs.jinja2
@@ -17,7 +17,7 @@
 #[derive(Clone, Copy)]
 pub enum EdgeLabel {
     // Built-in:
-    {% for label in model.kinds.built_in_labels -%}
+    {% for label in model.kinds.predefined_labels -%}
         {{ label | pascal_case }},
     {%- endfor %}
 

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -50,7 +50,7 @@ interface cst {
 
     /// Represents the different types of relationships between nodes in the syntax tree.
     enum edge-label {
-        {%- for label in model.kinds.built_in_labels %}
+        {%- for label in model.kinds.predefined_labels %}
             {{ label | wit_case }},
         {%- endfor %}
 

--- a/crates/codegen/runtime/generator/src/ast/mod.rs
+++ b/crates/codegen/runtime/generator/src/ast/mod.rs
@@ -1,4 +1,4 @@
-use codegen_language_definition::model::{self, BuiltInLabel};
+use codegen_language_definition::model::{self, PredefinedLabel};
 use indexmap::{IndexMap, IndexSet};
 use serde::Serialize;
 
@@ -208,7 +208,7 @@ impl AstModel {
         base_name: &model::Identifier,
         expression: &model::PrecedenceExpression,
     ) {
-        let operand = |label: BuiltInLabel| Field {
+        let operand = |label: PredefinedLabel| Field {
             label: label.as_ref().into(),
             r#type: Some(base_name.clone()),
             is_optional: false,
@@ -224,17 +224,17 @@ impl AstModel {
         match operator.model {
             model::OperatorModel::Prefix => {
                 fields.extend(self.convert_fields(&operator.fields));
-                fields.push(operand(BuiltInLabel::Operand));
+                fields.push(operand(PredefinedLabel::Operand));
             }
             model::OperatorModel::Postfix => {
-                fields.push(operand(BuiltInLabel::Operand));
+                fields.push(operand(PredefinedLabel::Operand));
                 fields.extend(self.convert_fields(&operator.fields));
             }
             model::OperatorModel::BinaryLeftAssociative
             | model::OperatorModel::BinaryRightAssociative => {
-                fields.push(operand(BuiltInLabel::LeftOperand));
+                fields.push(operand(PredefinedLabel::LeftOperand));
                 fields.extend(self.convert_fields(&operator.fields));
-                fields.push(operand(BuiltInLabel::RightOperand));
+                fields.push(operand(PredefinedLabel::RightOperand));
             }
         };
 

--- a/crates/codegen/runtime/generator/src/kinds/mod.rs
+++ b/crates/codegen/runtime/generator/src/kinds/mod.rs
@@ -14,7 +14,7 @@ pub struct KindsModel {
     trivia_scanner_names: BTreeSet<Identifier>,
     /// Defines `EdgeLabel` enum variants.
     labels: BTreeSet<Identifier>,
-    /// Built-in labels for edges.
+    /// Predefined labels for edges.
     predefined_labels: &'static [&'static str],
     // Defines the `LexicalContext(Type)` enum and type-level variants.
     lexical_contexts: BTreeSet<Identifier>,

--- a/crates/codegen/runtime/generator/src/kinds/mod.rs
+++ b/crates/codegen/runtime/generator/src/kinds/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use codegen_language_definition::model::{self, BuiltInLabel, Identifier, Item};
+use codegen_language_definition::model::{self, Identifier, Item, PredefinedLabel};
 use serde::Serialize;
 use strum::VariantNames;
 
@@ -15,7 +15,7 @@ pub struct KindsModel {
     /// Defines `EdgeLabel` enum variants.
     labels: BTreeSet<Identifier>,
     /// Built-in labels for edges.
-    built_in_labels: &'static [&'static str],
+    predefined_labels: &'static [&'static str],
     // Defines the `LexicalContext(Type)` enum and type-level variants.
     lexical_contexts: BTreeSet<Identifier>,
     /// Defines the root `NonterminalKind` for a source file of the language.
@@ -29,7 +29,7 @@ impl Default for KindsModel {
             terminal_kinds: BTreeSet::default(),
             trivia_scanner_names: BTreeSet::default(),
             labels: BTreeSet::default(),
-            built_in_labels: BuiltInLabel::VARIANTS,
+            predefined_labels: PredefinedLabel::VARIANTS,
             lexical_contexts: BTreeSet::default(),
             root_kind: Identifier::from("Stub1"),
         }

--- a/crates/infra/cli/Cargo.toml
+++ b/crates/infra/cli/Cargo.toml
@@ -14,6 +14,7 @@ clap_complete = { workspace = true }
 infra_utils = { workspace = true }
 itertools = { workspace = true }
 markdown = { workspace = true }
+rayon = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/infra/cli/src/toolchains/wasm/mod.rs
+++ b/crates/infra/cli/src/toolchains/wasm/mod.rs
@@ -7,7 +7,7 @@ use infra_utils::commands::Command;
 use infra_utils::paths::{FileWalker, PathExtensions};
 use strum_macros::EnumIter;
 
-pub const WASM_TARGET: &str = "wasm32-wasi";
+pub const WASM_TARGET: &str = "wasm32-wasip1";
 
 #[derive(Clone, Copy, EnumIter)]
 pub enum WasmPackage {


### PR DESCRIPTION
minor improvements to the codegen backend based on earlier changes in #1101 and #1120

- build npm packages in parallel
- rename `BuiltInLabel` to `PredefinedLabel` to disambiguate from the newly introduced built-ins in bindings.
- rename `wasm32-wasi` to `wasm32-wasip1`, as it is already deprecated in nightly.