### PR TITLE
Summarize Sanctuary results

### DIFF
--- a/.github/workflows/sanctuary.yml
+++ b/.github/workflows/sanctuary.yml
@@ -22,7 +22,7 @@ on:
         default: false
 
 jobs:
-  sanctuary:
+  singleShard:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
 
     strategy:
@@ -59,4 +59,23 @@ jobs:
       - name: "infra run solidity_testing_sanctuary"
         uses: "./.github/actions/devcontainer/run"
         with:
-          runCmd: "./scripts/bin/infra run --release --bin solidity_testing_sanctuary -- --shards-count ${{ env.SHARDS_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.chain }} ${{ inputs.network }}"
+          runCmd: "./scripts/bin/infra run --release --bin solidity_testing_sanctuary -- test --shards-count ${{ env.SHARDS_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.chain }} ${{ inputs.network }}"
+
+  combinedResults:
+    runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
+    needs: [singleShard]
+    if: "!cancelled()"
+    steps:
+      - name: "Checkout Repository"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+
+      - name: "Restore Cache"
+        uses: "./.github/actions/cache/restore"
+
+      - name: "Output shards results"
+        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "./target/__SLANG_SANCTUARY_SHARD_RESULTS__.json"
+
+      - name: "infra run solidity_testing_sanctuary"
+        uses: "./.github/actions/devcontainer/run"
+        with:
+          runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results ./target/__SLANG_SANCTUARY_SHARD_RESULTS__.json"

--- a/.github/workflows/sanctuary.yml
+++ b/.github/workflows/sanctuary.yml
@@ -25,22 +25,22 @@ jobs:
   singleShard:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
     outputs:
-      __SLANG_SANCTUARY_SHARD_RESULTS__0: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__0 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__1: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__1 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__2: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__2 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__3: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__3 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__4: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__4 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__5: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__5 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__6: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__6 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__7: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__7 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__8: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__8 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__9: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__9 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__10: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__10 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__11: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__11 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__12: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__12 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__13: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__13 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__14: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__14 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__15: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__15 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__0: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__0 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__1: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__1 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__2: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__2 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__3: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__3 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__4: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__4 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__5: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__5 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__6: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__6 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__7: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__7 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__8: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__8 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__9: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__9 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__10: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__10 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__11: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__11 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__12: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__12 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__13: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__13 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__14: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__14 }}"
+      __SLANG_SANCTUARY_SHARD_RESULTS__15: "${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__15 }}"
 
     strategy:
       fail-fast: false # Continue running all shards even if some fail.
@@ -79,13 +79,13 @@ jobs:
           runCmd: "./scripts/bin/infra run --release --bin solidity_testing_sanctuary -- test --shards-count ${{ env.SHARDS_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.chain }} ${{ inputs.network }}"
 
       - name: "Write shard results to output"
-        if:   "!cancelled()"
-        id:   output-shard-results
-        run:  echo "__SLANG_SANCTUARY_SHARD_RESULTS__${{ matrix.shard_index }}=$(cat target/__SLANG_SANCTUARY_SHARD_RESULTS__.json)" >> "$GITHUB_OUTPUT"
+        if: "!cancelled()"
+        id: "output-shard-results"
+        run: 'echo "__SLANG_SANCTUARY_SHARD_RESULTS__${{ matrix.shard_index }}=$(cat target/__SLANG_SANCTUARY_SHARD_RESULTS__.json)" >> "$GITHUB_OUTPUT"'
 
   combinedResults:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
-    needs: [singleShard]
+    needs: "singleShard"
     if: "!cancelled()"
     steps:
       - name: "Checkout Repository"
@@ -95,7 +95,7 @@ jobs:
         uses: "./.github/actions/cache/restore"
 
       - name: "Output shards results"
-        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "__SLANG_SANCTUARY_MATRIX_RESULTS__.json"
+        run: "echo '${{ toJSON(needs.singleShard.outputs) }}' > __SLANG_SANCTUARY_MATRIX_RESULTS__.json"
 
       - name: "Show combined results"
         uses: "./.github/actions/devcontainer/run"

--- a/.github/workflows/sanctuary.yml
+++ b/.github/workflows/sanctuary.yml
@@ -25,22 +25,22 @@ jobs:
   singleShard:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
     outputs:
-      __SLANG_SANCTUARY_SHARD_RESULTS__0: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__0 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__1: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__1 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__2: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__2 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__3: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__3 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__4: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__4 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__5: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__5 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__6: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__6 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__7: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__7 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__8: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__8 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__9: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__9 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__10: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__10 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__11: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__11 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__12: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__12 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__13: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__13 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__14: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__14 }}
-      __SLANG_SANCTUARY_SHARD_RESULTS__15: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__15 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__0: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__0 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__1: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__1 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__2: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__2 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__3: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__3 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__4: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__4 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__5: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__5 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__6: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__6 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__7: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__7 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__8: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__8 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__9: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__9 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__10: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__10 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__11: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__11 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__12: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__12 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__13: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__13 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__14: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__14 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__15: ${{ steps.output-shard-results.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__15 }}
 
     strategy:
       fail-fast: false # Continue running all shards even if some fail.
@@ -74,10 +74,14 @@ jobs:
         uses: "./.github/actions/cache/restore"
 
       - name: "infra run solidity_testing_sanctuary"
-        id:   run-sanctuary-test
         uses: "./.github/actions/devcontainer/run"
         with:
           runCmd: "./scripts/bin/infra run --release --bin solidity_testing_sanctuary -- test --shards-count ${{ env.SHARDS_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.chain }} ${{ inputs.network }}"
+
+      - name: "Write shard results to output"
+        if:   "!cancelled()"
+        id:   output-shard-results
+        run:  echo "__SLANG_SANCTUARY_SHARD_RESULTS__${{ matrix.shard_index }}=$(cat target/__SLANG_SANCTUARY_SHARD_RESULTS__.json)" >> "$GITHUB_OUTPUT"
 
   combinedResults:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
@@ -91,9 +95,9 @@ jobs:
         uses: "./.github/actions/cache/restore"
 
       - name: "Output shards results"
-        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "__SLANG_SANCTUARY_SHARD_RESULTS__.json"
+        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "__SLANG_SANCTUARY_MATRIX_RESULTS__.json"
 
       - name: "Show combined results"
         uses: "./.github/actions/devcontainer/run"
         with:
-          runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results __SLANG_SANCTUARY_SHARD_RESULTS__.json"
+          runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results __SLANG_SANCTUARY_MATRIX_RESULTS__.json"

--- a/.github/workflows/sanctuary.yml
+++ b/.github/workflows/sanctuary.yml
@@ -24,6 +24,23 @@ on:
 jobs:
   singleShard:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
+    outputs:
+      __SLANG_SANCTUARY_SHARD_RESULTS__0: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__0 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__1: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__1 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__2: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__2 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__3: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__3 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__4: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__4 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__5: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__5 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__6: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__6 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__7: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__7 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__8: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__8 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__9: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__9 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__10: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__10 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__11: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__11 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__12: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__12 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__13: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__13 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__14: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__14 }}
+      __SLANG_SANCTUARY_SHARD_RESULTS__15: ${{ steps.run-sanctuary-test.outputs.__SLANG_SANCTUARY_SHARD_RESULTS__15 }}
 
     strategy:
       fail-fast: false # Continue running all shards even if some fail.
@@ -57,6 +74,7 @@ jobs:
         uses: "./.github/actions/cache/restore"
 
       - name: "infra run solidity_testing_sanctuary"
+        id:   run-sanctuary-test
         uses: "./.github/actions/devcontainer/run"
         with:
           runCmd: "./scripts/bin/infra run --release --bin solidity_testing_sanctuary -- test --shards-count ${{ env.SHARDS_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.chain }} ${{ inputs.network }}"
@@ -75,7 +93,7 @@ jobs:
       - name: "Output shards results"
         run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "__SLANG_SANCTUARY_SHARD_RESULTS__.json"
 
-      - name: "infra run solidity_testing_sanctuary"
+      - name: "Show combined results"
         uses: "./.github/actions/devcontainer/run"
         with:
           runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results __SLANG_SANCTUARY_SHARD_RESULTS__.json"

--- a/.github/workflows/sanctuary.yml
+++ b/.github/workflows/sanctuary.yml
@@ -73,9 +73,9 @@ jobs:
         uses: "./.github/actions/cache/restore"
 
       - name: "Output shards results"
-        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "./target/__SLANG_SANCTUARY_SHARD_RESULTS__.json"
+        run: echo '${{ toJSON(needs.singleShard.outputs) }}' > "__SLANG_SANCTUARY_SHARD_RESULTS__.json"
 
       - name: "infra run solidity_testing_sanctuary"
         uses: "./.github/actions/devcontainer/run"
         with:
-          runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results ./target/__SLANG_SANCTUARY_SHARD_RESULTS__.json"
+          runCmd: "./scripts/bin/infra run --bin solidity_testing_sanctuary -- show-combined-results __SLANG_SANCTUARY_SHARD_RESULTS__.json"

--- a/crates/solidity/testing/sanctuary/src/events.rs
+++ b/crates/solidity/testing/sanctuary/src/events.rs
@@ -3,9 +3,8 @@ use std::cmp;
 use console::Color;
 use indicatif::ProgressBar;
 use infra_utils::github::GitHub;
-use serde::{ser::SerializeMap, Serialize};
 
-use crate::reporting::Reporter;
+use crate::{reporting::Reporter, results::ShardResults};
 
 const MAX_PRINTED_FAILURES: u64 = 1000;
 
@@ -134,20 +133,15 @@ impl Events {
     pub fn trace(&self, message: impl AsRef<str>) {
         self.reporter.println(message);
     }
-}
 
-impl Serialize for Events {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(6))?;
-        map.serialize_entry("source_files", &self.source_files.position())?;
-        map.serialize_entry("passed", &self.passed.position())?;
-        map.serialize_entry("failed", &self.failed.position())?;
-        map.serialize_entry("incompatible", &self.incompatible.position())?;
-        map.serialize_entry("not_found", &self.not_found.position())?;
-        map.serialize_entry("elapsed", &self.all_directories.elapsed())?;
-        map.end()
+    pub fn to_results(&self) -> ShardResults {
+        ShardResults {
+            source_files: self.source_files.position(),
+            passed: self.passed.position(),
+            failed: self.failed.position(),
+            incompatible: self.incompatible.position(),
+            not_found: self.not_found.position(),
+            elapsed: self.all_directories.elapsed(),
+        }
     }
 }

--- a/crates/solidity/testing/sanctuary/src/events.rs
+++ b/crates/solidity/testing/sanctuary/src/events.rs
@@ -4,7 +4,8 @@ use console::Color;
 use indicatif::ProgressBar;
 use infra_utils::github::GitHub;
 
-use crate::{reporting::Reporter, results::ShardResults};
+use crate::reporting::Reporter;
+use crate::results::ShardResults;
 
 const MAX_PRINTED_FAILURES: u64 = 1000;
 

--- a/crates/solidity/testing/sanctuary/src/events.rs
+++ b/crates/solidity/testing/sanctuary/src/events.rs
@@ -3,6 +3,7 @@ use std::cmp;
 use console::Color;
 use indicatif::ProgressBar;
 use infra_utils::github::GitHub;
+use serde::{ser::SerializeMap, Serialize};
 
 use crate::reporting::Reporter;
 
@@ -132,5 +133,21 @@ impl Events {
 
     pub fn trace(&self, message: impl AsRef<str>) {
         self.reporter.println(message);
+    }
+}
+
+impl Serialize for Events {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(6))?;
+        map.serialize_entry("source_files", &self.source_files.position())?;
+        map.serialize_entry("passed", &self.passed.position())?;
+        map.serialize_entry("failed", &self.failed.position())?;
+        map.serialize_entry("incompatible", &self.incompatible.position())?;
+        map.serialize_entry("not_found", &self.not_found.position())?;
+        map.serialize_entry("elapsed", &self.all_directories.elapsed())?;
+        map.end()
     }
 }

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -131,7 +131,7 @@ fn run_test_command(command: TestCommand) -> Result<()> {
     if GitHub::is_running_in_ci() {
         let output_path = std::env::var("GITHUB_OUTPUT")?;
         let key = format!(
-            "__SLANG_SANCTUARY_SHARD_RESULT__{shard_index}",
+            "__SLANG_SANCTUARY_SHARD_RESULTS__{shard_index}",
             shard_index = sharding_options
                 .shard_index
                 .map(|index| index.to_string())

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -129,7 +129,7 @@ fn run_test_command(command: TestCommand) -> Result<()> {
     }
 
     if GitHub::is_running_in_ci() {
-        let output_file = std::env::var("GITHUB_OUTPUT")?;
+        let output_path = std::env::var("GITHUB_OUTPUT")?;
         let key = format!(
             "__SLANG_SANCTUARY_SHARD_RESULT__{shard_index}",
             shard_index = sharding_options
@@ -143,9 +143,10 @@ fn run_test_command(command: TestCommand) -> Result<()> {
         let mut output_file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(output_file)?;
+            .open(&output_path)?;
 
         writeln!(output_file, "{key}={value}")?;
+        println!("Wrote results to {output_path}");
     }
 
     let failure_count = events.failure_count();

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -132,7 +132,7 @@ fn run_test_command(command: TestCommand) -> Result<()> {
         let value = serde_json::to_string(&results)?;
 
         std::fs::create_dir_all(output_path.parent().unwrap())?;
-        std::fs::write(&output_path, value)?;
+        output_path.write_string(value)?;
         println!("Wrote results to {output_path:?}");
     }
 
@@ -177,7 +177,7 @@ fn run_in_parallel(files: &Vec<SourceFile>, events: &Events, check_bindings: boo
 fn run_show_combined_results_command(command: ShowCombinedResultsCommand) -> Result<()> {
     let ShowCombinedResultsCommand { results_file } = command;
 
-    let contents = String::from_utf8(std::fs::read(results_file)?)?;
+    let contents = results_file.read_to_string()?;
     let all_results: AllResults = serde_json::from_str(&contents)?;
     display_all_results(&all_results);
     Ok(())

--- a/crates/solidity/testing/sanctuary/src/results.rs
+++ b/crates/solidity/testing/sanctuary/src/results.rs
@@ -1,8 +1,9 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
 use indicatif::{FormattedDuration, HumanCount};
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::time::Duration;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ShardResults {

--- a/crates/solidity/testing/sanctuary/src/results.rs
+++ b/crates/solidity/testing/sanctuary/src/results.rs
@@ -1,0 +1,114 @@
+use indicatif::{FormattedDuration, HumanCount};
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ShardResults {
+    pub source_files: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub incompatible: u64,
+    pub not_found: u64,
+    pub elapsed: Duration,
+}
+
+#[derive(Debug)]
+pub struct AllResults {
+    pub shards: BTreeMap<usize, ShardResults>,
+}
+
+impl<'de> Deserialize<'de> for AllResults {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(AllResultsVisitor {})
+    }
+}
+
+struct AllResultsVisitor {}
+
+impl<'de> Visitor<'de> for AllResultsVisitor {
+    type Value = AllResults;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a results map")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> std::result::Result<Self::Value, M::Error>
+    where
+        M: serde::de::MapAccess<'de>,
+    {
+        use serde::de::Unexpected;
+
+        let mut shards: BTreeMap<usize, ShardResults> = BTreeMap::new();
+        while let Some((key, value)) = access.next_entry::<String, String>()? {
+            let shard_index = key
+                .strip_prefix("__SLANG_SANCTUARY_SHARD_RESULT__")
+                .ok_or(Error::invalid_value(
+                    Unexpected::Str(&key),
+                    &"a string prefixed with __SLANG_SANCTUARY_SHARD_RESULT__",
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Error::invalid_value(Unexpected::Str(&key), &"a positive shard index")
+                })?;
+            let shard_results = serde_json::from_str(&value).map_err(|_| {
+                Error::invalid_value(
+                    Unexpected::Str(&value),
+                    &"a JSON string with the shard results",
+                )
+            })?;
+            shards.insert(shard_index, shard_results);
+        }
+
+        Ok(AllResults { shards })
+    }
+}
+
+pub fn display_all_results(all_results: &AllResults) {
+    let mut totals = ShardResults::default();
+    println!("Shard ID | Source files |       Passed |       Failed | Incompatible |    Not found | Elapsed");
+    println!("------------------------------------------------------------------------------------------------");
+    for (shard_index, shard_results) in &all_results.shards {
+        println!(
+            "{shard_index:<8} | \
+             {source_files:>12} | \
+             {passed:>12} | \
+             {failed:>12} | \
+             {incompatible:>12} | \
+             {not_found:>12} | \
+             {elapsed}",
+            source_files = format!("{}", HumanCount(shard_results.source_files)),
+            passed = format!("{}", HumanCount(shard_results.passed)),
+            failed = format!("{}", HumanCount(shard_results.failed)),
+            incompatible = format!("{}", HumanCount(shard_results.incompatible)),
+            not_found = format!("{}", HumanCount(shard_results.not_found)),
+            elapsed = FormattedDuration(shard_results.elapsed),
+        );
+        totals.source_files += shard_results.source_files;
+        totals.passed += shard_results.passed;
+        totals.failed += shard_results.failed;
+        totals.incompatible += shard_results.incompatible;
+        totals.not_found += shard_results.not_found;
+        totals.elapsed += shard_results.elapsed;
+    }
+    println!("------------------------------------------------------------------------------------------------");
+    println!(
+        "TOTALS   | \
+         {source_files:>12} | \
+         {passed:>12} | \
+         {failed:>12} | \
+         {incompatible:>12} | \
+         {not_found:>12} | \
+         {elapsed}",
+        source_files = format!("{}", HumanCount(totals.source_files)),
+        passed = format!("{}", HumanCount(totals.passed)),
+        failed = format!("{}", HumanCount(totals.failed)),
+        incompatible = format!("{}", HumanCount(totals.incompatible)),
+        not_found = format!("{}", HumanCount(totals.not_found)),
+        elapsed = FormattedDuration(totals.elapsed),
+    );
+}

--- a/crates/solidity/testing/sanctuary/src/results.rs
+++ b/crates/solidity/testing/sanctuary/src/results.rs
@@ -47,10 +47,10 @@ impl<'de> Visitor<'de> for AllResultsVisitor {
         let mut shards: BTreeMap<usize, ShardResults> = BTreeMap::new();
         while let Some((key, value)) = access.next_entry::<String, String>()? {
             let shard_index = key
-                .strip_prefix("__SLANG_SANCTUARY_SHARD_RESULT__")
+                .strip_prefix("__SLANG_SANCTUARY_SHARD_RESULTS__")
                 .ok_or(Error::invalid_value(
                     Unexpected::Str(&key),
-                    &"a string prefixed with __SLANG_SANCTUARY_SHARD_RESULT__",
+                    &"a string prefixed with __SLANG_SANCTUARY_SHARD_RESULTS__",
                 ))?
                 .parse()
                 .map_err(|_| {


### PR DESCRIPTION
This PR adds a result output when running in CI for `sanctuary` tests, which are then passed as job outputs for each shard to the `combinedResults` job that renders them in a table. We want to use this to get a baseline and a benchmark for both correctness and performance of the bindings rules.