### PR TITLE
consolidate `.children()` APIs and iterators

### DIFF
--- a/.changeset/curvy-fireants-float.md
+++ b/.changeset/curvy-fireants-float.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+add `node.descendants()` and `cursor.descendants()` APIs to allow iterating over all descendants of the current node in pre-order traversal.

--- a/.changeset/early-trees-lay.md
+++ b/.changeset/early-trees-lay.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+fix `node.children()` and `parseOutput.errors()` return types

--- a/.changeset/grumpy-cups-change.md
+++ b/.changeset/grumpy-cups-change.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+add `cursor.ancestors()` API to allow iterating over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.

--- a/.changeset/long-tips-pay.md
+++ b/.changeset/long-tips-pay.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+add `cursor.consume()` API to allow iterating over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.

--- a/.changeset/long-tips-pay.md
+++ b/.changeset/long-tips-pay.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/slang": minor
 ---
 
-add `cursor.consume()` API to allow iterating over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+add `cursor.remainingNodes()` API to allow iterating over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/mod.rs
@@ -41,7 +41,8 @@ pub type TerminalNode = metaslang_cst::nodes::TerminalNode<KindTypes>;
 pub type Edge = metaslang_cst::nodes::Edge<KindTypes>;
 
 pub type Cursor = metaslang_cst::cursor::Cursor<KindTypes>;
-pub type CursorWithEdges = metaslang_cst::cursor::CursorWithEdges<KindTypes>;
+pub type CursorIterator = metaslang_cst::cursor::CursorIterator<KindTypes>;
+pub type AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<KindTypes>;
 
 pub type Query = metaslang_cst::query::Query<KindTypes>;
 pub use metaslang_cst::query::QueryError;

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parse_output.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parse_output.rs
@@ -22,6 +22,6 @@ impl ParseOutput {
 
     /// Creates a cursor that starts at the root of the parse tree.
     pub fn create_tree_cursor(&self) -> Cursor {
-        self.parse_tree.cursor_with_offset(TextIndex::ZERO)
+        self.parse_tree.clone().cursor_with_offset(TextIndex::ZERO)
     }
 }

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/choice_helper.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/choice_helper.rs
@@ -139,7 +139,7 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
             edge.node
                 .clone()
                 .cursor_with_offset(TextIndex::ZERO)
-                .consume()
+                .remaining_nodes()
         })
         .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/choice_helper.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/choice_helper.rs
@@ -135,8 +135,13 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
 
     nodes
         .iter()
-        .flat_map(|child| child.cursor_with_offset(TextIndex::ZERO))
-        .filter_map(|node| match node {
+        .flat_map(|edge| {
+            edge.node
+                .clone()
+                .cursor_with_offset(TextIndex::ZERO)
+                .consume()
+        })
+        .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),
             _ => None,
         })

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
@@ -141,7 +141,7 @@ where
                         parse_tree
                             .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .consume()
+                            .remaining_nodes()
                             .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
@@ -139,8 +139,10 @@ where
                     debug_assert_eq!(
                         errors.is_empty(),
                         parse_tree
+                            .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .all(|node| node
+                            .consume()
+                            .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())
                                 .is_none())

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_result.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_result.rs
@@ -133,7 +133,7 @@ impl Match {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .all(|edge| {
                 edge.as_terminal()
@@ -214,7 +214,7 @@ impl IncompleteMatch {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .try_fold(0u8, |mut acc, edge| {
                 match edge.node {

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_result.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_result.rs
@@ -129,9 +129,14 @@ impl Match {
     pub fn is_full_recursive(&self) -> bool {
         self.nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .all(|node| {
-                node.as_terminal()
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .all(|edge| {
+                edge.as_terminal()
                     .filter(|tok| !tok.kind.is_valid())
                     .is_none()
             })
@@ -205,9 +210,14 @@ impl IncompleteMatch {
         let result = self
             .nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .try_fold(0u8, |mut acc, node| {
-                match node {
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .try_fold(0u8, |mut acc, edge| {
+                match edge.node {
                     Node::Terminal(tok) if tok.kind.is_valid() && !tok.kind.is_trivia() => {
                         acc += 1;
                     }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/config.json.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/config.json.jinja2
@@ -40,11 +40,6 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:nonterminal-node.children()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
     "nomic-foundation:slang:cst:terminal-node": {
       "Resource": {
         "custom_inspect": true
@@ -61,11 +56,6 @@
       }
     },
     "nomic-foundation:slang:cst:terminal-node.text-length()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:cst:terminal-node.children()": {
       "Function": {
         "as_getter": true
       }
@@ -95,9 +85,14 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:cursor.ancestors()": {
-      "Function": {
-        "as_getter": true
+    "nomic-foundation:slang:cst:cursor-iterator": {
+      "Resource": {
+        "as_iterator": true
+      }
+    },
+    "nomic-foundation:slang:cst:ancestors-iterator": {
+      "Resource": {
+        "as_iterator": true
       }
     },
     "nomic-foundation:slang:cst:query-match.captures": {
@@ -126,11 +121,6 @@
       }
     },
     "nomic-foundation:slang:parser:parse-output.tree()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:parser:parse-output.errors()": {
       "Function": {
         "as_getter": true
       }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/generated/config.json
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/generated/config.json
@@ -40,11 +40,6 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:nonterminal-node.children()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
     "nomic-foundation:slang:cst:terminal-node": {
       "Resource": {
         "custom_inspect": true
@@ -61,11 +56,6 @@
       }
     },
     "nomic-foundation:slang:cst:terminal-node.text-length()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:cst:terminal-node.children()": {
       "Function": {
         "as_getter": true
       }
@@ -95,9 +85,14 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:cursor.ancestors()": {
-      "Function": {
-        "as_getter": true
+    "nomic-foundation:slang:cst:cursor-iterator": {
+      "Resource": {
+        "as_iterator": true
+      }
+    },
+    "nomic-foundation:slang:cst:ancestors-iterator": {
+      "Resource": {
+        "as_iterator": true
       }
     },
     "nomic-foundation:slang:cst:query-match.captures": {
@@ -126,11 +121,6 @@
       }
     },
     "nomic-foundation:slang:parser:parse-output.tree()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:parser:parse-output.errors()": {
       "Function": {
         "as_getter": true
       }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -88,8 +88,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node and its children back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -111,8 +114,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of this node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -157,13 +163,19 @@ interface cst {
         /// Returns the current depth in the tree (i.e. number of ancestors).
         depth: func() -> u32;
 
-        /// Returns the list of ancestor nodes up to the root.
-        ancestors: func() -> list<nonterminal-node>;
+        /// Returns the list of child edges directly connected to this node.
+        children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+        ancestors: func() -> ancestors-iterator;
 
         /// Moves to the next node in pre-order traversal.
         go-to-next: func() -> bool;
         /// Moves to the next node that isn't a descendant of the current node.
-        go-to-next-non-descendent: func() -> bool;
+        go-to-next-non-descendant: func() -> bool;
         /// Moves to the previous node in pre-order traversal.
         go-to-previous: func() -> bool;
 
@@ -201,6 +213,18 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    resource cursor-iterator {
+        /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
+        next: func() -> option<edge>;
+    }
+
+    /// Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+    resource ancestors-iterator {
+        /// Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
+        next: func() -> option<nonterminal-node>;
+    }
+
     /// Represents a tree query for pattern matching in the syntax tree.
     resource query {
         /// Parses a query string into a query object.
@@ -228,19 +252,28 @@ interface cst {
 
     /// Iterator over query matches in the syntax tree.
     resource query-match-iterator {
-        /// Returns the next match or None if there are no more matches.
+        /// Returns the next match or `undefined` if there are no more matches.
         next: func() -> option<query-match>;
     }
 
     /// Represents a position in the source text, with indices for different unicode encodings of the source.
     record text-index {
         /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like Rust that use UTF-8.
         utf8: u32,
-        /// Character offset in UTF-16 encoding.
+        /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like JavaScript that use UTF-16.
         utf16: u32,
         /// Line number (0-based).
+        /// Lines are separated by:
+        ///
+        /// - carriage return `\r`.
+        /// - newline `\n`.
+        /// - line separator `\u2028`.
+        /// - paragraph separator `\u2029`.
         line: u32,
         /// Column number (0-based).
+        /// Columns are counted in [unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value).
         column: u32,
     }
 

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -167,8 +167,8 @@ interface cst {
         children: func() -> list<edge>;
         /// Returns an iterator over all descendants of the current node in pre-order traversal.
         descendants: func() -> cursor-iterator;
-        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
-        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
+        remaining-nodes: func() -> cursor-iterator;
         /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
         ancestors: func() -> ancestors-iterator;
 
@@ -213,7 +213,7 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
-    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
     resource cursor-iterator {
         /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
         next: func() -> option<edge>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
@@ -154,8 +154,8 @@ interface cst {
         children: func() -> list<edge>;
         /// Returns an iterator over all descendants of the current node in pre-order traversal.
         descendants: func() -> cursor-iterator;
-        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
-        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
+        remaining-nodes: func() -> cursor-iterator;
         /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
         ancestors: func() -> ancestors-iterator;
 
@@ -200,7 +200,7 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
-    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
     resource cursor-iterator {
         /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
         next: func() -> option<edge>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
@@ -75,8 +75,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node and its children back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -98,8 +101,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of this node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -144,13 +150,19 @@ interface cst {
         /// Returns the current depth in the tree (i.e. number of ancestors).
         depth: func() -> u32;
 
-        /// Returns the list of ancestor nodes up to the root.
-        ancestors: func() -> list<nonterminal-node>;
+        /// Returns the list of child edges directly connected to this node.
+        children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+        ancestors: func() -> ancestors-iterator;
 
         /// Moves to the next node in pre-order traversal.
         go-to-next: func() -> bool;
         /// Moves to the next node that isn't a descendant of the current node.
-        go-to-next-non-descendent: func() -> bool;
+        go-to-next-non-descendant: func() -> bool;
         /// Moves to the previous node in pre-order traversal.
         go-to-previous: func() -> bool;
 
@@ -188,6 +200,18 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    resource cursor-iterator {
+        /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
+        next: func() -> option<edge>;
+    }
+
+    /// Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+    resource ancestors-iterator {
+        /// Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
+        next: func() -> option<nonterminal-node>;
+    }
+
     /// Represents a tree query for pattern matching in the syntax tree.
     resource query {
         /// Parses a query string into a query object.
@@ -215,19 +239,28 @@ interface cst {
 
     /// Iterator over query matches in the syntax tree.
     resource query-match-iterator {
-        /// Returns the next match or None if there are no more matches.
+        /// Returns the next match or `undefined` if there are no more matches.
         next: func() -> option<query-match>;
     }
 
     /// Represents a position in the source text, with indices for different unicode encodings of the source.
     record text-index {
         /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like Rust that use UTF-8.
         utf8: u32,
-        /// Character offset in UTF-16 encoding.
+        /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like JavaScript that use UTF-16.
         utf16: u32,
         /// Line number (0-based).
+        /// Lines are separated by:
+        ///
+        /// - carriage return `\r`.
+        /// - newline `\n`.
+        /// - line separator `\u2028`.
+        /// - paragraph separator `\u2029`.
         line: u32,
         /// Column number (0-based).
+        /// Columns are counted in [unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value).
         column: u32,
     }
 

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
@@ -1,21 +1,26 @@
+use std::rc::Rc;
+
 use crate::wasm_crate::utils::{
     define_rc_wrapper, define_refcell_wrapper, define_wrapper, enum_to_enum, FromFFI, IntoFFI,
 };
 
 mod ffi {
     pub use crate::wasm_crate::bindings::exports::nomic_foundation::slang::cst::{
-        Cursor, CursorBorrow, Edge, EdgeLabel, Guest, GuestCursor, GuestNonterminalNode,
-        GuestQuery, GuestQueryMatchIterator, GuestTerminalKindExtensions, GuestTerminalNode, Node,
-        NonterminalKind, NonterminalNode, NonterminalNodeBorrow, Query, QueryBorrow, QueryError,
-        QueryMatch, QueryMatchIterator, QueryMatchIteratorBorrow, TerminalKind, TerminalNode,
-        TerminalNodeBorrow, TextIndex, TextRange,
+        AncestorsIterator, AncestorsIteratorBorrow, Cursor, CursorBorrow, CursorIterator,
+        CursorIteratorBorrow, Edge, EdgeLabel, Guest, GuestAncestorsIterator, GuestCursor,
+        GuestCursorIterator, GuestNonterminalNode, GuestQuery, GuestQueryMatchIterator,
+        GuestTerminalKindExtensions, GuestTerminalNode, Node, NonterminalKind, NonterminalNode,
+        NonterminalNodeBorrow, Query, QueryBorrow, QueryError, QueryMatch, QueryMatchIterator,
+        QueryMatchIteratorBorrow, TerminalKind, TerminalNode, TerminalNodeBorrow, TextIndex,
+        TextRange,
     };
 }
 
 mod rust {
     pub use crate::rust_crate::cst::{
-        Cursor, Edge, EdgeLabel, Node, NonterminalKind, NonterminalNode, Query, QueryError,
-        QueryMatch, QueryMatchIterator, TerminalKind, TerminalNode, TextIndex, TextRange,
+        AncestorsIterator, Cursor, CursorIterator, Edge, EdgeLabel, Node, NonterminalKind,
+        NonterminalNode, Query, QueryError, QueryMatch, QueryMatchIterator, TerminalKind,
+        TerminalNode, TextIndex, TextRange,
     };
 }
 
@@ -26,6 +31,8 @@ impl ffi::Guest for crate::wasm_crate::World {
     type TerminalNode = TerminalNodeWrapper;
 
     type Cursor = CursorWrapper;
+    type CursorIterator = CursorIteratorWrapper;
+    type AncestorsIterator = AncestorsIteratorWrapper;
 
     type Query = QueryWrapper;
     type QueryMatchIterator = QueryMatchIteratorWrapper;
@@ -109,7 +116,11 @@ define_rc_wrapper! { NonterminalNode {
     }
 
     fn children(&self) -> Vec<ffi::Edge> {
-        self._borrow_ffi().children.iter().map(|edge| edge.clone()._into_ffi()).collect()
+        self._borrow_ffi().children().iter().cloned().map(IntoFFI::_into_ffi).collect()
+    }
+
+    fn descendants(&self) -> ffi::CursorIterator {
+        Rc::clone(self._borrow_ffi()).descendants()._into_ffi()
     }
 
     fn unparse(&self) -> String {
@@ -145,7 +156,11 @@ define_rc_wrapper! { TerminalNode {
     }
 
     fn children(&self) -> Vec<ffi::Edge> {
-        Vec::new()
+        self._borrow_ffi().children().iter().cloned().map(IntoFFI::_into_ffi).collect()
+    }
+
+    fn descendants(&self) -> ffi::CursorIterator {
+        Rc::clone(self._borrow_ffi()).descendants()._into_ffi()
     }
 
     fn unparse(&self) -> String {
@@ -167,7 +182,7 @@ impl IntoFFI<ffi::Edge> for rust::Edge {
     #[inline]
     fn _into_ffi(self) -> ffi::Edge {
         ffi::Edge {
-            label: self.label.map(|label| label._into_ffi()),
+            label: self.label.map(IntoFFI::_into_ffi),
             node: self.node._into_ffi(),
         }
     }
@@ -220,16 +235,28 @@ define_refcell_wrapper! { Cursor {
         self._borrow_ffi().depth().try_into().unwrap()
     }
 
-    fn ancestors(&self) -> Vec<ffi::NonterminalNode> {
-        self._borrow_ffi().ancestors().map(|x|x._into_ffi()).collect()
+    fn children(&self) -> Vec<ffi::Edge> {
+        self._borrow_ffi().children().iter().cloned().map(IntoFFI::_into_ffi).collect()
+    }
+
+    fn descendants(&self) -> ffi::CursorIterator {
+        self._borrow_ffi().descendants()._into_ffi()
+    }
+
+    fn consume(&self) -> ffi::CursorIterator {
+        self._borrow_ffi().clone().consume()._into_ffi()
+    }
+
+    fn ancestors(&self) -> ffi::AncestorsIterator {
+        self._borrow_ffi().ancestors()._into_ffi()
     }
 
     fn go_to_next(&self) -> bool {
         self._borrow_mut_ffi().go_to_next()
     }
 
-    fn go_to_next_non_descendent(&self) -> bool {
-        self._borrow_mut_ffi().go_to_next_non_descendent()
+    fn go_to_next_non_descendant(&self) -> bool {
+        self._borrow_mut_ffi().go_to_next_non_descendant()
     }
 
     fn go_to_previous(&self) -> bool {
@@ -297,6 +324,30 @@ define_refcell_wrapper! { Cursor {
 
 //================================================
 //
+// resource cursor-iterator
+//
+//================================================
+
+define_refcell_wrapper! { CursorIterator {
+    fn next(&self) -> Option<ffi::Edge> {
+        self._borrow_mut_ffi().next().map(IntoFFI::_into_ffi)
+    }
+} }
+
+//================================================
+//
+// resource ancestors-iterator
+//
+//================================================
+
+define_refcell_wrapper! { AncestorsIterator {
+    fn next(&self) -> Option<ffi::NonterminalNode> {
+        self._borrow_mut_ffi().next().map(IntoFFI::_into_ffi)
+    }
+} }
+
+//================================================
+//
 // resource query
 //
 //================================================
@@ -350,7 +401,7 @@ impl IntoFFI<ffi::QueryMatch> for rust::QueryMatch {
             captures: self
                 .captures
                 .into_iter()
-                .map(|(k, v)| (k, v.into_iter().map(|c| c._into_ffi()).collect()))
+                .map(|(k, v)| (k, v.into_iter().map(IntoFFI::_into_ffi).collect()))
                 .collect(),
         }
     }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
@@ -243,8 +243,8 @@ define_refcell_wrapper! { Cursor {
         self._borrow_ffi().descendants()._into_ffi()
     }
 
-    fn consume(&self) -> ffi::CursorIterator {
-        self._borrow_ffi().clone().consume()._into_ffi()
+    fn remaining_nodes(&self) -> ffi::CursorIterator {
+        self._borrow_ffi().remaining_nodes()._into_ffi()
     }
 
     fn ancestors(&self) -> ffi::AncestorsIterator {

--- a/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
@@ -28,6 +28,12 @@ export type Edge = generated.cst.Edge;
 export const Cursor = generated.cst.Cursor;
 export type Cursor = generated.cst.Cursor;
 
+export const CursorIterator = generated.cst.CursorIterator;
+export type CursorIterator = generated.cst.CursorIterator;
+
+export const AncestorsIterator = generated.cst.AncestorsIterator;
+export type AncestorsIterator = generated.cst.AncestorsIterator;
+
 export const Query = generated.cst.Query;
 export type Query = generated.cst.Query;
 

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -5,6 +5,8 @@ export namespace NomicFoundationSlangCst {
   export { NonterminalNode };
   export { TerminalNode };
   export { Cursor };
+  export { CursorIterator };
+  export { AncestorsIterator };
   export { Query };
   export { QueryMatchIterator };
   export { NonterminalKind };
@@ -67,6 +69,11 @@ export interface TextRange {
   end: TextIndex;
 }
 
+export class AncestorsIterator {
+  [Symbol.iterator](): Iterator<NonterminalNode>;
+  next(): NonterminalNode | undefined;
+}
+
 export class Cursor {
   reset(): void;
   complete(): void;
@@ -78,9 +85,12 @@ export class Cursor {
   get textOffset(): TextIndex;
   get textRange(): TextRange;
   get depth(): number;
-  get ancestors(): NonterminalNode[];
+  children(): Edge[];
+  descendants(): CursorIterator;
+  consume(): CursorIterator;
+  ancestors(): AncestorsIterator;
   goToNext(): boolean;
-  goToNextNonDescendent(): boolean;
+  goToNextNonDescendant(): boolean;
   goToPrevious(): boolean;
   goToParent(): boolean;
   goToFirstChild(): boolean;
@@ -97,6 +107,11 @@ export class Cursor {
   query(queries: Query[]): QueryMatchIterator;
 }
 
+export class CursorIterator {
+  [Symbol.iterator](): Iterator<Edge>;
+  next(): Edge | undefined;
+}
+
 export class NonterminalNode {
   readonly nodeVariant = NodeVariant.NonterminalNode;
 
@@ -109,7 +124,8 @@ export class NonterminalNode {
   get id(): number;
   get kind(): NonterminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
   createCursor(textOffset: TextIndex): Cursor;
@@ -141,7 +157,8 @@ export class TerminalNode {
   get id(): number;
   get kind(): TerminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
 }

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -87,7 +87,7 @@ export class Cursor {
   get depth(): number;
   children(): Edge[];
   descendants(): CursorIterator;
-  consume(): CursorIterator;
+  remainingNodes(): CursorIterator;
   ancestors(): AncestorsIterator;
   goToNext(): boolean;
   goToNextNonDescendant(): boolean;

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
@@ -21,7 +21,7 @@ export class ParseError {
 
 export class ParseOutput {
   get tree(): Node;
-  get errors(): ParseError[];
+  errors(): ParseError[];
   isValid(): boolean;
   createTreeCursor(): Cursor;
 }

--- a/crates/metaslang/cst/generated/public_api.txt
+++ b/crates/metaslang/cst/generated/public_api.txt
@@ -13,7 +13,6 @@ impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::ancestors(&self) -> metaslang_cst::cursor::AncestorsIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::children(&self) -> &[metaslang_cst::nodes::Edge<T>]
 pub fn metaslang_cst::cursor::Cursor<T>::complete(&mut self)
-pub fn metaslang_cst::cursor::Cursor<T>::consume(self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::depth(&self) -> usize
 pub fn metaslang_cst::cursor::Cursor<T>::descendants(&self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_first_child(&mut self) -> bool
@@ -34,6 +33,7 @@ pub fn metaslang_cst::cursor::Cursor<T>::go_to_previous_sibling(&mut self) -> bo
 pub fn metaslang_cst::cursor::Cursor<T>::is_completed(&self) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::label(&self) -> core::option::Option<<T as metaslang_cst::kinds::KindTypes>::EdgeLabel>
 pub fn metaslang_cst::cursor::Cursor<T>::node(&self) -> metaslang_cst::nodes::Node<T>
+pub fn metaslang_cst::cursor::Cursor<T>::remaining_nodes(&self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::reset(&mut self)
 pub fn metaslang_cst::cursor::Cursor<T>::spawn(&self) -> Self
 pub fn metaslang_cst::cursor::Cursor<T>::text_offset(&self) -> metaslang_cst::text_index::TextIndex

--- a/crates/metaslang/cst/generated/public_api.txt
+++ b/crates/metaslang/cst/generated/public_api.txt
@@ -2,17 +2,24 @@
 
 pub mod metaslang_cst
 pub mod metaslang_cst::cursor
+pub struct metaslang_cst::cursor::AncestorsIterator<T: metaslang_cst::kinds::KindTypes>
+impl<T: metaslang_cst::kinds::KindTypes> core::iter::traits::iterator::Iterator for metaslang_cst::cursor::AncestorsIterator<T>
+pub type metaslang_cst::cursor::AncestorsIterator<T>::Item = alloc::rc::Rc<metaslang_cst::nodes::NonterminalNode<T>>
+pub fn metaslang_cst::cursor::AncestorsIterator<T>::next(&mut self) -> core::option::Option<Self::Item>
 pub struct metaslang_cst::cursor::Cursor<T: metaslang_cst::kinds::KindTypes>
 impl<T: metaslang_cst::kinds::KindTypes + 'static> metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::query(self, queries: alloc::vec::Vec<metaslang_cst::query::Query<T>>) -> metaslang_cst::query::QueryMatchIterator<T>
 impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::cursor::Cursor<T>
-pub fn metaslang_cst::cursor::Cursor<T>::ancestors(&self) -> impl core::iter::traits::iterator::Iterator<Item = alloc::rc::Rc<metaslang_cst::nodes::NonterminalNode<T>>>
+pub fn metaslang_cst::cursor::Cursor<T>::ancestors(&self) -> metaslang_cst::cursor::AncestorsIterator<T>
+pub fn metaslang_cst::cursor::Cursor<T>::children(&self) -> &[metaslang_cst::nodes::Edge<T>]
 pub fn metaslang_cst::cursor::Cursor<T>::complete(&mut self)
+pub fn metaslang_cst::cursor::Cursor<T>::consume(self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::depth(&self) -> usize
+pub fn metaslang_cst::cursor::Cursor<T>::descendants(&self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_first_child(&mut self) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_last_child(&mut self) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_next(&mut self) -> bool
-pub fn metaslang_cst::cursor::Cursor<T>::go_to_next_non_descendent(&mut self) -> bool
+pub fn metaslang_cst::cursor::Cursor<T>::go_to_next_non_descendant(&mut self) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_next_nonterminal(&mut self) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_next_nonterminal_with_kind(&mut self, kind: <T as metaslang_cst::kinds::KindTypes>::NonterminalKind) -> bool
 pub fn metaslang_cst::cursor::Cursor<T>::go_to_next_nonterminal_with_kinds(&mut self, kinds: &[<T as metaslang_cst::kinds::KindTypes>::NonterminalKind]) -> bool
@@ -31,8 +38,6 @@ pub fn metaslang_cst::cursor::Cursor<T>::reset(&mut self)
 pub fn metaslang_cst::cursor::Cursor<T>::spawn(&self) -> Self
 pub fn metaslang_cst::cursor::Cursor<T>::text_offset(&self) -> metaslang_cst::text_index::TextIndex
 pub fn metaslang_cst::cursor::Cursor<T>::text_range(&self) -> metaslang_cst::text_index::TextRange
-impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::cursor::Cursor<T>
-pub fn metaslang_cst::cursor::Cursor<T>::with_edges(self) -> metaslang_cst::cursor::CursorWithEdges<T>
 impl<T: core::clone::Clone + metaslang_cst::kinds::KindTypes> core::clone::Clone for metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::clone(&self) -> metaslang_cst::cursor::Cursor<T>
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::cursor::Cursor<T>
@@ -40,25 +45,11 @@ impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::Parti
 pub fn metaslang_cst::cursor::Cursor<T>::eq(&self, other: &metaslang_cst::cursor::Cursor<T>) -> bool
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::convert::From<metaslang_cst::cursor::Cursor<T>> for metaslang_cst::cursor::CursorWithEdges<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::from(cursor: metaslang_cst::cursor::Cursor<T>) -> Self
-impl<T: metaslang_cst::kinds::KindTypes> core::iter::traits::iterator::Iterator for metaslang_cst::cursor::Cursor<T>
-pub type metaslang_cst::cursor::Cursor<T>::Item = metaslang_cst::nodes::Node<T>
-pub fn metaslang_cst::cursor::Cursor<T>::next(&mut self) -> core::option::Option<Self::Item>
 impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::cursor::Cursor<T>
-pub struct metaslang_cst::cursor::CursorWithEdges<T: metaslang_cst::kinds::KindTypes>
-impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::cursor::CursorWithEdges<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::without_edges(self) -> metaslang_cst::cursor::Cursor<T>
-impl<T: metaslang_cst::kinds::KindTypes> core::convert::From<metaslang_cst::cursor::Cursor<T>> for metaslang_cst::cursor::CursorWithEdges<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::from(cursor: metaslang_cst::cursor::Cursor<T>) -> Self
-impl<T: metaslang_cst::kinds::KindTypes> core::iter::traits::iterator::Iterator for metaslang_cst::cursor::CursorWithEdges<T>
-pub type metaslang_cst::cursor::CursorWithEdges<T>::Item = metaslang_cst::nodes::Edge<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::next(&mut self) -> core::option::Option<Self::Item>
-impl<T: metaslang_cst::kinds::KindTypes> core::ops::deref::Deref for metaslang_cst::cursor::CursorWithEdges<T>
-pub type metaslang_cst::cursor::CursorWithEdges<T>::Target = metaslang_cst::cursor::Cursor<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::deref(&self) -> &Self::Target
-impl<T: metaslang_cst::kinds::KindTypes> core::ops::deref::DerefMut for metaslang_cst::cursor::CursorWithEdges<T>
-pub fn metaslang_cst::cursor::CursorWithEdges<T>::deref_mut(&mut self) -> &mut Self::Target
+pub struct metaslang_cst::cursor::CursorIterator<T: metaslang_cst::kinds::KindTypes>
+impl<T: metaslang_cst::kinds::KindTypes> core::iter::traits::iterator::Iterator for metaslang_cst::cursor::CursorIterator<T>
+pub type metaslang_cst::cursor::CursorIterator<T>::Item = metaslang_cst::nodes::Edge<T>
+pub fn metaslang_cst::cursor::CursorIterator<T>::next(&mut self) -> core::option::Option<Self::Item>
 pub mod metaslang_cst::kinds
 pub trait metaslang_cst::kinds::BaseKind: core::marker::Sized + core::fmt::Debug + core::marker::Copy + core::cmp::PartialEq + core::cmp::Eq + serde::ser::Serialize
 pub fn metaslang_cst::kinds::BaseKind::as_static_str(&self) -> &'static str
@@ -87,8 +78,8 @@ pub fn metaslang_cst::nodes::Node<T>::as_terminal(&self) -> core::option::Option
 pub fn metaslang_cst::nodes::Node<T>::as_terminal_with_kind(&self, kind: <T as metaslang_cst::kinds::KindTypes>::TerminalKind) -> core::option::Option<&alloc::rc::Rc<metaslang_cst::nodes::TerminalNode<T>>>
 pub fn metaslang_cst::nodes::Node<T>::as_terminal_with_kinds(&self, kinds: &[<T as metaslang_cst::kinds::KindTypes>::TerminalKind]) -> core::option::Option<&alloc::rc::Rc<metaslang_cst::nodes::TerminalNode<T>>>
 pub fn metaslang_cst::nodes::Node<T>::children(&self) -> &[metaslang_cst::nodes::Edge<T>]
-pub fn metaslang_cst::nodes::Node<T>::cursor_with_offset(&self, text_offset: metaslang_cst::text_index::TextIndex) -> metaslang_cst::cursor::Cursor<T>
-pub fn metaslang_cst::nodes::Node<T>::edges(&self) -> &[metaslang_cst::nodes::Edge<T>]
+pub fn metaslang_cst::nodes::Node<T>::cursor_with_offset(self, text_offset: metaslang_cst::text_index::TextIndex) -> metaslang_cst::cursor::Cursor<T>
+pub fn metaslang_cst::nodes::Node<T>::descendants(self) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::nodes::Node<T>::id(&self) -> usize
 pub fn metaslang_cst::nodes::Node<T>::into_nonterminal(self) -> core::option::Option<alloc::rc::Rc<metaslang_cst::nodes::NonterminalNode<T>>>
 pub fn metaslang_cst::nodes::Node<T>::into_terminal(self) -> core::option::Option<alloc::rc::Rc<metaslang_cst::nodes::TerminalNode<T>>>
@@ -100,7 +91,6 @@ pub fn metaslang_cst::nodes::Node<T>::is_terminal_with_kind(&self, kind: <T as m
 pub fn metaslang_cst::nodes::Node<T>::is_terminal_with_kinds(&self, kinds: &[<T as metaslang_cst::kinds::KindTypes>::TerminalKind]) -> bool
 pub fn metaslang_cst::nodes::Node<T>::is_trivia(&self) -> bool
 pub fn metaslang_cst::nodes::Node<T>::kind(&self) -> metaslang_cst::nodes::NodeKind<T>
-pub fn metaslang_cst::nodes::Node<T>::labeled_edges(&self) -> impl core::iter::traits::iterator::Iterator<Item = &metaslang_cst::nodes::Edge<T>>
 pub fn metaslang_cst::nodes::Node<T>::nonterminal(kind: <T as metaslang_cst::kinds::KindTypes>::NonterminalKind, children: alloc::vec::Vec<metaslang_cst::nodes::Edge<T>>) -> Self
 pub fn metaslang_cst::nodes::Node<T>::terminal(kind: <T as metaslang_cst::kinds::KindTypes>::TerminalKind, text: alloc::string::String) -> Self
 pub fn metaslang_cst::nodes::Node<T>::text_len(&self) -> metaslang_cst::text_index::TextIndex
@@ -158,7 +148,9 @@ pub metaslang_cst::nodes::NonterminalNode::children: alloc::vec::Vec<metaslang_c
 pub metaslang_cst::nodes::NonterminalNode::kind: <T as metaslang_cst::kinds::KindTypes>::NonterminalKind
 pub metaslang_cst::nodes::NonterminalNode::text_len: metaslang_cst::text_index::TextIndex
 impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::nodes::NonterminalNode<T>
+pub fn metaslang_cst::nodes::NonterminalNode<T>::children(self: &alloc::rc::Rc<Self>) -> &[metaslang_cst::nodes::Edge<T>]
 pub fn metaslang_cst::nodes::NonterminalNode<T>::cursor_with_offset(self: alloc::rc::Rc<Self>, text_offset: metaslang_cst::text_index::TextIndex) -> metaslang_cst::cursor::Cursor<T>
+pub fn metaslang_cst::nodes::NonterminalNode<T>::descendants(self: alloc::rc::Rc<Self>) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::nodes::NonterminalNode<T>::id(self: &alloc::rc::Rc<Self>) -> usize
 pub fn metaslang_cst::nodes::NonterminalNode<T>::unparse(&self) -> alloc::string::String
 impl<T: core::clone::Clone + metaslang_cst::kinds::KindTypes> core::clone::Clone for metaslang_cst::nodes::NonterminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::clone::Clone
@@ -175,6 +167,9 @@ pub struct metaslang_cst::nodes::TerminalNode<T: metaslang_cst::kinds::KindTypes
 pub metaslang_cst::nodes::TerminalNode::kind: <T as metaslang_cst::kinds::KindTypes>::TerminalKind
 pub metaslang_cst::nodes::TerminalNode::text: alloc::string::String
 impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::nodes::TerminalNode<T>
+pub fn metaslang_cst::nodes::TerminalNode<T>::children(self: &alloc::rc::Rc<Self>) -> &[metaslang_cst::nodes::Edge<T>]
+pub fn metaslang_cst::nodes::TerminalNode<T>::cursor_with_offset(self: alloc::rc::Rc<Self>, text_offset: metaslang_cst::text_index::TextIndex) -> metaslang_cst::cursor::Cursor<T>
+pub fn metaslang_cst::nodes::TerminalNode<T>::descendants(self: alloc::rc::Rc<Self>) -> metaslang_cst::cursor::CursorIterator<T>
 pub fn metaslang_cst::nodes::TerminalNode<T>::id(self: &alloc::rc::Rc<Self>) -> usize
 pub fn metaslang_cst::nodes::TerminalNode<T>::unparse(&self) -> alloc::string::String
 impl<T: core::clone::Clone + metaslang_cst::kinds::KindTypes> core::clone::Clone for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::clone::Clone

--- a/crates/metaslang/cst/src/cursor.rs
+++ b/crates/metaslang/cst/src/cursor.rs
@@ -159,9 +159,11 @@ impl<T: KindTypes> Cursor<T> {
         CursorIterator { cursor }
     }
 
-    /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
-    pub fn consume(self) -> CursorIterator<T> {
-        CursorIterator { cursor: self }
+    /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
+    pub fn remaining_nodes(&self) -> CursorIterator<T> {
+        CursorIterator {
+            cursor: self.clone(),
+        }
     }
 
     /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
@@ -426,7 +428,7 @@ impl<T: KindTypes> Iterator for CursorIterator<T> {
 
         let current = Edge {
             label: self.cursor.label(),
-            node: self.cursor.node().clone(),
+            node: self.cursor.node(),
         };
 
         self.cursor.go_to_next();

--- a/crates/metaslang/cst/src/nodes.rs
+++ b/crates/metaslang/cst/src/nodes.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use serde::Serialize;
 
-use crate::cursor::Cursor;
+use crate::cursor::{Cursor, CursorIterator};
 use crate::kinds::{BaseKind, KindTypes, TerminalKindExtensions};
 use crate::text_index::TextIndex;
 
@@ -117,26 +117,22 @@ impl<T: KindTypes> Node<T> {
         }
     }
 
-    /// Returns a slice of the edges (not all descendants) leaving this node.
-    pub fn edges(&self) -> &[Edge<T>] {
+    /// Returns the list of child edges directly connected to this node.
+    pub fn children(&self) -> &[Edge<T>] {
         match self {
-            Self::Nonterminal(node) => &node.children,
-            Self::Terminal(_) => &[],
+            Self::Nonterminal(node) => node.children(),
+            Self::Terminal(node) => node.children(),
         }
     }
 
-    pub fn labeled_edges(&self) -> impl Iterator<Item = &Edge<T>> {
-        self.edges().iter().filter(|edge| edge.label.is_some())
-    }
-
-    /// Returns a slice of the children (not all descendants) of this node.
-    pub fn children(&self) -> &[Edge<T>] {
-        self.edges()
+    /// Returns an iterator over all descendants of the current node in pre-order traversal.
+    pub fn descendants(self) -> CursorIterator<T> {
+        Cursor::new(self, TextIndex::ZERO).descendants()
     }
 
     /// Creates a [`Cursor`] that starts at the current node as the root and a given initial `text_offset`.
-    pub fn cursor_with_offset(&self, text_offset: TextIndex) -> Cursor<T> {
-        Cursor::new(self.clone(), text_offset)
+    pub fn cursor_with_offset(self, text_offset: TextIndex) -> Cursor<T> {
+        Cursor::new(self, text_offset)
     }
 
     /// Reconstructs the original source code from the node and its sub-tree.
@@ -253,9 +249,19 @@ impl<T: KindTypes> NonterminalNode<T> {
         Rc::as_ptr(self) as usize
     }
 
+    /// Returns the list of child edges directly connected to this node.
+    pub fn children(self: &Rc<Self>) -> &[Edge<T>] {
+        &self.children
+    }
+
+    /// Returns an iterator over all descendants of the current node in pre-order traversal.
+    pub fn descendants(self: Rc<Self>) -> CursorIterator<T> {
+        Node::Nonterminal(self).descendants()
+    }
+
     /// Creates a [`Cursor`] that starts at the current node as the root and a given initial `text_offset`.
     pub fn cursor_with_offset(self: Rc<Self>, text_offset: TextIndex) -> Cursor<T> {
-        Cursor::new(Node::Nonterminal(self), text_offset)
+        Node::Nonterminal(self).cursor_with_offset(text_offset)
     }
 
     /// Reconstructs the original source code from the node and its sub-tree.
@@ -280,6 +286,21 @@ impl<T: KindTypes> TerminalNode<T> {
     /// and cannot be used in a persistent/serialised sense.
     pub fn id(self: &Rc<Self>) -> usize {
         Rc::as_ptr(self) as usize
+    }
+
+    /// Returns the list of child edges directly connected to this node.
+    pub fn children(self: &Rc<Self>) -> &[Edge<T>] {
+        &[]
+    }
+
+    /// Returns an iterator over all descendants of the current node in pre-order traversal.
+    pub fn descendants(self: Rc<Self>) -> CursorIterator<T> {
+        Node::Terminal(self).descendants()
+    }
+
+    /// Creates a [`Cursor`] that starts at the current node as the root and a given initial `text_offset`.
+    pub fn cursor_with_offset(self: Rc<Self>, text_offset: TextIndex) -> Cursor<T> {
+        Node::Terminal(self).cursor_with_offset(text_offset)
     }
 
     /// Reconstructs the original source code from the node and its sub-tree.

--- a/crates/metaslang/cst/src/nodes.rs
+++ b/crates/metaslang/cst/src/nodes.rs
@@ -81,7 +81,7 @@ impl<T: KindTypes> std::ops::Deref for Edge<T> {
 
 impl<T: KindTypes> Node<T> {
     pub fn nonterminal(kind: T::NonterminalKind, children: Vec<Edge<T>>) -> Self {
-        let text_len = children.iter().map(|node| node.text_len()).sum();
+        let text_len = children.iter().map(|edge| edge.text_len()).sum();
 
         Self::Nonterminal(Rc::new(NonterminalNode {
             kind,

--- a/crates/metaslang/graph_builder/src/functions.rs
+++ b/crates/metaslang/graph_builder/src/functions.rs
@@ -281,8 +281,9 @@ pub mod stdlib {
                     ));
                 }
                 let index = parent
-                    .node()
-                    .labeled_edges()
+                    .children()
+                    .iter()
+                    .filter(|edge| edge.label.is_some())
                     .position(|edge| edge.node == node)
                     .ok_or(ExecutionError::FunctionFailed(
                         "named-child-index".into(),
@@ -402,7 +403,11 @@ pub mod stdlib {
             ) -> Result<Value, ExecutionError> {
                 let cursor = &graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
-                let named_child_count = cursor.node().labeled_edges().count();
+                let named_child_count = cursor
+                    .children()
+                    .iter()
+                    .filter(|edge| edge.label.is_some())
+                    .count();
                 Ok(Value::Integer(named_child_count as u32))
             }
         }

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -858,8 +858,9 @@ impl serde::ser::Serialize for slang_solidity::cst::TerminalKind
 pub fn slang_solidity::cst::TerminalKind::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 impl<'_derivative_strum> core::convert::From<&'_derivative_strum slang_solidity::cst::TerminalKind> for &'static str
 pub fn &'static str::from(x: &'_derivative_strum slang_solidity::cst::TerminalKind) -> &'static str
+pub type slang_solidity::cst::AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<slang_solidity::cst::KindTypes>
 pub type slang_solidity::cst::Cursor = metaslang_cst::cursor::Cursor<slang_solidity::cst::KindTypes>
-pub type slang_solidity::cst::CursorWithEdges = metaslang_cst::cursor::CursorWithEdges<slang_solidity::cst::KindTypes>
+pub type slang_solidity::cst::CursorIterator = metaslang_cst::cursor::CursorIterator<slang_solidity::cst::KindTypes>
 pub type slang_solidity::cst::Edge = metaslang_cst::nodes::Edge<slang_solidity::cst::KindTypes>
 pub type slang_solidity::cst::Node = metaslang_cst::nodes::Node<slang_solidity::cst::KindTypes>
 pub type slang_solidity::cst::NonterminalNode = metaslang_cst::nodes::NonterminalNode<slang_solidity::cst::KindTypes>

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/mod.rs
@@ -43,7 +43,8 @@ pub type TerminalNode = metaslang_cst::nodes::TerminalNode<KindTypes>;
 pub type Edge = metaslang_cst::nodes::Edge<KindTypes>;
 
 pub type Cursor = metaslang_cst::cursor::Cursor<KindTypes>;
-pub type CursorWithEdges = metaslang_cst::cursor::CursorWithEdges<KindTypes>;
+pub type CursorIterator = metaslang_cst::cursor::CursorIterator<KindTypes>;
+pub type AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<KindTypes>;
 
 pub type Query = metaslang_cst::query::Query<KindTypes>;
 pub use metaslang_cst::query::QueryError;

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parse_output.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parse_output.rs
@@ -24,6 +24,6 @@ impl ParseOutput {
 
     /// Creates a cursor that starts at the root of the parse tree.
     pub fn create_tree_cursor(&self) -> Cursor {
-        self.parse_tree.cursor_with_offset(TextIndex::ZERO)
+        self.parse_tree.clone().cursor_with_offset(TextIndex::ZERO)
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
@@ -137,8 +137,13 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
 
     nodes
         .iter()
-        .flat_map(|child| child.cursor_with_offset(TextIndex::ZERO))
-        .filter_map(|node| match node {
+        .flat_map(|edge| {
+            edge.node
+                .clone()
+                .cursor_with_offset(TextIndex::ZERO)
+                .consume()
+        })
+        .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),
             _ => None,
         })

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
@@ -141,7 +141,7 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
             edge.node
                 .clone()
                 .cursor_with_offset(TextIndex::ZERO)
-                .consume()
+                .remaining_nodes()
         })
         .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -141,8 +141,10 @@ where
                     debug_assert_eq!(
                         errors.is_empty(),
                         parse_tree
+                            .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .all(|node| node
+                            .consume()
+                            .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())
                                 .is_none())

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -143,7 +143,7 @@ where
                         parse_tree
                             .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .consume()
+                            .remaining_nodes()
                             .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
@@ -131,9 +131,14 @@ impl Match {
     pub fn is_full_recursive(&self) -> bool {
         self.nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .all(|node| {
-                node.as_terminal()
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .all(|edge| {
+                edge.as_terminal()
                     .filter(|tok| !tok.kind.is_valid())
                     .is_none()
             })
@@ -207,9 +212,14 @@ impl IncompleteMatch {
         let result = self
             .nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .try_fold(0u8, |mut acc, node| {
-                match node {
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .try_fold(0u8, |mut acc, edge| {
+                match edge.node {
                     Node::Terminal(tok) if tok.kind.is_valid() && !tok.kind.is_trivia() => {
                         acc += 1;
                     }

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
@@ -135,7 +135,7 @@ impl Match {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .all(|edge| {
                 edge.as_terminal()
@@ -216,7 +216,7 @@ impl IncompleteMatch {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .try_fold(0u8, |mut acc, edge| {
                 match edge.node {

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/renderer.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/renderer.rs
@@ -7,10 +7,10 @@ use anyhow::Result;
 use codegen_language_definition::model::Item;
 use inflector::Inflector;
 use once_cell::sync::Lazy;
-use slang_solidity::cst::{CursorWithEdges, Node, NonterminalKind, TextRangeExtensions};
+use slang_solidity::cst::{Cursor, Node, NonterminalKind, TextRangeExtensions};
 use solidity_language::SolidityDefinition;
 
-pub fn render(source: &str, errors: &Vec<String>, cursor: CursorWithEdges) -> Result<String> {
+pub fn render(source: &str, errors: &Vec<String>, cursor: Cursor) -> Result<String> {
     let mut w = String::new();
 
     write_source(&mut w, source)?;
@@ -85,7 +85,7 @@ fn write_errors(w: &mut String, errors: &Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn write_tree(w: &mut String, mut cursor: CursorWithEdges, source: &str) -> Result<()> {
+fn write_tree(w: &mut String, mut cursor: Cursor, source: &str) -> Result<()> {
     writeln!(w, "Tree:")?;
     write_node(w, &mut cursor, source, 0)?;
 
@@ -93,12 +93,7 @@ fn write_tree(w: &mut String, mut cursor: CursorWithEdges, source: &str) -> Resu
     Ok(())
 }
 
-fn write_node(
-    w: &mut String,
-    cursor: &mut CursorWithEdges,
-    source: &str,
-    depth: usize,
-) -> Result<()> {
+fn write_node(w: &mut String, cursor: &mut Cursor, source: &str, depth: usize) -> Result<()> {
     let indentation = " ".repeat(4 * depth);
     write!(w, "{indentation}  - ")?;
 
@@ -131,7 +126,7 @@ fn write_node(
     Ok(())
 }
 
-fn render_key(cursor: &mut CursorWithEdges) -> String {
+fn render_key(cursor: &mut Cursor) -> String {
     let kind = match cursor.node() {
         Node::Nonterminal(nonterminal) => nonterminal.kind.to_string(),
         Node::Terminal(terminal) => terminal.kind.to_string(),
@@ -144,7 +139,7 @@ fn render_key(cursor: &mut CursorWithEdges) -> String {
     }
 }
 
-fn render_value(cursor: &mut CursorWithEdges, source: &str) -> String {
+fn render_value(cursor: &mut Cursor, source: &str) -> String {
     let utf8_range = cursor.text_range().utf8();
     let char_range = {
         let start = source[..utf8_range.start].chars().count();

--- a/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst_output/runner.rs
@@ -57,7 +57,7 @@ pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
             })
             .collect();
 
-        let cursor = output.create_tree_cursor().with_edges();
+        let cursor = output.create_tree_cursor();
 
         let status = if output.is_valid() {
             TestStatus::Success

--- a/crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs
+++ b/crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs
@@ -88,14 +88,12 @@ fn using_the_cursor() -> Result<()> {
 
     {
         // --8<-- [start:using-iterator-api]
-        let cursor = parse_output.create_tree_cursor();
 
-        let identifiers: Vec<_> = cursor
-            .filter_map(|node| {
-                node.as_terminal_with_kind(TerminalKind::Identifier)
-                    .cloned()
-            })
-            .map(|identifier| identifier.text.clone())
+        let identifiers: Vec<_> = parse_output
+            .tree()
+            .descendants()
+            .filter(|node| node.is_terminal_with_kind(TerminalKind::Identifier))
+            .map(|identifier| identifier.unparse())
             .collect();
 
         assert_eq!(identifiers, &["Foo", "Bar", "Baz"]);
@@ -103,21 +101,18 @@ fn using_the_cursor() -> Result<()> {
     }
 
     {
-        // --8<-- [start:using-labeled-cursors]
-        let cursor = parse_output.create_tree_cursor();
+        // --8<-- [start:using-cursors-with-labels]
 
-        let identifiers: Vec<_> = cursor
-            .with_edges()
+        let identifiers: Vec<_> = parse_output
+            .tree()
+            .descendants()
             .filter(|node| node.label == Some(EdgeLabel::Name))
-            .filter_map(|node| {
-                node.as_terminal_with_kind(TerminalKind::Identifier)
-                    .cloned()
-            })
-            .map(|identifier| identifier.text.clone())
+            .filter(|node| node.is_terminal_with_kind(TerminalKind::Identifier))
+            .map(|identifier| identifier.unparse())
             .collect();
 
         assert_eq!(identifiers, &["Foo", "Bar", "Baz"]);
-        // --8<-- [end:using-labeled-cursors]
+        // --8<-- [end:using-cursors-with-labels]
     }
 
     Ok(())

--- a/crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs
+++ b/crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs
@@ -92,7 +92,7 @@ fn using_the_cursor() -> Result<()> {
         let identifiers: Vec<_> = parse_output
             .tree()
             .descendants()
-            .filter(|node| node.is_terminal_with_kind(TerminalKind::Identifier))
+            .filter(|edge| edge.is_terminal_with_kind(TerminalKind::Identifier))
             .map(|identifier| identifier.unparse())
             .collect();
 
@@ -106,8 +106,8 @@ fn using_the_cursor() -> Result<()> {
         let identifiers: Vec<_> = parse_output
             .tree()
             .descendants()
-            .filter(|node| node.label == Some(EdgeLabel::Name))
-            .filter(|node| node.is_terminal_with_kind(TerminalKind::Identifier))
+            .filter(|edge| edge.label == Some(EdgeLabel::Name))
+            .filter(|edge| edge.is_terminal_with_kind(TerminalKind::Identifier))
             .map(|identifier| identifier.unparse())
             .collect();
 

--- a/crates/solidity/outputs/cargo/tests/src/trivia.rs
+++ b/crates/solidity/outputs/cargo/tests/src/trivia.rs
@@ -30,7 +30,7 @@ fn compare_end_of_lines(input: &str, expected: &[&str]) -> Result<()> {
     let actual = output
         .tree()
         .descendants()
-        .filter(|node| node.is_terminal_with_kind(TerminalKind::EndOfLine))
+        .filter(|edge| edge.is_terminal_with_kind(TerminalKind::EndOfLine))
         .map(|eol| eol.unparse())
         .collect::<Vec<_>>();
 

--- a/crates/solidity/outputs/cargo/tests/src/trivia.rs
+++ b/crates/solidity/outputs/cargo/tests/src/trivia.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use semver::Version;
-use slang_solidity::cst::{Node, NonterminalKind, TerminalKind};
+use slang_solidity::cst::{NonterminalKind, TerminalKind};
 use slang_solidity::parser::Parser;
 
 #[test]
@@ -28,15 +28,10 @@ fn compare_end_of_lines(input: &str, expected: &[&str]) -> Result<()> {
     assert!(output.is_valid());
 
     let actual = output
-        .create_tree_cursor()
-        .filter_map(|node| match node {
-            Node::Nonterminal(_) => None,
-
-            Node::Terminal(terminal) => {
-                assert_eq!(terminal.kind, TerminalKind::EndOfLine);
-                Some(terminal.text.clone())
-            }
-        })
+        .tree()
+        .descendants()
+        .filter(|node| node.is_terminal_with_kind(TerminalKind::EndOfLine))
+        .map(|eol| eol.unparse())
         .collect::<Vec<_>>();
 
     let expected = expected.to_vec();

--- a/crates/solidity/outputs/cargo/wasm/src/generated/generated/config.json
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/generated/config.json
@@ -40,11 +40,6 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:nonterminal-node.children()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
     "nomic-foundation:slang:cst:terminal-node": {
       "Resource": {
         "custom_inspect": true
@@ -61,11 +56,6 @@
       }
     },
     "nomic-foundation:slang:cst:terminal-node.text-length()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:cst:terminal-node.children()": {
       "Function": {
         "as_getter": true
       }
@@ -95,9 +85,14 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:cursor.ancestors()": {
-      "Function": {
-        "as_getter": true
+    "nomic-foundation:slang:cst:cursor-iterator": {
+      "Resource": {
+        "as_iterator": true
+      }
+    },
+    "nomic-foundation:slang:cst:ancestors-iterator": {
+      "Resource": {
+        "as_iterator": true
       }
     },
     "nomic-foundation:slang:cst:query-match.captures": {
@@ -126,11 +121,6 @@
       }
     },
     "nomic-foundation:slang:parser:parse-output.tree()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:parser:parse-output.errors()": {
       "Function": {
         "as_getter": true
       }

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -852,8 +852,8 @@ interface cst {
         children: func() -> list<edge>;
         /// Returns an iterator over all descendants of the current node in pre-order traversal.
         descendants: func() -> cursor-iterator;
-        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
-        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
+        remaining-nodes: func() -> cursor-iterator;
         /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
         ancestors: func() -> ancestors-iterator;
 
@@ -898,7 +898,7 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
-    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
     resource cursor-iterator {
         /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
         next: func() -> option<edge>;

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -773,8 +773,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node and its children back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -796,8 +799,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of this node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -842,13 +848,19 @@ interface cst {
         /// Returns the current depth in the tree (i.e. number of ancestors).
         depth: func() -> u32;
 
-        /// Returns the list of ancestor nodes up to the root.
-        ancestors: func() -> list<nonterminal-node>;
+        /// Returns the list of child edges directly connected to this node.
+        children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+        ancestors: func() -> ancestors-iterator;
 
         /// Moves to the next node in pre-order traversal.
         go-to-next: func() -> bool;
         /// Moves to the next node that isn't a descendant of the current node.
-        go-to-next-non-descendent: func() -> bool;
+        go-to-next-non-descendant: func() -> bool;
         /// Moves to the previous node in pre-order traversal.
         go-to-previous: func() -> bool;
 
@@ -886,6 +898,18 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    resource cursor-iterator {
+        /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
+        next: func() -> option<edge>;
+    }
+
+    /// Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+    resource ancestors-iterator {
+        /// Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
+        next: func() -> option<nonterminal-node>;
+    }
+
     /// Represents a tree query for pattern matching in the syntax tree.
     resource query {
         /// Parses a query string into a query object.
@@ -913,19 +937,28 @@ interface cst {
 
     /// Iterator over query matches in the syntax tree.
     resource query-match-iterator {
-        /// Returns the next match or None if there are no more matches.
+        /// Returns the next match or `undefined` if there are no more matches.
         next: func() -> option<query-match>;
     }
 
     /// Represents a position in the source text, with indices for different unicode encodings of the source.
     record text-index {
         /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like Rust that use UTF-8.
         utf8: u32,
-        /// Character offset in UTF-16 encoding.
+        /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like JavaScript that use UTF-16.
         utf16: u32,
         /// Line number (0-based).
+        /// Lines are separated by:
+        ///
+        /// - carriage return `\r`.
+        /// - newline `\n`.
+        /// - line separator `\u2028`.
+        /// - paragraph separator `\u2029`.
         line: u32,
         /// Column number (0-based).
+        /// Columns are counted in [unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value).
         column: u32,
     }
 

--- a/crates/solidity/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
@@ -245,8 +245,8 @@ define_refcell_wrapper! { Cursor {
         self._borrow_ffi().descendants()._into_ffi()
     }
 
-    fn consume(&self) -> ffi::CursorIterator {
-        self._borrow_ffi().clone().consume()._into_ffi()
+    fn remaining_nodes(&self) -> ffi::CursorIterator {
+        self._borrow_ffi().remaining_nodes()._into_ffi()
     }
 
     fn ancestors(&self) -> ffi::AncestorsIterator {

--- a/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
@@ -30,6 +30,12 @@ export type Edge = generated.cst.Edge;
 export const Cursor = generated.cst.Cursor;
 export type Cursor = generated.cst.Cursor;
 
+export const CursorIterator = generated.cst.CursorIterator;
+export type CursorIterator = generated.cst.CursorIterator;
+
+export const AncestorsIterator = generated.cst.AncestorsIterator;
+export type AncestorsIterator = generated.cst.AncestorsIterator;
+
 export const Query = generated.cst.Query;
 export type Query = generated.cst.Query;
 

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -794,7 +794,7 @@ export class Cursor {
   get depth(): number;
   children(): Edge[];
   descendants(): CursorIterator;
-  consume(): CursorIterator;
+  remainingNodes(): CursorIterator;
   ancestors(): AncestorsIterator;
   goToNext(): boolean;
   goToNextNonDescendant(): boolean;

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -5,6 +5,8 @@ export namespace NomicFoundationSlangCst {
   export { NonterminalNode };
   export { TerminalNode };
   export { Cursor };
+  export { CursorIterator };
+  export { AncestorsIterator };
   export { Query };
   export { QueryMatchIterator };
   export { NonterminalKind };
@@ -774,6 +776,11 @@ export interface TextRange {
   end: TextIndex;
 }
 
+export class AncestorsIterator {
+  [Symbol.iterator](): Iterator<NonterminalNode>;
+  next(): NonterminalNode | undefined;
+}
+
 export class Cursor {
   reset(): void;
   complete(): void;
@@ -785,9 +792,12 @@ export class Cursor {
   get textOffset(): TextIndex;
   get textRange(): TextRange;
   get depth(): number;
-  get ancestors(): NonterminalNode[];
+  children(): Edge[];
+  descendants(): CursorIterator;
+  consume(): CursorIterator;
+  ancestors(): AncestorsIterator;
   goToNext(): boolean;
-  goToNextNonDescendent(): boolean;
+  goToNextNonDescendant(): boolean;
   goToPrevious(): boolean;
   goToParent(): boolean;
   goToFirstChild(): boolean;
@@ -804,6 +814,11 @@ export class Cursor {
   query(queries: Query[]): QueryMatchIterator;
 }
 
+export class CursorIterator {
+  [Symbol.iterator](): Iterator<Edge>;
+  next(): Edge | undefined;
+}
+
 export class NonterminalNode {
   readonly nodeVariant = NodeVariant.NonterminalNode;
 
@@ -816,7 +831,8 @@ export class NonterminalNode {
   get id(): number;
   get kind(): NonterminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
   createCursor(textOffset: TextIndex): Cursor;
@@ -848,7 +864,8 @@ export class TerminalNode {
   get id(): number;
   get kind(): TerminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
 }

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
@@ -21,7 +21,7 @@ export class ParseError {
 
 export class ParseOutput {
   get tree(): Node;
-  get errors(): ParseError[];
+  errors(): ParseError[];
   isValid(): boolean;
   createTreeCursor(): Cursor;
 }

--- a/crates/solidity/outputs/npm/tests/src/doc-examples/using-the-parser.test.mts
+++ b/crates/solidity/outputs/npm/tests/src/doc-examples/using-the-parser.test.mts
@@ -21,7 +21,7 @@ test("using the parser", async () => {
   // --8<-- [end:parse-input]
 
   // --8<-- [start:print-errors]
-  for (const error of parseOutput.errors) {
+  for (const error of parseOutput.errors()) {
     console.error(`Error at byte offset ${error.textRange.start.utf8}: ${error.message}`);
   }
   // --8<-- [end:print-errors]
@@ -34,7 +34,7 @@ test("using the parser", async () => {
   const contract = parseOutput.tree;
   assertIsNonterminalNode(contract, NonterminalKind.ContractDefinition);
 
-  const contractChildren = contract.children;
+  const contractChildren = contract.children();
   assert.equal(contractChildren.length, 7);
 
   const [contractKeyword, firstSpace, contractName, secondSpace, openBrace, members, closeBrace] = contractChildren;

--- a/crates/solidity/testing/perf/src/tests/cursor.rs
+++ b/crates/solidity/testing/perf/src/tests/cursor.rs
@@ -1,4 +1,4 @@
-use slang_solidity::cst::{NonterminalKind, TextIndex};
+use slang_solidity::cst::NonterminalKind;
 
 use crate::tests::parser::ParsedFile;
 
@@ -12,7 +12,7 @@ pub fn run(files: Vec<ParsedFile>) {
     let mut functions_count = 0;
 
     for file in &files {
-        let mut cursor = file.tree.cursor_with_offset(TextIndex::ZERO);
+        let mut cursor = file.parse_output.create_tree_cursor();
 
         while cursor.go_to_next_nonterminal_with_kind(NonterminalKind::FunctionDefinition) {
             functions_count += 1;

--- a/crates/solidity/testing/perf/src/tests/definitions.rs
+++ b/crates/solidity/testing/perf/src/tests/definitions.rs
@@ -1,5 +1,4 @@
 use slang_solidity::bindings::Bindings;
-use slang_solidity::cst::TextIndex;
 
 use crate::tests::parser::ParsedFile;
 
@@ -25,13 +24,10 @@ pub fn run(dependencies: Dependencies) -> Bindings {
     for ParsedFile {
         path,
         contents: _,
-        tree,
+        parse_output,
     } in &files
     {
-        bindings.add_user_file(
-            path.to_str().unwrap(),
-            tree.cursor_with_offset(TextIndex::ZERO),
-        );
+        bindings.add_user_file(path.to_str().unwrap(), parse_output.create_tree_cursor());
         definition_count += bindings.all_definitions().count();
     }
 

--- a/crates/solidity/testing/perf/src/tests/parser.rs
+++ b/crates/solidity/testing/perf/src/tests/parser.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
-use slang_solidity::cst::Node;
-use slang_solidity::parser::Parser;
+use slang_solidity::parser::{ParseOutput, Parser};
 
 use crate::dataset::{SourceFile, SOLC_VERSION};
 
@@ -11,7 +10,7 @@ pub struct ParsedFile {
     #[allow(dead_code)] // false-positive. it is used below.
     pub contents: String,
 
-    pub tree: Node,
+    pub parse_output: ParseOutput,
 }
 
 pub fn setup() -> Vec<SourceFile> {
@@ -35,7 +34,7 @@ pub fn run(files: Vec<SourceFile>) -> Vec<ParsedFile> {
         results.push(ParsedFile {
             path,
             contents,
-            tree: parse_output.tree(),
+            parse_output,
         });
     }
 

--- a/crates/solidity/testing/perf/src/tests/query.rs
+++ b/crates/solidity/testing/perf/src/tests/query.rs
@@ -1,4 +1,4 @@
-use slang_solidity::cst::{Query, TextIndex};
+use slang_solidity::cst::Query;
 
 use crate::tests::parser::ParsedFile;
 
@@ -19,7 +19,7 @@ pub fn run(files: Vec<ParsedFile>) {
     .unwrap()];
 
     for file in &files {
-        let cursor = file.tree.cursor_with_offset(TextIndex::ZERO);
+        let cursor = file.parse_output.create_tree_cursor();
 
         for query_match in cursor.query(queries.clone()) {
             assert_eq!(query_match.captures.len(), 1);

--- a/crates/testlang/outputs/cargo/crate/src/generated/cst/mod.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/cst/mod.rs
@@ -43,7 +43,8 @@ pub type TerminalNode = metaslang_cst::nodes::TerminalNode<KindTypes>;
 pub type Edge = metaslang_cst::nodes::Edge<KindTypes>;
 
 pub type Cursor = metaslang_cst::cursor::Cursor<KindTypes>;
-pub type CursorWithEdges = metaslang_cst::cursor::CursorWithEdges<KindTypes>;
+pub type CursorIterator = metaslang_cst::cursor::CursorIterator<KindTypes>;
+pub type AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<KindTypes>;
 
 pub type Query = metaslang_cst::query::Query<KindTypes>;
 pub use metaslang_cst::query::QueryError;

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parse_output.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parse_output.rs
@@ -24,6 +24,6 @@ impl ParseOutput {
 
     /// Creates a cursor that starts at the root of the parse tree.
     pub fn create_tree_cursor(&self) -> Cursor {
-        self.parse_tree.cursor_with_offset(TextIndex::ZERO)
+        self.parse_tree.clone().cursor_with_offset(TextIndex::ZERO)
     }
 }

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
@@ -137,8 +137,13 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
 
     nodes
         .iter()
-        .flat_map(|child| child.cursor_with_offset(TextIndex::ZERO))
-        .filter_map(|node| match node {
+        .flat_map(|edge| {
+            edge.node
+                .clone()
+                .cursor_with_offset(TextIndex::ZERO)
+                .consume()
+        })
+        .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),
             _ => None,
         })

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/choice_helper.rs
@@ -141,7 +141,7 @@ pub fn total_not_skipped_span(result: &ParserResult) -> usize {
             edge.node
                 .clone()
                 .cursor_with_offset(TextIndex::ZERO)
-                .consume()
+                .remaining_nodes()
         })
         .filter_map(|edge| match edge.node {
             Node::Terminal(terminal) if terminal.kind.is_valid() => Some(terminal.text.len()),

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -141,8 +141,10 @@ where
                     debug_assert_eq!(
                         errors.is_empty(),
                         parse_tree
+                            .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .all(|node| node
+                            .consume()
+                            .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())
                                 .is_none())

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -143,7 +143,7 @@ where
                         parse_tree
                             .clone()
                             .cursor_with_offset(TextIndex::ZERO)
-                            .consume()
+                            .remaining_nodes()
                             .all(|edge| edge
                                 .as_terminal()
                                 .filter(|tok| !tok.kind.is_valid())

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
@@ -131,9 +131,14 @@ impl Match {
     pub fn is_full_recursive(&self) -> bool {
         self.nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .all(|node| {
-                node.as_terminal()
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .all(|edge| {
+                edge.as_terminal()
                     .filter(|tok| !tok.kind.is_valid())
                     .is_none()
             })
@@ -207,9 +212,14 @@ impl IncompleteMatch {
         let result = self
             .nodes
             .iter()
-            .flat_map(|node| node.cursor_with_offset(TextIndex::ZERO))
-            .try_fold(0u8, |mut acc, node| {
-                match node {
+            .flat_map(|edge| {
+                edge.node
+                    .clone()
+                    .cursor_with_offset(TextIndex::ZERO)
+                    .consume()
+            })
+            .try_fold(0u8, |mut acc, edge| {
+                match edge.node {
                     Node::Terminal(tok) if tok.kind.is_valid() && !tok.kind.is_trivia() => {
                         acc += 1;
                     }

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_result.rs
@@ -135,7 +135,7 @@ impl Match {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .all(|edge| {
                 edge.as_terminal()
@@ -216,7 +216,7 @@ impl IncompleteMatch {
                 edge.node
                     .clone()
                     .cursor_with_offset(TextIndex::ZERO)
-                    .consume()
+                    .remaining_nodes()
             })
             .try_fold(0u8, |mut acc, edge| {
                 match edge.node {

--- a/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
+++ b/crates/testlang/outputs/cargo/tests/src/query/engine_tests.rs
@@ -82,8 +82,8 @@ macro_rules! query_matches {
 
 }
 
-fn run_query_test(tree: &Edge, query: &str, matches: Vec<BTreeMap<String, Vec<String>>>) {
-    let cursor = tree.cursor_with_offset(TextIndex::ZERO);
+fn run_query_test(tree: Edge, query: &str, matches: Vec<BTreeMap<String, Vec<String>>>) {
+    let cursor = tree.node.cursor_with_offset(TextIndex::ZERO);
     let query = vec![Query::parse(query).unwrap()];
     let mut matches = matches.into_iter();
     for QueryMatch { captures, .. } in cursor.query(query) {
@@ -137,7 +137,7 @@ fn common_test_tree_with_trivia() -> Edge {
 #[test]
 fn test_spread() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode @x1 [DelimitedIdentifier] @x2 [DelimitedIdentifier]]",
         query_matches! {
             {x1: ["A"], x2: ["B"]}
@@ -150,7 +150,7 @@ fn test_spread() {
 #[test]
 fn test_adjacent() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode @y1 [DelimitedIdentifier] . @y2 [DelimitedIdentifier]]",
         query_matches! {
             {y1: ["A"], y2: ["B"]}
@@ -162,7 +162,7 @@ fn test_adjacent() {
 #[test]
 fn test_adjacency_skips_trivia() {
     run_query_test(
-        &common_test_tree_with_trivia(),
+        common_test_tree_with_trivia(),
         "[TreeNode @y1 [DelimitedIdentifier] . @y2 [DelimitedIdentifier]]",
         query_matches! {
             {y1: ["A"], y2: ["B"]}
@@ -174,7 +174,7 @@ fn test_adjacency_skips_trivia() {
 #[test]
 fn test_anonymous_node_matcher_skips_trivia() {
     run_query_test(
-        &common_test_tree_with_trivia(),
+        common_test_tree_with_trivia(),
         "[TreeNodeChild @x [_]]",
         query_matches! {
             {x: ["D"]}
@@ -186,7 +186,7 @@ fn test_anonymous_node_matcher_skips_trivia() {
 #[test]
 fn test_child() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNodeChild @x [DelimitedIdentifier]]",
         query_matches! {
             {x: ["D"]}
@@ -198,7 +198,7 @@ fn test_child() {
 #[test]
 fn test_parent_and_child() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode @p node:[_] [TreeNodeChild @c [DelimitedIdentifier]]]",
         query_matches! {
             {c: ["D"], p: ["A"]}
@@ -210,7 +210,7 @@ fn test_parent_and_child() {
 #[test]
 fn test_named() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode @x node:[DelimitedIdentifier]]",
         query_matches! {
             {x: ["A"]}
@@ -221,7 +221,7 @@ fn test_named() {
 #[test]
 fn test_multilevel_adjacent() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[_ @x [DelimitedIdentifier] . @y [DelimitedIdentifier]]",
         query_matches! {
             {x: ["A"], y: ["B"]}
@@ -234,7 +234,7 @@ fn test_multilevel_adjacent() {
 #[test]
 fn test_multilevel_named() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[_ @x node:[_]]",
         query_matches! {
             {x: ["A"]}
@@ -246,7 +246,7 @@ fn test_multilevel_named() {
 #[test]
 fn test_text_value() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         r#"[TreeNode @z1 [DelimitedIdentifier] . ["B"] . @z2 [DelimitedIdentifier]]"#,
         query_matches! {
             {z1: ["A"], z2: ["C"]}
@@ -257,7 +257,7 @@ fn test_text_value() {
 #[test]
 fn test_one_or_more() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode (@x [DelimitedIdentifier])+ . [_] .]",
         query_matches! {
             {x: ["A", "B", "C"]}
@@ -270,7 +270,7 @@ fn test_one_or_more() {
 #[test]
 fn test_one_or_more_anonymous() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode (@x [_])+ .]",
         query_matches! {
             {x: ["A", "B", "C", "DE"]}
@@ -284,7 +284,7 @@ fn test_one_or_more_anonymous() {
 #[test]
 fn test_one_or_more_anonymous_both_adjacent() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode . (@x [_])+ .]",
         query_matches! {
             {x: ["A", "B", "C", "DE"]}
@@ -295,7 +295,7 @@ fn test_one_or_more_anonymous_both_adjacent() {
 #[test]
 fn test_one_or_more_anonymous_both_adjacent_with_trivia() {
     run_query_test(
-        &common_test_tree_with_trivia(),
+        common_test_tree_with_trivia(),
         "[TreeNodeChild . @children [_]+ .]",
         query_matches! {
             {children: ["D", "E"]}
@@ -306,7 +306,7 @@ fn test_one_or_more_anonymous_both_adjacent_with_trivia() {
 #[test]
 fn test_zero_or_more() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode (@y [DelimitedIdentifier])* . [_] .]",
         query_matches! {
             {y: ["A", "B", "C"]}
@@ -320,7 +320,7 @@ fn test_zero_or_more() {
 #[test]
 fn test_optional() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "[TreeNode (@z [DelimitedIdentifier])? . [_] .]",
         query_matches! {
             {z: ["C"]}
@@ -332,7 +332,7 @@ fn test_optional() {
 #[test]
 fn test_nested() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "@root [TreeNode @z [DelimitedIdentifier] . [_] .]",
         query_matches! {
             {root: ["ABCDE"], z: ["C"]}
@@ -343,7 +343,7 @@ fn test_nested() {
 #[test]
 fn test_alternatives() {
     run_query_test(
-        &common_test_tree(),
+        common_test_tree(),
         "(@x node:[_] | @y [DelimitedIdentifier] . @z [DelimitedIdentifier])",
         query_matches! {
             {x: ["A"]}
@@ -358,7 +358,7 @@ fn test_alternatives() {
 #[test]
 fn test_adjacency_at_beginning_skips_trivia() {
     run_query_test(
-        &common_test_tree_with_trivia(),
+        common_test_tree_with_trivia(),
         "[TreeNodeChild . @x [DelimitedIdentifier]]",
         query_matches! {
             {x: ["D"]}
@@ -369,7 +369,7 @@ fn test_adjacency_at_beginning_skips_trivia() {
 #[test]
 fn test_adjacency_at_end_skips_trivia() {
     run_query_test(
-        &common_test_tree_with_trivia(),
+        common_test_tree_with_trivia(),
         "[TreeNodeChild @x [DelimitedIdentifier] .]",
         query_matches! {
             {x: ["E"]}
@@ -391,8 +391,7 @@ fn flat_tree() -> Edge {
 
 #[test]
 fn test_ellipsis_followed_by_optional_grouping() {
-    run_query_test(
-        &flat_tree(),
+    run_query_test(flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] (@y [DelimitedIdentifier] . @z [DelimitedIdentifier])?]",
         query_matches! {
             {x: ["A"], y: ["B"], z: ["C"]}
@@ -408,8 +407,7 @@ fn test_ellipsis_followed_by_optional_grouping() {
 
 #[test]
 fn test_adjacency_followed_by_optional_grouping() {
-    run_query_test(
-        &flat_tree(),
+    run_query_test(flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] . (@y [DelimitedIdentifier] . @z [DelimitedIdentifier])?]",
         query_matches! {
             {x: ["A"]}
@@ -425,7 +423,7 @@ fn test_adjacency_followed_by_optional_grouping() {
 #[test]
 fn test_captures_followed_by_non_captured_matchers() {
     run_query_test(
-        &flat_tree(),
+        flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] [DelimitedIdentifier]]",
         query_matches! {
             {x: ["A"]}
@@ -441,7 +439,7 @@ fn test_captures_followed_by_non_captured_matchers() {
 #[test]
 fn test_captures_followed_by_anonymous_matchers() {
     run_query_test(
-        &flat_tree(),
+        flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] [_]]",
         query_matches! {
             {x: ["A"]}
@@ -457,7 +455,7 @@ fn test_captures_followed_by_anonymous_matchers() {
 #[test]
 fn test_captures_followed_by_non_captured_optional_matchers() {
     run_query_test(
-        &flat_tree(),
+        flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] [DelimitedIdentifier]?]",
         query_matches! {
             {x: ["A"]}
@@ -477,7 +475,7 @@ fn test_captures_followed_by_non_captured_optional_matchers() {
 #[test]
 fn test_captures_followed_by_captured_optional_matchers() {
     run_query_test(
-        &flat_tree(),
+        flat_tree(),
         "[TreeNode @x [DelimitedIdentifier] @y [DelimitedIdentifier]?]",
         query_matches! {
             {x: ["A"], y: ["B"]}
@@ -530,7 +528,7 @@ fn sample_deep_tree() -> Edge {
 #[test]
 fn test_deeply_nested_matchers() {
     run_query_test(
-        &sample_deep_tree(),
+        sample_deep_tree(),
         "@parent [TreeNode members: [TreeNodeChildren [TreeNodeChild @child variant: [TreeNode]]]]",
         query_matches! {
             {parent: ["[A[BC]]"], child: ["[BC]"]}

--- a/crates/testlang/outputs/cargo/wasm/src/generated/generated/config.json
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/generated/config.json
@@ -40,11 +40,6 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:nonterminal-node.children()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
     "nomic-foundation:slang:cst:terminal-node": {
       "Resource": {
         "custom_inspect": true
@@ -61,11 +56,6 @@
       }
     },
     "nomic-foundation:slang:cst:terminal-node.text-length()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:cst:terminal-node.children()": {
       "Function": {
         "as_getter": true
       }
@@ -95,9 +85,14 @@
         "as_getter": true
       }
     },
-    "nomic-foundation:slang:cst:cursor.ancestors()": {
-      "Function": {
-        "as_getter": true
+    "nomic-foundation:slang:cst:cursor-iterator": {
+      "Resource": {
+        "as_iterator": true
+      }
+    },
+    "nomic-foundation:slang:cst:ancestors-iterator": {
+      "Resource": {
+        "as_iterator": true
       }
     },
     "nomic-foundation:slang:cst:query-match.captures": {
@@ -126,11 +121,6 @@
       }
     },
     "nomic-foundation:slang:parser:parse-output.tree()": {
-      "Function": {
-        "as_getter": true
-      }
-    },
-    "nomic-foundation:slang:parser:parse-output.errors()": {
       "Function": {
         "as_getter": true
       }

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -173,8 +173,8 @@ interface cst {
         children: func() -> list<edge>;
         /// Returns an iterator over all descendants of the current node in pre-order traversal.
         descendants: func() -> cursor-iterator;
-        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
-        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
+        remaining-nodes: func() -> cursor-iterator;
         /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
         ancestors: func() -> ancestors-iterator;
 
@@ -219,7 +219,7 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
-    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
     resource cursor-iterator {
         /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
         next: func() -> option<edge>;

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -94,8 +94,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node and its children back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -117,8 +120,11 @@ interface cst {
         /// Returns the length of the text span this node covers.
         text-length: func() -> text-index;
 
-        /// Returns the list of child edges connected to this node.
+        /// Returns the list of child edges directly connected to this node.
         children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of this node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+
         /// Converts the node back to source code text.
         unparse: func() -> string;
         /// Converts the node to a JSON representation for debugging.
@@ -163,13 +169,19 @@ interface cst {
         /// Returns the current depth in the tree (i.e. number of ancestors).
         depth: func() -> u32;
 
-        /// Returns the list of ancestor nodes up to the root.
-        ancestors: func() -> list<nonterminal-node>;
+        /// Returns the list of child edges directly connected to this node.
+        children: func() -> list<edge>;
+        /// Returns an iterator over all descendants of the current node in pre-order traversal.
+        descendants: func() -> cursor-iterator;
+        /// Returns an iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+        consume: func() -> cursor-iterator;
+        /// Returns an iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+        ancestors: func() -> ancestors-iterator;
 
         /// Moves to the next node in pre-order traversal.
         go-to-next: func() -> bool;
         /// Moves to the next node that isn't a descendant of the current node.
-        go-to-next-non-descendent: func() -> bool;
+        go-to-next-non-descendant: func() -> bool;
         /// Moves to the previous node in pre-order traversal.
         go-to-previous: func() -> bool;
 
@@ -207,6 +219,18 @@ interface cst {
         query: func(queries: list<borrow<query>>) -> query-match-iterator;
     }
 
+    /// Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the cursor is completed.
+    resource cursor-iterator {
+        /// Returns the next edge in the iteration, or `undefined` if there are no more edges.
+        next: func() -> option<edge>;
+    }
+
+    /// Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
+    resource ancestors-iterator {
+        /// Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
+        next: func() -> option<nonterminal-node>;
+    }
+
     /// Represents a tree query for pattern matching in the syntax tree.
     resource query {
         /// Parses a query string into a query object.
@@ -234,19 +258,28 @@ interface cst {
 
     /// Iterator over query matches in the syntax tree.
     resource query-match-iterator {
-        /// Returns the next match or None if there are no more matches.
+        /// Returns the next match or `undefined` if there are no more matches.
         next: func() -> option<query-match>;
     }
 
     /// Represents a position in the source text, with indices for different unicode encodings of the source.
     record text-index {
         /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like Rust that use UTF-8.
         utf8: u32,
-        /// Character offset in UTF-16 encoding.
+        /// Byte offset in UTF-8 encoding.
+        /// This is useful when working with languages like JavaScript that use UTF-16.
         utf16: u32,
         /// Line number (0-based).
+        /// Lines are separated by:
+        ///
+        /// - carriage return `\r`.
+        /// - newline `\n`.
+        /// - line separator `\u2028`.
+        /// - paragraph separator `\u2029`.
         line: u32,
         /// Column number (0-based).
+        /// Columns are counted in [unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value).
         column: u32,
     }
 

--- a/crates/testlang/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
@@ -245,8 +245,8 @@ define_refcell_wrapper! { Cursor {
         self._borrow_ffi().descendants()._into_ffi()
     }
 
-    fn consume(&self) -> ffi::CursorIterator {
-        self._borrow_ffi().clone().consume()._into_ffi()
+    fn remaining_nodes(&self) -> ffi::CursorIterator {
+        self._borrow_ffi().remaining_nodes()._into_ffi()
     }
 
     fn ancestors(&self) -> ffi::AncestorsIterator {

--- a/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
@@ -30,6 +30,12 @@ export type Edge = generated.cst.Edge;
 export const Cursor = generated.cst.Cursor;
 export type Cursor = generated.cst.Cursor;
 
+export const CursorIterator = generated.cst.CursorIterator;
+export type CursorIterator = generated.cst.CursorIterator;
+
+export const AncestorsIterator = generated.cst.AncestorsIterator;
+export type AncestorsIterator = generated.cst.AncestorsIterator;
+
 export const Query = generated.cst.Query;
 export type Query = generated.cst.Query;
 

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -115,7 +115,7 @@ export class Cursor {
   get depth(): number;
   children(): Edge[];
   descendants(): CursorIterator;
-  consume(): CursorIterator;
+  remainingNodes(): CursorIterator;
   ancestors(): AncestorsIterator;
   goToNext(): boolean;
   goToNextNonDescendant(): boolean;

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -5,6 +5,8 @@ export namespace NomicFoundationSlangCst {
   export { NonterminalNode };
   export { TerminalNode };
   export { Cursor };
+  export { CursorIterator };
+  export { AncestorsIterator };
   export { Query };
   export { QueryMatchIterator };
   export { NonterminalKind };
@@ -95,6 +97,11 @@ export interface TextRange {
   end: TextIndex;
 }
 
+export class AncestorsIterator {
+  [Symbol.iterator](): Iterator<NonterminalNode>;
+  next(): NonterminalNode | undefined;
+}
+
 export class Cursor {
   reset(): void;
   complete(): void;
@@ -106,9 +113,12 @@ export class Cursor {
   get textOffset(): TextIndex;
   get textRange(): TextRange;
   get depth(): number;
-  get ancestors(): NonterminalNode[];
+  children(): Edge[];
+  descendants(): CursorIterator;
+  consume(): CursorIterator;
+  ancestors(): AncestorsIterator;
   goToNext(): boolean;
-  goToNextNonDescendent(): boolean;
+  goToNextNonDescendant(): boolean;
   goToPrevious(): boolean;
   goToParent(): boolean;
   goToFirstChild(): boolean;
@@ -125,6 +135,11 @@ export class Cursor {
   query(queries: Query[]): QueryMatchIterator;
 }
 
+export class CursorIterator {
+  [Symbol.iterator](): Iterator<Edge>;
+  next(): Edge | undefined;
+}
+
 export class NonterminalNode {
   readonly nodeVariant = NodeVariant.NonterminalNode;
 
@@ -137,7 +152,8 @@ export class NonterminalNode {
   get id(): number;
   get kind(): NonterminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
   createCursor(textOffset: TextIndex): Cursor;
@@ -169,7 +185,8 @@ export class TerminalNode {
   get id(): number;
   get kind(): TerminalKind;
   get textLength(): TextIndex;
-  get children(): Edge[];
+  children(): Edge[];
+  descendants(): CursorIterator;
   unparse(): string;
   toJson(): string;
 }

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-parser.d.ts
@@ -21,7 +21,7 @@ export class ParseError {
 
 export class ParseOutput {
   get tree(): Node;
-  get errors(): ParseError[];
+  errors(): ParseError[];
   isValid(): boolean;
   createTreeCursor(): Cursor;
 }

--- a/crates/testlang/outputs/npm/tests/src/ast/ast.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/ast/ast.test.mts
@@ -128,9 +128,10 @@ test("throws an exception on on using an incorrect/incomplete CST node", () => {
   const cst = parseOutput.tree;
   assertIsNonterminalNode(cst, NonterminalKind.Tree);
 
-  expect(cst.children).toHaveLength(2);
+  const children = cst.children();
+  expect(children).toHaveLength(2);
 
-  const [contractKeyword, skippedTerminal] = cst.children;
+  const [contractKeyword, skippedTerminal] = children;
   assertIsTerminalNode(contractKeyword!.node, TerminalKind.TreeKeyword, "tree");
   assertIsTerminalNode(skippedTerminal!.node, TerminalKind.Missing, "");
 

--- a/crates/testlang/outputs/npm/tests/src/cst/iterators.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/cst/iterators.test.mts
@@ -37,8 +37,8 @@ describe("iterators", () => {
     verifyDescendants(cursor.node.descendants());
   });
 
-  test("cursor.consume()", () => {
-    verifyConsume(cursor.consume());
+  test("cursor.remainingNodes()", () => {
+    verifyRemainingNodes(cursor.remainingNodes());
   });
 
   test("cursor.ancestors()", () => {
@@ -84,7 +84,7 @@ function verifyDescendants(iterator: CursorIterator) {
   ]);
 }
 
-function verifyConsume(iterator: CursorIterator) {
+function verifyRemainingNodes(iterator: CursorIterator) {
   const values = [];
 
   for (const edge of iterator) {

--- a/crates/testlang/outputs/npm/tests/src/cst/iterators.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/cst/iterators.test.mts
@@ -1,0 +1,134 @@
+import { Parser } from "@slang-private/testlang-npm-package/parser";
+import {
+  Cursor,
+  assertIsNonterminalNode,
+  NonterminalKind,
+  CursorIterator,
+  AncestorsIterator,
+  Edge,
+} from "@slang-private/testlang-npm-package/cst";
+
+describe("iterators", () => {
+  const source = "tree [A [B C] D];";
+  const parser = Parser.create("1.0.0");
+
+  const parseOutput = parser.parse(NonterminalKind.SourceUnit, source);
+  const cursor: Cursor = parseOutput.createTreeCursor();
+
+  assertIsNonterminalNode(cursor.node, NonterminalKind.SourceUnit);
+
+  // Go deep to the second TreeNode (`[B C]`):
+  expect(cursor.goToNextNonterminalWithKind(NonterminalKind.TreeNode)).toBe(true);
+  expect(cursor.goToNextNonterminalWithKind(NonterminalKind.TreeNode)).toBe(true);
+
+  test("cursor.children()", () => {
+    verifyChildren(cursor.children());
+  });
+
+  test("node.children()", () => {
+    verifyChildren(cursor.node.children());
+  });
+
+  test("cursor.descendants()", () => {
+    verifyDescendants(cursor.descendants());
+  });
+
+  test("node.descendants()", () => {
+    verifyDescendants(cursor.node.descendants());
+  });
+
+  test("cursor.consume()", () => {
+    verifyConsume(cursor.consume());
+  });
+
+  test("cursor.ancestors()", () => {
+    verifyAncestors(cursor.ancestors());
+  });
+});
+
+function verifyChildren(edges: Edge[]) {
+  const values = [];
+
+  for (const edge of edges) {
+    values.push(edge.node.unparse());
+  }
+
+  expect(values).toEqual([
+    // Only direct children:
+    " ",
+    "[",
+    "B C",
+    "]",
+  ]);
+}
+
+function verifyDescendants(iterator: CursorIterator) {
+  const values = [];
+
+  for (const edge of iterator) {
+    values.push(edge.node.unparse());
+  }
+
+  expect(values).toEqual([
+    // First child (trivia):
+    " ",
+    // Second child (another node):
+    "[",
+    "B C",
+    "B",
+    "B",
+    " C",
+    " ",
+    "C",
+    "]",
+  ]);
+}
+
+function verifyConsume(iterator: CursorIterator) {
+  const values = [];
+
+  for (const edge of iterator) {
+    values.push(edge.node.unparse());
+  }
+
+  expect(values).toEqual([
+    // The current node is the first one:
+    " [B C]",
+    // then its descendants:
+    " ",
+    "[",
+    "B C",
+    "B",
+    "B",
+    " C",
+    " ",
+    "C",
+    "]",
+    // then its following siblings:
+    " D",
+    " ",
+    "D",
+    "]",
+    // then the following siblings of the ancestors, all the way to the root:
+    ";",
+  ]);
+}
+
+function verifyAncestors(iterator: AncestorsIterator) {
+  const kinds = [];
+
+  for (const node of iterator) {
+    kinds.push(node.kind);
+  }
+
+  expect(kinds).toEqual([
+    // from the direct parent, up all the way to the root:
+    NonterminalKind.TreeNodeChild,
+    NonterminalKind.TreeNodeChildren,
+    NonterminalKind.TreeNode,
+    NonterminalKind.Tree,
+    NonterminalKind.SourceUnitMember,
+    NonterminalKind.SourceUnitMembers,
+    NonterminalKind.SourceUnit,
+  ]);
+}

--- a/crates/testlang/outputs/npm/tests/src/cst/nodes.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/cst/nodes.test.mts
@@ -35,7 +35,7 @@ describe("nodes", () => {
     });
   });
 
-  const terminal = nonTerminal.children[0]!.node;
+  const terminal = nonTerminal.children()[0]!.node;
   assertIsTerminalNode(terminal, TerminalKind.StringLiteral);
 
   describe("Terminal", () => {

--- a/crates/testlang/outputs/npm/tests/src/parser/parse-error.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/parser/parse-error.test.mts
@@ -8,7 +8,7 @@ test("render error reports", () => {
   const parseOutput = parser.parse(NonterminalKind.SourceUnit, source);
   expect(parseOutput.isValid()).toBeFalsy();
 
-  const errors = parseOutput.errors;
+  const errors = parseOutput.errors();
   expect(errors).toHaveLength(1);
 
   expect(errors[0]!.message).toBe("Expected Identifier or StringLiteral or TreeKeyword.");

--- a/crates/testlang/outputs/npm/tests/src/parser/parse.test.mts
+++ b/crates/testlang/outputs/npm/tests/src/parser/parse.test.mts
@@ -13,9 +13,10 @@ test("parse terminal", () => {
   const parseTree = parser.parse(NonterminalKind.TreeNodeChild, source).tree;
   assertIsNonterminalNode(parseTree, NonterminalKind.TreeNodeChild);
 
-  expect(parseTree.children).toHaveLength(1);
+  const children = parseTree.children();
+  expect(children).toHaveLength(1);
 
-  assertIsTerminalNode(parseTree.children[0]!.node, TerminalKind.DelimitedIdentifier, "About_time");
+  assertIsTerminalNode(children[0]!.node, TerminalKind.DelimitedIdentifier, "About_time");
 });
 
 test("parse nonterminal", () => {
@@ -25,9 +26,10 @@ test("parse nonterminal", () => {
   const parseTree = parser.parse(NonterminalKind.SourceUnit, source).tree;
   assertIsNonterminalNode(parseTree, NonterminalKind.SourceUnit);
 
-  expect(parseTree.children).toHaveLength(1);
+  const children = parseTree.children();
+  expect(children).toHaveLength(1);
 
-  assertIsNonterminalNode(parseTree.children[0]!.node, NonterminalKind.SourceUnitMembers);
+  assertIsNonterminalNode(children[0]!.node, NonterminalKind.SourceUnitMembers);
 });
 
 test("parse unicode characters", () => {
@@ -44,7 +46,7 @@ test("parse unicode characters", () => {
     utf8: 17,
   });
 
-  const terminal = nonTerminal.children[0]!.node;
+  const terminal = nonTerminal.children()[0]!.node;
 
   assertIsTerminalNode(terminal, TerminalKind.StringLiteral, `"some 😁 emoji"`);
 

--- a/documentation/public/user-guide/concepts.md
+++ b/documentation/public/user-guide/concepts.md
@@ -44,7 +44,7 @@ cursor was successfully moved, and `false` otherwise. There are three main ways
 to do it:
 
 -   According to the DFS order, i.e. `goToNext()` and `goToPrevious()`,
--   According to the relationship between the current node and the next node, i.e. `goToParent()`, `goToFirstChild()`, `goToNextNonDescendent()`
+-   According to the relationship between the current node and the next node, i.e. `goToParent()`, `goToFirstChild()`, `goToNextNonDescendant()`
 -   According to the kind of the next node, i.e. `goToNextTerminalWithKind(kind)`, `goToNextNonterminalWithKind(kind)`
 
 As such, the cursor is stateful and keeps track of the path it has taken through the CST.

--- a/documentation/public/user-guide/rust-crate/using-the-cursor.md
+++ b/documentation/public/user-guide/rust-crate/using-the-cursor.md
@@ -62,14 +62,11 @@ Let's use that to extract all `Identifier` nodes from the source text using that
     the "current" will point to the one that is not yet yielded by the iterator.
     This might be an important, when mixing the two styles.
 
-## Using a Cursor with Names
+## Using a Cursor with Labels
 
-In addition to the basic `Cursor`, there's also a `CursorWithLabels` type
-that keeps track of the names of the nodes it visits.
-You can create a `CursorWithLabels` from a `Cursor` by using the `with_labels()` API.
-
+The cursor also keeps track of the labels of the nodes it visits.
 Let's use that to extract all nodes that are labeled `Name`:
 
 ```{ .rust }
---8<-- "crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs:using-labeled-cursors"
+--8<-- "crates/solidity/outputs/cargo/tests/src/doc_examples/using_the_cursor.rs:using-cursors-with-labels"
 ```


### PR DESCRIPTION
Consolidate redundant `Node` and `Cursor` utilities like `.children()` vs `edges()`, or `Cursor` vs `CursorWithEdges`, and expose them to WASM:

- add `node.descendants()` and `cursor.descendants()` APIs to allow iterating over all descendants of the current node in pre-order traversal.
- add `cursor.ancestors()` API to allow iterating over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
- add `cursor.remainingNodes()` API to allow iterating over all the remaining nodes. in the current tree, moving in pre-order traversal, until the tree is completed.
- fix `node.children()` and `parseOutput.errors()` return types.
