### PR TITLE
Add missing `pop_begin`/`pop_end` for mapping types

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -767,6 +767,8 @@ inherit .lexical_scope
 @type_name [TypeName @mapping [MappingType]] {
   let @type_name.type_ref = @mapping.lexical_scope
   let @type_name.output = @mapping.output
+  let @type_name.pop_begin = @mapping.pop_begin
+  let @type_name.pop_end = @mapping.pop_end
 }
 
 
@@ -845,6 +847,10 @@ inherit .lexical_scope
 
   ; resolve the value type through our scope
   edge @value_type.type_ref -> @mapping.lexical_scope
+
+  ; We use the value_type's definition path as our, although that's not correct
+  let @mapping.pop_begin = @value_type.pop_begin
+  let @mapping.pop_end = @value_type.pop_end
 }
 
 

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -848,7 +848,9 @@ inherit .lexical_scope
   ; resolve the value type through our scope
   edge @value_type.type_ref -> @mapping.lexical_scope
 
-  ; We use the value_type's definition path as our, although that's not correct
+  ; We use the value_type's definition path as our own because it's needed when
+  ; a mapping is the target of a `using` directive. It's not correct, but we
+  ; don't have the analog referencing path either.
   let @mapping.pop_begin = @value_type.pop_begin
   let @mapping.pop_end = @value_type.pop_end
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -853,7 +853,9 @@ inherit .lexical_scope
   ; resolve the value type through our scope
   edge @value_type.type_ref -> @mapping.lexical_scope
 
-  ; We use the value_type's definition path as our, although that's not correct
+  ; We use the value_type's definition path as our own because it's needed when
+  ; a mapping is the target of a `using` directive. It's not correct, but we
+  ; don't have the analog referencing path either.
   let @mapping.pop_begin = @value_type.pop_begin
   let @mapping.pop_end = @value_type.pop_end
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -772,6 +772,8 @@ inherit .lexical_scope
 @type_name [TypeName @mapping [MappingType]] {
   let @type_name.type_ref = @mapping.lexical_scope
   let @type_name.output = @mapping.output
+  let @type_name.pop_begin = @mapping.pop_begin
+  let @type_name.pop_end = @mapping.pop_end
 }
 
 
@@ -850,6 +852,10 @@ inherit .lexical_scope
 
   ; resolve the value type through our scope
   edge @value_type.type_ref -> @mapping.lexical_scope
+
+  ; We use the value_type's definition path as our, although that's not correct
+  let @mapping.pop_begin = @value_type.pop_begin
+  let @mapping.pop_end = @value_type.pop_end
 }
 
 


### PR DESCRIPTION
I found this additional required fix after merging #1159. This is so bindings can be processed for files with using directives on mapping types without crashing. We want to merge this before #1149 to get a meaningful baseline before those fixes are applied.
