### PR TITLE
complete public API documentation

### DIFF
--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/edge_label.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/edge_label.rs.jinja2
@@ -15,20 +15,25 @@
 )]
 #[strum(serialize_all = "snake_case")]
 #[derive(Clone, Copy)]
+/// Represents the different types of relationships between nodes in the syntax tree.
 pub enum EdgeLabel {
-    // Built-in:
+    {# Built-in: #}
+
     {% for label in model.kinds.predefined_labels -%}
+        /// Represents a child node with the label `{{ label | snake_case }}`.
         {{ label | pascal_case }},
     {%- endfor %}
 
-    // Generated:
+    {# Generated: #}
+
     {% if rendering_in_stubs -%}
         Stub1,
         Stub2,
         Stub3,
     {%- else -%}
-        {% for variant in model.kinds.labels -%}
-            {{ variant | pascal_case }},
+        {% for label in model.kinds.labels -%}
+            /// Represents a child node with the label `{{ label | snake_case }}`.
+            {{ label | pascal_case }},
         {%- endfor -%}
     {%- endif -%}
 }

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/generated/edge_label.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/generated/edge_label.rs
@@ -16,18 +16,25 @@
 )]
 #[strum(serialize_all = "snake_case")]
 #[derive(Clone, Copy)]
+/// Represents the different types of relationships between nodes in the syntax tree.
 pub enum EdgeLabel {
-    // Built-in:
+    /// Represents a child node with the label `item`.
     Item,
+    /// Represents a child node with the label `variant`.
     Variant,
+    /// Represents a child node with the label `separator`.
     Separator,
+    /// Represents a child node with the label `operand`.
     Operand,
+    /// Represents a child node with the label `left_operand`.
     LeftOperand,
+    /// Represents a child node with the label `right_operand`.
     RightOperand,
+    /// Represents a child node with the label `leading_trivia`.
     LeadingTrivia,
+    /// Represents a child node with the label `trailing_trivia`.
     TrailingTrivia,
 
-    // Generated:
     Stub1,
     Stub2,
     Stub3,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/generated/terminal_kind.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/generated/terminal_kind.rs
@@ -20,11 +20,9 @@
 #[allow(clippy::doc_markdown)]
 #[allow(clippy::doc_link_with_quotes)]
 pub enum TerminalKind {
-    // Built-in:
     UNRECOGNIZED,
     MISSING,
 
-    // Generated:
     Stub1,
     Stub2,
     Stub3,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/nonterminal_kind.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/nonterminal_kind.rs.jinja2
@@ -24,10 +24,14 @@ pub enum NonterminalKind {
         Stub3,
     {%- else -%}
         {%- for variant in model.kinds.nonterminal_kinds -%}
+            /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+            ///
             /// ```ebnf
-            {{ variant.documentation | indent(prefix = "/// ", first = true, blank = true) }}
+            {%- for line in variant.documentation | split(pat="\n") %}
+            /// {{ line }}
+            {%- endfor %}
             /// ```
-            {{ variant.id }},
+            {{ variant.id | pascal_case }},
         {%- endfor -%}
     {%- endif -%}
 }

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/terminal_kind.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/terminal_kind.rs.jinja2
@@ -18,21 +18,27 @@
 #[allow(clippy::doc_markdown)]
 #[allow(clippy::doc_link_with_quotes)]
 pub enum TerminalKind {
-    // Built-in:
+    {# Built-in: #}
+
     UNRECOGNIZED,
     MISSING,
 
-    // Generated:
+    {# Generated: #}
+
     {% if rendering_in_stubs -%}
         Stub1,
         Stub2,
         Stub3,
     {%- else -%}
         {%- for variant in model.kinds.terminal_kinds -%}
+            /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+            ///
             /// ```ebnf
-            {{ variant.documentation | indent(prefix = "/// ", first = true, blank = true) }}
+            {%- for line in variant.documentation | split(pat="\n") %}
+            /// {{ line }}
+            {%- endfor %}
             /// ```
-            {{ variant.id }},
+            {{ variant.id | pascal_case }},
         {%- endfor -%}
     {%- endif -%}
 }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/ast.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/ast.wit.jinja2
@@ -1,6 +1,7 @@
 interface ast {
     use cst.{node, nonterminal-node};
 
+    /// @internal
     resource selectors {
         sequence: static func(node: borrow<nonterminal-node>) -> result<list<option<node>>, string>;
         choice: static func(node: borrow<nonterminal-node>) -> result<node, string>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/compilation.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/compilation.wit.jinja2
@@ -7,6 +7,8 @@ interface compilation {
     ///
     /// This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
     /// This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+    ///
+    /// @internal
     resource internal-compilation-builder {
         /// Creates a new compilation builder for the specified language version.
         create: static func(language-version: string) -> result<internal-compilation-builder, string>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -11,7 +11,7 @@ interface cst {
             stub3,
         {%- else %}
             {%- for variant in model.kinds.nonterminal_kinds %}
-                /// This kind represents a `{{ variant.id }}` node, with the following structure: 
+                /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
                 ///
                 /// ```ebnf
                 {%- for line in variant.documentation | split(pat="\n") %}
@@ -42,7 +42,7 @@ interface cst {
             stub3,
         {%- else %}
             {%- for variant in model.kinds.terminal_kinds %}
-                /// This kind represents a `{{ variant.id }}` node, with the following structure: 
+                /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
                 ///
                 /// ```ebnf
                 {%- for line in variant.documentation | split(pat="\n") %}
@@ -65,6 +65,7 @@ interface cst {
     /// Represents the different types of relationships between nodes in the syntax tree.
     enum edge-label {
         {%- for label in model.kinds.predefined_labels %}
+            /// Represents a child node with the label `{{ label | snake_case }}`.
             {{ label | wit_case }},
         {%- endfor %}
 
@@ -76,8 +77,9 @@ interface cst {
             /// Generated stub.
             stub3,
         {%- else %}
-            {%- for variant in model.kinds.labels %}
-                {{ variant | wit_case }},
+            {%- for label in model.kinds.labels %}
+                /// Represents a child node with the label `{{ label | snake_case }}`.
+                {{ label | wit_case }},
             {%- endfor %}
         {%- endif %}
     }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/ast.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/ast.wit
@@ -3,6 +3,7 @@
 interface ast {
     use cst.{node, nonterminal-node};
 
+    /// @internal
     resource selectors {
         sequence: static func(node: borrow<nonterminal-node>) -> result<list<option<node>>, string>;
         choice: static func(node: borrow<nonterminal-node>) -> result<node, string>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/compilation.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/compilation.wit
@@ -9,6 +9,8 @@ interface compilation {
     ///
     /// This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
     /// This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+    ///
+    /// @internal
     resource internal-compilation-builder {
         /// Creates a new compilation builder for the specified language version.
         create: static func(language-version: string) -> result<internal-compilation-builder, string>;

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
@@ -39,13 +39,21 @@ interface cst {
 
     /// Represents the different types of relationships between nodes in the syntax tree.
     enum edge-label {
+            /// Represents a child node with the label `item`.
             %item,
+            /// Represents a child node with the label `variant`.
             %variant,
+            /// Represents a child node with the label `separator`.
             %separator,
+            /// Represents a child node with the label `operand`.
             %operand,
+            /// Represents a child node with the label `left_operand`.
             %left-operand,
+            /// Represents a child node with the label `right_operand`.
             %right-operand,
+            /// Represents a child node with the label `leading_trivia`.
             %leading-trivia,
+            /// Represents a child node with the label `trailing_trivia`.
             %trailing-trivia,
             /// Generated stub.
             stub1,

--- a/crates/codegen/runtime/npm/package/src/runtime/ast/nodes.mts.jinja2
+++ b/crates/codegen/runtime/npm/package/src/runtime/ast/nodes.mts.jinja2
@@ -1,21 +1,30 @@
 {%- if rendering_in_stubs -%}
   export class StubAst {}
 {%- else -%}
-    import * as generated from "../../../../wasm/index.mjs";
+    import * as wasm from "../../../../wasm/index.mjs";
     import { NonterminalKind, NonterminalNode, TerminalNode } from "../../cst/index.mjs";
 
-    /*
-    * Sequences:
-    */
+    // 
+    // Sequences:
+    // 
 
     {% for sequence in model.ast.sequences %}
+      /**
+       * This node represents a `{{ sequence.parent_type }}` nonterminal, with the following structure:
+       *
+       * ```ebnf
+         {%- for line in sequence.ebnf | split(pat="\n") %}
+       * {{ line }}
+         {%- endfor %}
+       * ```
+       */
       export class {{ sequence.parent_type }} {
         private readonly fetch = once(() => {
           const [
             {%- for field in sequence.fields %}
               ${{ field.label | camel_case }},
             {%- endfor %}
-          ] = generated.ast.Selectors.sequence(this.cst);
+          ] = wasm.ast.Selectors.sequence(this.cst);
 
           return {
             {%- for field in sequence.fields %}
@@ -32,11 +41,22 @@
           };
         });
 
-        public constructor(public readonly cst: NonterminalNode) {
+        /**
+        * Constructs a new AST node of type `{{ sequence.parent_type }}`, given a nonterminal CST node of the same kind.
+        */
+        public constructor(
+          /**
+           * The underlying nonterminal CST node of kind `{{ sequence.parent_type }}`.
+           */
+          public readonly cst: NonterminalNode
+        ) {
           assertKind(this.cst.kind, NonterminalKind.{{ sequence.parent_type }});
         }
 
         {% for field in sequence.fields %}
+          /**
+           * Returns the child node that has the label `{{ field.label | snake_case }}`.
+           */
           public get {{ field.label | camel_case }}() :
             {%- if field.type -%}
               {{ field.type }}
@@ -53,11 +73,20 @@
       }
     {% endfor %}
 
-    /*
-    * Choices:
-    */
+    // 
+    // Choices:
+    // 
 
     {% for choice in model.ast.choices %}
+      /**
+       * This node represents a `{{ choice.parent_type }}` nonterminal, with the following structure:
+       *
+       * ```ebnf
+         {%- for line in choice.ebnf | split(pat="\n") %}
+       * {{ line }}
+         {%- endfor %}
+       * ```
+       */
       export class {{ choice.parent_type }} {
         {%- set variant_types = choice.nonterminal_types -%}
         {%- if choice.includes_terminals -%}
@@ -66,7 +95,7 @@
         {%- set variant_types = variant_types | join(sep = " | ") -%}
 
         private readonly fetch: () => {{ variant_types }} = once(() => {
-          const variant = generated.ast.Selectors.choice(this.cst);
+          const variant = wasm.ast.Selectors.choice(this.cst);
 
           {% if choice.nonterminal_types | length == 0 -%}
             return variant as TerminalNode;
@@ -89,24 +118,44 @@
           {%- endif %}
         });
 
-        public constructor(public readonly cst: NonterminalNode) {
+        /**
+        * Constructs a new AST node of type `{{ choice.parent_type }}`, given a nonterminal CST node of the same kind.
+        */
+        public constructor(
+          /**
+           * The underlying nonterminal CST node of kind `{{ choice.parent_type }}`.
+           */
+          public readonly cst: NonterminalNode
+        ) {
           assertKind(this.cst.kind, NonterminalKind.{{ choice.parent_type }});
         }
 
+        /**
+          * Returns the child node that has the label `variant`.
+          */
         public get variant(): {{ variant_types }} {
           return this.fetch();
         }
       }
     {% endfor %}
 
-    /*
-    * Repeated:
-    */
+    // 
+    // Repeated:
+    // 
 
     {% for repeated in model.ast.repeated %}
+      /**
+       * This node represents a `{{ repeated.parent_type }}` nonterminal, with the following structure:
+       *
+       * ```ebnf
+         {%- for line in repeated.ebnf | split(pat="\n") %}
+       * {{ line }}
+         {%- endfor %}
+       * ```
+       */
       export class {{ repeated.parent_type }} {
         private readonly fetch = once(() => {
-          const items = generated.ast.Selectors.repeated(this.cst);
+          const items = wasm.ast.Selectors.repeated(this.cst);
 
           {%- if repeated.item_type -%}
             return items.map((item) => new {{ repeated.item_type }}(item as NonterminalNode));
@@ -115,10 +164,21 @@
           {%- endif -%}
         });
           
-        public constructor(public readonly cst: NonterminalNode) {
+        /**
+        * Constructs a new AST node of type `{{ repeated.parent_type }}`, given a nonterminal CST node of the same kind.
+        */
+        public constructor(
+          /**
+           * The underlying nonterminal CST node of kind `{{ repeated.parent_type }}`.
+           */
+          public readonly cst: NonterminalNode
+        ) {
           assertKind(this.cst.kind, NonterminalKind.{{ repeated.parent_type }});
         }
 
+        /**
+          * Returns an array of the child nodes that have the label `item`. 
+          */
         public get items():
           {%- if repeated.item_type -%}
             readonly {{ repeated.item_type }}[]
@@ -131,14 +191,23 @@
       }
     {% endfor %}
 
-    /*
-    * Separated:
-    */
+    // 
+    // Separated:
+    // 
 
     {% for separated in model.ast.separated %}
+      /**
+       * This node represents a `{{ separated.parent_type }}` nonterminal, with the following structure:
+       *
+       * ```ebnf
+         {%- for line in separated.ebnf | split(pat="\n") %}
+       * {{ line }}
+         {%- endfor %}
+       * ```
+       */
       export class {{ separated.parent_type }} {
         private readonly fetch = once(() => {
-          const [items, separators] = generated.ast.Selectors.separated(this.cst);
+          const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
           return {
             {%- if separated.item_type -%}
@@ -150,10 +219,21 @@
           };
         });
 
-        public constructor(public readonly cst: NonterminalNode) {
+        /**
+        * Constructs a new AST node of type `{{ separated.parent_type }}`, given a nonterminal CST node of the same kind.
+        */
+        public constructor(
+          /**
+           * The underlying nonterminal CST node of kind `{{ separated.parent_type }}`.
+           */
+          public readonly cst: NonterminalNode
+        ) {
           assertKind(this.cst.kind, NonterminalKind.{{ separated.parent_type }});
         }
 
+        /**
+          * Returns an array of the child nodes that have the label `item`. 
+          */
         public get items():
           {%- if separated.item_type -%}
             readonly {{ separated.item_type }}[]
@@ -164,15 +244,14 @@
           return this.fetch().items;
         }
 
+        /**
+          * Returns an array of the child nodes that have the label `separator`. 
+          */
         public get separators(): readonly TerminalNode[] {
           return this.fetch().separators;
         }
       }
     {% endfor %}
-
-    /*
-    * Helpers:
-    */
 
     function once<T>(factory: () => T): () => T {
       let value: T | undefined;

--- a/crates/codegen/runtime/npm/package/src/runtime/bindings/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/bindings/index.mts
@@ -1,21 +1,34 @@
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const BindingGraph = generated.bindings.BindingGraph;
-export type BindingGraph = generated.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export const BindingGraph = wasm.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export type BindingGraph = wasm.bindings.BindingGraph;
 
-export const Definition = generated.bindings.Definition;
-export type Definition = generated.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export const Definition = wasm.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export type Definition = wasm.bindings.Definition;
 
-export const Reference = generated.bindings.Reference;
-export type Reference = generated.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export const Reference = wasm.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export type Reference = wasm.bindings.Reference;
 
-export type BindingLocation = generated.bindings.BindingLocation;
+/** {@inheritDoc wasm.bindings.BindingLocation} */
+export type BindingLocation = wasm.bindings.BindingLocation;
 
-export const BindingLocationType = generated.bindings.BindingLocationType;
-export type BindingLocationType = generated.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export const BindingLocationType = wasm.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export type BindingLocationType = wasm.bindings.BindingLocationType;
 
-export const UserFileLocation = generated.bindings.UserFileLocation;
-export type UserFileLocation = generated.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export const UserFileLocation = wasm.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export type UserFileLocation = wasm.bindings.UserFileLocation;
 
-export const BuiltInLocation = generated.bindings.BuiltInLocation;
-export type BuiltInLocation = generated.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export const BuiltInLocation = wasm.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export type BuiltInLocation = wasm.bindings.BuiltInLocation;

--- a/crates/codegen/runtime/npm/package/src/runtime/compilation/builder.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/compilation/builder.mts
@@ -1,10 +1,7 @@
 import { Cursor } from "../cst/index.mjs";
 import { CompilationUnit } from "./index.mjs";
 
-import * as generated from "../../../wasm/index.mjs";
-
-const InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
-type InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
+import * as wasm from "../../../wasm/index.mjs";
 
 /**
  * User-provided options and callbacks necessary for the `CompilationBuilder` class to perform its job.
@@ -49,7 +46,7 @@ export class CompilationBuilder {
   private readonly seenFiles: Set<string> = new Set();
 
   private constructor(
-    private readonly internalBuilder: InternalCompilationBuilder,
+    private readonly internalBuilder: wasm.compilation.InternalCompilationBuilder,
 
     /**
      * The user-supplied configuration.
@@ -61,7 +58,7 @@ export class CompilationBuilder {
    * Creates a new compilation builder for the specified language version.
    */
   public static create(config: CompilationBuilderConfig): CompilationBuilder {
-    const internalBuilder = InternalCompilationBuilder.create(config.languageVersion);
+    const internalBuilder = wasm.compilation.InternalCompilationBuilder.create(config.languageVersion);
     return new CompilationBuilder(internalBuilder, config);
   }
 

--- a/crates/codegen/runtime/npm/package/src/runtime/compilation/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/compilation/index.mts
@@ -1,14 +1,13 @@
-import * as generated from "../../../wasm/index.mjs";
-import * as builder from "./builder.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-// This is a wrapper around 'generated.compilation.InternalCompilationBuilder':
-export const CompilationBuilder = builder.CompilationBuilder;
-export type CompilationBuilder = builder.CompilationBuilder;
+export { CompilationBuilder, CompilationBuilderConfig } from "./builder.mjs";
 
-export type CompilationBuilderConfig = builder.CompilationBuilderConfig;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export const CompilationUnit = wasm.compilation.CompilationUnit;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export type CompilationUnit = wasm.compilation.CompilationUnit;
 
-export const CompilationUnit = generated.compilation.CompilationUnit;
-export type CompilationUnit = generated.compilation.CompilationUnit;
-
-export const File = generated.compilation.File;
-export type File = generated.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export const File = wasm.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export type File = wasm.compilation.File;

--- a/crates/codegen/runtime/npm/package/src/runtime/cst/assertions.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/cst/assertions.mts
@@ -1,0 +1,39 @@
+import { NonterminalKind, NonterminalNode, TerminalKind, TerminalNode } from "./index.mjs";
+
+/**
+ * Asserts that this node is a `NonterminalNode` with the provided kind and text.
+ */
+export function assertIsNonterminalNode(
+  node: unknown,
+  kind?: NonterminalKind,
+  text?: string,
+): asserts node is NonterminalNode {
+  if (!(node instanceof NonterminalNode)) {
+    throw new Error("Node provided is not a NonterminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}
+
+/**
+ * Asserts that this node is a `TerminalKind` with the provided kind and text.
+ */
+export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
+  if (!(node instanceof TerminalNode)) {
+    throw new Error("Node provided is not a TerminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}

--- a/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
@@ -1,87 +1,81 @@
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const NonterminalKind = generated.cst.NonterminalKind;
-export type NonterminalKind = generated.cst.NonterminalKind;
+export * from "./assertions.mjs";
 
-export const TerminalKind = generated.cst.TerminalKind;
-export type TerminalKind = generated.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export const NonterminalKind = wasm.cst.NonterminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export type NonterminalKind = wasm.cst.NonterminalKind;
 
-export const TerminalKindExtensions = generated.cst.TerminalKindExtensions;
-export type TerminalKindExtensions = generated.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export const TerminalKind = wasm.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export type TerminalKind = wasm.cst.TerminalKind;
 
-export const EdgeLabel = generated.cst.EdgeLabel;
-export type EdgeLabel = generated.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export const TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export type TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
 
-export type Node = generated.cst.Node;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export const EdgeLabel = wasm.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export type EdgeLabel = wasm.cst.EdgeLabel;
 
-export const NodeType = generated.cst.NodeType;
-export type NodeType = generated.cst.NodeType;
+/** {@inheritDoc wasm.cst.Node} */
+export type Node = wasm.cst.Node;
 
-export const NonterminalNode = generated.cst.NonterminalNode;
-export type NonterminalNode = generated.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NodeType} */
+export const NodeType = wasm.cst.NodeType;
+/** {@inheritDoc wasm.cst.NodeType} */
+export type NodeType = wasm.cst.NodeType;
 
-export const TerminalNode = generated.cst.TerminalNode;
-export type TerminalNode = generated.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export const NonterminalNode = wasm.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export type NonterminalNode = wasm.cst.NonterminalNode;
 
-export type Edge = generated.cst.Edge;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export const TerminalNode = wasm.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export type TerminalNode = wasm.cst.TerminalNode;
 
-export const Cursor = generated.cst.Cursor;
-export type Cursor = generated.cst.Cursor;
+/** {@inheritDoc wasm.cst.Edge} */
+export type Edge = wasm.cst.Edge;
 
-export const CursorIterator = generated.cst.CursorIterator;
-export type CursorIterator = generated.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.Cursor} */
+export const Cursor = wasm.cst.Cursor;
+/** {@inheritDoc wasm.cst.Cursor} */
+export type Cursor = wasm.cst.Cursor;
 
-export const AncestorsIterator = generated.cst.AncestorsIterator;
-export type AncestorsIterator = generated.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export const CursorIterator = wasm.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export type CursorIterator = wasm.cst.CursorIterator;
 
-export const Query = generated.cst.Query;
-export type Query = generated.cst.Query;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export const AncestorsIterator = wasm.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export type AncestorsIterator = wasm.cst.AncestorsIterator;
 
-export type QueryError = generated.cst.QueryError;
+/** {@inheritDoc wasm.cst.Query} */
+export const Query = wasm.cst.Query;
+/** {@inheritDoc wasm.cst.Query} */
+export type Query = wasm.cst.Query;
 
-export type QueryMatch = generated.cst.QueryMatch;
+/** {@inheritDoc wasm.cst.QueryError} */
+export type QueryError = wasm.cst.QueryError;
 
-export const QueryMatchIterator = generated.cst.QueryMatchIterator;
-export type QueryMatchIterator = generated.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatch} */
+export type QueryMatch = wasm.cst.QueryMatch;
 
-export type TextIndex = generated.cst.TextIndex;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export const QueryMatchIterator = wasm.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export type QueryMatchIterator = wasm.cst.QueryMatchIterator;
 
-export type TextRange = generated.cst.TextRange;
+/** {@inheritDoc wasm.cst.TextIndex} */
+export type TextIndex = wasm.cst.TextIndex;
 
-/**
- * Asserts that this node is a `NonterminalNode` with the provided kind and text.
- */
-export function assertIsNonterminalNode(
-  node: unknown,
-  kind?: NonterminalKind,
-  text?: string,
-): asserts node is NonterminalNode {
-  if (!(node instanceof NonterminalNode)) {
-    throw new Error("Node provided is not a NonterminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
-
-/**
- * Asserts that this node is a `TerminalKind` with the provided kind and text.
- */
-export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
-  if (!(node instanceof TerminalNode)) {
-    throw new Error("Node provided is not a TerminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
+/** {@inheritDoc wasm.cst.TextRange} */
+export type TextRange = wasm.cst.TextRange;

--- a/crates/codegen/runtime/npm/package/src/runtime/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/index.mts
@@ -1,3 +1,6 @@
+/*
+ * __SLANG_NPM_PACKAGE_EXPORTS__ (keep in sync)
+ */
 export * as ast from "./ast/index.mjs";
 export * as bindings from "./bindings/index.mjs";
 export * as compilation from "./compilation/index.mjs";

--- a/crates/codegen/runtime/npm/package/src/runtime/parser/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/parser/index.mts
@@ -1,10 +1,16 @@
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const Parser = generated.parser.Parser;
-export type Parser = generated.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export const Parser = wasm.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export type Parser = wasm.parser.Parser;
 
-export const ParseError = generated.parser.ParseError;
-export type ParseError = generated.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export const ParseError = wasm.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export type ParseError = wasm.parser.ParseError;
 
-export const ParseOutput = generated.parser.ParseOutput;
-export type ParseOutput = generated.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export const ParseOutput = wasm.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export type ParseOutput = wasm.parser.ParseOutput;

--- a/crates/codegen/runtime/npm/package/src/runtime/utils/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/utils/index.mts
@@ -1,4 +1,6 @@
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const LanguageFacts = generated.utils.LanguageFacts;
-export type LanguageFacts = generated.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export const LanguageFacts = wasm.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export type LanguageFacts = wasm.utils.LanguageFacts;

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
@@ -7,6 +7,10 @@ import type { Node } from "./nomic-foundation-slang-cst.js";
 export { Node };
 import type { NonterminalNode } from "./nomic-foundation-slang-cst.js";
 export { NonterminalNode };
+
+/**
+ * @internal
+ */
 export class Selectors {
   static sequence(node: NonterminalNode): (Node | undefined)[];
   static choice(node: NonterminalNode): Node;

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
@@ -16,8 +16,19 @@ export { Cursor };
  * It can either be in a user file, or a built-in in the language.
  */
 export type BindingLocation = UserFileLocation | BuiltInLocation;
+
+/**
+ * Enumerates different variants of the `BindingLocation` type.
+ */
 export enum BindingLocationType {
+  /**
+   * Represents a variant of type `UserFileLocation`.
+   */
   UserFileLocation = "UserFileLocation",
+
+  /**
+   * Represents a variant of type `BuiltInLocation`.
+   */
   BuiltInLocation = "BuiltInLocation",
 }
 

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
@@ -77,6 +77,8 @@ export class File {
  *
  * This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
  * This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+ *
+ * @internal
  */
 export class InternalCompilationBuilder {
   /**

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -65,13 +65,37 @@ export declare enum TerminalKind {
  * Represents the different types of relationships between nodes in the syntax tree.
  */
 export declare enum EdgeLabel {
+  /**
+   * Represents a child node with the label `item`.
+   */
   Item = "Item",
+  /**
+   * Represents a child node with the label `variant`.
+   */
   Variant = "Variant",
+  /**
+   * Represents a child node with the label `separator`.
+   */
   Separator = "Separator",
+  /**
+   * Represents a child node with the label `operand`.
+   */
   Operand = "Operand",
+  /**
+   * Represents a child node with the label `left_operand`.
+   */
   LeftOperand = "LeftOperand",
+  /**
+   * Represents a child node with the label `right_operand`.
+   */
   RightOperand = "RightOperand",
+  /**
+   * Represents a child node with the label `leading_trivia`.
+   */
   LeadingTrivia = "LeadingTrivia",
+  /**
+   * Represents a child node with the label `trailing_trivia`.
+   */
   TrailingTrivia = "TrailingTrivia",
   /**
    * Generated stub.
@@ -90,8 +114,19 @@ export declare enum EdgeLabel {
  * The super type of all nodes in a tree.
  */
 export type Node = NonterminalNode | TerminalNode;
+
+/**
+ * Enumerates different variants of the `Node` type.
+ */
 export enum NodeType {
+  /**
+   * Represents a variant of type `NonterminalNode`.
+   */
   NonterminalNode = "NonterminalNode",
+
+  /**
+   * Represents a variant of type `TerminalNode`.
+   */
   TerminalNode = "TerminalNode",
 }
 /**
@@ -185,6 +220,9 @@ export interface TextRange {
  * Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
  */
 export class AncestorsIterator {
+  /**
+   * Returns an iterator over `NonterminalNode` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<NonterminalNode>;
   /**
    * Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
@@ -326,6 +364,9 @@ export class Cursor {
  * Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
  */
 export class CursorIterator {
+  /**
+   * Returns an iterator over `Edge` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<Edge>;
   /**
    * Returns the next edge in the iteration, or `undefined` if there are no more edges.
@@ -414,6 +455,9 @@ export class Query {
  * Iterator over query matches in the syntax tree.
  */
 export class QueryMatchIterator {
+  /**
+   * Returns an iterator over `QueryMatch` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<QueryMatch>;
   /**
    * Returns the next match or `undefined` if there are no more matches.

--- a/crates/infra/cli/package.json
+++ b/crates/infra/cli/package.json
@@ -13,6 +13,7 @@
     "prettier": "3.4.2",
     "remark-parse": "11.0.0",
     "remark-stringify": "11.0.0",
+    "typedoc": "0.27.6",
     "typescript": "5.7.2",
     "unified": "11.0.5"
   }

--- a/crates/infra/cli/src/commands/lint/mod.rs
+++ b/crates/infra/cli/src/commands/lint/mod.rs
@@ -40,6 +40,8 @@ enum LintCommand {
     Tsc,
     /// Check for violations issues in Yaml files.
     Yamllint,
+    /// Check for violations in TypeScript documentation files.
+    Typedoc,
 }
 
 impl OrderedCommand for LintCommand {
@@ -55,6 +57,7 @@ impl OrderedCommand for LintCommand {
             LintCommand::Shellcheck => run_shellcheck()?,
             LintCommand::Tsc => run_tsc(),
             LintCommand::Yamllint => run_yamllint()?,
+            LintCommand::Typedoc => run_typedoc()?,
         };
 
         Ok(())
@@ -149,6 +152,18 @@ fn run_yamllint() -> Result<()> {
         .flag("--strict")
         .property("--config-file", config_file.unwrap_str())
         .run_xargs(yaml_files);
+
+    Ok(())
+}
+
+fn run_typedoc() -> Result<()> {
+    let options_files = FileWalker::from_repo_root().find(["**/typedoc.mjs"])?;
+
+    for options_file in options_files {
+        Command::new("typedoc")
+            .property("--options", options_file.unwrap_string())
+            .run();
+    }
 
     Ok(())
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/edge_label.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/edge_label.rs
@@ -16,141 +16,272 @@
 )]
 #[strum(serialize_all = "snake_case")]
 #[derive(Clone, Copy)]
+/// Represents the different types of relationships between nodes in the syntax tree.
 pub enum EdgeLabel {
-    // Built-in:
+    /// Represents a child node with the label `item`.
     Item,
+    /// Represents a child node with the label `variant`.
     Variant,
+    /// Represents a child node with the label `separator`.
     Separator,
+    /// Represents a child node with the label `operand`.
     Operand,
+    /// Represents a child node with the label `left_operand`.
     LeftOperand,
+    /// Represents a child node with the label `right_operand`.
     RightOperand,
+    /// Represents a child node with the label `leading_trivia`.
     LeadingTrivia,
+    /// Represents a child node with the label `trailing_trivia`.
     TrailingTrivia,
 
-    // Generated:
+    /// Represents a child node with the label `abicoder_keyword`.
     AbicoderKeyword,
+    /// Represents a child node with the label `abstract_keyword`.
     AbstractKeyword,
+    /// Represents a child node with the label `address_keyword`.
     AddressKeyword,
+    /// Represents a child node with the label `alias`.
     Alias,
+    /// Represents a child node with the label `anonymous_keyword`.
     AnonymousKeyword,
+    /// Represents a child node with the label `arguments`.
     Arguments,
+    /// Represents a child node with the label `as_keyword`.
     AsKeyword,
+    /// Represents a child node with the label `assembly_keyword`.
     AssemblyKeyword,
+    /// Represents a child node with the label `assignment`.
     Assignment,
+    /// Represents a child node with the label `asterisk`.
     Asterisk,
+    /// Represents a child node with the label `attributes`.
     Attributes,
+    /// Represents a child node with the label `block`.
     Block,
+    /// Represents a child node with the label `body`.
     Body,
+    /// Represents a child node with the label `break_keyword`.
     BreakKeyword,
+    /// Represents a child node with the label `case_keyword`.
     CaseKeyword,
+    /// Represents a child node with the label `cases`.
     Cases,
+    /// Represents a child node with the label `catch_clauses`.
     CatchClauses,
+    /// Represents a child node with the label `catch_keyword`.
     CatchKeyword,
+    /// Represents a child node with the label `clause`.
     Clause,
+    /// Represents a child node with the label `close_brace`.
     CloseBrace,
+    /// Represents a child node with the label `close_bracket`.
     CloseBracket,
+    /// Represents a child node with the label `close_paren`.
     CloseParen,
+    /// Represents a child node with the label `colon`.
     Colon,
+    /// Represents a child node with the label `condition`.
     Condition,
+    /// Represents a child node with the label `constant_keyword`.
     ConstantKeyword,
+    /// Represents a child node with the label `constructor_keyword`.
     ConstructorKeyword,
+    /// Represents a child node with the label `continue_keyword`.
     ContinueKeyword,
+    /// Represents a child node with the label `contract_keyword`.
     ContractKeyword,
+    /// Represents a child node with the label `default_keyword`.
     DefaultKeyword,
+    /// Represents a child node with the label `do_keyword`.
     DoKeyword,
+    /// Represents a child node with the label `elements`.
     Elements,
+    /// Represents a child node with the label `else_branch`.
     ElseBranch,
+    /// Represents a child node with the label `else_keyword`.
     ElseKeyword,
+    /// Represents a child node with the label `emit_keyword`.
     EmitKeyword,
+    /// Represents a child node with the label `end`.
     End,
+    /// Represents a child node with the label `enum_keyword`.
     EnumKeyword,
+    /// Represents a child node with the label `equal`.
     Equal,
+    /// Represents a child node with the label `equal_greater_than`.
     EqualGreaterThan,
+    /// Represents a child node with the label `error`.
     Error,
+    /// Represents a child node with the label `error_keyword`.
     ErrorKeyword,
+    /// Represents a child node with the label `event`.
     Event,
+    /// Represents a child node with the label `event_keyword`.
     EventKeyword,
+    /// Represents a child node with the label `experimental_keyword`.
     ExperimentalKeyword,
+    /// Represents a child node with the label `expression`.
     Expression,
+    /// Represents a child node with the label `fallback_keyword`.
     FallbackKeyword,
+    /// Represents a child node with the label `false_expression`.
     FalseExpression,
+    /// Represents a child node with the label `feature`.
     Feature,
+    /// Represents a child node with the label `flags`.
     Flags,
+    /// Represents a child node with the label `for_keyword`.
     ForKeyword,
+    /// Represents a child node with the label `from_keyword`.
     FromKeyword,
+    /// Represents a child node with the label `function_keyword`.
     FunctionKeyword,
+    /// Represents a child node with the label `global_keyword`.
     GlobalKeyword,
+    /// Represents a child node with the label `identifier`.
     Identifier,
+    /// Represents a child node with the label `if_keyword`.
     IfKeyword,
+    /// Represents a child node with the label `import_keyword`.
     ImportKeyword,
+    /// Represents a child node with the label `index`.
     Index,
+    /// Represents a child node with the label `indexed_keyword`.
     IndexedKeyword,
+    /// Represents a child node with the label `inheritance`.
     Inheritance,
+    /// Represents a child node with the label `initialization`.
     Initialization,
+    /// Represents a child node with the label `interface_keyword`.
     InterfaceKeyword,
+    /// Represents a child node with the label `is_keyword`.
     IsKeyword,
+    /// Represents a child node with the label `items`.
     Items,
+    /// Represents a child node with the label `iterator`.
     Iterator,
+    /// Represents a child node with the label `key_type`.
     KeyType,
+    /// Represents a child node with the label `label`.
     Label,
+    /// Represents a child node with the label `leave_keyword`.
     LeaveKeyword,
+    /// Represents a child node with the label `let_keyword`.
     LetKeyword,
+    /// Represents a child node with the label `library_keyword`.
     LibraryKeyword,
+    /// Represents a child node with the label `literal`.
     Literal,
+    /// Represents a child node with the label `mapping_keyword`.
     MappingKeyword,
+    /// Represents a child node with the label `member`.
     Member,
+    /// Represents a child node with the label `members`.
     Members,
+    /// Represents a child node with the label `minus`.
     Minus,
+    /// Represents a child node with the label `minus_greater_than`.
     MinusGreaterThan,
+    /// Represents a child node with the label `modifier_keyword`.
     ModifierKeyword,
+    /// Represents a child node with the label `name`.
     Name,
+    /// Represents a child node with the label `new_keyword`.
     NewKeyword,
+    /// Represents a child node with the label `open_brace`.
     OpenBrace,
+    /// Represents a child node with the label `open_bracket`.
     OpenBracket,
+    /// Represents a child node with the label `open_paren`.
     OpenParen,
+    /// Represents a child node with the label `operator`.
     Operator,
+    /// Represents a child node with the label `options`.
     Options,
+    /// Represents a child node with the label `overridden`.
     Overridden,
+    /// Represents a child node with the label `override_keyword`.
     OverrideKeyword,
+    /// Represents a child node with the label `parameters`.
     Parameters,
+    /// Represents a child node with the label `path`.
     Path,
+    /// Represents a child node with the label `paths`.
     Paths,
+    /// Represents a child node with the label `payable_keyword`.
     PayableKeyword,
+    /// Represents a child node with the label `period`.
     Period,
+    /// Represents a child node with the label `pragma`.
     Pragma,
+    /// Represents a child node with the label `pragma_keyword`.
     PragmaKeyword,
+    /// Represents a child node with the label `question_mark`.
     QuestionMark,
+    /// Represents a child node with the label `receive_keyword`.
     ReceiveKeyword,
+    /// Represents a child node with the label `return_keyword`.
     ReturnKeyword,
+    /// Represents a child node with the label `returns`.
     Returns,
+    /// Represents a child node with the label `returns_keyword`.
     ReturnsKeyword,
+    /// Represents a child node with the label `revert_keyword`.
     RevertKeyword,
+    /// Represents a child node with the label `semicolon`.
     Semicolon,
+    /// Represents a child node with the label `sets`.
     Sets,
+    /// Represents a child node with the label `solidity_keyword`.
     SolidityKeyword,
+    /// Represents a child node with the label `start`.
     Start,
+    /// Represents a child node with the label `statements`.
     Statements,
+    /// Represents a child node with the label `storage_location`.
     StorageLocation,
+    /// Represents a child node with the label `struct_keyword`.
     StructKeyword,
+    /// Represents a child node with the label `switch_keyword`.
     SwitchKeyword,
+    /// Represents a child node with the label `symbols`.
     Symbols,
+    /// Represents a child node with the label `target`.
     Target,
+    /// Represents a child node with the label `throw_keyword`.
     ThrowKeyword,
+    /// Represents a child node with the label `true_expression`.
     TrueExpression,
+    /// Represents a child node with the label `try_keyword`.
     TryKeyword,
+    /// Represents a child node with the label `type_keyword`.
     TypeKeyword,
+    /// Represents a child node with the label `type_name`.
     TypeName,
+    /// Represents a child node with the label `types`.
     Types,
+    /// Represents a child node with the label `unchecked_keyword`.
     UncheckedKeyword,
+    /// Represents a child node with the label `unit`.
     Unit,
+    /// Represents a child node with the label `using_keyword`.
     UsingKeyword,
+    /// Represents a child node with the label `value`.
     Value,
+    /// Represents a child node with the label `value_type`.
     ValueType,
+    /// Represents a child node with the label `var_keyword`.
     VarKeyword,
+    /// Represents a child node with the label `variable`.
     Variable,
+    /// Represents a child node with the label `variable_type`.
     VariableType,
+    /// Represents a child node with the label `variables`.
     Variables,
+    /// Represents a child node with the label `version`.
     Version,
+    /// Represents a child node with the label `while_keyword`.
     WhileKeyword,
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
@@ -19,11 +19,15 @@
     Copy,
 )]
 pub enum NonterminalKind {
+    /// Represents a node with kind `AbicoderPragma`, having the following structure:
+    ///
     /// ```ebnf
     /// AbicoderPragma = (* abicoder_keyword: *) ABICODER_KEYWORD
     ///                  (* version: *) IDENTIFIER;
     /// ```
     AbicoderPragma,
+    /// Represents a node with kind `AdditiveExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// AdditiveExpression = (* left_operand: *) Expression
@@ -36,11 +40,15 @@ pub enum NonterminalKind {
     ///                      (* right_operand: *) Expression;
     /// ```
     AdditiveExpression,
+    /// Represents a node with kind `AddressType`, having the following structure:
+    ///
     /// ```ebnf
     /// AddressType = (* address_keyword: *) ADDRESS_KEYWORD
     ///               (* payable_keyword: *) PAYABLE_KEYWORD?;
     /// ```
     AddressType,
+    /// Represents a node with kind `AndExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// AndExpression = (* left_operand: *) Expression
@@ -48,17 +56,23 @@ pub enum NonterminalKind {
     ///                 (* right_operand: *) Expression;
     /// ```
     AndExpression,
+    /// Represents a node with kind `ArgumentsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// ArgumentsDeclaration = (* variant: *) PositionalArgumentsDeclaration
     ///                      | (* variant: *) NamedArgumentsDeclaration;
     /// ```
     ArgumentsDeclaration,
+    /// Represents a node with kind `ArrayExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// ArrayExpression = (* open_bracket: *) OPEN_BRACKET
     ///                   (* items: *) ArrayValues
     ///                   (* close_bracket: *) CLOSE_BRACKET;
     /// ```
     ArrayExpression,
+    /// Represents a node with kind `ArrayTypeName`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// ArrayTypeName = (* operand: *) TypeName
@@ -67,20 +81,28 @@ pub enum NonterminalKind {
     ///                 (* close_bracket: *) CLOSE_BRACKET;
     /// ```
     ArrayTypeName,
+    /// Represents a node with kind `ArrayValues`, having the following structure:
+    ///
     /// ```ebnf
     /// ArrayValues = (* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*;
     /// ```
     ArrayValues,
+    /// Represents a node with kind `AssemblyFlags`, having the following structure:
+    ///
     /// ```ebnf
     /// AssemblyFlags = (* item: *) StringLiteral ((* separator: *) COMMA (* item: *) StringLiteral)*;
     /// ```
     AssemblyFlags,
+    /// Represents a node with kind `AssemblyFlagsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// AssemblyFlagsDeclaration = (* open_paren: *) OPEN_PAREN
     ///                            (* flags: *) AssemblyFlags
     ///                            (* close_paren: *) CLOSE_PAREN;
     /// ```
     AssemblyFlagsDeclaration,
+    /// Represents a node with kind `AssemblyStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// AssemblyStatement = (* assembly_keyword: *) ASSEMBLY_KEYWORD
     ///                     (* label: *) StringLiteral?
@@ -88,6 +110,8 @@ pub enum NonterminalKind {
     ///                     (* body: *) YulBlock;
     /// ```
     AssemblyStatement,
+    /// Represents a node with kind `AssignmentExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// AssignmentExpression = (* left_operand: *) Expression
@@ -150,6 +174,8 @@ pub enum NonterminalKind {
     ///                        (* right_operand: *) Expression;
     /// ```
     AssignmentExpression,
+    /// Represents a node with kind `BitwiseAndExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// BitwiseAndExpression = (* left_operand: *) Expression
@@ -157,6 +183,8 @@ pub enum NonterminalKind {
     ///                        (* right_operand: *) Expression;
     /// ```
     BitwiseAndExpression,
+    /// Represents a node with kind `BitwiseOrExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// BitwiseOrExpression = (* left_operand: *) Expression
@@ -164,6 +192,8 @@ pub enum NonterminalKind {
     ///                       (* right_operand: *) Expression;
     /// ```
     BitwiseOrExpression,
+    /// Represents a node with kind `BitwiseXorExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// BitwiseXorExpression = (* left_operand: *) Expression
@@ -171,22 +201,30 @@ pub enum NonterminalKind {
     ///                        (* right_operand: *) Expression;
     /// ```
     BitwiseXorExpression,
+    /// Represents a node with kind `Block`, having the following structure:
+    ///
     /// ```ebnf
     /// Block = (* open_brace: *) OPEN_BRACE
     ///         (* statements: *) Statements
     ///         (* close_brace: *) CLOSE_BRACE;
     /// ```
     Block,
+    /// Represents a node with kind `BreakStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// BreakStatement = (* break_keyword: *) BREAK_KEYWORD
     ///                  (* semicolon: *) SEMICOLON;
     /// ```
     BreakStatement,
+    /// Represents a node with kind `CallOptions`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.2 *)
     /// CallOptions = (* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*;
     /// ```
     CallOptions,
+    /// Represents a node with kind `CallOptionsExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// (* Introduced in 0.6.2 *)
@@ -196,6 +234,8 @@ pub enum NonterminalKind {
     ///                         (* close_brace: *) CLOSE_BRACE;
     /// ```
     CallOptionsExpression,
+    /// Represents a node with kind `CatchClause`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// CatchClause = (* catch_keyword: *) CATCH_KEYWORD
@@ -203,17 +243,23 @@ pub enum NonterminalKind {
     ///               (* body: *) Block;
     /// ```
     CatchClause,
+    /// Represents a node with kind `CatchClauseError`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// CatchClauseError = (* name: *) IDENTIFIER?
     ///                    (* parameters: *) ParametersDeclaration;
     /// ```
     CatchClauseError,
+    /// Represents a node with kind `CatchClauses`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// CatchClauses = (* item: *) CatchClause+;
     /// ```
     CatchClauses,
+    /// Represents a node with kind `ComparisonExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// ComparisonExpression = (* left_operand: *) Expression
@@ -236,6 +282,8 @@ pub enum NonterminalKind {
     ///                        (* right_operand: *) Expression;
     /// ```
     ComparisonExpression,
+    /// Represents a node with kind `ConditionalExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// ConditionalExpression = (* operand: *) Expression
@@ -245,6 +293,8 @@ pub enum NonterminalKind {
     ///                         (* false_expression: *) Expression;
     /// ```
     ConditionalExpression,
+    /// Represents a node with kind `ConstantDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.7.4 *)
     /// ConstantDefinition = (* type_name: *) TypeName
@@ -255,6 +305,8 @@ pub enum NonterminalKind {
     ///                      (* semicolon: *) SEMICOLON;
     /// ```
     ConstantDefinition,
+    /// Represents a node with kind `ConstructorAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.22 *)
     /// ConstructorAttribute = (* variant: *) ModifierInvocation
@@ -265,11 +317,15 @@ pub enum NonterminalKind {
     ///                      | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 and deprecated in 0.6.7. *)
     /// ```
     ConstructorAttribute,
+    /// Represents a node with kind `ConstructorAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.22 *)
     /// ConstructorAttributes = (* item: *) ConstructorAttribute*;
     /// ```
     ConstructorAttributes,
+    /// Represents a node with kind `ConstructorDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.22 *)
     /// ConstructorDefinition = (* constructor_keyword: *) CONSTRUCTOR_KEYWORD
@@ -278,11 +334,15 @@ pub enum NonterminalKind {
     ///                         (* body: *) Block;
     /// ```
     ConstructorDefinition,
+    /// Represents a node with kind `ContinueStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// ContinueStatement = (* continue_keyword: *) CONTINUE_KEYWORD
     ///                     (* semicolon: *) SEMICOLON;
     /// ```
     ContinueStatement,
+    /// Represents a node with kind `ContractDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// ContractDefinition = (* abstract_keyword: *) ABSTRACT_KEYWORD? (* Introduced in 0.6.0 *)
     ///                      (* contract_keyword: *) CONTRACT_KEYWORD
@@ -293,6 +353,8 @@ pub enum NonterminalKind {
     ///                      (* close_brace: *) CLOSE_BRACE;
     /// ```
     ContractDefinition,
+    /// Represents a node with kind `ContractMember`, having the following structure:
+    ///
     /// ```ebnf
     /// ContractMember = (* variant: *) UsingDirective
     ///                | (* variant: *) FunctionDefinition
@@ -309,15 +371,21 @@ pub enum NonterminalKind {
     ///                | (* variant: *) StateVariableDefinition;
     /// ```
     ContractMember,
+    /// Represents a node with kind `ContractMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// ContractMembers = (* item: *) ContractMember*;
     /// ```
     ContractMembers,
+    /// Represents a node with kind `DecimalNumberExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// DecimalNumberExpression = (* literal: *) DECIMAL_LITERAL
     ///                           (* unit: *) NumberUnit?;
     /// ```
     DecimalNumberExpression,
+    /// Represents a node with kind `DoWhileStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// DoWhileStatement = (* do_keyword: *) DO_KEYWORD
     ///                    (* body: *) Statement
@@ -328,6 +396,8 @@ pub enum NonterminalKind {
     ///                    (* semicolon: *) SEMICOLON;
     /// ```
     DoWhileStatement,
+    /// Represents a node with kind `ElementaryType`, having the following structure:
+    ///
     /// ```ebnf
     /// ElementaryType = (* variant: *) BOOL_KEYWORD
     ///                | (* variant: *) BYTE_KEYWORD (* Deprecated in 0.8.0 *)
@@ -340,11 +410,15 @@ pub enum NonterminalKind {
     ///                | (* variant: *) UFIXED_KEYWORD;
     /// ```
     ElementaryType,
+    /// Represents a node with kind `ElseBranch`, having the following structure:
+    ///
     /// ```ebnf
     /// ElseBranch = (* else_keyword: *) ELSE_KEYWORD
     ///              (* body: *) Statement;
     /// ```
     ElseBranch,
+    /// Represents a node with kind `EmitStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.21 *)
     /// EmitStatement = (* emit_keyword: *) EMIT_KEYWORD
@@ -353,6 +427,8 @@ pub enum NonterminalKind {
     ///                 (* semicolon: *) SEMICOLON;
     /// ```
     EmitStatement,
+    /// Represents a node with kind `EnumDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// EnumDefinition = (* enum_keyword: *) ENUM_KEYWORD
     ///                  (* name: *) IDENTIFIER
@@ -361,10 +437,14 @@ pub enum NonterminalKind {
     ///                  (* close_brace: *) CLOSE_BRACE;
     /// ```
     EnumDefinition,
+    /// Represents a node with kind `EnumMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// EnumMembers = ((* item: *) IDENTIFIER ((* separator: *) COMMA (* item: *) IDENTIFIER)*)?;
     /// ```
     EnumMembers,
+    /// Represents a node with kind `EqualityExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// EqualityExpression = (* left_operand: *) Expression
@@ -377,6 +457,8 @@ pub enum NonterminalKind {
     ///                      (* right_operand: *) Expression;
     /// ```
     EqualityExpression,
+    /// Represents a node with kind `ErrorDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// ErrorDefinition = (* error_keyword: *) ERROR_KEYWORD
@@ -385,17 +467,23 @@ pub enum NonterminalKind {
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     ErrorDefinition,
+    /// Represents a node with kind `ErrorParameter`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// ErrorParameter = (* type_name: *) TypeName
     ///                  (* name: *) IDENTIFIER?;
     /// ```
     ErrorParameter,
+    /// Represents a node with kind `ErrorParameters`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// ErrorParameters = ((* item: *) ErrorParameter ((* separator: *) COMMA (* item: *) ErrorParameter)*)?;
     /// ```
     ErrorParameters,
+    /// Represents a node with kind `ErrorParametersDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// ErrorParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -403,6 +491,8 @@ pub enum NonterminalKind {
     ///                              (* close_paren: *) CLOSE_PAREN;
     /// ```
     ErrorParametersDeclaration,
+    /// Represents a node with kind `EventDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// EventDefinition = (* event_keyword: *) EVENT_KEYWORD
     ///                   (* name: *) IDENTIFIER
@@ -411,32 +501,44 @@ pub enum NonterminalKind {
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     EventDefinition,
+    /// Represents a node with kind `EventParameter`, having the following structure:
+    ///
     /// ```ebnf
     /// EventParameter = (* type_name: *) TypeName
     ///                  (* indexed_keyword: *) INDEXED_KEYWORD?
     ///                  (* name: *) IDENTIFIER?;
     /// ```
     EventParameter,
+    /// Represents a node with kind `EventParameters`, having the following structure:
+    ///
     /// ```ebnf
     /// EventParameters = ((* item: *) EventParameter ((* separator: *) COMMA (* item: *) EventParameter)*)?;
     /// ```
     EventParameters,
+    /// Represents a node with kind `EventParametersDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// EventParametersDeclaration = (* open_paren: *) OPEN_PAREN
     ///                              (* parameters: *) EventParameters
     ///                              (* close_paren: *) CLOSE_PAREN;
     /// ```
     EventParametersDeclaration,
+    /// Represents a node with kind `ExperimentalFeature`, having the following structure:
+    ///
     /// ```ebnf
     /// ExperimentalFeature = (* variant: *) IDENTIFIER
     ///                     | (* variant: *) StringLiteral;
     /// ```
     ExperimentalFeature,
+    /// Represents a node with kind `ExperimentalPragma`, having the following structure:
+    ///
     /// ```ebnf
     /// ExperimentalPragma = (* experimental_keyword: *) EXPERIMENTAL_KEYWORD
     ///                      (* feature: *) ExperimentalFeature;
     /// ```
     ExperimentalPragma,
+    /// Represents a node with kind `ExponentiationExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// (* Deprecated in 0.8.0 *)
@@ -451,6 +553,8 @@ pub enum NonterminalKind {
     ///                            (* right_operand: *) Expression;
     /// ```
     ExponentiationExpression,
+    /// Represents a node with kind `Expression`, having the following structure:
+    ///
     /// ```ebnf
     /// Expression = (* variant: *) AssignmentExpression
     ///            | (* variant: *) ConditionalExpression
@@ -487,11 +591,15 @@ pub enum NonterminalKind {
     ///            | (* variant: *) IDENTIFIER;
     /// ```
     Expression,
+    /// Represents a node with kind `ExpressionStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// ExpressionStatement = (* expression: *) Expression
     ///                       (* semicolon: *) SEMICOLON;
     /// ```
     ExpressionStatement,
+    /// Represents a node with kind `FallbackFunctionAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// FallbackFunctionAttribute = (* variant: *) ModifierInvocation
@@ -503,11 +611,15 @@ pub enum NonterminalKind {
     ///                           | (* variant: *) VIRTUAL_KEYWORD;
     /// ```
     FallbackFunctionAttribute,
+    /// Represents a node with kind `FallbackFunctionAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// FallbackFunctionAttributes = (* item: *) FallbackFunctionAttribute*;
     /// ```
     FallbackFunctionAttributes,
+    /// Represents a node with kind `FallbackFunctionDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// FallbackFunctionDefinition = (* fallback_keyword: *) FALLBACK_KEYWORD
@@ -517,6 +629,8 @@ pub enum NonterminalKind {
     ///                              (* body: *) FunctionBody;
     /// ```
     FallbackFunctionDefinition,
+    /// Represents a node with kind `ForStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// ForStatement = (* for_keyword: *) FOR_KEYWORD
     ///                (* open_paren: *) OPEN_PAREN
@@ -527,11 +641,15 @@ pub enum NonterminalKind {
     ///                (* body: *) Statement;
     /// ```
     ForStatement,
+    /// Represents a node with kind `ForStatementCondition`, having the following structure:
+    ///
     /// ```ebnf
     /// ForStatementCondition = (* variant: *) ExpressionStatement
     ///                       | (* variant: *) SEMICOLON;
     /// ```
     ForStatementCondition,
+    /// Represents a node with kind `ForStatementInitialization`, having the following structure:
+    ///
     /// ```ebnf
     /// ForStatementInitialization = (* variant: *) TupleDeconstructionStatement
     ///                            | (* variant: *) VariableDeclarationStatement
@@ -539,6 +657,8 @@ pub enum NonterminalKind {
     ///                            | (* variant: *) SEMICOLON;
     /// ```
     ForStatementInitialization,
+    /// Represents a node with kind `FunctionAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionAttribute = (* variant: *) ModifierInvocation
     ///                   | (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
@@ -553,21 +673,29 @@ pub enum NonterminalKind {
     ///                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
     /// ```
     FunctionAttribute,
+    /// Represents a node with kind `FunctionAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionAttributes = (* item: *) FunctionAttribute*;
     /// ```
     FunctionAttributes,
+    /// Represents a node with kind `FunctionBody`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionBody = (* variant: *) Block
     ///              | (* variant: *) SEMICOLON;
     /// ```
     FunctionBody,
+    /// Represents a node with kind `FunctionCallExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// FunctionCallExpression = (* operand: *) Expression
     ///                          (* arguments: *) ArgumentsDeclaration;
     /// ```
     FunctionCallExpression,
+    /// Represents a node with kind `FunctionDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
     ///                      (* name: *) FunctionName
@@ -577,12 +705,16 @@ pub enum NonterminalKind {
     ///                      (* body: *) FunctionBody;
     /// ```
     FunctionDefinition,
+    /// Represents a node with kind `FunctionName`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionName = (* variant: *) IDENTIFIER
     ///              | (* variant: *) FALLBACK_KEYWORD
     ///              | (* variant: *) RECEIVE_KEYWORD;
     /// ```
     FunctionName,
+    /// Represents a node with kind `FunctionType`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionType = (* function_keyword: *) FUNCTION_KEYWORD
     ///                (* parameters: *) ParametersDeclaration
@@ -590,6 +722,8 @@ pub enum NonterminalKind {
     ///                (* returns: *) ReturnsDeclaration?;
     /// ```
     FunctionType,
+    /// Represents a node with kind `FunctionTypeAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionTypeAttribute = (* variant: *) INTERNAL_KEYWORD
     ///                       | (* variant: *) EXTERNAL_KEYWORD
@@ -601,29 +735,41 @@ pub enum NonterminalKind {
     ///                       | (* variant: *) PAYABLE_KEYWORD;
     /// ```
     FunctionTypeAttribute,
+    /// Represents a node with kind `FunctionTypeAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// FunctionTypeAttributes = (* item: *) FunctionTypeAttribute*;
     /// ```
     FunctionTypeAttributes,
+    /// Represents a node with kind `HexNumberExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// HexNumberExpression = (* literal: *) HEX_LITERAL
     ///                       (* unit: *) NumberUnit?; (* Deprecated in 0.5.0 *)
     /// ```
     HexNumberExpression,
+    /// Represents a node with kind `HexStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// HexStringLiteral = (* variant: *) SINGLE_QUOTED_HEX_STRING_LITERAL
     ///                  | (* variant: *) DOUBLE_QUOTED_HEX_STRING_LITERAL;
     /// ```
     HexStringLiteral,
+    /// Represents a node with kind `HexStringLiterals`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.14 *)
     /// HexStringLiterals = (* item: *) HexStringLiteral+;
     /// ```
     HexStringLiterals,
+    /// Represents a node with kind `IdentifierPath`, having the following structure:
+    ///
     /// ```ebnf
     /// IdentifierPath = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
     /// ```
     IdentifierPath,
+    /// Represents a node with kind `IfStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// IfStatement = (* if_keyword: *) IF_KEYWORD
     ///               (* open_paren: *) OPEN_PAREN
@@ -633,17 +779,23 @@ pub enum NonterminalKind {
     ///               (* else_branch: *) ElseBranch?;
     /// ```
     IfStatement,
+    /// Represents a node with kind `ImportAlias`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportAlias = (* as_keyword: *) AS_KEYWORD
     ///               (* identifier: *) IDENTIFIER;
     /// ```
     ImportAlias,
+    /// Represents a node with kind `ImportClause`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportClause = (* variant: *) PathImport
     ///              | (* variant: *) NamedImport
     ///              | (* variant: *) ImportDeconstruction;
     /// ```
     ImportClause,
+    /// Represents a node with kind `ImportDeconstruction`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportDeconstruction = (* open_brace: *) OPEN_BRACE
     ///                        (* symbols: *) ImportDeconstructionSymbols
@@ -652,26 +804,36 @@ pub enum NonterminalKind {
     ///                        (* path: *) StringLiteral;
     /// ```
     ImportDeconstruction,
+    /// Represents a node with kind `ImportDeconstructionSymbol`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportDeconstructionSymbol = (* name: *) IDENTIFIER
     ///                              (* alias: *) ImportAlias?;
     /// ```
     ImportDeconstructionSymbol,
+    /// Represents a node with kind `ImportDeconstructionSymbols`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportDeconstructionSymbols = (* item: *) ImportDeconstructionSymbol ((* separator: *) COMMA (* item: *) ImportDeconstructionSymbol)*;
     /// ```
     ImportDeconstructionSymbols,
+    /// Represents a node with kind `ImportDirective`, having the following structure:
+    ///
     /// ```ebnf
     /// ImportDirective = (* import_keyword: *) IMPORT_KEYWORD
     ///                   (* clause: *) ImportClause
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     ImportDirective,
+    /// Represents a node with kind `IndexAccessEnd`, having the following structure:
+    ///
     /// ```ebnf
     /// IndexAccessEnd = (* colon: *) COLON
     ///                  (* end: *) Expression?;
     /// ```
     IndexAccessEnd,
+    /// Represents a node with kind `IndexAccessExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// IndexAccessExpression = (* operand: *) Expression
@@ -681,20 +843,28 @@ pub enum NonterminalKind {
     ///                         (* close_bracket: *) CLOSE_BRACKET;
     /// ```
     IndexAccessExpression,
+    /// Represents a node with kind `InheritanceSpecifier`, having the following structure:
+    ///
     /// ```ebnf
     /// InheritanceSpecifier = (* is_keyword: *) IS_KEYWORD
     ///                        (* types: *) InheritanceTypes;
     /// ```
     InheritanceSpecifier,
+    /// Represents a node with kind `InheritanceType`, having the following structure:
+    ///
     /// ```ebnf
     /// InheritanceType = (* type_name: *) IdentifierPath
     ///                   (* arguments: *) ArgumentsDeclaration?;
     /// ```
     InheritanceType,
+    /// Represents a node with kind `InheritanceTypes`, having the following structure:
+    ///
     /// ```ebnf
     /// InheritanceTypes = (* item: *) InheritanceType ((* separator: *) COMMA (* item: *) InheritanceType)*;
     /// ```
     InheritanceTypes,
+    /// Represents a node with kind `InterfaceDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// InterfaceDefinition = (* interface_keyword: *) INTERFACE_KEYWORD
     ///                       (* name: *) IDENTIFIER
@@ -704,10 +874,14 @@ pub enum NonterminalKind {
     ///                       (* close_brace: *) CLOSE_BRACE;
     /// ```
     InterfaceDefinition,
+    /// Represents a node with kind `InterfaceMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// InterfaceMembers = (* item: *) ContractMember*;
     /// ```
     InterfaceMembers,
+    /// Represents a node with kind `LibraryDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// LibraryDefinition = (* library_keyword: *) LIBRARY_KEYWORD
     ///                     (* name: *) IDENTIFIER
@@ -716,20 +890,28 @@ pub enum NonterminalKind {
     ///                     (* close_brace: *) CLOSE_BRACE;
     /// ```
     LibraryDefinition,
+    /// Represents a node with kind `LibraryMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// LibraryMembers = (* item: *) ContractMember*;
     /// ```
     LibraryMembers,
+    /// Represents a node with kind `MappingKey`, having the following structure:
+    ///
     /// ```ebnf
     /// MappingKey = (* key_type: *) MappingKeyType
     ///              (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
     /// ```
     MappingKey,
+    /// Represents a node with kind `MappingKeyType`, having the following structure:
+    ///
     /// ```ebnf
     /// MappingKeyType = (* variant: *) ElementaryType
     ///                | (* variant: *) IdentifierPath;
     /// ```
     MappingKeyType,
+    /// Represents a node with kind `MappingType`, having the following structure:
+    ///
     /// ```ebnf
     /// MappingType = (* mapping_keyword: *) MAPPING_KEYWORD
     ///               (* open_paren: *) OPEN_PAREN
@@ -739,11 +921,15 @@ pub enum NonterminalKind {
     ///               (* close_paren: *) CLOSE_PAREN;
     /// ```
     MappingType,
+    /// Represents a node with kind `MappingValue`, having the following structure:
+    ///
     /// ```ebnf
     /// MappingValue = (* type_name: *) TypeName
     ///                (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
     /// ```
     MappingValue,
+    /// Represents a node with kind `MemberAccessExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// MemberAccessExpression = (* operand: *) Expression
@@ -751,15 +937,21 @@ pub enum NonterminalKind {
     ///                          (* member: *) IDENTIFIER;
     /// ```
     MemberAccessExpression,
+    /// Represents a node with kind `ModifierAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// ModifierAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
     ///                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
     /// ```
     ModifierAttribute,
+    /// Represents a node with kind `ModifierAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// ModifierAttributes = (* item: *) ModifierAttribute*;
     /// ```
     ModifierAttributes,
+    /// Represents a node with kind `ModifierDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// ModifierDefinition = (* modifier_keyword: *) MODIFIER_KEYWORD
     ///                      (* name: *) IDENTIFIER
@@ -768,11 +960,15 @@ pub enum NonterminalKind {
     ///                      (* body: *) FunctionBody;
     /// ```
     ModifierDefinition,
+    /// Represents a node with kind `ModifierInvocation`, having the following structure:
+    ///
     /// ```ebnf
     /// ModifierInvocation = (* name: *) IdentifierPath
     ///                      (* arguments: *) ArgumentsDeclaration?;
     /// ```
     ModifierInvocation,
+    /// Represents a node with kind `MultiplicativeExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// MultiplicativeExpression = (* left_operand: *) Expression
@@ -790,28 +986,38 @@ pub enum NonterminalKind {
     ///                            (* right_operand: *) Expression;
     /// ```
     MultiplicativeExpression,
+    /// Represents a node with kind `NamedArgument`, having the following structure:
+    ///
     /// ```ebnf
     /// NamedArgument = (* name: *) IDENTIFIER
     ///                 (* colon: *) COLON
     ///                 (* value: *) Expression;
     /// ```
     NamedArgument,
+    /// Represents a node with kind `NamedArgumentGroup`, having the following structure:
+    ///
     /// ```ebnf
     /// NamedArgumentGroup = (* open_brace: *) OPEN_BRACE
     ///                      (* arguments: *) NamedArguments
     ///                      (* close_brace: *) CLOSE_BRACE;
     /// ```
     NamedArgumentGroup,
+    /// Represents a node with kind `NamedArguments`, having the following structure:
+    ///
     /// ```ebnf
     /// NamedArguments = ((* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*)?;
     /// ```
     NamedArguments,
+    /// Represents a node with kind `NamedArgumentsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// NamedArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
     ///                             (* arguments: *) NamedArgumentGroup?
     ///                             (* close_paren: *) CLOSE_PAREN;
     /// ```
     NamedArgumentsDeclaration,
+    /// Represents a node with kind `NamedImport`, having the following structure:
+    ///
     /// ```ebnf
     /// NamedImport = (* asterisk: *) ASTERISK
     ///               (* alias: *) ImportAlias
@@ -819,11 +1025,15 @@ pub enum NonterminalKind {
     ///               (* path: *) StringLiteral;
     /// ```
     NamedImport,
+    /// Represents a node with kind `NewExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// NewExpression = (* new_keyword: *) NEW_KEYWORD
     ///                 (* type_name: *) TypeName;
     /// ```
     NewExpression,
+    /// Represents a node with kind `NumberUnit`, having the following structure:
+    ///
     /// ```ebnf
     /// NumberUnit = (* variant: *) WEI_KEYWORD
     ///            | (* variant: *) GWEI_KEYWORD (* Introduced in 0.6.11 *)
@@ -838,6 +1048,8 @@ pub enum NonterminalKind {
     ///            | (* variant: *) YEARS_KEYWORD; (* Deprecated in 0.5.0 *)
     /// ```
     NumberUnit,
+    /// Represents a node with kind `OrExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// OrExpression = (* left_operand: *) Expression
@@ -845,11 +1057,15 @@ pub enum NonterminalKind {
     ///                (* right_operand: *) Expression;
     /// ```
     OrExpression,
+    /// Represents a node with kind `OverridePaths`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// OverridePaths = (* item: *) IdentifierPath ((* separator: *) COMMA (* item: *) IdentifierPath)*;
     /// ```
     OverridePaths,
+    /// Represents a node with kind `OverridePathsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// OverridePathsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -857,43 +1073,59 @@ pub enum NonterminalKind {
     ///                            (* close_paren: *) CLOSE_PAREN;
     /// ```
     OverridePathsDeclaration,
+    /// Represents a node with kind `OverrideSpecifier`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// OverrideSpecifier = (* override_keyword: *) OVERRIDE_KEYWORD
     ///                     (* overridden: *) OverridePathsDeclaration?;
     /// ```
     OverrideSpecifier,
+    /// Represents a node with kind `Parameter`, having the following structure:
+    ///
     /// ```ebnf
     /// Parameter = (* type_name: *) TypeName
     ///             (* storage_location: *) StorageLocation?
     ///             (* name: *) IDENTIFIER?;
     /// ```
     Parameter,
+    /// Represents a node with kind `Parameters`, having the following structure:
+    ///
     /// ```ebnf
     /// Parameters = ((* item: *) Parameter ((* separator: *) COMMA (* item: *) Parameter)*)?;
     /// ```
     Parameters,
+    /// Represents a node with kind `ParametersDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// ParametersDeclaration = (* open_paren: *) OPEN_PAREN
     ///                         (* parameters: *) Parameters
     ///                         (* close_paren: *) CLOSE_PAREN;
     /// ```
     ParametersDeclaration,
+    /// Represents a node with kind `PathImport`, having the following structure:
+    ///
     /// ```ebnf
     /// PathImport = (* path: *) StringLiteral
     ///              (* alias: *) ImportAlias?;
     /// ```
     PathImport,
+    /// Represents a node with kind `PositionalArguments`, having the following structure:
+    ///
     /// ```ebnf
     /// PositionalArguments = ((* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*)?;
     /// ```
     PositionalArguments,
+    /// Represents a node with kind `PositionalArgumentsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// PositionalArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
     ///                                  (* arguments: *) PositionalArguments
     ///                                  (* close_paren: *) CLOSE_PAREN;
     /// ```
     PositionalArgumentsDeclaration,
+    /// Represents a node with kind `PostfixExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// PostfixExpression = (* operand: *) Expression
@@ -904,18 +1136,24 @@ pub enum NonterminalKind {
     ///                     (* operator: *) MINUS_MINUS;
     /// ```
     PostfixExpression,
+    /// Represents a node with kind `Pragma`, having the following structure:
+    ///
     /// ```ebnf
     /// Pragma = (* variant: *) AbicoderPragma
     ///        | (* variant: *) ExperimentalPragma
     ///        | (* variant: *) VersionPragma;
     /// ```
     Pragma,
+    /// Represents a node with kind `PragmaDirective`, having the following structure:
+    ///
     /// ```ebnf
     /// PragmaDirective = (* pragma_keyword: *) PRAGMA_KEYWORD
     ///                   (* pragma: *) Pragma
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     PragmaDirective,
+    /// Represents a node with kind `PrefixExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Prefix unary operator *)
     /// PrefixExpression = (* operator: *) PLUS_PLUS
@@ -947,6 +1185,8 @@ pub enum NonterminalKind {
     ///                    (* operand: *) Expression;
     /// ```
     PrefixExpression,
+    /// Represents a node with kind `ReceiveFunctionAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// ReceiveFunctionAttribute = (* variant: *) ModifierInvocation
@@ -956,11 +1196,15 @@ pub enum NonterminalKind {
     ///                          | (* variant: *) VIRTUAL_KEYWORD;
     /// ```
     ReceiveFunctionAttribute,
+    /// Represents a node with kind `ReceiveFunctionAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// ReceiveFunctionAttributes = (* item: *) ReceiveFunctionAttribute*;
     /// ```
     ReceiveFunctionAttributes,
+    /// Represents a node with kind `ReceiveFunctionDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// ReceiveFunctionDefinition = (* receive_keyword: *) RECEIVE_KEYWORD
@@ -969,17 +1213,23 @@ pub enum NonterminalKind {
     ///                             (* body: *) FunctionBody;
     /// ```
     ReceiveFunctionDefinition,
+    /// Represents a node with kind `ReturnStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// ReturnStatement = (* return_keyword: *) RETURN_KEYWORD
     ///                   (* expression: *) Expression?
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     ReturnStatement,
+    /// Represents a node with kind `ReturnsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// ReturnsDeclaration = (* returns_keyword: *) RETURNS_KEYWORD
     ///                      (* variables: *) ParametersDeclaration;
     /// ```
     ReturnsDeclaration,
+    /// Represents a node with kind `RevertStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// RevertStatement = (* revert_keyword: *) REVERT_KEYWORD
@@ -988,6 +1238,8 @@ pub enum NonterminalKind {
     ///                   (* semicolon: *) SEMICOLON;
     /// ```
     RevertStatement,
+    /// Represents a node with kind `ShiftExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// ShiftExpression = (* left_operand: *) Expression
@@ -1005,14 +1257,20 @@ pub enum NonterminalKind {
     ///                   (* right_operand: *) Expression;
     /// ```
     ShiftExpression,
+    /// Represents a node with kind `SimpleVersionLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// SimpleVersionLiteral = (* item: *) VERSION_SPECIFIER ((* separator: *) PERIOD (* item: *) VERSION_SPECIFIER)*;
     /// ```
     SimpleVersionLiteral,
+    /// Represents a node with kind `SourceUnit`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnit = (* members: *) SourceUnitMembers;
     /// ```
     SourceUnit,
+    /// Represents a node with kind `SourceUnitMember`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnitMember = (* variant: *) PragmaDirective
     ///                  | (* variant: *) ImportDirective
@@ -1029,10 +1287,14 @@ pub enum NonterminalKind {
     ///                  | (* variant: *) ConstantDefinition; (* Introduced in 0.7.4 *)
     /// ```
     SourceUnitMember,
+    /// Represents a node with kind `SourceUnitMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnitMembers = (* item: *) SourceUnitMember*;
     /// ```
     SourceUnitMembers,
+    /// Represents a node with kind `StateVariableAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// StateVariableAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
     ///                        | (* variant: *) CONSTANT_KEYWORD
@@ -1043,10 +1305,14 @@ pub enum NonterminalKind {
     ///                        | (* variant: *) TRANSIENT_KEYWORD; (* Introduced in 0.8.27 *)
     /// ```
     StateVariableAttribute,
+    /// Represents a node with kind `StateVariableAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// StateVariableAttributes = (* item: *) StateVariableAttribute*;
     /// ```
     StateVariableAttributes,
+    /// Represents a node with kind `StateVariableDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// StateVariableDefinition = (* type_name: *) TypeName
     ///                           (* attributes: *) StateVariableAttributes
@@ -1055,11 +1321,15 @@ pub enum NonterminalKind {
     ///                           (* semicolon: *) SEMICOLON;
     /// ```
     StateVariableDefinition,
+    /// Represents a node with kind `StateVariableDefinitionValue`, having the following structure:
+    ///
     /// ```ebnf
     /// StateVariableDefinitionValue = (* equal: *) EQUAL
     ///                                (* value: *) Expression;
     /// ```
     StateVariableDefinitionValue,
+    /// Represents a node with kind `Statement`, having the following structure:
+    ///
     /// ```ebnf
     /// Statement = (* variant: *) IfStatement
     ///           | (* variant: *) ForStatement
@@ -1080,16 +1350,22 @@ pub enum NonterminalKind {
     ///           | (* variant: *) ExpressionStatement;
     /// ```
     Statement,
+    /// Represents a node with kind `Statements`, having the following structure:
+    ///
     /// ```ebnf
     /// Statements = (* item: *) Statement*;
     /// ```
     Statements,
+    /// Represents a node with kind `StorageLocation`, having the following structure:
+    ///
     /// ```ebnf
     /// StorageLocation = (* variant: *) MEMORY_KEYWORD
     ///                 | (* variant: *) STORAGE_KEYWORD
     ///                 | (* variant: *) CALL_DATA_KEYWORD; (* Introduced in 0.5.0 *)
     /// ```
     StorageLocation,
+    /// Represents a node with kind `StringExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// StringExpression = (* variant: *) StringLiteral (* Deprecated in 0.5.14 *)
     ///                  | (* variant: *) StringLiterals (* Introduced in 0.5.14 *)
@@ -1098,16 +1374,22 @@ pub enum NonterminalKind {
     ///                  | (* variant: *) UnicodeStringLiterals; (* Introduced in 0.7.0 *)
     /// ```
     StringExpression,
+    /// Represents a node with kind `StringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// StringLiteral = (* variant: *) SINGLE_QUOTED_STRING_LITERAL
     ///               | (* variant: *) DOUBLE_QUOTED_STRING_LITERAL;
     /// ```
     StringLiteral,
+    /// Represents a node with kind `StringLiterals`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.14 *)
     /// StringLiterals = (* item: *) StringLiteral+;
     /// ```
     StringLiterals,
+    /// Represents a node with kind `StructDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// StructDefinition = (* struct_keyword: *) STRUCT_KEYWORD
     ///                    (* name: *) IDENTIFIER
@@ -1116,22 +1398,30 @@ pub enum NonterminalKind {
     ///                    (* close_brace: *) CLOSE_BRACE;
     /// ```
     StructDefinition,
+    /// Represents a node with kind `StructMember`, having the following structure:
+    ///
     /// ```ebnf
     /// StructMember = (* type_name: *) TypeName
     ///                (* name: *) IDENTIFIER
     ///                (* semicolon: *) SEMICOLON;
     /// ```
     StructMember,
+    /// Represents a node with kind `StructMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// StructMembers = (* item: *) StructMember*;
     /// ```
     StructMembers,
+    /// Represents a node with kind `ThrowStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// ThrowStatement = (* throw_keyword: *) THROW_KEYWORD
     ///                  (* semicolon: *) SEMICOLON;
     /// ```
     ThrowStatement,
+    /// Represents a node with kind `TryStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// TryStatement = (* try_keyword: *) TRY_KEYWORD
@@ -1141,14 +1431,20 @@ pub enum NonterminalKind {
     ///                (* catch_clauses: *) CatchClauses;
     /// ```
     TryStatement,
+    /// Represents a node with kind `TupleDeconstructionElement`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleDeconstructionElement = (* member: *) TupleMember?;
     /// ```
     TupleDeconstructionElement,
+    /// Represents a node with kind `TupleDeconstructionElements`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleDeconstructionElements = (* item: *) TupleDeconstructionElement ((* separator: *) COMMA (* item: *) TupleDeconstructionElement)*;
     /// ```
     TupleDeconstructionElements,
+    /// Represents a node with kind `TupleDeconstructionStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleDeconstructionStatement = (* var_keyword: *) VAR_KEYWORD? (* Deprecated in 0.5.0 *)
     ///                                (* open_paren: *) OPEN_PAREN
@@ -1159,25 +1455,35 @@ pub enum NonterminalKind {
     ///                                (* semicolon: *) SEMICOLON;
     /// ```
     TupleDeconstructionStatement,
+    /// Represents a node with kind `TupleExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleExpression = (* open_paren: *) OPEN_PAREN
     ///                   (* items: *) TupleValues
     ///                   (* close_paren: *) CLOSE_PAREN;
     /// ```
     TupleExpression,
+    /// Represents a node with kind `TupleMember`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleMember = (* variant: *) TypedTupleMember
     ///             | (* variant: *) UntypedTupleMember;
     /// ```
     TupleMember,
+    /// Represents a node with kind `TupleValue`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleValue = (* expression: *) Expression?;
     /// ```
     TupleValue,
+    /// Represents a node with kind `TupleValues`, having the following structure:
+    ///
     /// ```ebnf
     /// TupleValues = (* item: *) TupleValue ((* separator: *) COMMA (* item: *) TupleValue)*;
     /// ```
     TupleValues,
+    /// Represents a node with kind `TypeExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.3 *)
     /// TypeExpression = (* type_keyword: *) TYPE_KEYWORD
@@ -1186,6 +1492,8 @@ pub enum NonterminalKind {
     ///                  (* close_paren: *) CLOSE_PAREN;
     /// ```
     TypeExpression,
+    /// Represents a node with kind `TypeName`, having the following structure:
+    ///
     /// ```ebnf
     /// TypeName = (* variant: *) ArrayTypeName
     ///          | (* variant: *) FunctionType
@@ -1194,29 +1502,39 @@ pub enum NonterminalKind {
     ///          | (* variant: *) IdentifierPath;
     /// ```
     TypeName,
+    /// Represents a node with kind `TypedTupleMember`, having the following structure:
+    ///
     /// ```ebnf
     /// TypedTupleMember = (* type_name: *) TypeName
     ///                    (* storage_location: *) StorageLocation?
     ///                    (* name: *) IDENTIFIER;
     /// ```
     TypedTupleMember,
+    /// Represents a node with kind `UncheckedBlock`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.0 *)
     /// UncheckedBlock = (* unchecked_keyword: *) UNCHECKED_KEYWORD
     ///                  (* block: *) Block;
     /// ```
     UncheckedBlock,
+    /// Represents a node with kind `UnicodeStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.7.0 *)
     /// UnicodeStringLiteral = (* variant: *) SINGLE_QUOTED_UNICODE_STRING_LITERAL
     ///                      | (* variant: *) DOUBLE_QUOTED_UNICODE_STRING_LITERAL;
     /// ```
     UnicodeStringLiteral,
+    /// Represents a node with kind `UnicodeStringLiterals`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.7.0 *)
     /// UnicodeStringLiterals = (* item: *) UnicodeStringLiteral+;
     /// ```
     UnicodeStringLiterals,
+    /// Represents a node with kind `UnnamedFunctionAttribute`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.6.0 *)
     /// UnnamedFunctionAttribute = (* variant: *) ModifierInvocation
@@ -1230,11 +1548,15 @@ pub enum NonterminalKind {
     ///                          | (* variant: *) VIEW_KEYWORD; (* Introduced in 0.4.16 and deprecated in 0.6.0. *)
     /// ```
     UnnamedFunctionAttribute,
+    /// Represents a node with kind `UnnamedFunctionAttributes`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.6.0 *)
     /// UnnamedFunctionAttributes = (* item: *) UnnamedFunctionAttribute*;
     /// ```
     UnnamedFunctionAttributes,
+    /// Represents a node with kind `UnnamedFunctionDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.6.0 *)
     /// UnnamedFunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
@@ -1243,11 +1565,15 @@ pub enum NonterminalKind {
     ///                             (* body: *) FunctionBody;
     /// ```
     UnnamedFunctionDefinition,
+    /// Represents a node with kind `UntypedTupleMember`, having the following structure:
+    ///
     /// ```ebnf
     /// UntypedTupleMember = (* storage_location: *) StorageLocation?
     ///                      (* name: *) IDENTIFIER;
     /// ```
     UntypedTupleMember,
+    /// Represents a node with kind `UserDefinedValueTypeDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.8 *)
     /// UserDefinedValueTypeDefinition = (* type_keyword: *) TYPE_KEYWORD
@@ -1257,17 +1583,23 @@ pub enum NonterminalKind {
     ///                                  (* semicolon: *) SEMICOLON;
     /// ```
     UserDefinedValueTypeDefinition,
+    /// Represents a node with kind `UsingAlias`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.19 *)
     /// UsingAlias = (* as_keyword: *) AS_KEYWORD
     ///              (* operator: *) UsingOperator;
     /// ```
     UsingAlias,
+    /// Represents a node with kind `UsingClause`, having the following structure:
+    ///
     /// ```ebnf
     /// UsingClause = (* variant: *) IdentifierPath
     ///             | (* variant: *) UsingDeconstruction; (* Introduced in 0.8.13 *)
     /// ```
     UsingClause,
+    /// Represents a node with kind `UsingDeconstruction`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.13 *)
     /// UsingDeconstruction = (* open_brace: *) OPEN_BRACE
@@ -1275,17 +1607,23 @@ pub enum NonterminalKind {
     ///                       (* close_brace: *) CLOSE_BRACE;
     /// ```
     UsingDeconstruction,
+    /// Represents a node with kind `UsingDeconstructionSymbol`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.13 *)
     /// UsingDeconstructionSymbol = (* name: *) IdentifierPath
     ///                             (* alias: *) UsingAlias?; (* Introduced in 0.8.19 *)
     /// ```
     UsingDeconstructionSymbol,
+    /// Represents a node with kind `UsingDeconstructionSymbols`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.13 *)
     /// UsingDeconstructionSymbols = (* item: *) UsingDeconstructionSymbol ((* separator: *) COMMA (* item: *) UsingDeconstructionSymbol)*;
     /// ```
     UsingDeconstructionSymbols,
+    /// Represents a node with kind `UsingDirective`, having the following structure:
+    ///
     /// ```ebnf
     /// UsingDirective = (* using_keyword: *) USING_KEYWORD
     ///                  (* clause: *) UsingClause
@@ -1295,6 +1633,8 @@ pub enum NonterminalKind {
     ///                  (* semicolon: *) SEMICOLON;
     /// ```
     UsingDirective,
+    /// Represents a node with kind `UsingOperator`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.19 *)
     /// UsingOperator = (* variant: *) AMPERSAND
@@ -1314,11 +1654,15 @@ pub enum NonterminalKind {
     ///               | (* variant: *) TILDE;
     /// ```
     UsingOperator,
+    /// Represents a node with kind `UsingTarget`, having the following structure:
+    ///
     /// ```ebnf
     /// UsingTarget = (* variant: *) TypeName
     ///             | (* variant: *) ASTERISK;
     /// ```
     UsingTarget,
+    /// Represents a node with kind `VariableDeclarationStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// VariableDeclarationStatement = (* variable_type: *) VariableDeclarationType
     ///                                (* storage_location: *) StorageLocation?
@@ -1327,35 +1671,49 @@ pub enum NonterminalKind {
     ///                                (* semicolon: *) SEMICOLON;
     /// ```
     VariableDeclarationStatement,
+    /// Represents a node with kind `VariableDeclarationType`, having the following structure:
+    ///
     /// ```ebnf
     /// VariableDeclarationType = (* variant: *) TypeName
     ///                         | (* variant: *) VAR_KEYWORD; (* Deprecated in 0.5.0 *)
     /// ```
     VariableDeclarationType,
+    /// Represents a node with kind `VariableDeclarationValue`, having the following structure:
+    ///
     /// ```ebnf
     /// VariableDeclarationValue = (* equal: *) EQUAL
     ///                            (* expression: *) Expression;
     /// ```
     VariableDeclarationValue,
+    /// Represents a node with kind `VersionExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionExpression = (* variant: *) VersionRange
     ///                   | (* variant: *) VersionTerm;
     /// ```
     VersionExpression,
+    /// Represents a node with kind `VersionExpressionSet`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionExpressionSet = (* item: *) VersionExpression+;
     /// ```
     VersionExpressionSet,
+    /// Represents a node with kind `VersionExpressionSets`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionExpressionSets = (* item: *) VersionExpressionSet ((* separator: *) BAR_BAR (* item: *) VersionExpressionSet)*;
     /// ```
     VersionExpressionSets,
+    /// Represents a node with kind `VersionLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionLiteral = (* variant: *) SimpleVersionLiteral
     ///                | (* variant: *) SINGLE_QUOTED_VERSION_LITERAL
     ///                | (* variant: *) DOUBLE_QUOTED_VERSION_LITERAL;
     /// ```
     VersionLiteral,
+    /// Represents a node with kind `VersionOperator`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionOperator = (* variant: *) CARET
     ///                 | (* variant: *) TILDE
@@ -1366,22 +1724,30 @@ pub enum NonterminalKind {
     ///                 | (* variant: *) GREATER_THAN_EQUAL;
     /// ```
     VersionOperator,
+    /// Represents a node with kind `VersionPragma`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionPragma = (* solidity_keyword: *) SOLIDITY_KEYWORD
     ///                 (* sets: *) VersionExpressionSets;
     /// ```
     VersionPragma,
+    /// Represents a node with kind `VersionRange`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionRange = (* start: *) VersionLiteral
     ///                (* minus: *) MINUS
     ///                (* end: *) VersionLiteral;
     /// ```
     VersionRange,
+    /// Represents a node with kind `VersionTerm`, having the following structure:
+    ///
     /// ```ebnf
     /// VersionTerm = (* operator: *) VersionOperator?
     ///               (* literal: *) VersionLiteral;
     /// ```
     VersionTerm,
+    /// Represents a node with kind `WhileStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// WhileStatement = (* while_keyword: *) WHILE_KEYWORD
     ///                  (* open_paren: *) OPEN_PAREN
@@ -1390,25 +1756,35 @@ pub enum NonterminalKind {
     ///                  (* body: *) Statement;
     /// ```
     WhileStatement,
+    /// Represents a node with kind `YulArguments`, having the following structure:
+    ///
     /// ```ebnf
     /// YulArguments = ((* item: *) YulExpression ((* separator: *) COMMA (* item: *) YulExpression)*)?;
     /// ```
     YulArguments,
+    /// Represents a node with kind `YulAssignmentOperator`, having the following structure:
+    ///
     /// ```ebnf
     /// YulAssignmentOperator = (* variant: *) COLON_EQUAL
     ///                       | (* variant: *) YulColonAndEqual; (* Deprecated in 0.5.5 *)
     /// ```
     YulAssignmentOperator,
+    /// Represents a node with kind `YulBlock`, having the following structure:
+    ///
     /// ```ebnf
     /// YulBlock = (* open_brace: *) OPEN_BRACE
     ///            (* statements: *) YulStatements
     ///            (* close_brace: *) CLOSE_BRACE;
     /// ```
     YulBlock,
+    /// Represents a node with kind `YulBreakStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulBreakStatement = (* break_keyword: *) YUL_BREAK_KEYWORD;
     /// ```
     YulBreakStatement,
+    /// Represents a node with kind `YulBuiltInFunction`, having the following structure:
+    ///
     /// ```ebnf
     /// YulBuiltInFunction = (* variant: *) YUL_ADD_KEYWORD
     ///                    | (* variant: *) YUL_ADD_MOD_KEYWORD
@@ -1495,27 +1871,37 @@ pub enum NonterminalKind {
     ///                    | (* variant: *) YUL_M_COPY_KEYWORD; (* Introduced in 0.8.24 *)
     /// ```
     YulBuiltInFunction,
+    /// Represents a node with kind `YulColonAndEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.5 *)
     /// YulColonAndEqual = (* colon: *) COLON
     ///                    (* equal: *) EQUAL;
     /// ```
     YulColonAndEqual,
+    /// Represents a node with kind `YulContinueStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulContinueStatement = (* continue_keyword: *) YUL_CONTINUE_KEYWORD;
     /// ```
     YulContinueStatement,
+    /// Represents a node with kind `YulDefaultCase`, having the following structure:
+    ///
     /// ```ebnf
     /// YulDefaultCase = (* default_keyword: *) YUL_DEFAULT_KEYWORD
     ///                  (* body: *) YulBlock;
     /// ```
     YulDefaultCase,
+    /// Represents a node with kind `YulEqualAndColon`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YulEqualAndColon = (* equal: *) EQUAL
     ///                    (* colon: *) COLON;
     /// ```
     YulEqualAndColon,
+    /// Represents a node with kind `YulExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// YulExpression = (* variant: *) YulFunctionCallExpression
     ///               | (* variant: *) YulLiteral
@@ -1523,6 +1909,8 @@ pub enum NonterminalKind {
     ///               | (* variant: *) YulPath;
     /// ```
     YulExpression,
+    /// Represents a node with kind `YulForStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulForStatement = (* for_keyword: *) YUL_FOR_KEYWORD
     ///                   (* initialization: *) YulBlock
@@ -1531,6 +1919,8 @@ pub enum NonterminalKind {
     ///                   (* body: *) YulBlock;
     /// ```
     YulForStatement,
+    /// Represents a node with kind `YulFunctionCallExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// YulFunctionCallExpression = (* operand: *) YulExpression
@@ -1539,6 +1929,8 @@ pub enum NonterminalKind {
     ///                             (* close_paren: *) CLOSE_PAREN;
     /// ```
     YulFunctionCallExpression,
+    /// Represents a node with kind `YulFunctionDefinition`, having the following structure:
+    ///
     /// ```ebnf
     /// YulFunctionDefinition = (* function_keyword: *) YUL_FUNCTION_KEYWORD
     ///                         (* name: *) YUL_IDENTIFIER
@@ -1547,23 +1939,31 @@ pub enum NonterminalKind {
     ///                         (* body: *) YulBlock;
     /// ```
     YulFunctionDefinition,
+    /// Represents a node with kind `YulIfStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulIfStatement = (* if_keyword: *) YUL_IF_KEYWORD
     ///                  (* condition: *) YulExpression
     ///                  (* body: *) YulBlock;
     /// ```
     YulIfStatement,
+    /// Represents a node with kind `YulLabel`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YulLabel = (* label: *) YUL_IDENTIFIER
     ///            (* colon: *) COLON;
     /// ```
     YulLabel,
+    /// Represents a node with kind `YulLeaveStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// YulLeaveStatement = (* leave_keyword: *) YUL_LEAVE_KEYWORD;
     /// ```
     YulLeaveStatement,
+    /// Represents a node with kind `YulLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// YulLiteral = (* variant: *) YUL_TRUE_KEYWORD
     ///            | (* variant: *) YUL_FALSE_KEYWORD
@@ -1573,41 +1973,57 @@ pub enum NonterminalKind {
     ///            | (* variant: *) StringLiteral;
     /// ```
     YulLiteral,
+    /// Represents a node with kind `YulParameters`, having the following structure:
+    ///
     /// ```ebnf
     /// YulParameters = ((* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*)?;
     /// ```
     YulParameters,
+    /// Represents a node with kind `YulParametersDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// YulParametersDeclaration = (* open_paren: *) OPEN_PAREN
     ///                            (* parameters: *) YulParameters
     ///                            (* close_paren: *) CLOSE_PAREN;
     /// ```
     YulParametersDeclaration,
+    /// Represents a node with kind `YulPath`, having the following structure:
+    ///
     /// ```ebnf
     /// YulPath = (* item: *) YUL_IDENTIFIER ((* separator: *) PERIOD (* item: *) YUL_IDENTIFIER)*;
     /// ```
     YulPath,
+    /// Represents a node with kind `YulPaths`, having the following structure:
+    ///
     /// ```ebnf
     /// YulPaths = (* item: *) YulPath ((* separator: *) COMMA (* item: *) YulPath)*;
     /// ```
     YulPaths,
+    /// Represents a node with kind `YulReturnsDeclaration`, having the following structure:
+    ///
     /// ```ebnf
     /// YulReturnsDeclaration = (* minus_greater_than: *) MINUS_GREATER_THAN
     ///                         (* variables: *) YulVariableNames;
     /// ```
     YulReturnsDeclaration,
+    /// Represents a node with kind `YulStackAssignmentOperator`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YulStackAssignmentOperator = (* variant: *) EQUAL_COLON
     ///                            | (* variant: *) YulEqualAndColon;
     /// ```
     YulStackAssignmentOperator,
+    /// Represents a node with kind `YulStackAssignmentStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YulStackAssignmentStatement = (* assignment: *) YulStackAssignmentOperator
     ///                               (* variable: *) YUL_IDENTIFIER;
     /// ```
     YulStackAssignmentStatement,
+    /// Represents a node with kind `YulStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulStatement = (* variant: *) YulBlock
     ///              | (* variant: *) YulFunctionDefinition
@@ -1624,48 +2040,66 @@ pub enum NonterminalKind {
     ///              | (* variant: *) YulExpression;
     /// ```
     YulStatement,
+    /// Represents a node with kind `YulStatements`, having the following structure:
+    ///
     /// ```ebnf
     /// YulStatements = (* item: *) YulStatement*;
     /// ```
     YulStatements,
+    /// Represents a node with kind `YulSwitchCase`, having the following structure:
+    ///
     /// ```ebnf
     /// YulSwitchCase = (* variant: *) YulDefaultCase
     ///               | (* variant: *) YulValueCase;
     /// ```
     YulSwitchCase,
+    /// Represents a node with kind `YulSwitchCases`, having the following structure:
+    ///
     /// ```ebnf
     /// YulSwitchCases = (* item: *) YulSwitchCase+;
     /// ```
     YulSwitchCases,
+    /// Represents a node with kind `YulSwitchStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulSwitchStatement = (* switch_keyword: *) YUL_SWITCH_KEYWORD
     ///                      (* expression: *) YulExpression
     ///                      (* cases: *) YulSwitchCases;
     /// ```
     YulSwitchStatement,
+    /// Represents a node with kind `YulValueCase`, having the following structure:
+    ///
     /// ```ebnf
     /// YulValueCase = (* case_keyword: *) YUL_CASE_KEYWORD
     ///                (* value: *) YulLiteral
     ///                (* body: *) YulBlock;
     /// ```
     YulValueCase,
+    /// Represents a node with kind `YulVariableAssignmentStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulVariableAssignmentStatement = (* variables: *) YulPaths
     ///                                  (* assignment: *) YulAssignmentOperator
     ///                                  (* expression: *) YulExpression;
     /// ```
     YulVariableAssignmentStatement,
+    /// Represents a node with kind `YulVariableDeclarationStatement`, having the following structure:
+    ///
     /// ```ebnf
     /// YulVariableDeclarationStatement = (* let_keyword: *) YUL_LET_KEYWORD
     ///                                   (* variables: *) YulVariableNames
     ///                                   (* value: *) YulVariableDeclarationValue?;
     /// ```
     YulVariableDeclarationStatement,
+    /// Represents a node with kind `YulVariableDeclarationValue`, having the following structure:
+    ///
     /// ```ebnf
     /// YulVariableDeclarationValue = (* assignment: *) YulAssignmentOperator
     ///                               (* expression: *) YulExpression;
     /// ```
     YulVariableDeclarationValue,
+    /// Represents a node with kind `YulVariableNames`, having the following structure:
+    ///
     /// ```ebnf
     /// YulVariableNames = (* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*;
     /// ```

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
@@ -20,192 +20,276 @@
 #[allow(clippy::doc_markdown)]
 #[allow(clippy::doc_link_with_quotes)]
 pub enum TerminalKind {
-    // Built-in:
     UNRECOGNIZED,
     MISSING,
 
-    // Generated:
+    /// Represents a node with kind `AbicoderKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// ABICODER_KEYWORD = "abicoder";
     /// ```
     AbicoderKeyword,
+    /// Represents a node with kind `AbstractKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// ABSTRACT_KEYWORD = "abstract";
     /// ```
     AbstractKeyword,
+    /// Represents a node with kind `AddressKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// ADDRESS_KEYWORD = "address";
     /// ```
     AddressKeyword,
+    /// Represents a node with kind `AfterKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// AFTER_KEYWORD = "after";
     /// ```
     AfterKeyword,
+    /// Represents a node with kind `AliasKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// ALIAS_KEYWORD = "alias";
     /// ```
     AliasKeyword,
+    /// Represents a node with kind `Ampersand`, having the following structure:
+    ///
     /// ```ebnf
     /// AMPERSAND = "&";
     /// ```
     Ampersand,
+    /// Represents a node with kind `AmpersandAmpersand`, having the following structure:
+    ///
     /// ```ebnf
     /// AMPERSAND_AMPERSAND = "&&";
     /// ```
     AmpersandAmpersand,
+    /// Represents a node with kind `AmpersandEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// AMPERSAND_EQUAL = "&=";
     /// ```
     AmpersandEqual,
+    /// Represents a node with kind `AnonymousKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// ANONYMOUS_KEYWORD = "anonymous";
     /// ```
     AnonymousKeyword,
+    /// Represents a node with kind `ApplyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// APPLY_KEYWORD = "apply";
     /// ```
     ApplyKeyword,
+    /// Represents a node with kind `AsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// AS_KEYWORD = "as";
     /// ```
     AsKeyword,
+    /// Represents a node with kind `AssemblyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// ASSEMBLY_KEYWORD = "assembly";
     /// ```
     AssemblyKeyword,
+    /// Represents a node with kind `Asterisk`, having the following structure:
+    ///
     /// ```ebnf
     /// ASTERISK = "*";
     /// ```
     Asterisk,
+    /// Represents a node with kind `AsteriskAsterisk`, having the following structure:
+    ///
     /// ```ebnf
     /// ASTERISK_ASTERISK = "**";
     /// ```
     AsteriskAsterisk,
+    /// Represents a node with kind `AsteriskEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// ASTERISK_EQUAL = "*=";
     /// ```
     AsteriskEqual,
+    /// Represents a node with kind `AutoKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// AUTO_KEYWORD = "auto";
     /// ```
     AutoKeyword,
+    /// Represents a node with kind `Bang`, having the following structure:
+    ///
     /// ```ebnf
     /// BANG = "!";
     /// ```
     Bang,
+    /// Represents a node with kind `BangEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// BANG_EQUAL = "!=";
     /// ```
     BangEqual,
+    /// Represents a node with kind `Bar`, having the following structure:
+    ///
     /// ```ebnf
     /// BAR = "|";
     /// ```
     Bar,
+    /// Represents a node with kind `BarBar`, having the following structure:
+    ///
     /// ```ebnf
     /// BAR_BAR = "||";
     /// ```
     BarBar,
+    /// Represents a node with kind `BarEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// BAR_EQUAL = "|=";
     /// ```
     BarEqual,
+    /// Represents a node with kind `BoolKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// BOOL_KEYWORD = "bool";
     /// ```
     BoolKeyword,
+    /// Represents a node with kind `BreakKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// BREAK_KEYWORD = "break";
     /// ```
     BreakKeyword,
+    /// Represents a node with kind `ByteKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.8.0 *)
     /// BYTE_KEYWORD = "byte";
     /// ```
     ByteKeyword,
+    /// Represents a node with kind `BytesKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// BYTES_KEYWORD = "bytes" ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32")?;
     /// ```
     BytesKeyword,
+    /// Represents a node with kind `CallDataKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.0 *)
     /// (* Reserved in 0.5.0 *)
     /// CALL_DATA_KEYWORD = "calldata";
     /// ```
     CallDataKeyword,
+    /// Represents a node with kind `Caret`, having the following structure:
+    ///
     /// ```ebnf
     /// CARET = "^";
     /// ```
     Caret,
+    /// Represents a node with kind `CaretEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// CARET_EQUAL = "^=";
     /// ```
     CaretEqual,
+    /// Represents a node with kind `CaseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// CASE_KEYWORD = "case";
     /// ```
     CaseKeyword,
+    /// Represents a node with kind `CatchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// CATCH_KEYWORD = "catch";
     /// ```
     CatchKeyword,
+    /// Represents a node with kind `CloseBrace`, having the following structure:
+    ///
     /// ```ebnf
     /// CLOSE_BRACE = "}";
     /// ```
     CloseBrace,
+    /// Represents a node with kind `CloseBracket`, having the following structure:
+    ///
     /// ```ebnf
     /// CLOSE_BRACKET = "]";
     /// ```
     CloseBracket,
+    /// Represents a node with kind `CloseParen`, having the following structure:
+    ///
     /// ```ebnf
     /// CLOSE_PAREN = ")";
     /// ```
     CloseParen,
+    /// Represents a node with kind `Colon`, having the following structure:
+    ///
     /// ```ebnf
     /// COLON = ":";
     /// ```
     Colon,
+    /// Represents a node with kind `ColonEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// COLON_EQUAL = ":=";
     /// ```
     ColonEqual,
+    /// Represents a node with kind `Comma`, having the following structure:
+    ///
     /// ```ebnf
     /// COMMA = ",";
     /// ```
     Comma,
+    /// Represents a node with kind `ConstantKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// CONSTANT_KEYWORD = "constant";
     /// ```
     ConstantKeyword,
+    /// Represents a node with kind `ConstructorKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.22 *)
     /// (* Reserved in 0.5.0 *)
     /// CONSTRUCTOR_KEYWORD = "constructor";
     /// ```
     ConstructorKeyword,
+    /// Represents a node with kind `ContinueKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// CONTINUE_KEYWORD = "continue";
     /// ```
     ContinueKeyword,
+    /// Represents a node with kind `ContractKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// CONTRACT_KEYWORD = "contract";
     /// ```
     ContractKeyword,
+    /// Represents a node with kind `CopyOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// COPY_OF_KEYWORD = "copyof";
     /// ```
     CopyOfKeyword,
+    /// Represents a node with kind `DaysKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// DAYS_KEYWORD = "days";
     /// ```
     DaysKeyword,
+    /// Represents a node with kind `DecimalLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// DECIMAL_LITERAL = "." «DECIMAL_DIGITS» «DECIMAL_EXPONENT»?;
     ///
@@ -221,27 +305,39 @@ pub enum TerminalKind {
     /// DECIMAL_LITERAL = «DECIMAL_DIGITS» ("." «DECIMAL_DIGITS»)? «DECIMAL_EXPONENT»?;
     /// ```
     DecimalLiteral,
+    /// Represents a node with kind `DefaultKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// DEFAULT_KEYWORD = "default";
     /// ```
     DefaultKeyword,
+    /// Represents a node with kind `DefineKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// DEFINE_KEYWORD = "define";
     /// ```
     DefineKeyword,
+    /// Represents a node with kind `DeleteKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// DELETE_KEYWORD = "delete";
     /// ```
     DeleteKeyword,
+    /// Represents a node with kind `DoKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// DO_KEYWORD = "do";
     /// ```
     DoKeyword,
+    /// Represents a node with kind `DoubleQuotedHexStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// DOUBLE_QUOTED_HEX_STRING_LITERAL = 'hex"' «HEX_STRING_CONTENTS»? '"';
     /// ```
     DoubleQuotedHexStringLiteral,
+    /// Represents a node with kind `DoubleQuotedStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.4.25 *)
     /// DOUBLE_QUOTED_STRING_LITERAL = '"' («ESCAPE_SEQUENCE_ARBITRARY» | !('"' "\\" "\r" "\n"))* '"';
@@ -252,92 +348,132 @@ pub enum TerminalKind {
     /// DOUBLE_QUOTED_STRING_LITERAL = '"' («ESCAPE_SEQUENCE» | (" "…"!") | ("#"…"[") | ("]"…"~"))* '"';
     /// ```
     DoubleQuotedStringLiteral,
+    /// Represents a node with kind `DoubleQuotedUnicodeStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.7.0 *)
     /// DOUBLE_QUOTED_UNICODE_STRING_LITERAL = 'unicode"' («ESCAPE_SEQUENCE» | !('"' "\\" "\r" "\n"))* '"';
     /// ```
     DoubleQuotedUnicodeStringLiteral,
+    /// Represents a node with kind `DoubleQuotedVersionLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// DOUBLE_QUOTED_VERSION_LITERAL = '"' «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* '"';
     /// ```
     DoubleQuotedVersionLiteral,
+    /// Represents a node with kind `ElseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// ELSE_KEYWORD = "else";
     /// ```
     ElseKeyword,
+    /// Represents a node with kind `EmitKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.21 *)
     /// (* Reserved in 0.5.0 *)
     /// EMIT_KEYWORD = "emit";
     /// ```
     EmitKeyword,
+    /// Represents a node with kind `EndOfLine`, having the following structure:
+    ///
     /// ```ebnf
     /// END_OF_LINE = "\n" | ("\r" "\n"?);
     /// ```
     EndOfLine,
+    /// Represents a node with kind `EnumKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// ENUM_KEYWORD = "enum";
     /// ```
     EnumKeyword,
+    /// Represents a node with kind `Equal`, having the following structure:
+    ///
     /// ```ebnf
     /// EQUAL = "=";
     /// ```
     Equal,
+    /// Represents a node with kind `EqualColon`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// EQUAL_COLON = "=:";
     /// ```
     EqualColon,
+    /// Represents a node with kind `EqualEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// EQUAL_EQUAL = "==";
     /// ```
     EqualEqual,
+    /// Represents a node with kind `EqualGreaterThan`, having the following structure:
+    ///
     /// ```ebnf
     /// EQUAL_GREATER_THAN = "=>";
     /// ```
     EqualGreaterThan,
+    /// Represents a node with kind `ErrorKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// (* Never reserved *)
     /// ERROR_KEYWORD = "error";
     /// ```
     ErrorKeyword,
+    /// Represents a node with kind `EtherKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// ETHER_KEYWORD = "ether";
     /// ```
     EtherKeyword,
+    /// Represents a node with kind `EventKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// EVENT_KEYWORD = "event";
     /// ```
     EventKeyword,
+    /// Represents a node with kind `ExperimentalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// EXPERIMENTAL_KEYWORD = "experimental";
     /// ```
     ExperimentalKeyword,
+    /// Represents a node with kind `ExternalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// EXTERNAL_KEYWORD = "external";
     /// ```
     ExternalKeyword,
+    /// Represents a node with kind `FallbackKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.6.0 *)
     /// FALLBACK_KEYWORD = "fallback";
     /// ```
     FallbackKeyword,
+    /// Represents a node with kind `FalseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// FALSE_KEYWORD = "false";
     /// ```
     FalseKeyword,
+    /// Represents a node with kind `FinalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// FINAL_KEYWORD = "final";
     /// ```
     FinalKeyword,
+    /// Represents a node with kind `FinneyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.7.0 *)
     /// (* Reserved until 0.7.0 *)
     /// FINNEY_KEYWORD = "finney";
     /// ```
     FinneyKeyword,
+    /// Represents a node with kind `FixedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// FIXED_KEYWORD = "fixed";
     ///
@@ -352,59 +488,85 @@ pub enum TerminalKind {
     /// FIXED_KEYWORD = "fixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
     /// ```
     FixedKeyword,
+    /// Represents a node with kind `ForKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// FOR_KEYWORD = "for";
     /// ```
     ForKeyword,
+    /// Represents a node with kind `FromKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// FROM_KEYWORD = "from";
     /// ```
     FromKeyword,
+    /// Represents a node with kind `FunctionKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// FUNCTION_KEYWORD = "function";
     /// ```
     FunctionKeyword,
+    /// Represents a node with kind `GlobalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.13 *)
     /// (* Never reserved *)
     /// GLOBAL_KEYWORD = "global";
     /// ```
     GlobalKeyword,
+    /// Represents a node with kind `GreaterThan`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN = ">";
     /// ```
     GreaterThan,
+    /// Represents a node with kind `GreaterThanEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN_EQUAL = ">=";
     /// ```
     GreaterThanEqual,
+    /// Represents a node with kind `GreaterThanGreaterThan`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN_GREATER_THAN = ">>";
     /// ```
     GreaterThanGreaterThan,
+    /// Represents a node with kind `GreaterThanGreaterThanEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN_GREATER_THAN_EQUAL = ">>=";
     /// ```
     GreaterThanGreaterThanEqual,
+    /// Represents a node with kind `GreaterThanGreaterThanGreaterThan`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN_GREATER_THAN_GREATER_THAN = ">>>";
     /// ```
     GreaterThanGreaterThanGreaterThan,
+    /// Represents a node with kind `GreaterThanGreaterThanGreaterThanEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// GREATER_THAN_GREATER_THAN_GREATER_THAN_EQUAL = ">>>=";
     /// ```
     GreaterThanGreaterThanGreaterThanEqual,
+    /// Represents a node with kind `GweiKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.11 *)
     /// (* Reserved in 0.7.0 *)
     /// GWEI_KEYWORD = "gwei";
     /// ```
     GweiKeyword,
+    /// Represents a node with kind `HexKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// HEX_KEYWORD = "hex";
     /// ```
     HexKeyword,
+    /// Represents a node with kind `HexLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// HEX_LITERAL = "0x" «HEX_CHARACTER»+ ("_" «HEX_CHARACTER»+)*;
     ///
@@ -412,281 +574,413 @@ pub enum TerminalKind {
     /// HEX_LITERAL = "0X" «HEX_CHARACTER»+ ("_" «HEX_CHARACTER»+)*;
     /// ```
     HexLiteral,
+    /// Represents a node with kind `HoursKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// HOURS_KEYWORD = "hours";
     /// ```
     HoursKeyword,
+    /// Represents a node with kind `Identifier`, having the following structure:
+    ///
     /// ```ebnf
     /// IDENTIFIER = «IDENTIFIER_START» «IDENTIFIER_PART»*;
     /// ```
     Identifier,
+    /// Represents a node with kind `IfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// IF_KEYWORD = "if";
     /// ```
     IfKeyword,
+    /// Represents a node with kind `ImmutableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.5 *)
     /// (* Reserved in 0.5.0 *)
     /// IMMUTABLE_KEYWORD = "immutable";
     /// ```
     ImmutableKeyword,
+    /// Represents a node with kind `ImplementsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// IMPLEMENTS_KEYWORD = "implements";
     /// ```
     ImplementsKeyword,
+    /// Represents a node with kind `ImportKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// IMPORT_KEYWORD = "import";
     /// ```
     ImportKeyword,
+    /// Represents a node with kind `InKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// IN_KEYWORD = "in";
     /// ```
     InKeyword,
+    /// Represents a node with kind `IndexedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// INDEXED_KEYWORD = "indexed";
     /// ```
     IndexedKeyword,
+    /// Represents a node with kind `InlineKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// INLINE_KEYWORD = "inline";
     /// ```
     InlineKeyword,
+    /// Represents a node with kind `IntKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// INT_KEYWORD = "int" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
     /// ```
     IntKeyword,
+    /// Represents a node with kind `InterfaceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// INTERFACE_KEYWORD = "interface";
     /// ```
     InterfaceKeyword,
+    /// Represents a node with kind `InternalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// INTERNAL_KEYWORD = "internal";
     /// ```
     InternalKeyword,
+    /// Represents a node with kind `IsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// IS_KEYWORD = "is";
     /// ```
     IsKeyword,
+    /// Represents a node with kind `LessThan`, having the following structure:
+    ///
     /// ```ebnf
     /// LESS_THAN = "<";
     /// ```
     LessThan,
+    /// Represents a node with kind `LessThanEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// LESS_THAN_EQUAL = "<=";
     /// ```
     LessThanEqual,
+    /// Represents a node with kind `LessThanLessThan`, having the following structure:
+    ///
     /// ```ebnf
     /// LESS_THAN_LESS_THAN = "<<";
     /// ```
     LessThanLessThan,
+    /// Represents a node with kind `LessThanLessThanEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// LESS_THAN_LESS_THAN_EQUAL = "<<=";
     /// ```
     LessThanLessThanEqual,
+    /// Represents a node with kind `LetKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// LET_KEYWORD = "let";
     /// ```
     LetKeyword,
+    /// Represents a node with kind `LibraryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// LIBRARY_KEYWORD = "library";
     /// ```
     LibraryKeyword,
+    /// Represents a node with kind `MacroKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// MACRO_KEYWORD = "macro";
     /// ```
     MacroKeyword,
+    /// Represents a node with kind `MappingKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// MAPPING_KEYWORD = "mapping";
     /// ```
     MappingKeyword,
+    /// Represents a node with kind `MatchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// MATCH_KEYWORD = "match";
     /// ```
     MatchKeyword,
+    /// Represents a node with kind `MemoryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// MEMORY_KEYWORD = "memory";
     /// ```
     MemoryKeyword,
+    /// Represents a node with kind `Minus`, having the following structure:
+    ///
     /// ```ebnf
     /// MINUS = "-";
     /// ```
     Minus,
+    /// Represents a node with kind `MinusEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// MINUS_EQUAL = "-=";
     /// ```
     MinusEqual,
+    /// Represents a node with kind `MinusGreaterThan`, having the following structure:
+    ///
     /// ```ebnf
     /// MINUS_GREATER_THAN = "->";
     /// ```
     MinusGreaterThan,
+    /// Represents a node with kind `MinusMinus`, having the following structure:
+    ///
     /// ```ebnf
     /// MINUS_MINUS = "--";
     /// ```
     MinusMinus,
+    /// Represents a node with kind `MinutesKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// MINUTES_KEYWORD = "minutes";
     /// ```
     MinutesKeyword,
+    /// Represents a node with kind `ModifierKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// MODIFIER_KEYWORD = "modifier";
     /// ```
     ModifierKeyword,
+    /// Represents a node with kind `MultiLineComment`, having the following structure:
+    ///
     /// ```ebnf
     /// MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*/";
     /// ```
     MultiLineComment,
+    /// Represents a node with kind `MultiLineNatSpecComment`, having the following structure:
+    ///
     /// ```ebnf
     /// MULTI_LINE_NAT_SPEC_COMMENT = "/**" (!"*" | "*")* "*/";
     /// ```
     MultiLineNatSpecComment,
+    /// Represents a node with kind `MutableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// MUTABLE_KEYWORD = "mutable";
     /// ```
     MutableKeyword,
+    /// Represents a node with kind `NewKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// NEW_KEYWORD = "new";
     /// ```
     NewKeyword,
+    /// Represents a node with kind `NullKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// NULL_KEYWORD = "null";
     /// ```
     NullKeyword,
+    /// Represents a node with kind `OfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// OF_KEYWORD = "of";
     /// ```
     OfKeyword,
+    /// Represents a node with kind `OpenBrace`, having the following structure:
+    ///
     /// ```ebnf
     /// OPEN_BRACE = "{";
     /// ```
     OpenBrace,
+    /// Represents a node with kind `OpenBracket`, having the following structure:
+    ///
     /// ```ebnf
     /// OPEN_BRACKET = "[";
     /// ```
     OpenBracket,
+    /// Represents a node with kind `OpenParen`, having the following structure:
+    ///
     /// ```ebnf
     /// OPEN_PAREN = "(";
     /// ```
     OpenParen,
+    /// Represents a node with kind `OverrideKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// (* Reserved in 0.5.0 *)
     /// OVERRIDE_KEYWORD = "override";
     /// ```
     OverrideKeyword,
+    /// Represents a node with kind `PartialKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// PARTIAL_KEYWORD = "partial";
     /// ```
     PartialKeyword,
+    /// Represents a node with kind `PayableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// PAYABLE_KEYWORD = "payable";
     /// ```
     PayableKeyword,
+    /// Represents a node with kind `Percent`, having the following structure:
+    ///
     /// ```ebnf
     /// PERCENT = "%";
     /// ```
     Percent,
+    /// Represents a node with kind `PercentEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// PERCENT_EQUAL = "%=";
     /// ```
     PercentEqual,
+    /// Represents a node with kind `Period`, having the following structure:
+    ///
     /// ```ebnf
     /// PERIOD = ".";
     /// ```
     Period,
+    /// Represents a node with kind `Plus`, having the following structure:
+    ///
     /// ```ebnf
     /// PLUS = "+";
     /// ```
     Plus,
+    /// Represents a node with kind `PlusEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// PLUS_EQUAL = "+=";
     /// ```
     PlusEqual,
+    /// Represents a node with kind `PlusPlus`, having the following structure:
+    ///
     /// ```ebnf
     /// PLUS_PLUS = "++";
     /// ```
     PlusPlus,
+    /// Represents a node with kind `PragmaKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// PRAGMA_KEYWORD = "pragma";
     /// ```
     PragmaKeyword,
+    /// Represents a node with kind `PrivateKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// PRIVATE_KEYWORD = "private";
     /// ```
     PrivateKeyword,
+    /// Represents a node with kind `PromiseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// PROMISE_KEYWORD = "promise";
     /// ```
     PromiseKeyword,
+    /// Represents a node with kind `PublicKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// PUBLIC_KEYWORD = "public";
     /// ```
     PublicKeyword,
+    /// Represents a node with kind `PureKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.16 *)
     /// PURE_KEYWORD = "pure";
     /// ```
     PureKeyword,
+    /// Represents a node with kind `QuestionMark`, having the following structure:
+    ///
     /// ```ebnf
     /// QUESTION_MARK = "?";
     /// ```
     QuestionMark,
+    /// Represents a node with kind `ReceiveKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.6.0 *)
     /// RECEIVE_KEYWORD = "receive";
     /// ```
     ReceiveKeyword,
+    /// Represents a node with kind `ReferenceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// REFERENCE_KEYWORD = "reference";
     /// ```
     ReferenceKeyword,
+    /// Represents a node with kind `RelocatableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// RELOCATABLE_KEYWORD = "relocatable";
     /// ```
     RelocatableKeyword,
+    /// Represents a node with kind `ReturnKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// RETURN_KEYWORD = "return";
     /// ```
     ReturnKeyword,
+    /// Represents a node with kind `ReturnsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// RETURNS_KEYWORD = "returns";
     /// ```
     ReturnsKeyword,
+    /// Represents a node with kind `RevertKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.4 *)
     /// (* Never reserved *)
     /// REVERT_KEYWORD = "revert";
     /// ```
     RevertKeyword,
+    /// Represents a node with kind `SealedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// SEALED_KEYWORD = "sealed";
     /// ```
     SealedKeyword,
+    /// Represents a node with kind `SecondsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// SECONDS_KEYWORD = "seconds";
     /// ```
     SecondsKeyword,
+    /// Represents a node with kind `Semicolon`, having the following structure:
+    ///
     /// ```ebnf
     /// SEMICOLON = ";";
     /// ```
     Semicolon,
+    /// Represents a node with kind `SingleLineComment`, having the following structure:
+    ///
     /// ```ebnf
     /// SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
     /// ```
     SingleLineComment,
+    /// Represents a node with kind `SingleLineNatSpecComment`, having the following structure:
+    ///
     /// ```ebnf
     /// SINGLE_LINE_NAT_SPEC_COMMENT = "///" (!("\r" "\n"))*;
     /// ```
     SingleLineNatSpecComment,
+    /// Represents a node with kind `SingleQuotedHexStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// SINGLE_QUOTED_HEX_STRING_LITERAL = "hex'" «HEX_STRING_CONTENTS»? "'";
     /// ```
     SingleQuotedHexStringLiteral,
+    /// Represents a node with kind `SingleQuotedStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.4.25 *)
     /// SINGLE_QUOTED_STRING_LITERAL = "'" («ESCAPE_SEQUENCE_ARBITRARY» | !("'" "\\" "\r" "\n"))* "'";
@@ -697,110 +991,158 @@ pub enum TerminalKind {
     /// SINGLE_QUOTED_STRING_LITERAL = "'" («ESCAPE_SEQUENCE» | (" "…"&") | ("("…"[") | ("]"…"~"))* "'";
     /// ```
     SingleQuotedStringLiteral,
+    /// Represents a node with kind `SingleQuotedUnicodeStringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.7.0 *)
     /// SINGLE_QUOTED_UNICODE_STRING_LITERAL = "unicode'" («ESCAPE_SEQUENCE» | !("'" "\\" "\r" "\n"))* "'";
     /// ```
     SingleQuotedUnicodeStringLiteral,
+    /// Represents a node with kind `SingleQuotedVersionLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// SINGLE_QUOTED_VERSION_LITERAL = "'" «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* "'";
     /// ```
     SingleQuotedVersionLiteral,
+    /// Represents a node with kind `SizeOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// SIZE_OF_KEYWORD = "sizeof";
     /// ```
     SizeOfKeyword,
+    /// Represents a node with kind `Slash`, having the following structure:
+    ///
     /// ```ebnf
     /// SLASH = "/";
     /// ```
     Slash,
+    /// Represents a node with kind `SlashEqual`, having the following structure:
+    ///
     /// ```ebnf
     /// SLASH_EQUAL = "/=";
     /// ```
     SlashEqual,
+    /// Represents a node with kind `SolidityKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// SOLIDITY_KEYWORD = "solidity";
     /// ```
     SolidityKeyword,
+    /// Represents a node with kind `StaticKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// STATIC_KEYWORD = "static";
     /// ```
     StaticKeyword,
+    /// Represents a node with kind `StorageKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// STORAGE_KEYWORD = "storage";
     /// ```
     StorageKeyword,
+    /// Represents a node with kind `StringKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// STRING_KEYWORD = "string";
     /// ```
     StringKeyword,
+    /// Represents a node with kind `StructKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// STRUCT_KEYWORD = "struct";
     /// ```
     StructKeyword,
+    /// Represents a node with kind `SuperKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// SUPER_KEYWORD = "super";
     /// ```
     SuperKeyword,
+    /// Represents a node with kind `SupportsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// SUPPORTS_KEYWORD = "supports";
     /// ```
     SupportsKeyword,
+    /// Represents a node with kind `SwitchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// SWITCH_KEYWORD = "switch";
     /// ```
     SwitchKeyword,
+    /// Represents a node with kind `SzaboKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.7.0 *)
     /// (* Reserved until 0.7.0 *)
     /// SZABO_KEYWORD = "szabo";
     /// ```
     SzaboKeyword,
+    /// Represents a node with kind `ThisKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// THIS_KEYWORD = "this";
     /// ```
     ThisKeyword,
+    /// Represents a node with kind `ThrowKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// THROW_KEYWORD = "throw";
     /// ```
     ThrowKeyword,
+    /// Represents a node with kind `Tilde`, having the following structure:
+    ///
     /// ```ebnf
     /// TILDE = "~";
     /// ```
     Tilde,
+    /// Represents a node with kind `TransientKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.27 *)
     /// (* Never reserved *)
     /// TRANSIENT_KEYWORD = "transient";
     /// ```
     TransientKeyword,
+    /// Represents a node with kind `TrueKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// TRUE_KEYWORD = "true";
     /// ```
     TrueKeyword,
+    /// Represents a node with kind `TryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// TRY_KEYWORD = "try";
     /// ```
     TryKeyword,
+    /// Represents a node with kind `TypeDefKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.0 *)
     /// TYPE_DEF_KEYWORD = "typedef";
     /// ```
     TypeDefKeyword,
+    /// Represents a node with kind `TypeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.3 *)
     /// TYPE_KEYWORD = "type";
     /// ```
     TypeKeyword,
+    /// Represents a node with kind `TypeOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// TYPE_OF_KEYWORD = "typeof";
     /// ```
     TypeOfKeyword,
+    /// Represents a node with kind `UfixedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// UFIXED_KEYWORD = "ufixed";
     ///
@@ -815,359 +1157,513 @@ pub enum TerminalKind {
     /// UFIXED_KEYWORD = "ufixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
     /// ```
     UfixedKeyword,
+    /// Represents a node with kind `UintKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// UINT_KEYWORD = "uint" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
     /// ```
     UintKeyword,
+    /// Represents a node with kind `UncheckedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.0 *)
     /// (* Reserved in 0.5.0 *)
     /// UNCHECKED_KEYWORD = "unchecked";
     /// ```
     UncheckedKeyword,
+    /// Represents a node with kind `UsingKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// USING_KEYWORD = "using";
     /// ```
     UsingKeyword,
+    /// Represents a node with kind `VarKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// VAR_KEYWORD = "var";
     /// ```
     VarKeyword,
+    /// Represents a node with kind `VersionSpecifier`, having the following structure:
+    ///
     /// ```ebnf
     /// VERSION_SPECIFIER = «VERSION_SPECIFIER_FRAGMENT»;
     /// ```
     VersionSpecifier,
+    /// Represents a node with kind `ViewKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.16 *)
     /// VIEW_KEYWORD = "view";
     /// ```
     ViewKeyword,
+    /// Represents a node with kind `VirtualKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// (* Reserved in 0.6.0 *)
     /// VIRTUAL_KEYWORD = "virtual";
     /// ```
     VirtualKeyword,
+    /// Represents a node with kind `WeeksKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// WEEKS_KEYWORD = "weeks";
     /// ```
     WeeksKeyword,
+    /// Represents a node with kind `WeiKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// WEI_KEYWORD = "wei";
     /// ```
     WeiKeyword,
+    /// Represents a node with kind `WhileKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// WHILE_KEYWORD = "while";
     /// ```
     WhileKeyword,
+    /// Represents a node with kind `Whitespace`, having the following structure:
+    ///
     /// ```ebnf
     /// WHITESPACE = (" " | "\t")+;
     /// ```
     Whitespace,
+    /// Represents a node with kind `YearsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YEARS_KEYWORD = "years";
     /// ```
     YearsKeyword,
+    /// Represents a node with kind `YulAbstractKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ABSTRACT_KEYWORD = "abstract";
     /// ```
     YulAbstractKeyword,
+    /// Represents a node with kind `YulAddKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_ADD_KEYWORD = "add";
     /// ```
     YulAddKeyword,
+    /// Represents a node with kind `YulAddModKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_ADD_MOD_KEYWORD = "addmod";
     /// ```
     YulAddModKeyword,
+    /// Represents a node with kind `YulAddressKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Never reserved *)
     /// YUL_ADDRESS_KEYWORD = "address";
     /// ```
     YulAddressKeyword,
+    /// Represents a node with kind `YulAfterKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_AFTER_KEYWORD = "after";
     /// ```
     YulAfterKeyword,
+    /// Represents a node with kind `YulAliasKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_ALIAS_KEYWORD = "alias";
     /// ```
     YulAliasKeyword,
+    /// Represents a node with kind `YulAndKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_AND_KEYWORD = "and";
     /// ```
     YulAndKeyword,
+    /// Represents a node with kind `YulAnonymousKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ANONYMOUS_KEYWORD = "anonymous";
     /// ```
     YulAnonymousKeyword,
+    /// Represents a node with kind `YulApplyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_APPLY_KEYWORD = "apply";
     /// ```
     YulApplyKeyword,
+    /// Represents a node with kind `YulAsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_AS_KEYWORD = "as";
     /// ```
     YulAsKeyword,
+    /// Represents a node with kind `YulAssemblyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ASSEMBLY_KEYWORD = "assembly";
     /// ```
     YulAssemblyKeyword,
+    /// Represents a node with kind `YulAutoKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_AUTO_KEYWORD = "auto";
     /// ```
     YulAutoKeyword,
+    /// Represents a node with kind `YulBalanceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_BALANCE_KEYWORD = "balance";
     /// ```
     YulBalanceKeyword,
+    /// Represents a node with kind `YulBaseFeeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.7 *)
     /// (* Reserved in 0.8.7 *)
     /// YUL_BASE_FEE_KEYWORD = "basefee";
     /// ```
     YulBaseFeeKeyword,
+    /// Represents a node with kind `YulBlobBaseFeeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.24 *)
     /// (* Reserved in 0.8.25 *)
     /// YUL_BLOB_BASE_FEE_KEYWORD = "blobbasefee";
     /// ```
     YulBlobBaseFeeKeyword,
+    /// Represents a node with kind `YulBlobHashKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.24 *)
     /// (* Reserved in 0.8.25 *)
     /// YUL_BLOB_HASH_KEYWORD = "blobhash";
     /// ```
     YulBlobHashKeyword,
+    /// Represents a node with kind `YulBlockHashKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_BLOCK_HASH_KEYWORD = "blockhash";
     /// ```
     YulBlockHashKeyword,
+    /// Represents a node with kind `YulBoolKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.5.10 *)
     /// YUL_BOOL_KEYWORD = "bool";
     /// ```
     YulBoolKeyword,
+    /// Represents a node with kind `YulBreakKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_BREAK_KEYWORD = "break";
     /// ```
     YulBreakKeyword,
+    /// Represents a node with kind `YulByteKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_BYTE_KEYWORD = "byte";
     /// ```
     YulByteKeyword,
+    /// Represents a node with kind `YulBytesKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_BYTES_KEYWORD = "bytes" ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32")?;
     /// ```
     YulBytesKeyword,
+    /// Represents a node with kind `YulCallCodeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_CODE_KEYWORD = "callcode";
     /// ```
     YulCallCodeKeyword,
+    /// Represents a node with kind `YulCallDataCopyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_DATA_COPY_KEYWORD = "calldatacopy";
     /// ```
     YulCallDataCopyKeyword,
+    /// Represents a node with kind `YulCallDataKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_CALL_DATA_KEYWORD = "calldata";
     /// ```
     YulCallDataKeyword,
+    /// Represents a node with kind `YulCallDataLoadKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_DATA_LOAD_KEYWORD = "calldataload";
     /// ```
     YulCallDataLoadKeyword,
+    /// Represents a node with kind `YulCallDataSizeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_DATA_SIZE_KEYWORD = "calldatasize";
     /// ```
     YulCallDataSizeKeyword,
+    /// Represents a node with kind `YulCallKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_KEYWORD = "call";
     /// ```
     YulCallKeyword,
+    /// Represents a node with kind `YulCallValueKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALL_VALUE_KEYWORD = "callvalue";
     /// ```
     YulCallValueKeyword,
+    /// Represents a node with kind `YulCallerKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CALLER_KEYWORD = "caller";
     /// ```
     YulCallerKeyword,
+    /// Represents a node with kind `YulCaseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CASE_KEYWORD = "case";
     /// ```
     YulCaseKeyword,
+    /// Represents a node with kind `YulCatchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_CATCH_KEYWORD = "catch";
     /// ```
     YulCatchKeyword,
+    /// Represents a node with kind `YulChainIdKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.12 *)
     /// YUL_CHAIN_ID_KEYWORD = "chainid";
     /// ```
     YulChainIdKeyword,
+    /// Represents a node with kind `YulCoinBaseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_COIN_BASE_KEYWORD = "coinbase";
     /// ```
     YulCoinBaseKeyword,
+    /// Represents a node with kind `YulConstantKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_CONSTANT_KEYWORD = "constant";
     /// ```
     YulConstantKeyword,
+    /// Represents a node with kind `YulConstructorKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_CONSTRUCTOR_KEYWORD = "constructor";
     /// ```
     YulConstructorKeyword,
+    /// Represents a node with kind `YulContinueKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CONTINUE_KEYWORD = "continue";
     /// ```
     YulContinueKeyword,
+    /// Represents a node with kind `YulContractKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_CONTRACT_KEYWORD = "contract";
     /// ```
     YulContractKeyword,
+    /// Represents a node with kind `YulCopyOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_COPY_OF_KEYWORD = "copyof";
     /// ```
     YulCopyOfKeyword,
+    /// Represents a node with kind `YulCreate2Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.12 *)
     /// (* Reserved in 0.4.12 *)
     /// YUL_CREATE_2_KEYWORD = "create2";
     /// ```
     YulCreate2Keyword,
+    /// Represents a node with kind `YulCreateKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_CREATE_KEYWORD = "create";
     /// ```
     YulCreateKeyword,
+    /// Represents a node with kind `YulDaysKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_DAYS_KEYWORD = "days";
     /// ```
     YulDaysKeyword,
+    /// Represents a node with kind `YulDecimalLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_DECIMAL_LITERAL = "0" | (("1"…"9") ("0"…"9")*);
     /// ```
     YulDecimalLiteral,
+    /// Represents a node with kind `YulDefaultKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_DEFAULT_KEYWORD = "default";
     /// ```
     YulDefaultKeyword,
+    /// Represents a node with kind `YulDefineKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_DEFINE_KEYWORD = "define";
     /// ```
     YulDefineKeyword,
+    /// Represents a node with kind `YulDelegateCallKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_DELEGATE_CALL_KEYWORD = "delegatecall";
     /// ```
     YulDelegateCallKeyword,
+    /// Represents a node with kind `YulDeleteKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_DELETE_KEYWORD = "delete";
     /// ```
     YulDeleteKeyword,
+    /// Represents a node with kind `YulDifficultyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.8.18 *)
     /// YUL_DIFFICULTY_KEYWORD = "difficulty";
     /// ```
     YulDifficultyKeyword,
+    /// Represents a node with kind `YulDivKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_DIV_KEYWORD = "div";
     /// ```
     YulDivKeyword,
+    /// Represents a node with kind `YulDoKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_DO_KEYWORD = "do";
     /// ```
     YulDoKeyword,
+    /// Represents a node with kind `YulElseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ELSE_KEYWORD = "else";
     /// ```
     YulElseKeyword,
+    /// Represents a node with kind `YulEmitKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_EMIT_KEYWORD = "emit";
     /// ```
     YulEmitKeyword,
+    /// Represents a node with kind `YulEnumKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ENUM_KEYWORD = "enum";
     /// ```
     YulEnumKeyword,
+    /// Represents a node with kind `YulEqKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_EQ_KEYWORD = "eq";
     /// ```
     YulEqKeyword,
+    /// Represents a node with kind `YulEtherKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_ETHER_KEYWORD = "ether";
     /// ```
     YulEtherKeyword,
+    /// Represents a node with kind `YulEventKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_EVENT_KEYWORD = "event";
     /// ```
     YulEventKeyword,
+    /// Represents a node with kind `YulExpKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_EXP_KEYWORD = "exp";
     /// ```
     YulExpKeyword,
+    /// Represents a node with kind `YulExtCodeCopyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_EXT_CODE_COPY_KEYWORD = "extcodecopy";
     /// ```
     YulExtCodeCopyKeyword,
+    /// Represents a node with kind `YulExtCodeHashKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.0 *)
     /// (* Reserved in 0.5.0 *)
     /// YUL_EXT_CODE_HASH_KEYWORD = "extcodehash";
     /// ```
     YulExtCodeHashKeyword,
+    /// Represents a node with kind `YulExtCodeSizeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_EXT_CODE_SIZE_KEYWORD = "extcodesize";
     /// ```
     YulExtCodeSizeKeyword,
+    /// Represents a node with kind `YulExternalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_EXTERNAL_KEYWORD = "external";
     /// ```
     YulExternalKeyword,
+    /// Represents a node with kind `YulFallbackKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.6.0 until 0.7.1 *)
     /// YUL_FALLBACK_KEYWORD = "fallback";
     /// ```
     YulFallbackKeyword,
+    /// Represents a node with kind `YulFalseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_FALSE_KEYWORD = "false";
     /// ```
     YulFalseKeyword,
+    /// Represents a node with kind `YulFinalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_FINAL_KEYWORD = "final";
     /// ```
     YulFinalKeyword,
+    /// Represents a node with kind `YulFinneyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.0 *)
     /// YUL_FINNEY_KEYWORD = "finney";
     /// ```
     YulFinneyKeyword,
+    /// Represents a node with kind `YulFixedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_FIXED_KEYWORD = "fixed";
@@ -1185,48 +1681,70 @@ pub enum TerminalKind {
     /// YUL_FIXED_KEYWORD = "fixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
     /// ```
     YulFixedKeyword,
+    /// Represents a node with kind `YulForKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_FOR_KEYWORD = "for";
     /// ```
     YulForKeyword,
+    /// Represents a node with kind `YulFunctionKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_FUNCTION_KEYWORD = "function";
     /// ```
     YulFunctionKeyword,
+    /// Represents a node with kind `YulGasKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_GAS_KEYWORD = "gas";
     /// ```
     YulGasKeyword,
+    /// Represents a node with kind `YulGasLimitKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_GAS_LIMIT_KEYWORD = "gaslimit";
     /// ```
     YulGasLimitKeyword,
+    /// Represents a node with kind `YulGasPriceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_GAS_PRICE_KEYWORD = "gasprice";
     /// ```
     YulGasPriceKeyword,
+    /// Represents a node with kind `YulGtKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_GT_KEYWORD = "gt";
     /// ```
     YulGtKeyword,
+    /// Represents a node with kind `YulGweiKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.7.0 until 0.7.1 *)
     /// YUL_GWEI_KEYWORD = "gwei";
     /// ```
     YulGweiKeyword,
+    /// Represents a node with kind `YulHexKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_HEX_KEYWORD = "hex";
     /// ```
     YulHexKeyword,
+    /// Represents a node with kind `YulHexLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_HEX_LITERAL = "0x" «HEX_CHARACTER»+;
     /// ```
     YulHexLiteral,
+    /// Represents a node with kind `YulHoursKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_HOURS_KEYWORD = "hours";
     /// ```
     YulHoursKeyword,
+    /// Represents a node with kind `YulIdentifier`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.5.8 and deprecated in 0.7.0. *)
     /// YUL_IDENTIFIER = «IDENTIFIER_START» («IDENTIFIER_PART» | ".")*;
@@ -1234,493 +1752,701 @@ pub enum TerminalKind {
     /// YUL_IDENTIFIER = «IDENTIFIER_START» «IDENTIFIER_PART»*;
     /// ```
     YulIdentifier,
+    /// Represents a node with kind `YulIfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_IF_KEYWORD = "if";
     /// ```
     YulIfKeyword,
+    /// Represents a node with kind `YulImmutableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_IMMUTABLE_KEYWORD = "immutable";
     /// ```
     YulImmutableKeyword,
+    /// Represents a node with kind `YulImplementsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_IMPLEMENTS_KEYWORD = "implements";
     /// ```
     YulImplementsKeyword,
+    /// Represents a node with kind `YulImportKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_IMPORT_KEYWORD = "import";
     /// ```
     YulImportKeyword,
+    /// Represents a node with kind `YulInKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.6.8 *)
     /// YUL_IN_KEYWORD = "in";
     /// ```
     YulInKeyword,
+    /// Represents a node with kind `YulIndexedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_INDEXED_KEYWORD = "indexed";
     /// ```
     YulIndexedKeyword,
+    /// Represents a node with kind `YulInlineKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_INLINE_KEYWORD = "inline";
     /// ```
     YulInlineKeyword,
+    /// Represents a node with kind `YulIntKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_INT_KEYWORD = "int" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
     /// ```
     YulIntKeyword,
+    /// Represents a node with kind `YulInterfaceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_INTERFACE_KEYWORD = "interface";
     /// ```
     YulInterfaceKeyword,
+    /// Represents a node with kind `YulInternalKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_INTERNAL_KEYWORD = "internal";
     /// ```
     YulInternalKeyword,
+    /// Represents a node with kind `YulInvalidKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_INVALID_KEYWORD = "invalid";
     /// ```
     YulInvalidKeyword,
+    /// Represents a node with kind `YulIsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_IS_KEYWORD = "is";
     /// ```
     YulIsKeyword,
+    /// Represents a node with kind `YulIsZeroKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_IS_ZERO_KEYWORD = "iszero";
     /// ```
     YulIsZeroKeyword,
+    /// Represents a node with kind `YulJumpKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YUL_JUMP_KEYWORD = "jump";
     /// ```
     YulJumpKeyword,
+    /// Represents a node with kind `YulJumpiKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// YUL_JUMPI_KEYWORD = "jumpi";
     /// ```
     YulJumpiKeyword,
+    /// Represents a node with kind `YulKeccak256Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.12 *)
     /// (* Reserved in 0.4.12 *)
     /// YUL_KECCAK_256_KEYWORD = "keccak256";
     /// ```
     YulKeccak256Keyword,
+    /// Represents a node with kind `YulLeaveKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.6.0 *)
     /// (* Reserved in 0.7.1 *)
     /// YUL_LEAVE_KEYWORD = "leave";
     /// ```
     YulLeaveKeyword,
+    /// Represents a node with kind `YulLetKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LET_KEYWORD = "let";
     /// ```
     YulLetKeyword,
+    /// Represents a node with kind `YulLibraryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_LIBRARY_KEYWORD = "library";
     /// ```
     YulLibraryKeyword,
+    /// Represents a node with kind `YulLog0Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LOG_0_KEYWORD = "log0";
     /// ```
     YulLog0Keyword,
+    /// Represents a node with kind `YulLog1Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LOG_1_KEYWORD = "log1";
     /// ```
     YulLog1Keyword,
+    /// Represents a node with kind `YulLog2Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LOG_2_KEYWORD = "log2";
     /// ```
     YulLog2Keyword,
+    /// Represents a node with kind `YulLog3Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LOG_3_KEYWORD = "log3";
     /// ```
     YulLog3Keyword,
+    /// Represents a node with kind `YulLog4Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LOG_4_KEYWORD = "log4";
     /// ```
     YulLog4Keyword,
+    /// Represents a node with kind `YulLtKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_LT_KEYWORD = "lt";
     /// ```
     YulLtKeyword,
+    /// Represents a node with kind `YulMCopyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.24 *)
     /// (* Reserved in 0.8.25 *)
     /// YUL_M_COPY_KEYWORD = "mcopy";
     /// ```
     YulMCopyKeyword,
+    /// Represents a node with kind `YulMLoadKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_M_LOAD_KEYWORD = "mload";
     /// ```
     YulMLoadKeyword,
+    /// Represents a node with kind `YulMSizeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_M_SIZE_KEYWORD = "msize";
     /// ```
     YulMSizeKeyword,
+    /// Represents a node with kind `YulMStore8Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_M_STORE_8_KEYWORD = "mstore8";
     /// ```
     YulMStore8Keyword,
+    /// Represents a node with kind `YulMStoreKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_M_STORE_KEYWORD = "mstore";
     /// ```
     YulMStoreKeyword,
+    /// Represents a node with kind `YulMacroKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_MACRO_KEYWORD = "macro";
     /// ```
     YulMacroKeyword,
+    /// Represents a node with kind `YulMappingKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_MAPPING_KEYWORD = "mapping";
     /// ```
     YulMappingKeyword,
+    /// Represents a node with kind `YulMatchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_MATCH_KEYWORD = "match";
     /// ```
     YulMatchKeyword,
+    /// Represents a node with kind `YulMemoryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_MEMORY_KEYWORD = "memory";
     /// ```
     YulMemoryKeyword,
+    /// Represents a node with kind `YulMinutesKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_MINUTES_KEYWORD = "minutes";
     /// ```
     YulMinutesKeyword,
+    /// Represents a node with kind `YulModKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_MOD_KEYWORD = "mod";
     /// ```
     YulModKeyword,
+    /// Represents a node with kind `YulModifierKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_MODIFIER_KEYWORD = "modifier";
     /// ```
     YulModifierKeyword,
+    /// Represents a node with kind `YulMulKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_MUL_KEYWORD = "mul";
     /// ```
     YulMulKeyword,
+    /// Represents a node with kind `YulMulModKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_MUL_MOD_KEYWORD = "mulmod";
     /// ```
     YulMulModKeyword,
+    /// Represents a node with kind `YulMutableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_MUTABLE_KEYWORD = "mutable";
     /// ```
     YulMutableKeyword,
+    /// Represents a node with kind `YulNewKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_NEW_KEYWORD = "new";
     /// ```
     YulNewKeyword,
+    /// Represents a node with kind `YulNotKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_NOT_KEYWORD = "not";
     /// ```
     YulNotKeyword,
+    /// Represents a node with kind `YulNullKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_NULL_KEYWORD = "null";
     /// ```
     YulNullKeyword,
+    /// Represents a node with kind `YulNumberKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_NUMBER_KEYWORD = "number";
     /// ```
     YulNumberKeyword,
+    /// Represents a node with kind `YulOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_OF_KEYWORD = "of";
     /// ```
     YulOfKeyword,
+    /// Represents a node with kind `YulOrKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_OR_KEYWORD = "or";
     /// ```
     YulOrKeyword,
+    /// Represents a node with kind `YulOriginKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_ORIGIN_KEYWORD = "origin";
     /// ```
     YulOriginKeyword,
+    /// Represents a node with kind `YulOverrideKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_OVERRIDE_KEYWORD = "override";
     /// ```
     YulOverrideKeyword,
+    /// Represents a node with kind `YulPartialKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_PARTIAL_KEYWORD = "partial";
     /// ```
     YulPartialKeyword,
+    /// Represents a node with kind `YulPayableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_PAYABLE_KEYWORD = "payable";
     /// ```
     YulPayableKeyword,
+    /// Represents a node with kind `YulPopKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_POP_KEYWORD = "pop";
     /// ```
     YulPopKeyword,
+    /// Represents a node with kind `YulPragmaKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_PRAGMA_KEYWORD = "pragma";
     /// ```
     YulPragmaKeyword,
+    /// Represents a node with kind `YulPrevRandaoKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.18 *)
     /// (* Reserved in 0.8.18 *)
     /// YUL_PREV_RANDAO_KEYWORD = "prevrandao";
     /// ```
     YulPrevRandaoKeyword,
+    /// Represents a node with kind `YulPrivateKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_PRIVATE_KEYWORD = "private";
     /// ```
     YulPrivateKeyword,
+    /// Represents a node with kind `YulPromiseKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_PROMISE_KEYWORD = "promise";
     /// ```
     YulPromiseKeyword,
+    /// Represents a node with kind `YulPublicKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_PUBLIC_KEYWORD = "public";
     /// ```
     YulPublicKeyword,
+    /// Represents a node with kind `YulPureKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_PURE_KEYWORD = "pure";
     /// ```
     YulPureKeyword,
+    /// Represents a node with kind `YulReceiveKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.6.0 until 0.7.1 *)
     /// YUL_RECEIVE_KEYWORD = "receive";
     /// ```
     YulReceiveKeyword,
+    /// Represents a node with kind `YulReferenceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_REFERENCE_KEYWORD = "reference";
     /// ```
     YulReferenceKeyword,
+    /// Represents a node with kind `YulRelocatableKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_RELOCATABLE_KEYWORD = "relocatable";
     /// ```
     YulRelocatableKeyword,
+    /// Represents a node with kind `YulReturnDataCopyKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.12 *)
     /// (* Reserved in 0.4.12 *)
     /// YUL_RETURN_DATA_COPY_KEYWORD = "returndatacopy";
     /// ```
     YulReturnDataCopyKeyword,
+    /// Represents a node with kind `YulReturnDataSizeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.12 *)
     /// (* Reserved in 0.4.12 *)
     /// YUL_RETURN_DATA_SIZE_KEYWORD = "returndatasize";
     /// ```
     YulReturnDataSizeKeyword,
+    /// Represents a node with kind `YulReturnKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_RETURN_KEYWORD = "return";
     /// ```
     YulReturnKeyword,
+    /// Represents a node with kind `YulReturnsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_RETURNS_KEYWORD = "returns";
     /// ```
     YulReturnsKeyword,
+    /// Represents a node with kind `YulRevertKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_REVERT_KEYWORD = "revert";
     /// ```
     YulRevertKeyword,
+    /// Represents a node with kind `YulSDivKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_S_DIV_KEYWORD = "sdiv";
     /// ```
     YulSDivKeyword,
+    /// Represents a node with kind `YulSLoadKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_S_LOAD_KEYWORD = "sload";
     /// ```
     YulSLoadKeyword,
+    /// Represents a node with kind `YulSModKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_S_MOD_KEYWORD = "smod";
     /// ```
     YulSModKeyword,
+    /// Represents a node with kind `YulSStoreKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_S_STORE_KEYWORD = "sstore";
     /// ```
     YulSStoreKeyword,
+    /// Represents a node with kind `YulSarKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.4.21 *)
     /// YUL_SAR_KEYWORD = "sar";
     /// ```
     YulSarKeyword,
+    /// Represents a node with kind `YulSealedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_SEALED_KEYWORD = "sealed";
     /// ```
     YulSealedKeyword,
+    /// Represents a node with kind `YulSecondsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_SECONDS_KEYWORD = "seconds";
     /// ```
     YulSecondsKeyword,
+    /// Represents a node with kind `YulSelfBalanceKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.5.12 *)
     /// YUL_SELF_BALANCE_KEYWORD = "selfbalance";
     /// ```
     YulSelfBalanceKeyword,
+    /// Represents a node with kind `YulSelfDestructKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SELF_DESTRUCT_KEYWORD = "selfdestruct";
     /// ```
     YulSelfDestructKeyword,
+    /// Represents a node with kind `YulSgtKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SGT_KEYWORD = "sgt";
     /// ```
     YulSgtKeyword,
+    /// Represents a node with kind `YulSha3Keyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// (* Reserved until 0.5.0 *)
     /// YUL_SHA_3_KEYWORD = "sha3";
     /// ```
     YulSha3Keyword,
+    /// Represents a node with kind `YulShlKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.4.21 *)
     /// YUL_SHL_KEYWORD = "shl";
     /// ```
     YulShlKeyword,
+    /// Represents a node with kind `YulShrKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved in 0.4.21 *)
     /// YUL_SHR_KEYWORD = "shr";
     /// ```
     YulShrKeyword,
+    /// Represents a node with kind `YulSignExtendKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SIGN_EXTEND_KEYWORD = "signextend";
     /// ```
     YulSignExtendKeyword,
+    /// Represents a node with kind `YulSizeOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_SIZE_OF_KEYWORD = "sizeof";
     /// ```
     YulSizeOfKeyword,
+    /// Represents a node with kind `YulSltKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SLT_KEYWORD = "slt";
     /// ```
     YulSltKeyword,
+    /// Represents a node with kind `YulStaticCallKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.4.12 *)
     /// (* Reserved in 0.4.12 *)
     /// YUL_STATIC_CALL_KEYWORD = "staticcall";
     /// ```
     YulStaticCallKeyword,
+    /// Represents a node with kind `YulStaticKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_STATIC_KEYWORD = "static";
     /// ```
     YulStaticKeyword,
+    /// Represents a node with kind `YulStopKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_STOP_KEYWORD = "stop";
     /// ```
     YulStopKeyword,
+    /// Represents a node with kind `YulStorageKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_STORAGE_KEYWORD = "storage";
     /// ```
     YulStorageKeyword,
+    /// Represents a node with kind `YulStringKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_STRING_KEYWORD = "string";
     /// ```
     YulStringKeyword,
+    /// Represents a node with kind `YulStructKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_STRUCT_KEYWORD = "struct";
     /// ```
     YulStructKeyword,
+    /// Represents a node with kind `YulSubKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SUB_KEYWORD = "sub";
     /// ```
     YulSubKeyword,
+    /// Represents a node with kind `YulSuicideKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Deprecated in 0.5.0 *)
     /// (* Reserved until 0.5.0 *)
     /// YUL_SUICIDE_KEYWORD = "suicide";
     /// ```
     YulSuicideKeyword,
+    /// Represents a node with kind `YulSuperKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SUPER_KEYWORD = "super";
     /// ```
     YulSuperKeyword,
+    /// Represents a node with kind `YulSupportsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_SUPPORTS_KEYWORD = "supports";
     /// ```
     YulSupportsKeyword,
+    /// Represents a node with kind `YulSwitchKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_SWITCH_KEYWORD = "switch";
     /// ```
     YulSwitchKeyword,
+    /// Represents a node with kind `YulSzaboKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.0 *)
     /// YUL_SZABO_KEYWORD = "szabo";
     /// ```
     YulSzaboKeyword,
+    /// Represents a node with kind `YulTLoadKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.24 *)
     /// (* Reserved in 0.8.25 *)
     /// YUL_T_LOAD_KEYWORD = "tload";
     /// ```
     YulTLoadKeyword,
+    /// Represents a node with kind `YulTStoreKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 0.8.24 *)
     /// (* Reserved in 0.8.25 *)
     /// YUL_T_STORE_KEYWORD = "tstore";
     /// ```
     YulTStoreKeyword,
+    /// Represents a node with kind `YulThisKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_THIS_KEYWORD = "this";
     /// ```
     YulThisKeyword,
+    /// Represents a node with kind `YulThrowKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_THROW_KEYWORD = "throw";
     /// ```
     YulThrowKeyword,
+    /// Represents a node with kind `YulTimestampKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_TIMESTAMP_KEYWORD = "timestamp";
     /// ```
     YulTimestampKeyword,
+    /// Represents a node with kind `YulTrueKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_TRUE_KEYWORD = "true";
     /// ```
     YulTrueKeyword,
+    /// Represents a node with kind `YulTryKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_TRY_KEYWORD = "try";
     /// ```
     YulTryKeyword,
+    /// Represents a node with kind `YulTypeDefKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_TYPE_DEF_KEYWORD = "typedef";
     /// ```
     YulTypeDefKeyword,
+    /// Represents a node with kind `YulTypeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_TYPE_KEYWORD = "type";
     /// ```
     YulTypeKeyword,
+    /// Represents a node with kind `YulTypeOfKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_TYPE_OF_KEYWORD = "typeof";
     /// ```
     YulTypeOfKeyword,
+    /// Represents a node with kind `YulUfixedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_UFIXED_KEYWORD = "ufixed";
@@ -1738,55 +2464,77 @@ pub enum TerminalKind {
     /// YUL_UFIXED_KEYWORD = "ufixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
     /// ```
     YulUfixedKeyword,
+    /// Represents a node with kind `YulUintKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_UINT_KEYWORD = "uint" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
     /// ```
     YulUintKeyword,
+    /// Represents a node with kind `YulUncheckedKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.5.0 until 0.7.1 *)
     /// YUL_UNCHECKED_KEYWORD = "unchecked";
     /// ```
     YulUncheckedKeyword,
+    /// Represents a node with kind `YulUsingKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_USING_KEYWORD = "using";
     /// ```
     YulUsingKeyword,
+    /// Represents a node with kind `YulVarKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.6.5 *)
     /// YUL_VAR_KEYWORD = "var";
     /// ```
     YulVarKeyword,
+    /// Represents a node with kind `YulViewKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_VIEW_KEYWORD = "view";
     /// ```
     YulViewKeyword,
+    /// Represents a node with kind `YulVirtualKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved from 0.6.0 until 0.7.1 *)
     /// YUL_VIRTUAL_KEYWORD = "virtual";
     /// ```
     YulVirtualKeyword,
+    /// Represents a node with kind `YulWeeksKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_WEEKS_KEYWORD = "weeks";
     /// ```
     YulWeeksKeyword,
+    /// Represents a node with kind `YulWeiKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_WEI_KEYWORD = "wei";
     /// ```
     YulWeiKeyword,
+    /// Represents a node with kind `YulWhileKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_WHILE_KEYWORD = "while";
     /// ```
     YulWhileKeyword,
+    /// Represents a node with kind `YulXorKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// YUL_XOR_KEYWORD = "xor";
     /// ```
     YulXorKeyword,
+    /// Represents a node with kind `YulYearsKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Reserved until 0.7.1 *)
     /// YUL_YEARS_KEYWORD = "years";

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/ast.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/ast.wit
@@ -3,6 +3,7 @@
 interface ast {
     use cst.{node, nonterminal-node};
 
+    /// @internal
     resource selectors {
         sequence: static func(node: borrow<nonterminal-node>) -> result<list<option<node>>, string>;
         choice: static func(node: borrow<nonterminal-node>) -> result<node, string>;

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/compilation.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/compilation.wit
@@ -9,6 +9,8 @@ interface compilation {
     ///
     /// This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
     /// This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+    ///
+    /// @internal
     resource internal-compilation-builder {
         /// Creates a new compilation builder for the specified language version.
         create: static func(language-version: string) -> result<internal-compilation-builder, string>;

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -4,14 +4,14 @@ interface cst {
     /// Represents different kinds of nonterminal nodes in the syntax tree.
     /// These are nodes that can have child nodes and represent higher-level language constructs.
     enum nonterminal-kind {
-                /// This kind represents a `AbicoderPragma` node, with the following structure: 
+                /// Represents a node with kind `AbicoderPragma`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AbicoderPragma = (* abicoder_keyword: *) ABICODER_KEYWORD
                 ///                  (* version: *) IDENTIFIER;
                 /// ```
                 %abicoder-pragma,
-                /// This kind represents a `AdditiveExpression` node, with the following structure: 
+                /// Represents a node with kind `AdditiveExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -25,14 +25,14 @@ interface cst {
                 ///                      (* right_operand: *) Expression;
                 /// ```
                 %additive-expression,
-                /// This kind represents a `AddressType` node, with the following structure: 
+                /// Represents a node with kind `AddressType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AddressType = (* address_keyword: *) ADDRESS_KEYWORD
                 ///               (* payable_keyword: *) PAYABLE_KEYWORD?;
                 /// ```
                 %address-type,
-                /// This kind represents a `AndExpression` node, with the following structure: 
+                /// Represents a node with kind `AndExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -41,14 +41,14 @@ interface cst {
                 ///                 (* right_operand: *) Expression;
                 /// ```
                 %and-expression,
-                /// This kind represents a `ArgumentsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `ArgumentsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ArgumentsDeclaration = (* variant: *) PositionalArgumentsDeclaration
                 ///                      | (* variant: *) NamedArgumentsDeclaration;
                 /// ```
                 %arguments-declaration,
-                /// This kind represents a `ArrayExpression` node, with the following structure: 
+                /// Represents a node with kind `ArrayExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ArrayExpression = (* open_bracket: *) OPEN_BRACKET
@@ -56,7 +56,7 @@ interface cst {
                 ///                   (* close_bracket: *) CLOSE_BRACKET;
                 /// ```
                 %array-expression,
-                /// This kind represents a `ArrayTypeName` node, with the following structure: 
+                /// Represents a node with kind `ArrayTypeName`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -66,19 +66,19 @@ interface cst {
                 ///                 (* close_bracket: *) CLOSE_BRACKET;
                 /// ```
                 %array-type-name,
-                /// This kind represents a `ArrayValues` node, with the following structure: 
+                /// Represents a node with kind `ArrayValues`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ArrayValues = (* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*;
                 /// ```
                 %array-values,
-                /// This kind represents a `AssemblyFlags` node, with the following structure: 
+                /// Represents a node with kind `AssemblyFlags`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AssemblyFlags = (* item: *) StringLiteral ((* separator: *) COMMA (* item: *) StringLiteral)*;
                 /// ```
                 %assembly-flags,
-                /// This kind represents a `AssemblyFlagsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `AssemblyFlagsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AssemblyFlagsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -86,7 +86,7 @@ interface cst {
                 ///                            (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %assembly-flags-declaration,
-                /// This kind represents a `AssemblyStatement` node, with the following structure: 
+                /// Represents a node with kind `AssemblyStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AssemblyStatement = (* assembly_keyword: *) ASSEMBLY_KEYWORD
@@ -95,7 +95,7 @@ interface cst {
                 ///                     (* body: *) YulBlock;
                 /// ```
                 %assembly-statement,
-                /// This kind represents a `AssignmentExpression` node, with the following structure: 
+                /// Represents a node with kind `AssignmentExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -159,7 +159,7 @@ interface cst {
                 ///                        (* right_operand: *) Expression;
                 /// ```
                 %assignment-expression,
-                /// This kind represents a `BitwiseAndExpression` node, with the following structure: 
+                /// Represents a node with kind `BitwiseAndExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -168,7 +168,7 @@ interface cst {
                 ///                        (* right_operand: *) Expression;
                 /// ```
                 %bitwise-and-expression,
-                /// This kind represents a `BitwiseOrExpression` node, with the following structure: 
+                /// Represents a node with kind `BitwiseOrExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -177,7 +177,7 @@ interface cst {
                 ///                       (* right_operand: *) Expression;
                 /// ```
                 %bitwise-or-expression,
-                /// This kind represents a `BitwiseXorExpression` node, with the following structure: 
+                /// Represents a node with kind `BitwiseXorExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -186,7 +186,7 @@ interface cst {
                 ///                        (* right_operand: *) Expression;
                 /// ```
                 %bitwise-xor-expression,
-                /// This kind represents a `Block` node, with the following structure: 
+                /// Represents a node with kind `Block`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Block = (* open_brace: *) OPEN_BRACE
@@ -194,21 +194,21 @@ interface cst {
                 ///         (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %block,
-                /// This kind represents a `BreakStatement` node, with the following structure: 
+                /// Represents a node with kind `BreakStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BreakStatement = (* break_keyword: *) BREAK_KEYWORD
                 ///                  (* semicolon: *) SEMICOLON;
                 /// ```
                 %break-statement,
-                /// This kind represents a `CallOptions` node, with the following structure: 
+                /// Represents a node with kind `CallOptions`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.2 *)
                 /// CallOptions = (* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*;
                 /// ```
                 %call-options,
-                /// This kind represents a `CallOptionsExpression` node, with the following structure: 
+                /// Represents a node with kind `CallOptionsExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -219,7 +219,7 @@ interface cst {
                 ///                         (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %call-options-expression,
-                /// This kind represents a `CatchClause` node, with the following structure: 
+                /// Represents a node with kind `CatchClause`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -228,7 +228,7 @@ interface cst {
                 ///               (* body: *) Block;
                 /// ```
                 %catch-clause,
-                /// This kind represents a `CatchClauseError` node, with the following structure: 
+                /// Represents a node with kind `CatchClauseError`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -236,14 +236,14 @@ interface cst {
                 ///                    (* parameters: *) ParametersDeclaration;
                 /// ```
                 %catch-clause-error,
-                /// This kind represents a `CatchClauses` node, with the following structure: 
+                /// Represents a node with kind `CatchClauses`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// CatchClauses = (* item: *) CatchClause+;
                 /// ```
                 %catch-clauses,
-                /// This kind represents a `ComparisonExpression` node, with the following structure: 
+                /// Represents a node with kind `ComparisonExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -267,7 +267,7 @@ interface cst {
                 ///                        (* right_operand: *) Expression;
                 /// ```
                 %comparison-expression,
-                /// This kind represents a `ConditionalExpression` node, with the following structure: 
+                /// Represents a node with kind `ConditionalExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -278,7 +278,7 @@ interface cst {
                 ///                         (* false_expression: *) Expression;
                 /// ```
                 %conditional-expression,
-                /// This kind represents a `ConstantDefinition` node, with the following structure: 
+                /// Represents a node with kind `ConstantDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.7.4 *)
@@ -290,7 +290,7 @@ interface cst {
                 ///                      (* semicolon: *) SEMICOLON;
                 /// ```
                 %constant-definition,
-                /// This kind represents a `ConstructorAttribute` node, with the following structure: 
+                /// Represents a node with kind `ConstructorAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.22 *)
@@ -302,14 +302,14 @@ interface cst {
                 ///                      | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 and deprecated in 0.6.7. *)
                 /// ```
                 %constructor-attribute,
-                /// This kind represents a `ConstructorAttributes` node, with the following structure: 
+                /// Represents a node with kind `ConstructorAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.22 *)
                 /// ConstructorAttributes = (* item: *) ConstructorAttribute*;
                 /// ```
                 %constructor-attributes,
-                /// This kind represents a `ConstructorDefinition` node, with the following structure: 
+                /// Represents a node with kind `ConstructorDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.22 *)
@@ -319,14 +319,14 @@ interface cst {
                 ///                         (* body: *) Block;
                 /// ```
                 %constructor-definition,
-                /// This kind represents a `ContinueStatement` node, with the following structure: 
+                /// Represents a node with kind `ContinueStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ContinueStatement = (* continue_keyword: *) CONTINUE_KEYWORD
                 ///                     (* semicolon: *) SEMICOLON;
                 /// ```
                 %continue-statement,
-                /// This kind represents a `ContractDefinition` node, with the following structure: 
+                /// Represents a node with kind `ContractDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ContractDefinition = (* abstract_keyword: *) ABSTRACT_KEYWORD? (* Introduced in 0.6.0 *)
@@ -338,7 +338,7 @@ interface cst {
                 ///                      (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %contract-definition,
-                /// This kind represents a `ContractMember` node, with the following structure: 
+                /// Represents a node with kind `ContractMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ContractMember = (* variant: *) UsingDirective
@@ -356,20 +356,20 @@ interface cst {
                 ///                | (* variant: *) StateVariableDefinition;
                 /// ```
                 %contract-member,
-                /// This kind represents a `ContractMembers` node, with the following structure: 
+                /// Represents a node with kind `ContractMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ContractMembers = (* item: *) ContractMember*;
                 /// ```
                 %contract-members,
-                /// This kind represents a `DecimalNumberExpression` node, with the following structure: 
+                /// Represents a node with kind `DecimalNumberExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DecimalNumberExpression = (* literal: *) DECIMAL_LITERAL
                 ///                           (* unit: *) NumberUnit?;
                 /// ```
                 %decimal-number-expression,
-                /// This kind represents a `DoWhileStatement` node, with the following structure: 
+                /// Represents a node with kind `DoWhileStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DoWhileStatement = (* do_keyword: *) DO_KEYWORD
@@ -381,7 +381,7 @@ interface cst {
                 ///                    (* semicolon: *) SEMICOLON;
                 /// ```
                 %do-while-statement,
-                /// This kind represents a `ElementaryType` node, with the following structure: 
+                /// Represents a node with kind `ElementaryType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ElementaryType = (* variant: *) BOOL_KEYWORD
@@ -395,14 +395,14 @@ interface cst {
                 ///                | (* variant: *) UFIXED_KEYWORD;
                 /// ```
                 %elementary-type,
-                /// This kind represents a `ElseBranch` node, with the following structure: 
+                /// Represents a node with kind `ElseBranch`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ElseBranch = (* else_keyword: *) ELSE_KEYWORD
                 ///              (* body: *) Statement;
                 /// ```
                 %else-branch,
-                /// This kind represents a `EmitStatement` node, with the following structure: 
+                /// Represents a node with kind `EmitStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.21 *)
@@ -412,7 +412,7 @@ interface cst {
                 ///                 (* semicolon: *) SEMICOLON;
                 /// ```
                 %emit-statement,
-                /// This kind represents a `EnumDefinition` node, with the following structure: 
+                /// Represents a node with kind `EnumDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EnumDefinition = (* enum_keyword: *) ENUM_KEYWORD
@@ -422,13 +422,13 @@ interface cst {
                 ///                  (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %enum-definition,
-                /// This kind represents a `EnumMembers` node, with the following structure: 
+                /// Represents a node with kind `EnumMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EnumMembers = ((* item: *) IDENTIFIER ((* separator: *) COMMA (* item: *) IDENTIFIER)*)?;
                 /// ```
                 %enum-members,
-                /// This kind represents a `EqualityExpression` node, with the following structure: 
+                /// Represents a node with kind `EqualityExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -442,7 +442,7 @@ interface cst {
                 ///                      (* right_operand: *) Expression;
                 /// ```
                 %equality-expression,
-                /// This kind represents a `ErrorDefinition` node, with the following structure: 
+                /// Represents a node with kind `ErrorDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -452,7 +452,7 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %error-definition,
-                /// This kind represents a `ErrorParameter` node, with the following structure: 
+                /// Represents a node with kind `ErrorParameter`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -460,14 +460,14 @@ interface cst {
                 ///                  (* name: *) IDENTIFIER?;
                 /// ```
                 %error-parameter,
-                /// This kind represents a `ErrorParameters` node, with the following structure: 
+                /// Represents a node with kind `ErrorParameters`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
                 /// ErrorParameters = ((* item: *) ErrorParameter ((* separator: *) COMMA (* item: *) ErrorParameter)*)?;
                 /// ```
                 %error-parameters,
-                /// This kind represents a `ErrorParametersDeclaration` node, with the following structure: 
+                /// Represents a node with kind `ErrorParametersDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -476,7 +476,7 @@ interface cst {
                 ///                              (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %error-parameters-declaration,
-                /// This kind represents a `EventDefinition` node, with the following structure: 
+                /// Represents a node with kind `EventDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EventDefinition = (* event_keyword: *) EVENT_KEYWORD
@@ -486,7 +486,7 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %event-definition,
-                /// This kind represents a `EventParameter` node, with the following structure: 
+                /// Represents a node with kind `EventParameter`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EventParameter = (* type_name: *) TypeName
@@ -494,13 +494,13 @@ interface cst {
                 ///                  (* name: *) IDENTIFIER?;
                 /// ```
                 %event-parameter,
-                /// This kind represents a `EventParameters` node, with the following structure: 
+                /// Represents a node with kind `EventParameters`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EventParameters = ((* item: *) EventParameter ((* separator: *) COMMA (* item: *) EventParameter)*)?;
                 /// ```
                 %event-parameters,
-                /// This kind represents a `EventParametersDeclaration` node, with the following structure: 
+                /// Represents a node with kind `EventParametersDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EventParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -508,21 +508,21 @@ interface cst {
                 ///                              (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %event-parameters-declaration,
-                /// This kind represents a `ExperimentalFeature` node, with the following structure: 
+                /// Represents a node with kind `ExperimentalFeature`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ExperimentalFeature = (* variant: *) IDENTIFIER
                 ///                     | (* variant: *) StringLiteral;
                 /// ```
                 %experimental-feature,
-                /// This kind represents a `ExperimentalPragma` node, with the following structure: 
+                /// Represents a node with kind `ExperimentalPragma`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ExperimentalPragma = (* experimental_keyword: *) EXPERIMENTAL_KEYWORD
                 ///                      (* feature: *) ExperimentalFeature;
                 /// ```
                 %experimental-pragma,
-                /// This kind represents a `ExponentiationExpression` node, with the following structure: 
+                /// Represents a node with kind `ExponentiationExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -538,7 +538,7 @@ interface cst {
                 ///                            (* right_operand: *) Expression;
                 /// ```
                 %exponentiation-expression,
-                /// This kind represents a `Expression` node, with the following structure: 
+                /// Represents a node with kind `Expression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Expression = (* variant: *) AssignmentExpression
@@ -576,14 +576,14 @@ interface cst {
                 ///            | (* variant: *) IDENTIFIER;
                 /// ```
                 %expression,
-                /// This kind represents a `ExpressionStatement` node, with the following structure: 
+                /// Represents a node with kind `ExpressionStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ExpressionStatement = (* expression: *) Expression
                 ///                       (* semicolon: *) SEMICOLON;
                 /// ```
                 %expression-statement,
-                /// This kind represents a `FallbackFunctionAttribute` node, with the following structure: 
+                /// Represents a node with kind `FallbackFunctionAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -596,14 +596,14 @@ interface cst {
                 ///                           | (* variant: *) VIRTUAL_KEYWORD;
                 /// ```
                 %fallback-function-attribute,
-                /// This kind represents a `FallbackFunctionAttributes` node, with the following structure: 
+                /// Represents a node with kind `FallbackFunctionAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// FallbackFunctionAttributes = (* item: *) FallbackFunctionAttribute*;
                 /// ```
                 %fallback-function-attributes,
-                /// This kind represents a `FallbackFunctionDefinition` node, with the following structure: 
+                /// Represents a node with kind `FallbackFunctionDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -614,7 +614,7 @@ interface cst {
                 ///                              (* body: *) FunctionBody;
                 /// ```
                 %fallback-function-definition,
-                /// This kind represents a `ForStatement` node, with the following structure: 
+                /// Represents a node with kind `ForStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ForStatement = (* for_keyword: *) FOR_KEYWORD
@@ -626,14 +626,14 @@ interface cst {
                 ///                (* body: *) Statement;
                 /// ```
                 %for-statement,
-                /// This kind represents a `ForStatementCondition` node, with the following structure: 
+                /// Represents a node with kind `ForStatementCondition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ForStatementCondition = (* variant: *) ExpressionStatement
                 ///                       | (* variant: *) SEMICOLON;
                 /// ```
                 %for-statement-condition,
-                /// This kind represents a `ForStatementInitialization` node, with the following structure: 
+                /// Represents a node with kind `ForStatementInitialization`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ForStatementInitialization = (* variant: *) TupleDeconstructionStatement
@@ -642,7 +642,7 @@ interface cst {
                 ///                            | (* variant: *) SEMICOLON;
                 /// ```
                 %for-statement-initialization,
-                /// This kind represents a `FunctionAttribute` node, with the following structure: 
+                /// Represents a node with kind `FunctionAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionAttribute = (* variant: *) ModifierInvocation
@@ -658,20 +658,20 @@ interface cst {
                 ///                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
                 /// ```
                 %function-attribute,
-                /// This kind represents a `FunctionAttributes` node, with the following structure: 
+                /// Represents a node with kind `FunctionAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionAttributes = (* item: *) FunctionAttribute*;
                 /// ```
                 %function-attributes,
-                /// This kind represents a `FunctionBody` node, with the following structure: 
+                /// Represents a node with kind `FunctionBody`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionBody = (* variant: *) Block
                 ///              | (* variant: *) SEMICOLON;
                 /// ```
                 %function-body,
-                /// This kind represents a `FunctionCallExpression` node, with the following structure: 
+                /// Represents a node with kind `FunctionCallExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -679,7 +679,7 @@ interface cst {
                 ///                          (* arguments: *) ArgumentsDeclaration;
                 /// ```
                 %function-call-expression,
-                /// This kind represents a `FunctionDefinition` node, with the following structure: 
+                /// Represents a node with kind `FunctionDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
@@ -690,7 +690,7 @@ interface cst {
                 ///                      (* body: *) FunctionBody;
                 /// ```
                 %function-definition,
-                /// This kind represents a `FunctionName` node, with the following structure: 
+                /// Represents a node with kind `FunctionName`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionName = (* variant: *) IDENTIFIER
@@ -698,7 +698,7 @@ interface cst {
                 ///              | (* variant: *) RECEIVE_KEYWORD;
                 /// ```
                 %function-name,
-                /// This kind represents a `FunctionType` node, with the following structure: 
+                /// Represents a node with kind `FunctionType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionType = (* function_keyword: *) FUNCTION_KEYWORD
@@ -707,7 +707,7 @@ interface cst {
                 ///                (* returns: *) ReturnsDeclaration?;
                 /// ```
                 %function-type,
-                /// This kind represents a `FunctionTypeAttribute` node, with the following structure: 
+                /// Represents a node with kind `FunctionTypeAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionTypeAttribute = (* variant: *) INTERNAL_KEYWORD
@@ -720,40 +720,40 @@ interface cst {
                 ///                       | (* variant: *) PAYABLE_KEYWORD;
                 /// ```
                 %function-type-attribute,
-                /// This kind represents a `FunctionTypeAttributes` node, with the following structure: 
+                /// Represents a node with kind `FunctionTypeAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FunctionTypeAttributes = (* item: *) FunctionTypeAttribute*;
                 /// ```
                 %function-type-attributes,
-                /// This kind represents a `HexNumberExpression` node, with the following structure: 
+                /// Represents a node with kind `HexNumberExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// HexNumberExpression = (* literal: *) HEX_LITERAL
                 ///                       (* unit: *) NumberUnit?; (* Deprecated in 0.5.0 *)
                 /// ```
                 %hex-number-expression,
-                /// This kind represents a `HexStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `HexStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// HexStringLiteral = (* variant: *) SINGLE_QUOTED_HEX_STRING_LITERAL
                 ///                  | (* variant: *) DOUBLE_QUOTED_HEX_STRING_LITERAL;
                 /// ```
                 %hex-string-literal,
-                /// This kind represents a `HexStringLiterals` node, with the following structure: 
+                /// Represents a node with kind `HexStringLiterals`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.14 *)
                 /// HexStringLiterals = (* item: *) HexStringLiteral+;
                 /// ```
                 %hex-string-literals,
-                /// This kind represents a `IdentifierPath` node, with the following structure: 
+                /// Represents a node with kind `IdentifierPath`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IdentifierPath = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
                 /// ```
                 %identifier-path,
-                /// This kind represents a `IfStatement` node, with the following structure: 
+                /// Represents a node with kind `IfStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IfStatement = (* if_keyword: *) IF_KEYWORD
@@ -764,14 +764,14 @@ interface cst {
                 ///               (* else_branch: *) ElseBranch?;
                 /// ```
                 %if-statement,
-                /// This kind represents a `ImportAlias` node, with the following structure: 
+                /// Represents a node with kind `ImportAlias`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportAlias = (* as_keyword: *) AS_KEYWORD
                 ///               (* identifier: *) IDENTIFIER;
                 /// ```
                 %import-alias,
-                /// This kind represents a `ImportClause` node, with the following structure: 
+                /// Represents a node with kind `ImportClause`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportClause = (* variant: *) PathImport
@@ -779,7 +779,7 @@ interface cst {
                 ///              | (* variant: *) ImportDeconstruction;
                 /// ```
                 %import-clause,
-                /// This kind represents a `ImportDeconstruction` node, with the following structure: 
+                /// Represents a node with kind `ImportDeconstruction`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportDeconstruction = (* open_brace: *) OPEN_BRACE
@@ -789,20 +789,20 @@ interface cst {
                 ///                        (* path: *) StringLiteral;
                 /// ```
                 %import-deconstruction,
-                /// This kind represents a `ImportDeconstructionSymbol` node, with the following structure: 
+                /// Represents a node with kind `ImportDeconstructionSymbol`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportDeconstructionSymbol = (* name: *) IDENTIFIER
                 ///                              (* alias: *) ImportAlias?;
                 /// ```
                 %import-deconstruction-symbol,
-                /// This kind represents a `ImportDeconstructionSymbols` node, with the following structure: 
+                /// Represents a node with kind `ImportDeconstructionSymbols`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportDeconstructionSymbols = (* item: *) ImportDeconstructionSymbol ((* separator: *) COMMA (* item: *) ImportDeconstructionSymbol)*;
                 /// ```
                 %import-deconstruction-symbols,
-                /// This kind represents a `ImportDirective` node, with the following structure: 
+                /// Represents a node with kind `ImportDirective`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ImportDirective = (* import_keyword: *) IMPORT_KEYWORD
@@ -810,14 +810,14 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %import-directive,
-                /// This kind represents a `IndexAccessEnd` node, with the following structure: 
+                /// Represents a node with kind `IndexAccessEnd`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IndexAccessEnd = (* colon: *) COLON
                 ///                  (* end: *) Expression?;
                 /// ```
                 %index-access-end,
-                /// This kind represents a `IndexAccessExpression` node, with the following structure: 
+                /// Represents a node with kind `IndexAccessExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -828,27 +828,27 @@ interface cst {
                 ///                         (* close_bracket: *) CLOSE_BRACKET;
                 /// ```
                 %index-access-expression,
-                /// This kind represents a `InheritanceSpecifier` node, with the following structure: 
+                /// Represents a node with kind `InheritanceSpecifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// InheritanceSpecifier = (* is_keyword: *) IS_KEYWORD
                 ///                        (* types: *) InheritanceTypes;
                 /// ```
                 %inheritance-specifier,
-                /// This kind represents a `InheritanceType` node, with the following structure: 
+                /// Represents a node with kind `InheritanceType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// InheritanceType = (* type_name: *) IdentifierPath
                 ///                   (* arguments: *) ArgumentsDeclaration?;
                 /// ```
                 %inheritance-type,
-                /// This kind represents a `InheritanceTypes` node, with the following structure: 
+                /// Represents a node with kind `InheritanceTypes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// InheritanceTypes = (* item: *) InheritanceType ((* separator: *) COMMA (* item: *) InheritanceType)*;
                 /// ```
                 %inheritance-types,
-                /// This kind represents a `InterfaceDefinition` node, with the following structure: 
+                /// Represents a node with kind `InterfaceDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// InterfaceDefinition = (* interface_keyword: *) INTERFACE_KEYWORD
@@ -859,13 +859,13 @@ interface cst {
                 ///                       (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %interface-definition,
-                /// This kind represents a `InterfaceMembers` node, with the following structure: 
+                /// Represents a node with kind `InterfaceMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// InterfaceMembers = (* item: *) ContractMember*;
                 /// ```
                 %interface-members,
-                /// This kind represents a `LibraryDefinition` node, with the following structure: 
+                /// Represents a node with kind `LibraryDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LibraryDefinition = (* library_keyword: *) LIBRARY_KEYWORD
@@ -875,27 +875,27 @@ interface cst {
                 ///                     (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %library-definition,
-                /// This kind represents a `LibraryMembers` node, with the following structure: 
+                /// Represents a node with kind `LibraryMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LibraryMembers = (* item: *) ContractMember*;
                 /// ```
                 %library-members,
-                /// This kind represents a `MappingKey` node, with the following structure: 
+                /// Represents a node with kind `MappingKey`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MappingKey = (* key_type: *) MappingKeyType
                 ///              (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
                 /// ```
                 %mapping-key,
-                /// This kind represents a `MappingKeyType` node, with the following structure: 
+                /// Represents a node with kind `MappingKeyType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MappingKeyType = (* variant: *) ElementaryType
                 ///                | (* variant: *) IdentifierPath;
                 /// ```
                 %mapping-key-type,
-                /// This kind represents a `MappingType` node, with the following structure: 
+                /// Represents a node with kind `MappingType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MappingType = (* mapping_keyword: *) MAPPING_KEYWORD
@@ -906,14 +906,14 @@ interface cst {
                 ///               (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %mapping-type,
-                /// This kind represents a `MappingValue` node, with the following structure: 
+                /// Represents a node with kind `MappingValue`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MappingValue = (* type_name: *) TypeName
                 ///                (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
                 /// ```
                 %mapping-value,
-                /// This kind represents a `MemberAccessExpression` node, with the following structure: 
+                /// Represents a node with kind `MemberAccessExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -922,20 +922,20 @@ interface cst {
                 ///                          (* member: *) IDENTIFIER;
                 /// ```
                 %member-access-expression,
-                /// This kind represents a `ModifierAttribute` node, with the following structure: 
+                /// Represents a node with kind `ModifierAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ModifierAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
                 ///                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
                 /// ```
                 %modifier-attribute,
-                /// This kind represents a `ModifierAttributes` node, with the following structure: 
+                /// Represents a node with kind `ModifierAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ModifierAttributes = (* item: *) ModifierAttribute*;
                 /// ```
                 %modifier-attributes,
-                /// This kind represents a `ModifierDefinition` node, with the following structure: 
+                /// Represents a node with kind `ModifierDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ModifierDefinition = (* modifier_keyword: *) MODIFIER_KEYWORD
@@ -945,14 +945,14 @@ interface cst {
                 ///                      (* body: *) FunctionBody;
                 /// ```
                 %modifier-definition,
-                /// This kind represents a `ModifierInvocation` node, with the following structure: 
+                /// Represents a node with kind `ModifierInvocation`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ModifierInvocation = (* name: *) IdentifierPath
                 ///                      (* arguments: *) ArgumentsDeclaration?;
                 /// ```
                 %modifier-invocation,
-                /// This kind represents a `MultiplicativeExpression` node, with the following structure: 
+                /// Represents a node with kind `MultiplicativeExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -971,7 +971,7 @@ interface cst {
                 ///                            (* right_operand: *) Expression;
                 /// ```
                 %multiplicative-expression,
-                /// This kind represents a `NamedArgument` node, with the following structure: 
+                /// Represents a node with kind `NamedArgument`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NamedArgument = (* name: *) IDENTIFIER
@@ -979,7 +979,7 @@ interface cst {
                 ///                 (* value: *) Expression;
                 /// ```
                 %named-argument,
-                /// This kind represents a `NamedArgumentGroup` node, with the following structure: 
+                /// Represents a node with kind `NamedArgumentGroup`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NamedArgumentGroup = (* open_brace: *) OPEN_BRACE
@@ -987,13 +987,13 @@ interface cst {
                 ///                      (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %named-argument-group,
-                /// This kind represents a `NamedArguments` node, with the following structure: 
+                /// Represents a node with kind `NamedArguments`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NamedArguments = ((* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*)?;
                 /// ```
                 %named-arguments,
-                /// This kind represents a `NamedArgumentsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `NamedArgumentsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NamedArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1001,7 +1001,7 @@ interface cst {
                 ///                             (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %named-arguments-declaration,
-                /// This kind represents a `NamedImport` node, with the following structure: 
+                /// Represents a node with kind `NamedImport`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NamedImport = (* asterisk: *) ASTERISK
@@ -1010,14 +1010,14 @@ interface cst {
                 ///               (* path: *) StringLiteral;
                 /// ```
                 %named-import,
-                /// This kind represents a `NewExpression` node, with the following structure: 
+                /// Represents a node with kind `NewExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NewExpression = (* new_keyword: *) NEW_KEYWORD
                 ///                 (* type_name: *) TypeName;
                 /// ```
                 %new-expression,
-                /// This kind represents a `NumberUnit` node, with the following structure: 
+                /// Represents a node with kind `NumberUnit`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NumberUnit = (* variant: *) WEI_KEYWORD
@@ -1033,7 +1033,7 @@ interface cst {
                 ///            | (* variant: *) YEARS_KEYWORD; (* Deprecated in 0.5.0 *)
                 /// ```
                 %number-unit,
-                /// This kind represents a `OrExpression` node, with the following structure: 
+                /// Represents a node with kind `OrExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -1042,14 +1042,14 @@ interface cst {
                 ///                (* right_operand: *) Expression;
                 /// ```
                 %or-expression,
-                /// This kind represents a `OverridePaths` node, with the following structure: 
+                /// Represents a node with kind `OverridePaths`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// OverridePaths = (* item: *) IdentifierPath ((* separator: *) COMMA (* item: *) IdentifierPath)*;
                 /// ```
                 %override-paths,
-                /// This kind represents a `OverridePathsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `OverridePathsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -1058,7 +1058,7 @@ interface cst {
                 ///                            (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %override-paths-declaration,
-                /// This kind represents a `OverrideSpecifier` node, with the following structure: 
+                /// Represents a node with kind `OverrideSpecifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -1066,7 +1066,7 @@ interface cst {
                 ///                     (* overridden: *) OverridePathsDeclaration?;
                 /// ```
                 %override-specifier,
-                /// This kind represents a `Parameter` node, with the following structure: 
+                /// Represents a node with kind `Parameter`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Parameter = (* type_name: *) TypeName
@@ -1074,13 +1074,13 @@ interface cst {
                 ///             (* name: *) IDENTIFIER?;
                 /// ```
                 %parameter,
-                /// This kind represents a `Parameters` node, with the following structure: 
+                /// Represents a node with kind `Parameters`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Parameters = ((* item: *) Parameter ((* separator: *) COMMA (* item: *) Parameter)*)?;
                 /// ```
                 %parameters,
-                /// This kind represents a `ParametersDeclaration` node, with the following structure: 
+                /// Represents a node with kind `ParametersDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1088,20 +1088,20 @@ interface cst {
                 ///                         (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %parameters-declaration,
-                /// This kind represents a `PathImport` node, with the following structure: 
+                /// Represents a node with kind `PathImport`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PathImport = (* path: *) StringLiteral
                 ///              (* alias: *) ImportAlias?;
                 /// ```
                 %path-import,
-                /// This kind represents a `PositionalArguments` node, with the following structure: 
+                /// Represents a node with kind `PositionalArguments`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PositionalArguments = ((* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*)?;
                 /// ```
                 %positional-arguments,
-                /// This kind represents a `PositionalArgumentsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `PositionalArgumentsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PositionalArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1109,7 +1109,7 @@ interface cst {
                 ///                                  (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %positional-arguments-declaration,
-                /// This kind represents a `PostfixExpression` node, with the following structure: 
+                /// Represents a node with kind `PostfixExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -1121,7 +1121,7 @@ interface cst {
                 ///                     (* operator: *) MINUS_MINUS;
                 /// ```
                 %postfix-expression,
-                /// This kind represents a `Pragma` node, with the following structure: 
+                /// Represents a node with kind `Pragma`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Pragma = (* variant: *) AbicoderPragma
@@ -1129,7 +1129,7 @@ interface cst {
                 ///        | (* variant: *) VersionPragma;
                 /// ```
                 %pragma,
-                /// This kind represents a `PragmaDirective` node, with the following structure: 
+                /// Represents a node with kind `PragmaDirective`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PragmaDirective = (* pragma_keyword: *) PRAGMA_KEYWORD
@@ -1137,7 +1137,7 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %pragma-directive,
-                /// This kind represents a `PrefixExpression` node, with the following structure: 
+                /// Represents a node with kind `PrefixExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Prefix unary operator *)
@@ -1170,7 +1170,7 @@ interface cst {
                 ///                    (* operand: *) Expression;
                 /// ```
                 %prefix-expression,
-                /// This kind represents a `ReceiveFunctionAttribute` node, with the following structure: 
+                /// Represents a node with kind `ReceiveFunctionAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -1181,14 +1181,14 @@ interface cst {
                 ///                          | (* variant: *) VIRTUAL_KEYWORD;
                 /// ```
                 %receive-function-attribute,
-                /// This kind represents a `ReceiveFunctionAttributes` node, with the following structure: 
+                /// Represents a node with kind `ReceiveFunctionAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// ReceiveFunctionAttributes = (* item: *) ReceiveFunctionAttribute*;
                 /// ```
                 %receive-function-attributes,
-                /// This kind represents a `ReceiveFunctionDefinition` node, with the following structure: 
+                /// Represents a node with kind `ReceiveFunctionDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -1198,7 +1198,7 @@ interface cst {
                 ///                             (* body: *) FunctionBody;
                 /// ```
                 %receive-function-definition,
-                /// This kind represents a `ReturnStatement` node, with the following structure: 
+                /// Represents a node with kind `ReturnStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ReturnStatement = (* return_keyword: *) RETURN_KEYWORD
@@ -1206,14 +1206,14 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %return-statement,
-                /// This kind represents a `ReturnsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `ReturnsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ReturnsDeclaration = (* returns_keyword: *) RETURNS_KEYWORD
                 ///                      (* variables: *) ParametersDeclaration;
                 /// ```
                 %returns-declaration,
-                /// This kind represents a `RevertStatement` node, with the following structure: 
+                /// Represents a node with kind `RevertStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -1223,7 +1223,7 @@ interface cst {
                 ///                   (* semicolon: *) SEMICOLON;
                 /// ```
                 %revert-statement,
-                /// This kind represents a `ShiftExpression` node, with the following structure: 
+                /// Represents a node with kind `ShiftExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -1242,19 +1242,19 @@ interface cst {
                 ///                   (* right_operand: *) Expression;
                 /// ```
                 %shift-expression,
-                /// This kind represents a `SimpleVersionLiteral` node, with the following structure: 
+                /// Represents a node with kind `SimpleVersionLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SimpleVersionLiteral = (* item: *) VERSION_SPECIFIER ((* separator: *) PERIOD (* item: *) VERSION_SPECIFIER)*;
                 /// ```
                 %simple-version-literal,
-                /// This kind represents a `SourceUnit` node, with the following structure: 
+                /// Represents a node with kind `SourceUnit`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnit = (* members: *) SourceUnitMembers;
                 /// ```
                 %source-unit,
-                /// This kind represents a `SourceUnitMember` node, with the following structure: 
+                /// Represents a node with kind `SourceUnitMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnitMember = (* variant: *) PragmaDirective
@@ -1272,13 +1272,13 @@ interface cst {
                 ///                  | (* variant: *) ConstantDefinition; (* Introduced in 0.7.4 *)
                 /// ```
                 %source-unit-member,
-                /// This kind represents a `SourceUnitMembers` node, with the following structure: 
+                /// Represents a node with kind `SourceUnitMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnitMembers = (* item: *) SourceUnitMember*;
                 /// ```
                 %source-unit-members,
-                /// This kind represents a `StateVariableAttribute` node, with the following structure: 
+                /// Represents a node with kind `StateVariableAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StateVariableAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
@@ -1290,13 +1290,13 @@ interface cst {
                 ///                        | (* variant: *) TRANSIENT_KEYWORD; (* Introduced in 0.8.27 *)
                 /// ```
                 %state-variable-attribute,
-                /// This kind represents a `StateVariableAttributes` node, with the following structure: 
+                /// Represents a node with kind `StateVariableAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StateVariableAttributes = (* item: *) StateVariableAttribute*;
                 /// ```
                 %state-variable-attributes,
-                /// This kind represents a `StateVariableDefinition` node, with the following structure: 
+                /// Represents a node with kind `StateVariableDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StateVariableDefinition = (* type_name: *) TypeName
@@ -1306,14 +1306,14 @@ interface cst {
                 ///                           (* semicolon: *) SEMICOLON;
                 /// ```
                 %state-variable-definition,
-                /// This kind represents a `StateVariableDefinitionValue` node, with the following structure: 
+                /// Represents a node with kind `StateVariableDefinitionValue`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StateVariableDefinitionValue = (* equal: *) EQUAL
                 ///                                (* value: *) Expression;
                 /// ```
                 %state-variable-definition-value,
-                /// This kind represents a `Statement` node, with the following structure: 
+                /// Represents a node with kind `Statement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Statement = (* variant: *) IfStatement
@@ -1335,13 +1335,13 @@ interface cst {
                 ///           | (* variant: *) ExpressionStatement;
                 /// ```
                 %statement,
-                /// This kind represents a `Statements` node, with the following structure: 
+                /// Represents a node with kind `Statements`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Statements = (* item: *) Statement*;
                 /// ```
                 %statements,
-                /// This kind represents a `StorageLocation` node, with the following structure: 
+                /// Represents a node with kind `StorageLocation`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StorageLocation = (* variant: *) MEMORY_KEYWORD
@@ -1349,7 +1349,7 @@ interface cst {
                 ///                 | (* variant: *) CALL_DATA_KEYWORD; (* Introduced in 0.5.0 *)
                 /// ```
                 %storage-location,
-                /// This kind represents a `StringExpression` node, with the following structure: 
+                /// Represents a node with kind `StringExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StringExpression = (* variant: *) StringLiteral (* Deprecated in 0.5.14 *)
@@ -1359,21 +1359,21 @@ interface cst {
                 ///                  | (* variant: *) UnicodeStringLiterals; (* Introduced in 0.7.0 *)
                 /// ```
                 %string-expression,
-                /// This kind represents a `StringLiteral` node, with the following structure: 
+                /// Represents a node with kind `StringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StringLiteral = (* variant: *) SINGLE_QUOTED_STRING_LITERAL
                 ///               | (* variant: *) DOUBLE_QUOTED_STRING_LITERAL;
                 /// ```
                 %string-literal,
-                /// This kind represents a `StringLiterals` node, with the following structure: 
+                /// Represents a node with kind `StringLiterals`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.14 *)
                 /// StringLiterals = (* item: *) StringLiteral+;
                 /// ```
                 %string-literals,
-                /// This kind represents a `StructDefinition` node, with the following structure: 
+                /// Represents a node with kind `StructDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StructDefinition = (* struct_keyword: *) STRUCT_KEYWORD
@@ -1383,7 +1383,7 @@ interface cst {
                 ///                    (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %struct-definition,
-                /// This kind represents a `StructMember` node, with the following structure: 
+                /// Represents a node with kind `StructMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StructMember = (* type_name: *) TypeName
@@ -1391,13 +1391,13 @@ interface cst {
                 ///                (* semicolon: *) SEMICOLON;
                 /// ```
                 %struct-member,
-                /// This kind represents a `StructMembers` node, with the following structure: 
+                /// Represents a node with kind `StructMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// StructMembers = (* item: *) StructMember*;
                 /// ```
                 %struct-members,
-                /// This kind represents a `ThrowStatement` node, with the following structure: 
+                /// Represents a node with kind `ThrowStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -1405,7 +1405,7 @@ interface cst {
                 ///                  (* semicolon: *) SEMICOLON;
                 /// ```
                 %throw-statement,
-                /// This kind represents a `TryStatement` node, with the following structure: 
+                /// Represents a node with kind `TryStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -1416,19 +1416,19 @@ interface cst {
                 ///                (* catch_clauses: *) CatchClauses;
                 /// ```
                 %try-statement,
-                /// This kind represents a `TupleDeconstructionElement` node, with the following structure: 
+                /// Represents a node with kind `TupleDeconstructionElement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleDeconstructionElement = (* member: *) TupleMember?;
                 /// ```
                 %tuple-deconstruction-element,
-                /// This kind represents a `TupleDeconstructionElements` node, with the following structure: 
+                /// Represents a node with kind `TupleDeconstructionElements`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleDeconstructionElements = (* item: *) TupleDeconstructionElement ((* separator: *) COMMA (* item: *) TupleDeconstructionElement)*;
                 /// ```
                 %tuple-deconstruction-elements,
-                /// This kind represents a `TupleDeconstructionStatement` node, with the following structure: 
+                /// Represents a node with kind `TupleDeconstructionStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleDeconstructionStatement = (* var_keyword: *) VAR_KEYWORD? (* Deprecated in 0.5.0 *)
@@ -1440,7 +1440,7 @@ interface cst {
                 ///                                (* semicolon: *) SEMICOLON;
                 /// ```
                 %tuple-deconstruction-statement,
-                /// This kind represents a `TupleExpression` node, with the following structure: 
+                /// Represents a node with kind `TupleExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleExpression = (* open_paren: *) OPEN_PAREN
@@ -1448,26 +1448,26 @@ interface cst {
                 ///                   (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %tuple-expression,
-                /// This kind represents a `TupleMember` node, with the following structure: 
+                /// Represents a node with kind `TupleMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleMember = (* variant: *) TypedTupleMember
                 ///             | (* variant: *) UntypedTupleMember;
                 /// ```
                 %tuple-member,
-                /// This kind represents a `TupleValue` node, with the following structure: 
+                /// Represents a node with kind `TupleValue`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleValue = (* expression: *) Expression?;
                 /// ```
                 %tuple-value,
-                /// This kind represents a `TupleValues` node, with the following structure: 
+                /// Represents a node with kind `TupleValues`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TupleValues = (* item: *) TupleValue ((* separator: *) COMMA (* item: *) TupleValue)*;
                 /// ```
                 %tuple-values,
-                /// This kind represents a `TypeExpression` node, with the following structure: 
+                /// Represents a node with kind `TypeExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.3 *)
@@ -1477,7 +1477,7 @@ interface cst {
                 ///                  (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %type-expression,
-                /// This kind represents a `TypeName` node, with the following structure: 
+                /// Represents a node with kind `TypeName`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TypeName = (* variant: *) ArrayTypeName
@@ -1487,7 +1487,7 @@ interface cst {
                 ///          | (* variant: *) IdentifierPath;
                 /// ```
                 %type-name,
-                /// This kind represents a `TypedTupleMember` node, with the following structure: 
+                /// Represents a node with kind `TypedTupleMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TypedTupleMember = (* type_name: *) TypeName
@@ -1495,7 +1495,7 @@ interface cst {
                 ///                    (* name: *) IDENTIFIER;
                 /// ```
                 %typed-tuple-member,
-                /// This kind represents a `UncheckedBlock` node, with the following structure: 
+                /// Represents a node with kind `UncheckedBlock`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.0 *)
@@ -1503,7 +1503,7 @@ interface cst {
                 ///                  (* block: *) Block;
                 /// ```
                 %unchecked-block,
-                /// This kind represents a `UnicodeStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `UnicodeStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.7.0 *)
@@ -1511,14 +1511,14 @@ interface cst {
                 ///                      | (* variant: *) DOUBLE_QUOTED_UNICODE_STRING_LITERAL;
                 /// ```
                 %unicode-string-literal,
-                /// This kind represents a `UnicodeStringLiterals` node, with the following structure: 
+                /// Represents a node with kind `UnicodeStringLiterals`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.7.0 *)
                 /// UnicodeStringLiterals = (* item: *) UnicodeStringLiteral+;
                 /// ```
                 %unicode-string-literals,
-                /// This kind represents a `UnnamedFunctionAttribute` node, with the following structure: 
+                /// Represents a node with kind `UnnamedFunctionAttribute`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.6.0 *)
@@ -1533,14 +1533,14 @@ interface cst {
                 ///                          | (* variant: *) VIEW_KEYWORD; (* Introduced in 0.4.16 and deprecated in 0.6.0. *)
                 /// ```
                 %unnamed-function-attribute,
-                /// This kind represents a `UnnamedFunctionAttributes` node, with the following structure: 
+                /// Represents a node with kind `UnnamedFunctionAttributes`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.6.0 *)
                 /// UnnamedFunctionAttributes = (* item: *) UnnamedFunctionAttribute*;
                 /// ```
                 %unnamed-function-attributes,
-                /// This kind represents a `UnnamedFunctionDefinition` node, with the following structure: 
+                /// Represents a node with kind `UnnamedFunctionDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.6.0 *)
@@ -1550,14 +1550,14 @@ interface cst {
                 ///                             (* body: *) FunctionBody;
                 /// ```
                 %unnamed-function-definition,
-                /// This kind represents a `UntypedTupleMember` node, with the following structure: 
+                /// Represents a node with kind `UntypedTupleMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UntypedTupleMember = (* storage_location: *) StorageLocation?
                 ///                      (* name: *) IDENTIFIER;
                 /// ```
                 %untyped-tuple-member,
-                /// This kind represents a `UserDefinedValueTypeDefinition` node, with the following structure: 
+                /// Represents a node with kind `UserDefinedValueTypeDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.8 *)
@@ -1568,7 +1568,7 @@ interface cst {
                 ///                                  (* semicolon: *) SEMICOLON;
                 /// ```
                 %user-defined-value-type-definition,
-                /// This kind represents a `UsingAlias` node, with the following structure: 
+                /// Represents a node with kind `UsingAlias`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.19 *)
@@ -1576,14 +1576,14 @@ interface cst {
                 ///              (* operator: *) UsingOperator;
                 /// ```
                 %using-alias,
-                /// This kind represents a `UsingClause` node, with the following structure: 
+                /// Represents a node with kind `UsingClause`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UsingClause = (* variant: *) IdentifierPath
                 ///             | (* variant: *) UsingDeconstruction; (* Introduced in 0.8.13 *)
                 /// ```
                 %using-clause,
-                /// This kind represents a `UsingDeconstruction` node, with the following structure: 
+                /// Represents a node with kind `UsingDeconstruction`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.13 *)
@@ -1592,7 +1592,7 @@ interface cst {
                 ///                       (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %using-deconstruction,
-                /// This kind represents a `UsingDeconstructionSymbol` node, with the following structure: 
+                /// Represents a node with kind `UsingDeconstructionSymbol`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.13 *)
@@ -1600,14 +1600,14 @@ interface cst {
                 ///                             (* alias: *) UsingAlias?; (* Introduced in 0.8.19 *)
                 /// ```
                 %using-deconstruction-symbol,
-                /// This kind represents a `UsingDeconstructionSymbols` node, with the following structure: 
+                /// Represents a node with kind `UsingDeconstructionSymbols`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.13 *)
                 /// UsingDeconstructionSymbols = (* item: *) UsingDeconstructionSymbol ((* separator: *) COMMA (* item: *) UsingDeconstructionSymbol)*;
                 /// ```
                 %using-deconstruction-symbols,
-                /// This kind represents a `UsingDirective` node, with the following structure: 
+                /// Represents a node with kind `UsingDirective`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UsingDirective = (* using_keyword: *) USING_KEYWORD
@@ -1618,7 +1618,7 @@ interface cst {
                 ///                  (* semicolon: *) SEMICOLON;
                 /// ```
                 %using-directive,
-                /// This kind represents a `UsingOperator` node, with the following structure: 
+                /// Represents a node with kind `UsingOperator`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.19 *)
@@ -1639,14 +1639,14 @@ interface cst {
                 ///               | (* variant: *) TILDE;
                 /// ```
                 %using-operator,
-                /// This kind represents a `UsingTarget` node, with the following structure: 
+                /// Represents a node with kind `UsingTarget`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UsingTarget = (* variant: *) TypeName
                 ///             | (* variant: *) ASTERISK;
                 /// ```
                 %using-target,
-                /// This kind represents a `VariableDeclarationStatement` node, with the following structure: 
+                /// Represents a node with kind `VariableDeclarationStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VariableDeclarationStatement = (* variable_type: *) VariableDeclarationType
@@ -1656,40 +1656,40 @@ interface cst {
                 ///                                (* semicolon: *) SEMICOLON;
                 /// ```
                 %variable-declaration-statement,
-                /// This kind represents a `VariableDeclarationType` node, with the following structure: 
+                /// Represents a node with kind `VariableDeclarationType`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VariableDeclarationType = (* variant: *) TypeName
                 ///                         | (* variant: *) VAR_KEYWORD; (* Deprecated in 0.5.0 *)
                 /// ```
                 %variable-declaration-type,
-                /// This kind represents a `VariableDeclarationValue` node, with the following structure: 
+                /// Represents a node with kind `VariableDeclarationValue`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VariableDeclarationValue = (* equal: *) EQUAL
                 ///                            (* expression: *) Expression;
                 /// ```
                 %variable-declaration-value,
-                /// This kind represents a `VersionExpression` node, with the following structure: 
+                /// Represents a node with kind `VersionExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionExpression = (* variant: *) VersionRange
                 ///                   | (* variant: *) VersionTerm;
                 /// ```
                 %version-expression,
-                /// This kind represents a `VersionExpressionSet` node, with the following structure: 
+                /// Represents a node with kind `VersionExpressionSet`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionExpressionSet = (* item: *) VersionExpression+;
                 /// ```
                 %version-expression-set,
-                /// This kind represents a `VersionExpressionSets` node, with the following structure: 
+                /// Represents a node with kind `VersionExpressionSets`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionExpressionSets = (* item: *) VersionExpressionSet ((* separator: *) BAR_BAR (* item: *) VersionExpressionSet)*;
                 /// ```
                 %version-expression-sets,
-                /// This kind represents a `VersionLiteral` node, with the following structure: 
+                /// Represents a node with kind `VersionLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionLiteral = (* variant: *) SimpleVersionLiteral
@@ -1697,7 +1697,7 @@ interface cst {
                 ///                | (* variant: *) DOUBLE_QUOTED_VERSION_LITERAL;
                 /// ```
                 %version-literal,
-                /// This kind represents a `VersionOperator` node, with the following structure: 
+                /// Represents a node with kind `VersionOperator`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionOperator = (* variant: *) CARET
@@ -1709,14 +1709,14 @@ interface cst {
                 ///                 | (* variant: *) GREATER_THAN_EQUAL;
                 /// ```
                 %version-operator,
-                /// This kind represents a `VersionPragma` node, with the following structure: 
+                /// Represents a node with kind `VersionPragma`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionPragma = (* solidity_keyword: *) SOLIDITY_KEYWORD
                 ///                 (* sets: *) VersionExpressionSets;
                 /// ```
                 %version-pragma,
-                /// This kind represents a `VersionRange` node, with the following structure: 
+                /// Represents a node with kind `VersionRange`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionRange = (* start: *) VersionLiteral
@@ -1724,14 +1724,14 @@ interface cst {
                 ///                (* end: *) VersionLiteral;
                 /// ```
                 %version-range,
-                /// This kind represents a `VersionTerm` node, with the following structure: 
+                /// Represents a node with kind `VersionTerm`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VersionTerm = (* operator: *) VersionOperator?
                 ///               (* literal: *) VersionLiteral;
                 /// ```
                 %version-term,
-                /// This kind represents a `WhileStatement` node, with the following structure: 
+                /// Represents a node with kind `WhileStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WhileStatement = (* while_keyword: *) WHILE_KEYWORD
@@ -1741,20 +1741,20 @@ interface cst {
                 ///                  (* body: *) Statement;
                 /// ```
                 %while-statement,
-                /// This kind represents a `YulArguments` node, with the following structure: 
+                /// Represents a node with kind `YulArguments`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulArguments = ((* item: *) YulExpression ((* separator: *) COMMA (* item: *) YulExpression)*)?;
                 /// ```
                 %yul-arguments,
-                /// This kind represents a `YulAssignmentOperator` node, with the following structure: 
+                /// Represents a node with kind `YulAssignmentOperator`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulAssignmentOperator = (* variant: *) COLON_EQUAL
                 ///                       | (* variant: *) YulColonAndEqual; (* Deprecated in 0.5.5 *)
                 /// ```
                 %yul-assignment-operator,
-                /// This kind represents a `YulBlock` node, with the following structure: 
+                /// Represents a node with kind `YulBlock`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulBlock = (* open_brace: *) OPEN_BRACE
@@ -1762,13 +1762,13 @@ interface cst {
                 ///            (* close_brace: *) CLOSE_BRACE;
                 /// ```
                 %yul-block,
-                /// This kind represents a `YulBreakStatement` node, with the following structure: 
+                /// Represents a node with kind `YulBreakStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulBreakStatement = (* break_keyword: *) YUL_BREAK_KEYWORD;
                 /// ```
                 %yul-break-statement,
-                /// This kind represents a `YulBuiltInFunction` node, with the following structure: 
+                /// Represents a node with kind `YulBuiltInFunction`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulBuiltInFunction = (* variant: *) YUL_ADD_KEYWORD
@@ -1856,7 +1856,7 @@ interface cst {
                 ///                    | (* variant: *) YUL_M_COPY_KEYWORD; (* Introduced in 0.8.24 *)
                 /// ```
                 %yul-built-in-function,
-                /// This kind represents a `YulColonAndEqual` node, with the following structure: 
+                /// Represents a node with kind `YulColonAndEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.5 *)
@@ -1864,20 +1864,20 @@ interface cst {
                 ///                    (* equal: *) EQUAL;
                 /// ```
                 %yul-colon-and-equal,
-                /// This kind represents a `YulContinueStatement` node, with the following structure: 
+                /// Represents a node with kind `YulContinueStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulContinueStatement = (* continue_keyword: *) YUL_CONTINUE_KEYWORD;
                 /// ```
                 %yul-continue-statement,
-                /// This kind represents a `YulDefaultCase` node, with the following structure: 
+                /// Represents a node with kind `YulDefaultCase`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulDefaultCase = (* default_keyword: *) YUL_DEFAULT_KEYWORD
                 ///                  (* body: *) YulBlock;
                 /// ```
                 %yul-default-case,
-                /// This kind represents a `YulEqualAndColon` node, with the following structure: 
+                /// Represents a node with kind `YulEqualAndColon`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -1885,7 +1885,7 @@ interface cst {
                 ///                    (* colon: *) COLON;
                 /// ```
                 %yul-equal-and-colon,
-                /// This kind represents a `YulExpression` node, with the following structure: 
+                /// Represents a node with kind `YulExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulExpression = (* variant: *) YulFunctionCallExpression
@@ -1894,7 +1894,7 @@ interface cst {
                 ///               | (* variant: *) YulPath;
                 /// ```
                 %yul-expression,
-                /// This kind represents a `YulForStatement` node, with the following structure: 
+                /// Represents a node with kind `YulForStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulForStatement = (* for_keyword: *) YUL_FOR_KEYWORD
@@ -1904,7 +1904,7 @@ interface cst {
                 ///                   (* body: *) YulBlock;
                 /// ```
                 %yul-for-statement,
-                /// This kind represents a `YulFunctionCallExpression` node, with the following structure: 
+                /// Represents a node with kind `YulFunctionCallExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -1914,7 +1914,7 @@ interface cst {
                 ///                             (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %yul-function-call-expression,
-                /// This kind represents a `YulFunctionDefinition` node, with the following structure: 
+                /// Represents a node with kind `YulFunctionDefinition`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulFunctionDefinition = (* function_keyword: *) YUL_FUNCTION_KEYWORD
@@ -1924,7 +1924,7 @@ interface cst {
                 ///                         (* body: *) YulBlock;
                 /// ```
                 %yul-function-definition,
-                /// This kind represents a `YulIfStatement` node, with the following structure: 
+                /// Represents a node with kind `YulIfStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulIfStatement = (* if_keyword: *) YUL_IF_KEYWORD
@@ -1932,7 +1932,7 @@ interface cst {
                 ///                  (* body: *) YulBlock;
                 /// ```
                 %yul-if-statement,
-                /// This kind represents a `YulLabel` node, with the following structure: 
+                /// Represents a node with kind `YulLabel`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -1940,14 +1940,14 @@ interface cst {
                 ///            (* colon: *) COLON;
                 /// ```
                 %yul-label,
-                /// This kind represents a `YulLeaveStatement` node, with the following structure: 
+                /// Represents a node with kind `YulLeaveStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// YulLeaveStatement = (* leave_keyword: *) YUL_LEAVE_KEYWORD;
                 /// ```
                 %yul-leave-statement,
-                /// This kind represents a `YulLiteral` node, with the following structure: 
+                /// Represents a node with kind `YulLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulLiteral = (* variant: *) YUL_TRUE_KEYWORD
@@ -1958,13 +1958,13 @@ interface cst {
                 ///            | (* variant: *) StringLiteral;
                 /// ```
                 %yul-literal,
-                /// This kind represents a `YulParameters` node, with the following structure: 
+                /// Represents a node with kind `YulParameters`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulParameters = ((* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*)?;
                 /// ```
                 %yul-parameters,
-                /// This kind represents a `YulParametersDeclaration` node, with the following structure: 
+                /// Represents a node with kind `YulParametersDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1972,26 +1972,26 @@ interface cst {
                 ///                            (* close_paren: *) CLOSE_PAREN;
                 /// ```
                 %yul-parameters-declaration,
-                /// This kind represents a `YulPath` node, with the following structure: 
+                /// Represents a node with kind `YulPath`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulPath = (* item: *) YUL_IDENTIFIER ((* separator: *) PERIOD (* item: *) YUL_IDENTIFIER)*;
                 /// ```
                 %yul-path,
-                /// This kind represents a `YulPaths` node, with the following structure: 
+                /// Represents a node with kind `YulPaths`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulPaths = (* item: *) YulPath ((* separator: *) COMMA (* item: *) YulPath)*;
                 /// ```
                 %yul-paths,
-                /// This kind represents a `YulReturnsDeclaration` node, with the following structure: 
+                /// Represents a node with kind `YulReturnsDeclaration`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulReturnsDeclaration = (* minus_greater_than: *) MINUS_GREATER_THAN
                 ///                         (* variables: *) YulVariableNames;
                 /// ```
                 %yul-returns-declaration,
-                /// This kind represents a `YulStackAssignmentOperator` node, with the following structure: 
+                /// Represents a node with kind `YulStackAssignmentOperator`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -1999,7 +1999,7 @@ interface cst {
                 ///                            | (* variant: *) YulEqualAndColon;
                 /// ```
                 %yul-stack-assignment-operator,
-                /// This kind represents a `YulStackAssignmentStatement` node, with the following structure: 
+                /// Represents a node with kind `YulStackAssignmentStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -2007,7 +2007,7 @@ interface cst {
                 ///                               (* variable: *) YUL_IDENTIFIER;
                 /// ```
                 %yul-stack-assignment-statement,
-                /// This kind represents a `YulStatement` node, with the following structure: 
+                /// Represents a node with kind `YulStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulStatement = (* variant: *) YulBlock
@@ -2025,26 +2025,26 @@ interface cst {
                 ///              | (* variant: *) YulExpression;
                 /// ```
                 %yul-statement,
-                /// This kind represents a `YulStatements` node, with the following structure: 
+                /// Represents a node with kind `YulStatements`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulStatements = (* item: *) YulStatement*;
                 /// ```
                 %yul-statements,
-                /// This kind represents a `YulSwitchCase` node, with the following structure: 
+                /// Represents a node with kind `YulSwitchCase`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulSwitchCase = (* variant: *) YulDefaultCase
                 ///               | (* variant: *) YulValueCase;
                 /// ```
                 %yul-switch-case,
-                /// This kind represents a `YulSwitchCases` node, with the following structure: 
+                /// Represents a node with kind `YulSwitchCases`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulSwitchCases = (* item: *) YulSwitchCase+;
                 /// ```
                 %yul-switch-cases,
-                /// This kind represents a `YulSwitchStatement` node, with the following structure: 
+                /// Represents a node with kind `YulSwitchStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulSwitchStatement = (* switch_keyword: *) YUL_SWITCH_KEYWORD
@@ -2052,7 +2052,7 @@ interface cst {
                 ///                      (* cases: *) YulSwitchCases;
                 /// ```
                 %yul-switch-statement,
-                /// This kind represents a `YulValueCase` node, with the following structure: 
+                /// Represents a node with kind `YulValueCase`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulValueCase = (* case_keyword: *) YUL_CASE_KEYWORD
@@ -2060,7 +2060,7 @@ interface cst {
                 ///                (* body: *) YulBlock;
                 /// ```
                 %yul-value-case,
-                /// This kind represents a `YulVariableAssignmentStatement` node, with the following structure: 
+                /// Represents a node with kind `YulVariableAssignmentStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulVariableAssignmentStatement = (* variables: *) YulPaths
@@ -2068,7 +2068,7 @@ interface cst {
                 ///                                  (* expression: *) YulExpression;
                 /// ```
                 %yul-variable-assignment-statement,
-                /// This kind represents a `YulVariableDeclarationStatement` node, with the following structure: 
+                /// Represents a node with kind `YulVariableDeclarationStatement`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulVariableDeclarationStatement = (* let_keyword: *) YUL_LET_KEYWORD
@@ -2076,14 +2076,14 @@ interface cst {
                 ///                                   (* value: *) YulVariableDeclarationValue?;
                 /// ```
                 %yul-variable-declaration-statement,
-                /// This kind represents a `YulVariableDeclarationValue` node, with the following structure: 
+                /// Represents a node with kind `YulVariableDeclarationValue`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulVariableDeclarationValue = (* assignment: *) YulAssignmentOperator
                 ///                               (* expression: *) YulExpression;
                 /// ```
                 %yul-variable-declaration-value,
-                /// This kind represents a `YulVariableNames` node, with the following structure: 
+                /// Represents a node with kind `YulVariableNames`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YulVariableNames = (* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*;
@@ -2100,164 +2100,164 @@ interface cst {
         /// This terminal is created when the parser is expecting a certain terminal, but it cannot find it.
         /// Adding the missing input in this position may allow the parser to produce a valid tree there.
         missing,
-                /// This kind represents a `AbicoderKeyword` node, with the following structure: 
+                /// Represents a node with kind `AbicoderKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// ABICODER_KEYWORD = "abicoder";
                 /// ```
                 %abicoder-keyword,
-                /// This kind represents a `AbstractKeyword` node, with the following structure: 
+                /// Represents a node with kind `AbstractKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// ABSTRACT_KEYWORD = "abstract";
                 /// ```
                 %abstract-keyword,
-                /// This kind represents a `AddressKeyword` node, with the following structure: 
+                /// Represents a node with kind `AddressKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// ADDRESS_KEYWORD = "address";
                 /// ```
                 %address-keyword,
-                /// This kind represents a `AfterKeyword` node, with the following structure: 
+                /// Represents a node with kind `AfterKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AFTER_KEYWORD = "after";
                 /// ```
                 %after-keyword,
-                /// This kind represents a `AliasKeyword` node, with the following structure: 
+                /// Represents a node with kind `AliasKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// ALIAS_KEYWORD = "alias";
                 /// ```
                 %alias-keyword,
-                /// This kind represents a `Ampersand` node, with the following structure: 
+                /// Represents a node with kind `Ampersand`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AMPERSAND = "&";
                 /// ```
                 %ampersand,
-                /// This kind represents a `AmpersandAmpersand` node, with the following structure: 
+                /// Represents a node with kind `AmpersandAmpersand`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AMPERSAND_AMPERSAND = "&&";
                 /// ```
                 %ampersand-ampersand,
-                /// This kind represents a `AmpersandEqual` node, with the following structure: 
+                /// Represents a node with kind `AmpersandEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AMPERSAND_EQUAL = "&=";
                 /// ```
                 %ampersand-equal,
-                /// This kind represents a `AnonymousKeyword` node, with the following structure: 
+                /// Represents a node with kind `AnonymousKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ANONYMOUS_KEYWORD = "anonymous";
                 /// ```
                 %anonymous-keyword,
-                /// This kind represents a `ApplyKeyword` node, with the following structure: 
+                /// Represents a node with kind `ApplyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// APPLY_KEYWORD = "apply";
                 /// ```
                 %apply-keyword,
-                /// This kind represents a `AsKeyword` node, with the following structure: 
+                /// Represents a node with kind `AsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// AS_KEYWORD = "as";
                 /// ```
                 %as-keyword,
-                /// This kind represents a `AssemblyKeyword` node, with the following structure: 
+                /// Represents a node with kind `AssemblyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ASSEMBLY_KEYWORD = "assembly";
                 /// ```
                 %assembly-keyword,
-                /// This kind represents a `Asterisk` node, with the following structure: 
+                /// Represents a node with kind `Asterisk`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ASTERISK = "*";
                 /// ```
                 %asterisk,
-                /// This kind represents a `AsteriskAsterisk` node, with the following structure: 
+                /// Represents a node with kind `AsteriskAsterisk`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ASTERISK_ASTERISK = "**";
                 /// ```
                 %asterisk-asterisk,
-                /// This kind represents a `AsteriskEqual` node, with the following structure: 
+                /// Represents a node with kind `AsteriskEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ASTERISK_EQUAL = "*=";
                 /// ```
                 %asterisk-equal,
-                /// This kind represents a `AutoKeyword` node, with the following structure: 
+                /// Represents a node with kind `AutoKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// AUTO_KEYWORD = "auto";
                 /// ```
                 %auto-keyword,
-                /// This kind represents a `Bang` node, with the following structure: 
+                /// Represents a node with kind `Bang`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BANG = "!";
                 /// ```
                 %bang,
-                /// This kind represents a `BangEqual` node, with the following structure: 
+                /// Represents a node with kind `BangEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BANG_EQUAL = "!=";
                 /// ```
                 %bang-equal,
-                /// This kind represents a `Bar` node, with the following structure: 
+                /// Represents a node with kind `Bar`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BAR = "|";
                 /// ```
                 %bar,
-                /// This kind represents a `BarBar` node, with the following structure: 
+                /// Represents a node with kind `BarBar`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BAR_BAR = "||";
                 /// ```
                 %bar-bar,
-                /// This kind represents a `BarEqual` node, with the following structure: 
+                /// Represents a node with kind `BarEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BAR_EQUAL = "|=";
                 /// ```
                 %bar-equal,
-                /// This kind represents a `BoolKeyword` node, with the following structure: 
+                /// Represents a node with kind `BoolKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BOOL_KEYWORD = "bool";
                 /// ```
                 %bool-keyword,
-                /// This kind represents a `BreakKeyword` node, with the following structure: 
+                /// Represents a node with kind `BreakKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BREAK_KEYWORD = "break";
                 /// ```
                 %break-keyword,
-                /// This kind represents a `ByteKeyword` node, with the following structure: 
+                /// Represents a node with kind `ByteKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.8.0 *)
                 /// BYTE_KEYWORD = "byte";
                 /// ```
                 %byte-keyword,
-                /// This kind represents a `BytesKeyword` node, with the following structure: 
+                /// Represents a node with kind `BytesKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BYTES_KEYWORD = "bytes" ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32")?;
                 /// ```
                 %bytes-keyword,
-                /// This kind represents a `CallDataKeyword` node, with the following structure: 
+                /// Represents a node with kind `CallDataKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.0 *)
@@ -2265,74 +2265,74 @@ interface cst {
                 /// CALL_DATA_KEYWORD = "calldata";
                 /// ```
                 %call-data-keyword,
-                /// This kind represents a `Caret` node, with the following structure: 
+                /// Represents a node with kind `Caret`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CARET = "^";
                 /// ```
                 %caret,
-                /// This kind represents a `CaretEqual` node, with the following structure: 
+                /// Represents a node with kind `CaretEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CARET_EQUAL = "^=";
                 /// ```
                 %caret-equal,
-                /// This kind represents a `CaseKeyword` node, with the following structure: 
+                /// Represents a node with kind `CaseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CASE_KEYWORD = "case";
                 /// ```
                 %case-keyword,
-                /// This kind represents a `CatchKeyword` node, with the following structure: 
+                /// Represents a node with kind `CatchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// CATCH_KEYWORD = "catch";
                 /// ```
                 %catch-keyword,
-                /// This kind represents a `CloseBrace` node, with the following structure: 
+                /// Represents a node with kind `CloseBrace`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CLOSE_BRACE = "}";
                 /// ```
                 %close-brace,
-                /// This kind represents a `CloseBracket` node, with the following structure: 
+                /// Represents a node with kind `CloseBracket`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CLOSE_BRACKET = "]";
                 /// ```
                 %close-bracket,
-                /// This kind represents a `CloseParen` node, with the following structure: 
+                /// Represents a node with kind `CloseParen`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CLOSE_PAREN = ")";
                 /// ```
                 %close-paren,
-                /// This kind represents a `Colon` node, with the following structure: 
+                /// Represents a node with kind `Colon`, having the following structure:
                 ///
                 /// ```ebnf
                 /// COLON = ":";
                 /// ```
                 %colon,
-                /// This kind represents a `ColonEqual` node, with the following structure: 
+                /// Represents a node with kind `ColonEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// COLON_EQUAL = ":=";
                 /// ```
                 %colon-equal,
-                /// This kind represents a `Comma` node, with the following structure: 
+                /// Represents a node with kind `Comma`, having the following structure:
                 ///
                 /// ```ebnf
                 /// COMMA = ",";
                 /// ```
                 %comma,
-                /// This kind represents a `ConstantKeyword` node, with the following structure: 
+                /// Represents a node with kind `ConstantKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CONSTANT_KEYWORD = "constant";
                 /// ```
                 %constant-keyword,
-                /// This kind represents a `ConstructorKeyword` node, with the following structure: 
+                /// Represents a node with kind `ConstructorKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.22 *)
@@ -2340,32 +2340,32 @@ interface cst {
                 /// CONSTRUCTOR_KEYWORD = "constructor";
                 /// ```
                 %constructor-keyword,
-                /// This kind represents a `ContinueKeyword` node, with the following structure: 
+                /// Represents a node with kind `ContinueKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CONTINUE_KEYWORD = "continue";
                 /// ```
                 %continue-keyword,
-                /// This kind represents a `ContractKeyword` node, with the following structure: 
+                /// Represents a node with kind `ContractKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CONTRACT_KEYWORD = "contract";
                 /// ```
                 %contract-keyword,
-                /// This kind represents a `CopyOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `CopyOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// COPY_OF_KEYWORD = "copyof";
                 /// ```
                 %copy-of-keyword,
-                /// This kind represents a `DaysKeyword` node, with the following structure: 
+                /// Represents a node with kind `DaysKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DAYS_KEYWORD = "days";
                 /// ```
                 %days-keyword,
-                /// This kind represents a `DecimalLiteral` node, with the following structure: 
+                /// Represents a node with kind `DecimalLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DECIMAL_LITERAL = "." «DECIMAL_DIGITS» «DECIMAL_EXPONENT»?;
@@ -2382,38 +2382,38 @@ interface cst {
                 /// DECIMAL_LITERAL = «DECIMAL_DIGITS» ("." «DECIMAL_DIGITS»)? «DECIMAL_EXPONENT»?;
                 /// ```
                 %decimal-literal,
-                /// This kind represents a `DefaultKeyword` node, with the following structure: 
+                /// Represents a node with kind `DefaultKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DEFAULT_KEYWORD = "default";
                 /// ```
                 %default-keyword,
-                /// This kind represents a `DefineKeyword` node, with the following structure: 
+                /// Represents a node with kind `DefineKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// DEFINE_KEYWORD = "define";
                 /// ```
                 %define-keyword,
-                /// This kind represents a `DeleteKeyword` node, with the following structure: 
+                /// Represents a node with kind `DeleteKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DELETE_KEYWORD = "delete";
                 /// ```
                 %delete-keyword,
-                /// This kind represents a `DoKeyword` node, with the following structure: 
+                /// Represents a node with kind `DoKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DO_KEYWORD = "do";
                 /// ```
                 %do-keyword,
-                /// This kind represents a `DoubleQuotedHexStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `DoubleQuotedHexStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DOUBLE_QUOTED_HEX_STRING_LITERAL = 'hex"' «HEX_STRING_CONTENTS»? '"';
                 /// ```
                 %double-quoted-hex-string-literal,
-                /// This kind represents a `DoubleQuotedStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `DoubleQuotedStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.4.25 *)
@@ -2425,26 +2425,26 @@ interface cst {
                 /// DOUBLE_QUOTED_STRING_LITERAL = '"' («ESCAPE_SEQUENCE» | (" "…"!") | ("#"…"[") | ("]"…"~"))* '"';
                 /// ```
                 %double-quoted-string-literal,
-                /// This kind represents a `DoubleQuotedUnicodeStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `DoubleQuotedUnicodeStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.7.0 *)
                 /// DOUBLE_QUOTED_UNICODE_STRING_LITERAL = 'unicode"' («ESCAPE_SEQUENCE» | !('"' "\\" "\r" "\n"))* '"';
                 /// ```
                 %double-quoted-unicode-string-literal,
-                /// This kind represents a `DoubleQuotedVersionLiteral` node, with the following structure: 
+                /// Represents a node with kind `DoubleQuotedVersionLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DOUBLE_QUOTED_VERSION_LITERAL = '"' «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* '"';
                 /// ```
                 %double-quoted-version-literal,
-                /// This kind represents a `ElseKeyword` node, with the following structure: 
+                /// Represents a node with kind `ElseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ELSE_KEYWORD = "else";
                 /// ```
                 %else-keyword,
-                /// This kind represents a `EmitKeyword` node, with the following structure: 
+                /// Represents a node with kind `EmitKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.21 *)
@@ -2452,44 +2452,44 @@ interface cst {
                 /// EMIT_KEYWORD = "emit";
                 /// ```
                 %emit-keyword,
-                /// This kind represents a `EndOfLine` node, with the following structure: 
+                /// Represents a node with kind `EndOfLine`, having the following structure:
                 ///
                 /// ```ebnf
                 /// END_OF_LINE = "\n" | ("\r" "\n"?);
                 /// ```
                 %end-of-line,
-                /// This kind represents a `EnumKeyword` node, with the following structure: 
+                /// Represents a node with kind `EnumKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ENUM_KEYWORD = "enum";
                 /// ```
                 %enum-keyword,
-                /// This kind represents a `Equal` node, with the following structure: 
+                /// Represents a node with kind `Equal`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EQUAL = "=";
                 /// ```
                 %equal,
-                /// This kind represents a `EqualColon` node, with the following structure: 
+                /// Represents a node with kind `EqualColon`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// EQUAL_COLON = "=:";
                 /// ```
                 %equal-colon,
-                /// This kind represents a `EqualEqual` node, with the following structure: 
+                /// Represents a node with kind `EqualEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EQUAL_EQUAL = "==";
                 /// ```
                 %equal-equal,
-                /// This kind represents a `EqualGreaterThan` node, with the following structure: 
+                /// Represents a node with kind `EqualGreaterThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EQUAL_GREATER_THAN = "=>";
                 /// ```
                 %equal-greater-than,
-                /// This kind represents a `ErrorKeyword` node, with the following structure: 
+                /// Represents a node with kind `ErrorKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -2497,51 +2497,51 @@ interface cst {
                 /// ERROR_KEYWORD = "error";
                 /// ```
                 %error-keyword,
-                /// This kind represents a `EtherKeyword` node, with the following structure: 
+                /// Represents a node with kind `EtherKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// ETHER_KEYWORD = "ether";
                 /// ```
                 %ether-keyword,
-                /// This kind represents a `EventKeyword` node, with the following structure: 
+                /// Represents a node with kind `EventKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EVENT_KEYWORD = "event";
                 /// ```
                 %event-keyword,
-                /// This kind represents a `ExperimentalKeyword` node, with the following structure: 
+                /// Represents a node with kind `ExperimentalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// EXPERIMENTAL_KEYWORD = "experimental";
                 /// ```
                 %experimental-keyword,
-                /// This kind represents a `ExternalKeyword` node, with the following structure: 
+                /// Represents a node with kind `ExternalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// EXTERNAL_KEYWORD = "external";
                 /// ```
                 %external-keyword,
-                /// This kind represents a `FallbackKeyword` node, with the following structure: 
+                /// Represents a node with kind `FallbackKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.6.0 *)
                 /// FALLBACK_KEYWORD = "fallback";
                 /// ```
                 %fallback-keyword,
-                /// This kind represents a `FalseKeyword` node, with the following structure: 
+                /// Represents a node with kind `FalseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FALSE_KEYWORD = "false";
                 /// ```
                 %false-keyword,
-                /// This kind represents a `FinalKeyword` node, with the following structure: 
+                /// Represents a node with kind `FinalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FINAL_KEYWORD = "final";
                 /// ```
                 %final-keyword,
-                /// This kind represents a `FinneyKeyword` node, with the following structure: 
+                /// Represents a node with kind `FinneyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.7.0 *)
@@ -2549,7 +2549,7 @@ interface cst {
                 /// FINNEY_KEYWORD = "finney";
                 /// ```
                 %finney-keyword,
-                /// This kind represents a `FixedKeyword` node, with the following structure: 
+                /// Represents a node with kind `FixedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FIXED_KEYWORD = "fixed";
@@ -2565,26 +2565,26 @@ interface cst {
                 /// FIXED_KEYWORD = "fixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
                 /// ```
                 %fixed-keyword,
-                /// This kind represents a `ForKeyword` node, with the following structure: 
+                /// Represents a node with kind `ForKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FOR_KEYWORD = "for";
                 /// ```
                 %for-keyword,
-                /// This kind represents a `FromKeyword` node, with the following structure: 
+                /// Represents a node with kind `FromKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// FROM_KEYWORD = "from";
                 /// ```
                 %from-keyword,
-                /// This kind represents a `FunctionKeyword` node, with the following structure: 
+                /// Represents a node with kind `FunctionKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// FUNCTION_KEYWORD = "function";
                 /// ```
                 %function-keyword,
-                /// This kind represents a `GlobalKeyword` node, with the following structure: 
+                /// Represents a node with kind `GlobalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.13 *)
@@ -2592,43 +2592,43 @@ interface cst {
                 /// GLOBAL_KEYWORD = "global";
                 /// ```
                 %global-keyword,
-                /// This kind represents a `GreaterThan` node, with the following structure: 
+                /// Represents a node with kind `GreaterThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN = ">";
                 /// ```
                 %greater-than,
-                /// This kind represents a `GreaterThanEqual` node, with the following structure: 
+                /// Represents a node with kind `GreaterThanEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN_EQUAL = ">=";
                 /// ```
                 %greater-than-equal,
-                /// This kind represents a `GreaterThanGreaterThan` node, with the following structure: 
+                /// Represents a node with kind `GreaterThanGreaterThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN_GREATER_THAN = ">>";
                 /// ```
                 %greater-than-greater-than,
-                /// This kind represents a `GreaterThanGreaterThanEqual` node, with the following structure: 
+                /// Represents a node with kind `GreaterThanGreaterThanEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN_GREATER_THAN_EQUAL = ">>=";
                 /// ```
                 %greater-than-greater-than-equal,
-                /// This kind represents a `GreaterThanGreaterThanGreaterThan` node, with the following structure: 
+                /// Represents a node with kind `GreaterThanGreaterThanGreaterThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN_GREATER_THAN_GREATER_THAN = ">>>";
                 /// ```
                 %greater-than-greater-than-greater-than,
-                /// This kind represents a `GreaterThanGreaterThanGreaterThanEqual` node, with the following structure: 
+                /// Represents a node with kind `GreaterThanGreaterThanGreaterThanEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// GREATER_THAN_GREATER_THAN_GREATER_THAN_EQUAL = ">>>=";
                 /// ```
                 %greater-than-greater-than-greater-than-equal,
-                /// This kind represents a `GweiKeyword` node, with the following structure: 
+                /// Represents a node with kind `GweiKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.11 *)
@@ -2636,13 +2636,13 @@ interface cst {
                 /// GWEI_KEYWORD = "gwei";
                 /// ```
                 %gwei-keyword,
-                /// This kind represents a `HexKeyword` node, with the following structure: 
+                /// Represents a node with kind `HexKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// HEX_KEYWORD = "hex";
                 /// ```
                 %hex-keyword,
-                /// This kind represents a `HexLiteral` node, with the following structure: 
+                /// Represents a node with kind `HexLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// HEX_LITERAL = "0x" «HEX_CHARACTER»+ ("_" «HEX_CHARACTER»+)*;
@@ -2651,25 +2651,25 @@ interface cst {
                 /// HEX_LITERAL = "0X" «HEX_CHARACTER»+ ("_" «HEX_CHARACTER»+)*;
                 /// ```
                 %hex-literal,
-                /// This kind represents a `HoursKeyword` node, with the following structure: 
+                /// Represents a node with kind `HoursKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// HOURS_KEYWORD = "hours";
                 /// ```
                 %hours-keyword,
-                /// This kind represents a `Identifier` node, with the following structure: 
+                /// Represents a node with kind `Identifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IDENTIFIER = «IDENTIFIER_START» «IDENTIFIER_PART»*;
                 /// ```
                 %identifier,
-                /// This kind represents a `IfKeyword` node, with the following structure: 
+                /// Represents a node with kind `IfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IF_KEYWORD = "if";
                 /// ```
                 %if-keyword,
-                /// This kind represents a `ImmutableKeyword` node, with the following structure: 
+                /// Represents a node with kind `ImmutableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.5 *)
@@ -2677,214 +2677,214 @@ interface cst {
                 /// IMMUTABLE_KEYWORD = "immutable";
                 /// ```
                 %immutable-keyword,
-                /// This kind represents a `ImplementsKeyword` node, with the following structure: 
+                /// Represents a node with kind `ImplementsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// IMPLEMENTS_KEYWORD = "implements";
                 /// ```
                 %implements-keyword,
-                /// This kind represents a `ImportKeyword` node, with the following structure: 
+                /// Represents a node with kind `ImportKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IMPORT_KEYWORD = "import";
                 /// ```
                 %import-keyword,
-                /// This kind represents a `InKeyword` node, with the following structure: 
+                /// Represents a node with kind `InKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IN_KEYWORD = "in";
                 /// ```
                 %in-keyword,
-                /// This kind represents a `IndexedKeyword` node, with the following structure: 
+                /// Represents a node with kind `IndexedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// INDEXED_KEYWORD = "indexed";
                 /// ```
                 %indexed-keyword,
-                /// This kind represents a `InlineKeyword` node, with the following structure: 
+                /// Represents a node with kind `InlineKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// INLINE_KEYWORD = "inline";
                 /// ```
                 %inline-keyword,
-                /// This kind represents a `IntKeyword` node, with the following structure: 
+                /// Represents a node with kind `IntKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// INT_KEYWORD = "int" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
                 /// ```
                 %int-keyword,
-                /// This kind represents a `InterfaceKeyword` node, with the following structure: 
+                /// Represents a node with kind `InterfaceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// INTERFACE_KEYWORD = "interface";
                 /// ```
                 %interface-keyword,
-                /// This kind represents a `InternalKeyword` node, with the following structure: 
+                /// Represents a node with kind `InternalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// INTERNAL_KEYWORD = "internal";
                 /// ```
                 %internal-keyword,
-                /// This kind represents a `IsKeyword` node, with the following structure: 
+                /// Represents a node with kind `IsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IS_KEYWORD = "is";
                 /// ```
                 %is-keyword,
-                /// This kind represents a `LessThan` node, with the following structure: 
+                /// Represents a node with kind `LessThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LESS_THAN = "<";
                 /// ```
                 %less-than,
-                /// This kind represents a `LessThanEqual` node, with the following structure: 
+                /// Represents a node with kind `LessThanEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LESS_THAN_EQUAL = "<=";
                 /// ```
                 %less-than-equal,
-                /// This kind represents a `LessThanLessThan` node, with the following structure: 
+                /// Represents a node with kind `LessThanLessThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LESS_THAN_LESS_THAN = "<<";
                 /// ```
                 %less-than-less-than,
-                /// This kind represents a `LessThanLessThanEqual` node, with the following structure: 
+                /// Represents a node with kind `LessThanLessThanEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LESS_THAN_LESS_THAN_EQUAL = "<<=";
                 /// ```
                 %less-than-less-than-equal,
-                /// This kind represents a `LetKeyword` node, with the following structure: 
+                /// Represents a node with kind `LetKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LET_KEYWORD = "let";
                 /// ```
                 %let-keyword,
-                /// This kind represents a `LibraryKeyword` node, with the following structure: 
+                /// Represents a node with kind `LibraryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// LIBRARY_KEYWORD = "library";
                 /// ```
                 %library-keyword,
-                /// This kind represents a `MacroKeyword` node, with the following structure: 
+                /// Represents a node with kind `MacroKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// MACRO_KEYWORD = "macro";
                 /// ```
                 %macro-keyword,
-                /// This kind represents a `MappingKeyword` node, with the following structure: 
+                /// Represents a node with kind `MappingKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MAPPING_KEYWORD = "mapping";
                 /// ```
                 %mapping-keyword,
-                /// This kind represents a `MatchKeyword` node, with the following structure: 
+                /// Represents a node with kind `MatchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MATCH_KEYWORD = "match";
                 /// ```
                 %match-keyword,
-                /// This kind represents a `MemoryKeyword` node, with the following structure: 
+                /// Represents a node with kind `MemoryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MEMORY_KEYWORD = "memory";
                 /// ```
                 %memory-keyword,
-                /// This kind represents a `Minus` node, with the following structure: 
+                /// Represents a node with kind `Minus`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MINUS = "-";
                 /// ```
                 %minus,
-                /// This kind represents a `MinusEqual` node, with the following structure: 
+                /// Represents a node with kind `MinusEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MINUS_EQUAL = "-=";
                 /// ```
                 %minus-equal,
-                /// This kind represents a `MinusGreaterThan` node, with the following structure: 
+                /// Represents a node with kind `MinusGreaterThan`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MINUS_GREATER_THAN = "->";
                 /// ```
                 %minus-greater-than,
-                /// This kind represents a `MinusMinus` node, with the following structure: 
+                /// Represents a node with kind `MinusMinus`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MINUS_MINUS = "--";
                 /// ```
                 %minus-minus,
-                /// This kind represents a `MinutesKeyword` node, with the following structure: 
+                /// Represents a node with kind `MinutesKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MINUTES_KEYWORD = "minutes";
                 /// ```
                 %minutes-keyword,
-                /// This kind represents a `ModifierKeyword` node, with the following structure: 
+                /// Represents a node with kind `ModifierKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MODIFIER_KEYWORD = "modifier";
                 /// ```
                 %modifier-keyword,
-                /// This kind represents a `MultiLineComment` node, with the following structure: 
+                /// Represents a node with kind `MultiLineComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*/";
                 /// ```
                 %multi-line-comment,
-                /// This kind represents a `MultiLineNatSpecComment` node, with the following structure: 
+                /// Represents a node with kind `MultiLineNatSpecComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MULTI_LINE_NAT_SPEC_COMMENT = "/**" (!"*" | "*")* "*/";
                 /// ```
                 %multi-line-nat-spec-comment,
-                /// This kind represents a `MutableKeyword` node, with the following structure: 
+                /// Represents a node with kind `MutableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// MUTABLE_KEYWORD = "mutable";
                 /// ```
                 %mutable-keyword,
-                /// This kind represents a `NewKeyword` node, with the following structure: 
+                /// Represents a node with kind `NewKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NEW_KEYWORD = "new";
                 /// ```
                 %new-keyword,
-                /// This kind represents a `NullKeyword` node, with the following structure: 
+                /// Represents a node with kind `NullKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// NULL_KEYWORD = "null";
                 /// ```
                 %null-keyword,
-                /// This kind represents a `OfKeyword` node, with the following structure: 
+                /// Represents a node with kind `OfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// OF_KEYWORD = "of";
                 /// ```
                 %of-keyword,
-                /// This kind represents a `OpenBrace` node, with the following structure: 
+                /// Represents a node with kind `OpenBrace`, having the following structure:
                 ///
                 /// ```ebnf
                 /// OPEN_BRACE = "{";
                 /// ```
                 %open-brace,
-                /// This kind represents a `OpenBracket` node, with the following structure: 
+                /// Represents a node with kind `OpenBracket`, having the following structure:
                 ///
                 /// ```ebnf
                 /// OPEN_BRACKET = "[";
                 /// ```
                 %open-bracket,
-                /// This kind represents a `OpenParen` node, with the following structure: 
+                /// Represents a node with kind `OpenParen`, having the following structure:
                 ///
                 /// ```ebnf
                 /// OPEN_PAREN = "(";
                 /// ```
                 %open-paren,
-                /// This kind represents a `OverrideKeyword` node, with the following structure: 
+                /// Represents a node with kind `OverrideKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -2892,126 +2892,126 @@ interface cst {
                 /// OVERRIDE_KEYWORD = "override";
                 /// ```
                 %override-keyword,
-                /// This kind represents a `PartialKeyword` node, with the following structure: 
+                /// Represents a node with kind `PartialKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// PARTIAL_KEYWORD = "partial";
                 /// ```
                 %partial-keyword,
-                /// This kind represents a `PayableKeyword` node, with the following structure: 
+                /// Represents a node with kind `PayableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PAYABLE_KEYWORD = "payable";
                 /// ```
                 %payable-keyword,
-                /// This kind represents a `Percent` node, with the following structure: 
+                /// Represents a node with kind `Percent`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PERCENT = "%";
                 /// ```
                 %percent,
-                /// This kind represents a `PercentEqual` node, with the following structure: 
+                /// Represents a node with kind `PercentEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PERCENT_EQUAL = "%=";
                 /// ```
                 %percent-equal,
-                /// This kind represents a `Period` node, with the following structure: 
+                /// Represents a node with kind `Period`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PERIOD = ".";
                 /// ```
                 %period,
-                /// This kind represents a `Plus` node, with the following structure: 
+                /// Represents a node with kind `Plus`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PLUS = "+";
                 /// ```
                 %plus,
-                /// This kind represents a `PlusEqual` node, with the following structure: 
+                /// Represents a node with kind `PlusEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PLUS_EQUAL = "+=";
                 /// ```
                 %plus-equal,
-                /// This kind represents a `PlusPlus` node, with the following structure: 
+                /// Represents a node with kind `PlusPlus`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PLUS_PLUS = "++";
                 /// ```
                 %plus-plus,
-                /// This kind represents a `PragmaKeyword` node, with the following structure: 
+                /// Represents a node with kind `PragmaKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PRAGMA_KEYWORD = "pragma";
                 /// ```
                 %pragma-keyword,
-                /// This kind represents a `PrivateKeyword` node, with the following structure: 
+                /// Represents a node with kind `PrivateKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PRIVATE_KEYWORD = "private";
                 /// ```
                 %private-keyword,
-                /// This kind represents a `PromiseKeyword` node, with the following structure: 
+                /// Represents a node with kind `PromiseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// PROMISE_KEYWORD = "promise";
                 /// ```
                 %promise-keyword,
-                /// This kind represents a `PublicKeyword` node, with the following structure: 
+                /// Represents a node with kind `PublicKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PUBLIC_KEYWORD = "public";
                 /// ```
                 %public-keyword,
-                /// This kind represents a `PureKeyword` node, with the following structure: 
+                /// Represents a node with kind `PureKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.16 *)
                 /// PURE_KEYWORD = "pure";
                 /// ```
                 %pure-keyword,
-                /// This kind represents a `QuestionMark` node, with the following structure: 
+                /// Represents a node with kind `QuestionMark`, having the following structure:
                 ///
                 /// ```ebnf
                 /// QUESTION_MARK = "?";
                 /// ```
                 %question-mark,
-                /// This kind represents a `ReceiveKeyword` node, with the following structure: 
+                /// Represents a node with kind `ReceiveKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.6.0 *)
                 /// RECEIVE_KEYWORD = "receive";
                 /// ```
                 %receive-keyword,
-                /// This kind represents a `ReferenceKeyword` node, with the following structure: 
+                /// Represents a node with kind `ReferenceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// REFERENCE_KEYWORD = "reference";
                 /// ```
                 %reference-keyword,
-                /// This kind represents a `RelocatableKeyword` node, with the following structure: 
+                /// Represents a node with kind `RelocatableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// RELOCATABLE_KEYWORD = "relocatable";
                 /// ```
                 %relocatable-keyword,
-                /// This kind represents a `ReturnKeyword` node, with the following structure: 
+                /// Represents a node with kind `ReturnKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// RETURN_KEYWORD = "return";
                 /// ```
                 %return-keyword,
-                /// This kind represents a `ReturnsKeyword` node, with the following structure: 
+                /// Represents a node with kind `ReturnsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// RETURNS_KEYWORD = "returns";
                 /// ```
                 %returns-keyword,
-                /// This kind represents a `RevertKeyword` node, with the following structure: 
+                /// Represents a node with kind `RevertKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.4 *)
@@ -3019,44 +3019,44 @@ interface cst {
                 /// REVERT_KEYWORD = "revert";
                 /// ```
                 %revert-keyword,
-                /// This kind represents a `SealedKeyword` node, with the following structure: 
+                /// Represents a node with kind `SealedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// SEALED_KEYWORD = "sealed";
                 /// ```
                 %sealed-keyword,
-                /// This kind represents a `SecondsKeyword` node, with the following structure: 
+                /// Represents a node with kind `SecondsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SECONDS_KEYWORD = "seconds";
                 /// ```
                 %seconds-keyword,
-                /// This kind represents a `Semicolon` node, with the following structure: 
+                /// Represents a node with kind `Semicolon`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SEMICOLON = ";";
                 /// ```
                 %semicolon,
-                /// This kind represents a `SingleLineComment` node, with the following structure: 
+                /// Represents a node with kind `SingleLineComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
                 /// ```
                 %single-line-comment,
-                /// This kind represents a `SingleLineNatSpecComment` node, with the following structure: 
+                /// Represents a node with kind `SingleLineNatSpecComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SINGLE_LINE_NAT_SPEC_COMMENT = "///" (!("\r" "\n"))*;
                 /// ```
                 %single-line-nat-spec-comment,
-                /// This kind represents a `SingleQuotedHexStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `SingleQuotedHexStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SINGLE_QUOTED_HEX_STRING_LITERAL = "hex'" «HEX_STRING_CONTENTS»? "'";
                 /// ```
                 %single-quoted-hex-string-literal,
-                /// This kind represents a `SingleQuotedStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `SingleQuotedStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.4.25 *)
@@ -3068,89 +3068,89 @@ interface cst {
                 /// SINGLE_QUOTED_STRING_LITERAL = "'" («ESCAPE_SEQUENCE» | (" "…"&") | ("("…"[") | ("]"…"~"))* "'";
                 /// ```
                 %single-quoted-string-literal,
-                /// This kind represents a `SingleQuotedUnicodeStringLiteral` node, with the following structure: 
+                /// Represents a node with kind `SingleQuotedUnicodeStringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.7.0 *)
                 /// SINGLE_QUOTED_UNICODE_STRING_LITERAL = "unicode'" («ESCAPE_SEQUENCE» | !("'" "\\" "\r" "\n"))* "'";
                 /// ```
                 %single-quoted-unicode-string-literal,
-                /// This kind represents a `SingleQuotedVersionLiteral` node, with the following structure: 
+                /// Represents a node with kind `SingleQuotedVersionLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SINGLE_QUOTED_VERSION_LITERAL = "'" «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* "'";
                 /// ```
                 %single-quoted-version-literal,
-                /// This kind represents a `SizeOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `SizeOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// SIZE_OF_KEYWORD = "sizeof";
                 /// ```
                 %size-of-keyword,
-                /// This kind represents a `Slash` node, with the following structure: 
+                /// Represents a node with kind `Slash`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SLASH = "/";
                 /// ```
                 %slash,
-                /// This kind represents a `SlashEqual` node, with the following structure: 
+                /// Represents a node with kind `SlashEqual`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SLASH_EQUAL = "/=";
                 /// ```
                 %slash-equal,
-                /// This kind represents a `SolidityKeyword` node, with the following structure: 
+                /// Represents a node with kind `SolidityKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// SOLIDITY_KEYWORD = "solidity";
                 /// ```
                 %solidity-keyword,
-                /// This kind represents a `StaticKeyword` node, with the following structure: 
+                /// Represents a node with kind `StaticKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// STATIC_KEYWORD = "static";
                 /// ```
                 %static-keyword,
-                /// This kind represents a `StorageKeyword` node, with the following structure: 
+                /// Represents a node with kind `StorageKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// STORAGE_KEYWORD = "storage";
                 /// ```
                 %storage-keyword,
-                /// This kind represents a `StringKeyword` node, with the following structure: 
+                /// Represents a node with kind `StringKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// STRING_KEYWORD = "string";
                 /// ```
                 %string-keyword,
-                /// This kind represents a `StructKeyword` node, with the following structure: 
+                /// Represents a node with kind `StructKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// STRUCT_KEYWORD = "struct";
                 /// ```
                 %struct-keyword,
-                /// This kind represents a `SuperKeyword` node, with the following structure: 
+                /// Represents a node with kind `SuperKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SUPER_KEYWORD = "super";
                 /// ```
                 %super-keyword,
-                /// This kind represents a `SupportsKeyword` node, with the following structure: 
+                /// Represents a node with kind `SupportsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// SUPPORTS_KEYWORD = "supports";
                 /// ```
                 %supports-keyword,
-                /// This kind represents a `SwitchKeyword` node, with the following structure: 
+                /// Represents a node with kind `SwitchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SWITCH_KEYWORD = "switch";
                 /// ```
                 %switch-keyword,
-                /// This kind represents a `SzaboKeyword` node, with the following structure: 
+                /// Represents a node with kind `SzaboKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.7.0 *)
@@ -3158,26 +3158,26 @@ interface cst {
                 /// SZABO_KEYWORD = "szabo";
                 /// ```
                 %szabo-keyword,
-                /// This kind represents a `ThisKeyword` node, with the following structure: 
+                /// Represents a node with kind `ThisKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// THIS_KEYWORD = "this";
                 /// ```
                 %this-keyword,
-                /// This kind represents a `ThrowKeyword` node, with the following structure: 
+                /// Represents a node with kind `ThrowKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// THROW_KEYWORD = "throw";
                 /// ```
                 %throw-keyword,
-                /// This kind represents a `Tilde` node, with the following structure: 
+                /// Represents a node with kind `Tilde`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TILDE = "~";
                 /// ```
                 %tilde,
-                /// This kind represents a `TransientKeyword` node, with the following structure: 
+                /// Represents a node with kind `TransientKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.27 *)
@@ -3185,40 +3185,40 @@ interface cst {
                 /// TRANSIENT_KEYWORD = "transient";
                 /// ```
                 %transient-keyword,
-                /// This kind represents a `TrueKeyword` node, with the following structure: 
+                /// Represents a node with kind `TrueKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TRUE_KEYWORD = "true";
                 /// ```
                 %true-keyword,
-                /// This kind represents a `TryKeyword` node, with the following structure: 
+                /// Represents a node with kind `TryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
                 /// TRY_KEYWORD = "try";
                 /// ```
                 %try-keyword,
-                /// This kind represents a `TypeDefKeyword` node, with the following structure: 
+                /// Represents a node with kind `TypeDefKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.0 *)
                 /// TYPE_DEF_KEYWORD = "typedef";
                 /// ```
                 %type-def-keyword,
-                /// This kind represents a `TypeKeyword` node, with the following structure: 
+                /// Represents a node with kind `TypeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.3 *)
                 /// TYPE_KEYWORD = "type";
                 /// ```
                 %type-keyword,
-                /// This kind represents a `TypeOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `TypeOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TYPE_OF_KEYWORD = "typeof";
                 /// ```
                 %type-of-keyword,
-                /// This kind represents a `UfixedKeyword` node, with the following structure: 
+                /// Represents a node with kind `UfixedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UFIXED_KEYWORD = "ufixed";
@@ -3234,13 +3234,13 @@ interface cst {
                 /// UFIXED_KEYWORD = "ufixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
                 /// ```
                 %ufixed-keyword,
-                /// This kind represents a `UintKeyword` node, with the following structure: 
+                /// Represents a node with kind `UintKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// UINT_KEYWORD = "uint" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
                 /// ```
                 %uint-keyword,
-                /// This kind represents a `UncheckedKeyword` node, with the following structure: 
+                /// Represents a node with kind `UncheckedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.0 *)
@@ -3248,33 +3248,33 @@ interface cst {
                 /// UNCHECKED_KEYWORD = "unchecked";
                 /// ```
                 %unchecked-keyword,
-                /// This kind represents a `UsingKeyword` node, with the following structure: 
+                /// Represents a node with kind `UsingKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// USING_KEYWORD = "using";
                 /// ```
                 %using-keyword,
-                /// This kind represents a `VarKeyword` node, with the following structure: 
+                /// Represents a node with kind `VarKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// VAR_KEYWORD = "var";
                 /// ```
                 %var-keyword,
-                /// This kind represents a `VersionSpecifier` node, with the following structure: 
+                /// Represents a node with kind `VersionSpecifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// VERSION_SPECIFIER = «VERSION_SPECIFIER_FRAGMENT»;
                 /// ```
                 %version-specifier,
-                /// This kind represents a `ViewKeyword` node, with the following structure: 
+                /// Represents a node with kind `ViewKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.16 *)
                 /// VIEW_KEYWORD = "view";
                 /// ```
                 %view-keyword,
-                /// This kind represents a `VirtualKeyword` node, with the following structure: 
+                /// Represents a node with kind `VirtualKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -3282,125 +3282,125 @@ interface cst {
                 /// VIRTUAL_KEYWORD = "virtual";
                 /// ```
                 %virtual-keyword,
-                /// This kind represents a `WeeksKeyword` node, with the following structure: 
+                /// Represents a node with kind `WeeksKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WEEKS_KEYWORD = "weeks";
                 /// ```
                 %weeks-keyword,
-                /// This kind represents a `WeiKeyword` node, with the following structure: 
+                /// Represents a node with kind `WeiKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WEI_KEYWORD = "wei";
                 /// ```
                 %wei-keyword,
-                /// This kind represents a `WhileKeyword` node, with the following structure: 
+                /// Represents a node with kind `WhileKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WHILE_KEYWORD = "while";
                 /// ```
                 %while-keyword,
-                /// This kind represents a `Whitespace` node, with the following structure: 
+                /// Represents a node with kind `Whitespace`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WHITESPACE = (" " | "\t")+;
                 /// ```
                 %whitespace,
-                /// This kind represents a `YearsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YearsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// YEARS_KEYWORD = "years";
                 /// ```
                 %years-keyword,
-                /// This kind represents a `YulAbstractKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAbstractKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ABSTRACT_KEYWORD = "abstract";
                 /// ```
                 %yul-abstract-keyword,
-                /// This kind represents a `YulAddKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAddKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_ADD_KEYWORD = "add";
                 /// ```
                 %yul-add-keyword,
-                /// This kind represents a `YulAddModKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAddModKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_ADD_MOD_KEYWORD = "addmod";
                 /// ```
                 %yul-add-mod-keyword,
-                /// This kind represents a `YulAddressKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAddressKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Never reserved *)
                 /// YUL_ADDRESS_KEYWORD = "address";
                 /// ```
                 %yul-address-keyword,
-                /// This kind represents a `YulAfterKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAfterKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_AFTER_KEYWORD = "after";
                 /// ```
                 %yul-after-keyword,
-                /// This kind represents a `YulAliasKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAliasKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_ALIAS_KEYWORD = "alias";
                 /// ```
                 %yul-alias-keyword,
-                /// This kind represents a `YulAndKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAndKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_AND_KEYWORD = "and";
                 /// ```
                 %yul-and-keyword,
-                /// This kind represents a `YulAnonymousKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAnonymousKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ANONYMOUS_KEYWORD = "anonymous";
                 /// ```
                 %yul-anonymous-keyword,
-                /// This kind represents a `YulApplyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulApplyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_APPLY_KEYWORD = "apply";
                 /// ```
                 %yul-apply-keyword,
-                /// This kind represents a `YulAsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_AS_KEYWORD = "as";
                 /// ```
                 %yul-as-keyword,
-                /// This kind represents a `YulAssemblyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAssemblyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ASSEMBLY_KEYWORD = "assembly";
                 /// ```
                 %yul-assembly-keyword,
-                /// This kind represents a `YulAutoKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulAutoKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_AUTO_KEYWORD = "auto";
                 /// ```
                 %yul-auto-keyword,
-                /// This kind represents a `YulBalanceKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBalanceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_BALANCE_KEYWORD = "balance";
                 /// ```
                 %yul-balance-keyword,
-                /// This kind represents a `YulBaseFeeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBaseFeeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.7 *)
@@ -3408,7 +3408,7 @@ interface cst {
                 /// YUL_BASE_FEE_KEYWORD = "basefee";
                 /// ```
                 %yul-base-fee-keyword,
-                /// This kind represents a `YulBlobBaseFeeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBlobBaseFeeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.24 *)
@@ -3416,7 +3416,7 @@ interface cst {
                 /// YUL_BLOB_BASE_FEE_KEYWORD = "blobbasefee";
                 /// ```
                 %yul-blob-base-fee-keyword,
-                /// This kind represents a `YulBlobHashKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBlobHashKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.24 *)
@@ -3424,148 +3424,148 @@ interface cst {
                 /// YUL_BLOB_HASH_KEYWORD = "blobhash";
                 /// ```
                 %yul-blob-hash-keyword,
-                /// This kind represents a `YulBlockHashKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBlockHashKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_BLOCK_HASH_KEYWORD = "blockhash";
                 /// ```
                 %yul-block-hash-keyword,
-                /// This kind represents a `YulBoolKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBoolKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.5.10 *)
                 /// YUL_BOOL_KEYWORD = "bool";
                 /// ```
                 %yul-bool-keyword,
-                /// This kind represents a `YulBreakKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBreakKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_BREAK_KEYWORD = "break";
                 /// ```
                 %yul-break-keyword,
-                /// This kind represents a `YulByteKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulByteKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_BYTE_KEYWORD = "byte";
                 /// ```
                 %yul-byte-keyword,
-                /// This kind represents a `YulBytesKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulBytesKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_BYTES_KEYWORD = "bytes" ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32")?;
                 /// ```
                 %yul-bytes-keyword,
-                /// This kind represents a `YulCallCodeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallCodeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_CODE_KEYWORD = "callcode";
                 /// ```
                 %yul-call-code-keyword,
-                /// This kind represents a `YulCallDataCopyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallDataCopyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_DATA_COPY_KEYWORD = "calldatacopy";
                 /// ```
                 %yul-call-data-copy-keyword,
-                /// This kind represents a `YulCallDataKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallDataKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_CALL_DATA_KEYWORD = "calldata";
                 /// ```
                 %yul-call-data-keyword,
-                /// This kind represents a `YulCallDataLoadKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallDataLoadKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_DATA_LOAD_KEYWORD = "calldataload";
                 /// ```
                 %yul-call-data-load-keyword,
-                /// This kind represents a `YulCallDataSizeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallDataSizeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_DATA_SIZE_KEYWORD = "calldatasize";
                 /// ```
                 %yul-call-data-size-keyword,
-                /// This kind represents a `YulCallKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_KEYWORD = "call";
                 /// ```
                 %yul-call-keyword,
-                /// This kind represents a `YulCallValueKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallValueKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALL_VALUE_KEYWORD = "callvalue";
                 /// ```
                 %yul-call-value-keyword,
-                /// This kind represents a `YulCallerKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCallerKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CALLER_KEYWORD = "caller";
                 /// ```
                 %yul-caller-keyword,
-                /// This kind represents a `YulCaseKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCaseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CASE_KEYWORD = "case";
                 /// ```
                 %yul-case-keyword,
-                /// This kind represents a `YulCatchKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCatchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_CATCH_KEYWORD = "catch";
                 /// ```
                 %yul-catch-keyword,
-                /// This kind represents a `YulChainIdKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulChainIdKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.12 *)
                 /// YUL_CHAIN_ID_KEYWORD = "chainid";
                 /// ```
                 %yul-chain-id-keyword,
-                /// This kind represents a `YulCoinBaseKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCoinBaseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_COIN_BASE_KEYWORD = "coinbase";
                 /// ```
                 %yul-coin-base-keyword,
-                /// This kind represents a `YulConstantKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulConstantKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_CONSTANT_KEYWORD = "constant";
                 /// ```
                 %yul-constant-keyword,
-                /// This kind represents a `YulConstructorKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulConstructorKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_CONSTRUCTOR_KEYWORD = "constructor";
                 /// ```
                 %yul-constructor-keyword,
-                /// This kind represents a `YulContinueKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulContinueKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CONTINUE_KEYWORD = "continue";
                 /// ```
                 %yul-continue-keyword,
-                /// This kind represents a `YulContractKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulContractKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_CONTRACT_KEYWORD = "contract";
                 /// ```
                 %yul-contract-keyword,
-                /// This kind represents a `YulCopyOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCopyOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_COPY_OF_KEYWORD = "copyof";
                 /// ```
                 %yul-copy-of-keyword,
-                /// This kind represents a `YulCreate2Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulCreate2Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.12 *)
@@ -3573,125 +3573,125 @@ interface cst {
                 /// YUL_CREATE_2_KEYWORD = "create2";
                 /// ```
                 %yul-create2-keyword,
-                /// This kind represents a `YulCreateKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulCreateKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_CREATE_KEYWORD = "create";
                 /// ```
                 %yul-create-keyword,
-                /// This kind represents a `YulDaysKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDaysKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_DAYS_KEYWORD = "days";
                 /// ```
                 %yul-days-keyword,
-                /// This kind represents a `YulDecimalLiteral` node, with the following structure: 
+                /// Represents a node with kind `YulDecimalLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_DECIMAL_LITERAL = "0" | (("1"…"9") ("0"…"9")*);
                 /// ```
                 %yul-decimal-literal,
-                /// This kind represents a `YulDefaultKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDefaultKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_DEFAULT_KEYWORD = "default";
                 /// ```
                 %yul-default-keyword,
-                /// This kind represents a `YulDefineKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDefineKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_DEFINE_KEYWORD = "define";
                 /// ```
                 %yul-define-keyword,
-                /// This kind represents a `YulDelegateCallKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDelegateCallKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_DELEGATE_CALL_KEYWORD = "delegatecall";
                 /// ```
                 %yul-delegate-call-keyword,
-                /// This kind represents a `YulDeleteKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDeleteKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_DELETE_KEYWORD = "delete";
                 /// ```
                 %yul-delete-keyword,
-                /// This kind represents a `YulDifficultyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDifficultyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.8.18 *)
                 /// YUL_DIFFICULTY_KEYWORD = "difficulty";
                 /// ```
                 %yul-difficulty-keyword,
-                /// This kind represents a `YulDivKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDivKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_DIV_KEYWORD = "div";
                 /// ```
                 %yul-div-keyword,
-                /// This kind represents a `YulDoKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulDoKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_DO_KEYWORD = "do";
                 /// ```
                 %yul-do-keyword,
-                /// This kind represents a `YulElseKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulElseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ELSE_KEYWORD = "else";
                 /// ```
                 %yul-else-keyword,
-                /// This kind represents a `YulEmitKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulEmitKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_EMIT_KEYWORD = "emit";
                 /// ```
                 %yul-emit-keyword,
-                /// This kind represents a `YulEnumKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulEnumKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ENUM_KEYWORD = "enum";
                 /// ```
                 %yul-enum-keyword,
-                /// This kind represents a `YulEqKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulEqKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_EQ_KEYWORD = "eq";
                 /// ```
                 %yul-eq-keyword,
-                /// This kind represents a `YulEtherKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulEtherKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_ETHER_KEYWORD = "ether";
                 /// ```
                 %yul-ether-keyword,
-                /// This kind represents a `YulEventKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulEventKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_EVENT_KEYWORD = "event";
                 /// ```
                 %yul-event-keyword,
-                /// This kind represents a `YulExpKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulExpKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_EXP_KEYWORD = "exp";
                 /// ```
                 %yul-exp-keyword,
-                /// This kind represents a `YulExtCodeCopyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulExtCodeCopyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_EXT_CODE_COPY_KEYWORD = "extcodecopy";
                 /// ```
                 %yul-ext-code-copy-keyword,
-                /// This kind represents a `YulExtCodeHashKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulExtCodeHashKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.0 *)
@@ -3699,47 +3699,47 @@ interface cst {
                 /// YUL_EXT_CODE_HASH_KEYWORD = "extcodehash";
                 /// ```
                 %yul-ext-code-hash-keyword,
-                /// This kind represents a `YulExtCodeSizeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulExtCodeSizeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_EXT_CODE_SIZE_KEYWORD = "extcodesize";
                 /// ```
                 %yul-ext-code-size-keyword,
-                /// This kind represents a `YulExternalKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulExternalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_EXTERNAL_KEYWORD = "external";
                 /// ```
                 %yul-external-keyword,
-                /// This kind represents a `YulFallbackKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFallbackKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.6.0 until 0.7.1 *)
                 /// YUL_FALLBACK_KEYWORD = "fallback";
                 /// ```
                 %yul-fallback-keyword,
-                /// This kind represents a `YulFalseKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFalseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_FALSE_KEYWORD = "false";
                 /// ```
                 %yul-false-keyword,
-                /// This kind represents a `YulFinalKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFinalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_FINAL_KEYWORD = "final";
                 /// ```
                 %yul-final-keyword,
-                /// This kind represents a `YulFinneyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFinneyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.0 *)
                 /// YUL_FINNEY_KEYWORD = "finney";
                 /// ```
                 %yul-finney-keyword,
-                /// This kind represents a `YulFixedKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFixedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
@@ -3758,69 +3758,69 @@ interface cst {
                 /// YUL_FIXED_KEYWORD = "fixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
                 /// ```
                 %yul-fixed-keyword,
-                /// This kind represents a `YulForKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulForKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_FOR_KEYWORD = "for";
                 /// ```
                 %yul-for-keyword,
-                /// This kind represents a `YulFunctionKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulFunctionKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_FUNCTION_KEYWORD = "function";
                 /// ```
                 %yul-function-keyword,
-                /// This kind represents a `YulGasKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulGasKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_GAS_KEYWORD = "gas";
                 /// ```
                 %yul-gas-keyword,
-                /// This kind represents a `YulGasLimitKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulGasLimitKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_GAS_LIMIT_KEYWORD = "gaslimit";
                 /// ```
                 %yul-gas-limit-keyword,
-                /// This kind represents a `YulGasPriceKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulGasPriceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_GAS_PRICE_KEYWORD = "gasprice";
                 /// ```
                 %yul-gas-price-keyword,
-                /// This kind represents a `YulGtKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulGtKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_GT_KEYWORD = "gt";
                 /// ```
                 %yul-gt-keyword,
-                /// This kind represents a `YulGweiKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulGweiKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.7.0 until 0.7.1 *)
                 /// YUL_GWEI_KEYWORD = "gwei";
                 /// ```
                 %yul-gwei-keyword,
-                /// This kind represents a `YulHexKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulHexKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_HEX_KEYWORD = "hex";
                 /// ```
                 %yul-hex-keyword,
-                /// This kind represents a `YulHexLiteral` node, with the following structure: 
+                /// Represents a node with kind `YulHexLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_HEX_LITERAL = "0x" «HEX_CHARACTER»+;
                 /// ```
                 %yul-hex-literal,
-                /// This kind represents a `YulHoursKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulHoursKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_HOURS_KEYWORD = "hours";
                 /// ```
                 %yul-hours-keyword,
-                /// This kind represents a `YulIdentifier` node, with the following structure: 
+                /// Represents a node with kind `YulIdentifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.5.8 and deprecated in 0.7.0. *)
@@ -3829,109 +3829,109 @@ interface cst {
                 /// YUL_IDENTIFIER = «IDENTIFIER_START» «IDENTIFIER_PART»*;
                 /// ```
                 %yul-identifier,
-                /// This kind represents a `YulIfKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulIfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_IF_KEYWORD = "if";
                 /// ```
                 %yul-if-keyword,
-                /// This kind represents a `YulImmutableKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulImmutableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_IMMUTABLE_KEYWORD = "immutable";
                 /// ```
                 %yul-immutable-keyword,
-                /// This kind represents a `YulImplementsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulImplementsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_IMPLEMENTS_KEYWORD = "implements";
                 /// ```
                 %yul-implements-keyword,
-                /// This kind represents a `YulImportKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulImportKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_IMPORT_KEYWORD = "import";
                 /// ```
                 %yul-import-keyword,
-                /// This kind represents a `YulInKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulInKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.6.8 *)
                 /// YUL_IN_KEYWORD = "in";
                 /// ```
                 %yul-in-keyword,
-                /// This kind represents a `YulIndexedKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulIndexedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_INDEXED_KEYWORD = "indexed";
                 /// ```
                 %yul-indexed-keyword,
-                /// This kind represents a `YulInlineKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulInlineKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_INLINE_KEYWORD = "inline";
                 /// ```
                 %yul-inline-keyword,
-                /// This kind represents a `YulIntKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulIntKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_INT_KEYWORD = "int" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
                 /// ```
                 %yul-int-keyword,
-                /// This kind represents a `YulInterfaceKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulInterfaceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_INTERFACE_KEYWORD = "interface";
                 /// ```
                 %yul-interface-keyword,
-                /// This kind represents a `YulInternalKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulInternalKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_INTERNAL_KEYWORD = "internal";
                 /// ```
                 %yul-internal-keyword,
-                /// This kind represents a `YulInvalidKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulInvalidKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_INVALID_KEYWORD = "invalid";
                 /// ```
                 %yul-invalid-keyword,
-                /// This kind represents a `YulIsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulIsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_IS_KEYWORD = "is";
                 /// ```
                 %yul-is-keyword,
-                /// This kind represents a `YulIsZeroKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulIsZeroKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_IS_ZERO_KEYWORD = "iszero";
                 /// ```
                 %yul-is-zero-keyword,
-                /// This kind represents a `YulJumpKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulJumpKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// YUL_JUMP_KEYWORD = "jump";
                 /// ```
                 %yul-jump-keyword,
-                /// This kind represents a `YulJumpiKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulJumpiKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
                 /// YUL_JUMPI_KEYWORD = "jumpi";
                 /// ```
                 %yul-jumpi-keyword,
-                /// This kind represents a `YulKeccak256Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulKeccak256Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.12 *)
@@ -3939,7 +3939,7 @@ interface cst {
                 /// YUL_KECCAK_256_KEYWORD = "keccak256";
                 /// ```
                 %yul-keccak256-keyword,
-                /// This kind represents a `YulLeaveKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulLeaveKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.6.0 *)
@@ -3947,56 +3947,56 @@ interface cst {
                 /// YUL_LEAVE_KEYWORD = "leave";
                 /// ```
                 %yul-leave-keyword,
-                /// This kind represents a `YulLetKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulLetKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LET_KEYWORD = "let";
                 /// ```
                 %yul-let-keyword,
-                /// This kind represents a `YulLibraryKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulLibraryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_LIBRARY_KEYWORD = "library";
                 /// ```
                 %yul-library-keyword,
-                /// This kind represents a `YulLog0Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulLog0Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LOG_0_KEYWORD = "log0";
                 /// ```
                 %yul-log0-keyword,
-                /// This kind represents a `YulLog1Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulLog1Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LOG_1_KEYWORD = "log1";
                 /// ```
                 %yul-log1-keyword,
-                /// This kind represents a `YulLog2Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulLog2Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LOG_2_KEYWORD = "log2";
                 /// ```
                 %yul-log2-keyword,
-                /// This kind represents a `YulLog3Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulLog3Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LOG_3_KEYWORD = "log3";
                 /// ```
                 %yul-log3-keyword,
-                /// This kind represents a `YulLog4Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulLog4Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LOG_4_KEYWORD = "log4";
                 /// ```
                 %yul-log4-keyword,
-                /// This kind represents a `YulLtKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulLtKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_LT_KEYWORD = "lt";
                 /// ```
                 %yul-lt-keyword,
-                /// This kind represents a `YulMCopyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMCopyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.24 *)
@@ -4004,177 +4004,177 @@ interface cst {
                 /// YUL_M_COPY_KEYWORD = "mcopy";
                 /// ```
                 %yul-mcopy-keyword,
-                /// This kind represents a `YulMLoadKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMLoadKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_M_LOAD_KEYWORD = "mload";
                 /// ```
                 %yul-mload-keyword,
-                /// This kind represents a `YulMSizeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMSizeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_M_SIZE_KEYWORD = "msize";
                 /// ```
                 %yul-msize-keyword,
-                /// This kind represents a `YulMStore8Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulMStore8Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_M_STORE_8_KEYWORD = "mstore8";
                 /// ```
                 %yul-mstore8-keyword,
-                /// This kind represents a `YulMStoreKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMStoreKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_M_STORE_KEYWORD = "mstore";
                 /// ```
                 %yul-mstore-keyword,
-                /// This kind represents a `YulMacroKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMacroKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_MACRO_KEYWORD = "macro";
                 /// ```
                 %yul-macro-keyword,
-                /// This kind represents a `YulMappingKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMappingKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_MAPPING_KEYWORD = "mapping";
                 /// ```
                 %yul-mapping-keyword,
-                /// This kind represents a `YulMatchKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMatchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_MATCH_KEYWORD = "match";
                 /// ```
                 %yul-match-keyword,
-                /// This kind represents a `YulMemoryKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMemoryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_MEMORY_KEYWORD = "memory";
                 /// ```
                 %yul-memory-keyword,
-                /// This kind represents a `YulMinutesKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMinutesKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_MINUTES_KEYWORD = "minutes";
                 /// ```
                 %yul-minutes-keyword,
-                /// This kind represents a `YulModKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulModKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_MOD_KEYWORD = "mod";
                 /// ```
                 %yul-mod-keyword,
-                /// This kind represents a `YulModifierKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulModifierKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_MODIFIER_KEYWORD = "modifier";
                 /// ```
                 %yul-modifier-keyword,
-                /// This kind represents a `YulMulKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMulKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_MUL_KEYWORD = "mul";
                 /// ```
                 %yul-mul-keyword,
-                /// This kind represents a `YulMulModKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMulModKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_MUL_MOD_KEYWORD = "mulmod";
                 /// ```
                 %yul-mul-mod-keyword,
-                /// This kind represents a `YulMutableKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulMutableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_MUTABLE_KEYWORD = "mutable";
                 /// ```
                 %yul-mutable-keyword,
-                /// This kind represents a `YulNewKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulNewKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_NEW_KEYWORD = "new";
                 /// ```
                 %yul-new-keyword,
-                /// This kind represents a `YulNotKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulNotKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_NOT_KEYWORD = "not";
                 /// ```
                 %yul-not-keyword,
-                /// This kind represents a `YulNullKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulNullKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_NULL_KEYWORD = "null";
                 /// ```
                 %yul-null-keyword,
-                /// This kind represents a `YulNumberKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulNumberKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_NUMBER_KEYWORD = "number";
                 /// ```
                 %yul-number-keyword,
-                /// This kind represents a `YulOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_OF_KEYWORD = "of";
                 /// ```
                 %yul-of-keyword,
-                /// This kind represents a `YulOrKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulOrKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_OR_KEYWORD = "or";
                 /// ```
                 %yul-or-keyword,
-                /// This kind represents a `YulOriginKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulOriginKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_ORIGIN_KEYWORD = "origin";
                 /// ```
                 %yul-origin-keyword,
-                /// This kind represents a `YulOverrideKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulOverrideKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_OVERRIDE_KEYWORD = "override";
                 /// ```
                 %yul-override-keyword,
-                /// This kind represents a `YulPartialKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPartialKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_PARTIAL_KEYWORD = "partial";
                 /// ```
                 %yul-partial-keyword,
-                /// This kind represents a `YulPayableKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPayableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_PAYABLE_KEYWORD = "payable";
                 /// ```
                 %yul-payable-keyword,
-                /// This kind represents a `YulPopKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPopKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_POP_KEYWORD = "pop";
                 /// ```
                 %yul-pop-keyword,
-                /// This kind represents a `YulPragmaKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPragmaKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_PRAGMA_KEYWORD = "pragma";
                 /// ```
                 %yul-pragma-keyword,
-                /// This kind represents a `YulPrevRandaoKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPrevRandaoKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.18 *)
@@ -4182,56 +4182,56 @@ interface cst {
                 /// YUL_PREV_RANDAO_KEYWORD = "prevrandao";
                 /// ```
                 %yul-prev-randao-keyword,
-                /// This kind represents a `YulPrivateKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPrivateKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_PRIVATE_KEYWORD = "private";
                 /// ```
                 %yul-private-keyword,
-                /// This kind represents a `YulPromiseKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPromiseKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_PROMISE_KEYWORD = "promise";
                 /// ```
                 %yul-promise-keyword,
-                /// This kind represents a `YulPublicKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPublicKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_PUBLIC_KEYWORD = "public";
                 /// ```
                 %yul-public-keyword,
-                /// This kind represents a `YulPureKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulPureKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_PURE_KEYWORD = "pure";
                 /// ```
                 %yul-pure-keyword,
-                /// This kind represents a `YulReceiveKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReceiveKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.6.0 until 0.7.1 *)
                 /// YUL_RECEIVE_KEYWORD = "receive";
                 /// ```
                 %yul-receive-keyword,
-                /// This kind represents a `YulReferenceKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReferenceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_REFERENCE_KEYWORD = "reference";
                 /// ```
                 %yul-reference-keyword,
-                /// This kind represents a `YulRelocatableKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulRelocatableKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_RELOCATABLE_KEYWORD = "relocatable";
                 /// ```
                 %yul-relocatable-keyword,
-                /// This kind represents a `YulReturnDataCopyKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReturnDataCopyKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.12 *)
@@ -4239,7 +4239,7 @@ interface cst {
                 /// YUL_RETURN_DATA_COPY_KEYWORD = "returndatacopy";
                 /// ```
                 %yul-return-data-copy-keyword,
-                /// This kind represents a `YulReturnDataSizeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReturnDataSizeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.12 *)
@@ -4247,90 +4247,90 @@ interface cst {
                 /// YUL_RETURN_DATA_SIZE_KEYWORD = "returndatasize";
                 /// ```
                 %yul-return-data-size-keyword,
-                /// This kind represents a `YulReturnKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReturnKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_RETURN_KEYWORD = "return";
                 /// ```
                 %yul-return-keyword,
-                /// This kind represents a `YulReturnsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulReturnsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_RETURNS_KEYWORD = "returns";
                 /// ```
                 %yul-returns-keyword,
-                /// This kind represents a `YulRevertKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulRevertKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_REVERT_KEYWORD = "revert";
                 /// ```
                 %yul-revert-keyword,
-                /// This kind represents a `YulSDivKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSDivKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_S_DIV_KEYWORD = "sdiv";
                 /// ```
                 %yul-sdiv-keyword,
-                /// This kind represents a `YulSLoadKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSLoadKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_S_LOAD_KEYWORD = "sload";
                 /// ```
                 %yul-sload-keyword,
-                /// This kind represents a `YulSModKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSModKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_S_MOD_KEYWORD = "smod";
                 /// ```
                 %yul-smod-keyword,
-                /// This kind represents a `YulSStoreKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSStoreKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_S_STORE_KEYWORD = "sstore";
                 /// ```
                 %yul-sstore-keyword,
-                /// This kind represents a `YulSarKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSarKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.4.21 *)
                 /// YUL_SAR_KEYWORD = "sar";
                 /// ```
                 %yul-sar-keyword,
-                /// This kind represents a `YulSealedKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSealedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_SEALED_KEYWORD = "sealed";
                 /// ```
                 %yul-sealed-keyword,
-                /// This kind represents a `YulSecondsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSecondsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_SECONDS_KEYWORD = "seconds";
                 /// ```
                 %yul-seconds-keyword,
-                /// This kind represents a `YulSelfBalanceKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSelfBalanceKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.5.12 *)
                 /// YUL_SELF_BALANCE_KEYWORD = "selfbalance";
                 /// ```
                 %yul-self-balance-keyword,
-                /// This kind represents a `YulSelfDestructKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSelfDestructKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SELF_DESTRUCT_KEYWORD = "selfdestruct";
                 /// ```
                 %yul-self-destruct-keyword,
-                /// This kind represents a `YulSgtKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSgtKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SGT_KEYWORD = "sgt";
                 /// ```
                 %yul-sgt-keyword,
-                /// This kind represents a `YulSha3Keyword` node, with the following structure: 
+                /// Represents a node with kind `YulSha3Keyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -4338,40 +4338,40 @@ interface cst {
                 /// YUL_SHA_3_KEYWORD = "sha3";
                 /// ```
                 %yul-sha3-keyword,
-                /// This kind represents a `YulShlKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulShlKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.4.21 *)
                 /// YUL_SHL_KEYWORD = "shl";
                 /// ```
                 %yul-shl-keyword,
-                /// This kind represents a `YulShrKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulShrKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved in 0.4.21 *)
                 /// YUL_SHR_KEYWORD = "shr";
                 /// ```
                 %yul-shr-keyword,
-                /// This kind represents a `YulSignExtendKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSignExtendKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SIGN_EXTEND_KEYWORD = "signextend";
                 /// ```
                 %yul-sign-extend-keyword,
-                /// This kind represents a `YulSizeOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSizeOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_SIZE_OF_KEYWORD = "sizeof";
                 /// ```
                 %yul-size-of-keyword,
-                /// This kind represents a `YulSltKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSltKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SLT_KEYWORD = "slt";
                 /// ```
                 %yul-slt-keyword,
-                /// This kind represents a `YulStaticCallKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStaticCallKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.12 *)
@@ -4379,47 +4379,47 @@ interface cst {
                 /// YUL_STATIC_CALL_KEYWORD = "staticcall";
                 /// ```
                 %yul-static-call-keyword,
-                /// This kind represents a `YulStaticKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStaticKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_STATIC_KEYWORD = "static";
                 /// ```
                 %yul-static-keyword,
-                /// This kind represents a `YulStopKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStopKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_STOP_KEYWORD = "stop";
                 /// ```
                 %yul-stop-keyword,
-                /// This kind represents a `YulStorageKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStorageKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_STORAGE_KEYWORD = "storage";
                 /// ```
                 %yul-storage-keyword,
-                /// This kind represents a `YulStringKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStringKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_STRING_KEYWORD = "string";
                 /// ```
                 %yul-string-keyword,
-                /// This kind represents a `YulStructKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulStructKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_STRUCT_KEYWORD = "struct";
                 /// ```
                 %yul-struct-keyword,
-                /// This kind represents a `YulSubKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSubKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SUB_KEYWORD = "sub";
                 /// ```
                 %yul-sub-keyword,
-                /// This kind represents a `YulSuicideKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSuicideKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Deprecated in 0.5.0 *)
@@ -4427,33 +4427,33 @@ interface cst {
                 /// YUL_SUICIDE_KEYWORD = "suicide";
                 /// ```
                 %yul-suicide-keyword,
-                /// This kind represents a `YulSuperKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSuperKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SUPER_KEYWORD = "super";
                 /// ```
                 %yul-super-keyword,
-                /// This kind represents a `YulSupportsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSupportsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_SUPPORTS_KEYWORD = "supports";
                 /// ```
                 %yul-supports-keyword,
-                /// This kind represents a `YulSwitchKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSwitchKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_SWITCH_KEYWORD = "switch";
                 /// ```
                 %yul-switch-keyword,
-                /// This kind represents a `YulSzaboKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulSzaboKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.0 *)
                 /// YUL_SZABO_KEYWORD = "szabo";
                 /// ```
                 %yul-szabo-keyword,
-                /// This kind represents a `YulTLoadKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTLoadKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.24 *)
@@ -4461,7 +4461,7 @@ interface cst {
                 /// YUL_T_LOAD_KEYWORD = "tload";
                 /// ```
                 %yul-tload-keyword,
-                /// This kind represents a `YulTStoreKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTStoreKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.8.24 *)
@@ -4469,60 +4469,60 @@ interface cst {
                 /// YUL_T_STORE_KEYWORD = "tstore";
                 /// ```
                 %yul-tstore-keyword,
-                /// This kind represents a `YulThisKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulThisKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_THIS_KEYWORD = "this";
                 /// ```
                 %yul-this-keyword,
-                /// This kind represents a `YulThrowKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulThrowKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_THROW_KEYWORD = "throw";
                 /// ```
                 %yul-throw-keyword,
-                /// This kind represents a `YulTimestampKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTimestampKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_TIMESTAMP_KEYWORD = "timestamp";
                 /// ```
                 %yul-timestamp-keyword,
-                /// This kind represents a `YulTrueKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTrueKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_TRUE_KEYWORD = "true";
                 /// ```
                 %yul-true-keyword,
-                /// This kind represents a `YulTryKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTryKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_TRY_KEYWORD = "try";
                 /// ```
                 %yul-try-keyword,
-                /// This kind represents a `YulTypeDefKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTypeDefKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_TYPE_DEF_KEYWORD = "typedef";
                 /// ```
                 %yul-type-def-keyword,
-                /// This kind represents a `YulTypeKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTypeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_TYPE_KEYWORD = "type";
                 /// ```
                 %yul-type-keyword,
-                /// This kind represents a `YulTypeOfKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulTypeOfKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_TYPE_OF_KEYWORD = "typeof";
                 /// ```
                 %yul-type-of-keyword,
-                /// This kind represents a `YulUfixedKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulUfixedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
@@ -4541,76 +4541,76 @@ interface cst {
                 /// YUL_UFIXED_KEYWORD = "ufixed" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256") "x" ("0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "73" | "74" | "75" | "76" | "77" | "78" | "79");
                 /// ```
                 %yul-ufixed-keyword,
-                /// This kind represents a `YulUintKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulUintKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_UINT_KEYWORD = "uint" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
                 /// ```
                 %yul-uint-keyword,
-                /// This kind represents a `YulUncheckedKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulUncheckedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.5.0 until 0.7.1 *)
                 /// YUL_UNCHECKED_KEYWORD = "unchecked";
                 /// ```
                 %yul-unchecked-keyword,
-                /// This kind represents a `YulUsingKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulUsingKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_USING_KEYWORD = "using";
                 /// ```
                 %yul-using-keyword,
-                /// This kind represents a `YulVarKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulVarKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.6.5 *)
                 /// YUL_VAR_KEYWORD = "var";
                 /// ```
                 %yul-var-keyword,
-                /// This kind represents a `YulViewKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulViewKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_VIEW_KEYWORD = "view";
                 /// ```
                 %yul-view-keyword,
-                /// This kind represents a `YulVirtualKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulVirtualKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved from 0.6.0 until 0.7.1 *)
                 /// YUL_VIRTUAL_KEYWORD = "virtual";
                 /// ```
                 %yul-virtual-keyword,
-                /// This kind represents a `YulWeeksKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulWeeksKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_WEEKS_KEYWORD = "weeks";
                 /// ```
                 %yul-weeks-keyword,
-                /// This kind represents a `YulWeiKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulWeiKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_WEI_KEYWORD = "wei";
                 /// ```
                 %yul-wei-keyword,
-                /// This kind represents a `YulWhileKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulWhileKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
                 /// YUL_WHILE_KEYWORD = "while";
                 /// ```
                 %yul-while-keyword,
-                /// This kind represents a `YulXorKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulXorKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// YUL_XOR_KEYWORD = "xor";
                 /// ```
                 %yul-xor-keyword,
-                /// This kind represents a `YulYearsKeyword` node, with the following structure: 
+                /// Represents a node with kind `YulYearsKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Reserved until 0.7.1 *)
@@ -4629,137 +4629,269 @@ interface cst {
 
     /// Represents the different types of relationships between nodes in the syntax tree.
     enum edge-label {
+            /// Represents a child node with the label `item`.
             %item,
+            /// Represents a child node with the label `variant`.
             %variant,
+            /// Represents a child node with the label `separator`.
             %separator,
+            /// Represents a child node with the label `operand`.
             %operand,
+            /// Represents a child node with the label `left_operand`.
             %left-operand,
+            /// Represents a child node with the label `right_operand`.
             %right-operand,
+            /// Represents a child node with the label `leading_trivia`.
             %leading-trivia,
+            /// Represents a child node with the label `trailing_trivia`.
             %trailing-trivia,
+                /// Represents a child node with the label `abicoder_keyword`.
                 %abicoder-keyword,
+                /// Represents a child node with the label `abstract_keyword`.
                 %abstract-keyword,
+                /// Represents a child node with the label `address_keyword`.
                 %address-keyword,
+                /// Represents a child node with the label `alias`.
                 %alias,
+                /// Represents a child node with the label `anonymous_keyword`.
                 %anonymous-keyword,
+                /// Represents a child node with the label `arguments`.
                 %arguments,
+                /// Represents a child node with the label `as_keyword`.
                 %as-keyword,
+                /// Represents a child node with the label `assembly_keyword`.
                 %assembly-keyword,
+                /// Represents a child node with the label `assignment`.
                 %assignment,
+                /// Represents a child node with the label `asterisk`.
                 %asterisk,
+                /// Represents a child node with the label `attributes`.
                 %attributes,
+                /// Represents a child node with the label `block`.
                 %block,
+                /// Represents a child node with the label `body`.
                 %body,
+                /// Represents a child node with the label `break_keyword`.
                 %break-keyword,
+                /// Represents a child node with the label `case_keyword`.
                 %case-keyword,
+                /// Represents a child node with the label `cases`.
                 %cases,
+                /// Represents a child node with the label `catch_clauses`.
                 %catch-clauses,
+                /// Represents a child node with the label `catch_keyword`.
                 %catch-keyword,
+                /// Represents a child node with the label `clause`.
                 %clause,
+                /// Represents a child node with the label `close_brace`.
                 %close-brace,
+                /// Represents a child node with the label `close_bracket`.
                 %close-bracket,
+                /// Represents a child node with the label `close_paren`.
                 %close-paren,
+                /// Represents a child node with the label `colon`.
                 %colon,
+                /// Represents a child node with the label `condition`.
                 %condition,
+                /// Represents a child node with the label `constant_keyword`.
                 %constant-keyword,
+                /// Represents a child node with the label `constructor_keyword`.
                 %constructor-keyword,
+                /// Represents a child node with the label `continue_keyword`.
                 %continue-keyword,
+                /// Represents a child node with the label `contract_keyword`.
                 %contract-keyword,
+                /// Represents a child node with the label `default_keyword`.
                 %default-keyword,
+                /// Represents a child node with the label `do_keyword`.
                 %do-keyword,
+                /// Represents a child node with the label `elements`.
                 %elements,
+                /// Represents a child node with the label `else_branch`.
                 %else-branch,
+                /// Represents a child node with the label `else_keyword`.
                 %else-keyword,
+                /// Represents a child node with the label `emit_keyword`.
                 %emit-keyword,
+                /// Represents a child node with the label `end`.
                 %end,
+                /// Represents a child node with the label `enum_keyword`.
                 %enum-keyword,
+                /// Represents a child node with the label `equal`.
                 %equal,
+                /// Represents a child node with the label `equal_greater_than`.
                 %equal-greater-than,
+                /// Represents a child node with the label `error`.
                 %error,
+                /// Represents a child node with the label `error_keyword`.
                 %error-keyword,
+                /// Represents a child node with the label `event`.
                 %event,
+                /// Represents a child node with the label `event_keyword`.
                 %event-keyword,
+                /// Represents a child node with the label `experimental_keyword`.
                 %experimental-keyword,
+                /// Represents a child node with the label `expression`.
                 %expression,
+                /// Represents a child node with the label `fallback_keyword`.
                 %fallback-keyword,
+                /// Represents a child node with the label `false_expression`.
                 %false-expression,
+                /// Represents a child node with the label `feature`.
                 %feature,
+                /// Represents a child node with the label `flags`.
                 %flags,
+                /// Represents a child node with the label `for_keyword`.
                 %for-keyword,
+                /// Represents a child node with the label `from_keyword`.
                 %from-keyword,
+                /// Represents a child node with the label `function_keyword`.
                 %function-keyword,
+                /// Represents a child node with the label `global_keyword`.
                 %global-keyword,
+                /// Represents a child node with the label `identifier`.
                 %identifier,
+                /// Represents a child node with the label `if_keyword`.
                 %if-keyword,
+                /// Represents a child node with the label `import_keyword`.
                 %import-keyword,
+                /// Represents a child node with the label `index`.
                 %index,
+                /// Represents a child node with the label `indexed_keyword`.
                 %indexed-keyword,
+                /// Represents a child node with the label `inheritance`.
                 %inheritance,
+                /// Represents a child node with the label `initialization`.
                 %initialization,
+                /// Represents a child node with the label `interface_keyword`.
                 %interface-keyword,
+                /// Represents a child node with the label `is_keyword`.
                 %is-keyword,
+                /// Represents a child node with the label `items`.
                 %items,
+                /// Represents a child node with the label `iterator`.
                 %iterator,
+                /// Represents a child node with the label `key_type`.
                 %key-type,
+                /// Represents a child node with the label `label`.
                 %label,
+                /// Represents a child node with the label `leave_keyword`.
                 %leave-keyword,
+                /// Represents a child node with the label `let_keyword`.
                 %let-keyword,
+                /// Represents a child node with the label `library_keyword`.
                 %library-keyword,
+                /// Represents a child node with the label `literal`.
                 %literal,
+                /// Represents a child node with the label `mapping_keyword`.
                 %mapping-keyword,
+                /// Represents a child node with the label `member`.
                 %member,
+                /// Represents a child node with the label `members`.
                 %members,
+                /// Represents a child node with the label `minus`.
                 %minus,
+                /// Represents a child node with the label `minus_greater_than`.
                 %minus-greater-than,
+                /// Represents a child node with the label `modifier_keyword`.
                 %modifier-keyword,
+                /// Represents a child node with the label `name`.
                 %name,
+                /// Represents a child node with the label `new_keyword`.
                 %new-keyword,
+                /// Represents a child node with the label `open_brace`.
                 %open-brace,
+                /// Represents a child node with the label `open_bracket`.
                 %open-bracket,
+                /// Represents a child node with the label `open_paren`.
                 %open-paren,
+                /// Represents a child node with the label `operator`.
                 %operator,
+                /// Represents a child node with the label `options`.
                 %options,
+                /// Represents a child node with the label `overridden`.
                 %overridden,
+                /// Represents a child node with the label `override_keyword`.
                 %override-keyword,
+                /// Represents a child node with the label `parameters`.
                 %parameters,
+                /// Represents a child node with the label `path`.
                 %path,
+                /// Represents a child node with the label `paths`.
                 %paths,
+                /// Represents a child node with the label `payable_keyword`.
                 %payable-keyword,
+                /// Represents a child node with the label `period`.
                 %period,
+                /// Represents a child node with the label `pragma`.
                 %pragma,
+                /// Represents a child node with the label `pragma_keyword`.
                 %pragma-keyword,
+                /// Represents a child node with the label `question_mark`.
                 %question-mark,
+                /// Represents a child node with the label `receive_keyword`.
                 %receive-keyword,
+                /// Represents a child node with the label `return_keyword`.
                 %return-keyword,
+                /// Represents a child node with the label `returns`.
                 %returns,
+                /// Represents a child node with the label `returns_keyword`.
                 %returns-keyword,
+                /// Represents a child node with the label `revert_keyword`.
                 %revert-keyword,
+                /// Represents a child node with the label `semicolon`.
                 %semicolon,
+                /// Represents a child node with the label `sets`.
                 %sets,
+                /// Represents a child node with the label `solidity_keyword`.
                 %solidity-keyword,
+                /// Represents a child node with the label `start`.
                 %start,
+                /// Represents a child node with the label `statements`.
                 %statements,
+                /// Represents a child node with the label `storage_location`.
                 %storage-location,
+                /// Represents a child node with the label `struct_keyword`.
                 %struct-keyword,
+                /// Represents a child node with the label `switch_keyword`.
                 %switch-keyword,
+                /// Represents a child node with the label `symbols`.
                 %symbols,
+                /// Represents a child node with the label `target`.
                 %target,
+                /// Represents a child node with the label `throw_keyword`.
                 %throw-keyword,
+                /// Represents a child node with the label `true_expression`.
                 %true-expression,
+                /// Represents a child node with the label `try_keyword`.
                 %try-keyword,
+                /// Represents a child node with the label `type_keyword`.
                 %type-keyword,
+                /// Represents a child node with the label `type_name`.
                 %type-name,
+                /// Represents a child node with the label `types`.
                 %types,
+                /// Represents a child node with the label `unchecked_keyword`.
                 %unchecked-keyword,
+                /// Represents a child node with the label `unit`.
                 %unit,
+                /// Represents a child node with the label `using_keyword`.
                 %using-keyword,
+                /// Represents a child node with the label `value`.
                 %value,
+                /// Represents a child node with the label `value_type`.
                 %value-type,
+                /// Represents a child node with the label `var_keyword`.
                 %var-keyword,
+                /// Represents a child node with the label `variable`.
                 %variable,
+                /// Represents a child node with the label `variable_type`.
                 %variable-type,
+                /// Represents a child node with the label `variables`.
                 %variables,
+                /// Represents a child node with the label `version`.
                 %version,
+                /// Represents a child node with the label `while_keyword`.
                 %while-keyword,
     }
 

--- a/crates/solidity/outputs/npm/package/src/generated/ast/generated/nodes.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/ast/generated/nodes.mts
@@ -1,33 +1,60 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../../wasm/index.mjs";
+import * as wasm from "../../../../wasm/index.mjs";
 import { NonterminalKind, NonterminalNode, TerminalNode } from "../../cst/index.mjs";
 
-/*
- * Sequences:
- */
+//
+// Sequences:
+//
 
+/**
+ * This node represents a `SourceUnit` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnit = (* members: *) SourceUnitMembers;
+ * ```
+ */
 export class SourceUnit {
   private readonly fetch = once(() => {
-    const [$members] = generated.ast.Selectors.sequence(this.cst);
+    const [$members] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       members: new SourceUnitMembers($members as NonterminalNode),
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnit`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnit`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnit);
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): SourceUnitMembers {
     return this.fetch().members;
   }
 }
 
+/**
+ * This node represents a `PragmaDirective` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * PragmaDirective = (* pragma_keyword: *) PRAGMA_KEYWORD
+ *                   (* pragma: *) Pragma
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class PragmaDirective {
   private readonly fetch = once(() => {
-    const [$pragmaKeyword, $pragma, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$pragmaKeyword, $pragma, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       pragmaKeyword: $pragmaKeyword as TerminalNode,
@@ -36,26 +63,51 @@ export class PragmaDirective {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PragmaDirective`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PragmaDirective`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PragmaDirective);
   }
 
+  /**
+   * Returns the child node that has the label `pragma_keyword`.
+   */
   public get pragmaKeyword(): TerminalNode {
     return this.fetch().pragmaKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `pragma`.
+   */
   public get pragma(): Pragma {
     return this.fetch().pragma;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `AbicoderPragma` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * AbicoderPragma = (* abicoder_keyword: *) ABICODER_KEYWORD
+ *                  (* version: *) IDENTIFIER;
+ * ```
+ */
 export class AbicoderPragma {
   private readonly fetch = once(() => {
-    const [$abicoderKeyword, $version] = generated.ast.Selectors.sequence(this.cst);
+    const [$abicoderKeyword, $version] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       abicoderKeyword: $abicoderKeyword as TerminalNode,
@@ -63,22 +115,44 @@ export class AbicoderPragma {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AbicoderPragma`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AbicoderPragma`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AbicoderPragma);
   }
 
+  /**
+   * Returns the child node that has the label `abicoder_keyword`.
+   */
   public get abicoderKeyword(): TerminalNode {
     return this.fetch().abicoderKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `version`.
+   */
   public get version(): TerminalNode {
     return this.fetch().version;
   }
 }
 
+/**
+ * This node represents a `ExperimentalPragma` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ExperimentalPragma = (* experimental_keyword: *) EXPERIMENTAL_KEYWORD
+ *                      (* feature: *) ExperimentalFeature;
+ * ```
+ */
 export class ExperimentalPragma {
   private readonly fetch = once(() => {
-    const [$experimentalKeyword, $feature] = generated.ast.Selectors.sequence(this.cst);
+    const [$experimentalKeyword, $feature] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       experimentalKeyword: $experimentalKeyword as TerminalNode,
@@ -86,22 +160,44 @@ export class ExperimentalPragma {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ExperimentalPragma`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ExperimentalPragma`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ExperimentalPragma);
   }
 
+  /**
+   * Returns the child node that has the label `experimental_keyword`.
+   */
   public get experimentalKeyword(): TerminalNode {
     return this.fetch().experimentalKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `feature`.
+   */
   public get feature(): ExperimentalFeature {
     return this.fetch().feature;
   }
 }
 
+/**
+ * This node represents a `VersionPragma` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionPragma = (* solidity_keyword: *) SOLIDITY_KEYWORD
+ *                 (* sets: *) VersionExpressionSets;
+ * ```
+ */
 export class VersionPragma {
   private readonly fetch = once(() => {
-    const [$solidityKeyword, $sets] = generated.ast.Selectors.sequence(this.cst);
+    const [$solidityKeyword, $sets] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       solidityKeyword: $solidityKeyword as TerminalNode,
@@ -109,22 +205,45 @@ export class VersionPragma {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionPragma`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionPragma`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionPragma);
   }
 
+  /**
+   * Returns the child node that has the label `solidity_keyword`.
+   */
   public get solidityKeyword(): TerminalNode {
     return this.fetch().solidityKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `sets`.
+   */
   public get sets(): VersionExpressionSets {
     return this.fetch().sets;
   }
 }
 
+/**
+ * This node represents a `VersionRange` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionRange = (* start: *) VersionLiteral
+ *                (* minus: *) MINUS
+ *                (* end: *) VersionLiteral;
+ * ```
+ */
 export class VersionRange {
   private readonly fetch = once(() => {
-    const [$start, $minus, $end] = generated.ast.Selectors.sequence(this.cst);
+    const [$start, $minus, $end] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       start: new VersionLiteral($start as NonterminalNode),
@@ -133,26 +252,51 @@ export class VersionRange {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionRange`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionRange`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionRange);
   }
 
+  /**
+   * Returns the child node that has the label `start`.
+   */
   public get start(): VersionLiteral {
     return this.fetch().start;
   }
 
+  /**
+   * Returns the child node that has the label `minus`.
+   */
   public get minus(): TerminalNode {
     return this.fetch().minus;
   }
 
+  /**
+   * Returns the child node that has the label `end`.
+   */
   public get end(): VersionLiteral {
     return this.fetch().end;
   }
 }
 
+/**
+ * This node represents a `VersionTerm` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionTerm = (* operator: *) VersionOperator?
+ *               (* literal: *) VersionLiteral;
+ * ```
+ */
 export class VersionTerm {
   private readonly fetch = once(() => {
-    const [$operator, $literal] = generated.ast.Selectors.sequence(this.cst);
+    const [$operator, $literal] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operator: $operator === undefined ? undefined : new VersionOperator($operator as NonterminalNode),
@@ -160,22 +304,45 @@ export class VersionTerm {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionTerm`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionTerm`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionTerm);
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): VersionOperator | undefined {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `literal`.
+   */
   public get literal(): VersionLiteral {
     return this.fetch().literal;
   }
 }
 
+/**
+ * This node represents a `ImportDirective` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportDirective = (* import_keyword: *) IMPORT_KEYWORD
+ *                   (* clause: *) ImportClause
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ImportDirective {
   private readonly fetch = once(() => {
-    const [$importKeyword, $clause, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$importKeyword, $clause, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       importKeyword: $importKeyword as TerminalNode,
@@ -184,26 +351,51 @@ export class ImportDirective {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportDirective`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportDirective`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportDirective);
   }
 
+  /**
+   * Returns the child node that has the label `import_keyword`.
+   */
   public get importKeyword(): TerminalNode {
     return this.fetch().importKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `clause`.
+   */
   public get clause(): ImportClause {
     return this.fetch().clause;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `PathImport` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * PathImport = (* path: *) StringLiteral
+ *              (* alias: *) ImportAlias?;
+ * ```
+ */
 export class PathImport {
   private readonly fetch = once(() => {
-    const [$path, $alias] = generated.ast.Selectors.sequence(this.cst);
+    const [$path, $alias] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       path: new StringLiteral($path as NonterminalNode),
@@ -211,22 +403,46 @@ export class PathImport {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PathImport`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PathImport`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PathImport);
   }
 
+  /**
+   * Returns the child node that has the label `path`.
+   */
   public get path(): StringLiteral {
     return this.fetch().path;
   }
 
+  /**
+   * Returns the child node that has the label `alias`.
+   */
   public get alias(): ImportAlias | undefined {
     return this.fetch().alias;
   }
 }
 
+/**
+ * This node represents a `NamedImport` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NamedImport = (* asterisk: *) ASTERISK
+ *               (* alias: *) ImportAlias
+ *               (* from_keyword: *) FROM_KEYWORD
+ *               (* path: *) StringLiteral;
+ * ```
+ */
 export class NamedImport {
   private readonly fetch = once(() => {
-    const [$asterisk, $alias, $fromKeyword, $path] = generated.ast.Selectors.sequence(this.cst);
+    const [$asterisk, $alias, $fromKeyword, $path] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       asterisk: $asterisk as TerminalNode,
@@ -236,30 +452,61 @@ export class NamedImport {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NamedImport`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NamedImport`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NamedImport);
   }
 
+  /**
+   * Returns the child node that has the label `asterisk`.
+   */
   public get asterisk(): TerminalNode {
     return this.fetch().asterisk;
   }
 
+  /**
+   * Returns the child node that has the label `alias`.
+   */
   public get alias(): ImportAlias {
     return this.fetch().alias;
   }
 
+  /**
+   * Returns the child node that has the label `from_keyword`.
+   */
   public get fromKeyword(): TerminalNode {
     return this.fetch().fromKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `path`.
+   */
   public get path(): StringLiteral {
     return this.fetch().path;
   }
 }
 
+/**
+ * This node represents a `ImportDeconstruction` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportDeconstruction = (* open_brace: *) OPEN_BRACE
+ *                        (* symbols: *) ImportDeconstructionSymbols
+ *                        (* close_brace: *) CLOSE_BRACE
+ *                        (* from_keyword: *) FROM_KEYWORD
+ *                        (* path: *) StringLiteral;
+ * ```
+ */
 export class ImportDeconstruction {
   private readonly fetch = once(() => {
-    const [$openBrace, $symbols, $closeBrace, $fromKeyword, $path] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBrace, $symbols, $closeBrace, $fromKeyword, $path] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBrace: $openBrace as TerminalNode,
@@ -270,34 +517,65 @@ export class ImportDeconstruction {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportDeconstruction`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportDeconstruction`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportDeconstruction);
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `symbols`.
+   */
   public get symbols(): ImportDeconstructionSymbols {
     return this.fetch().symbols;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 
+  /**
+   * Returns the child node that has the label `from_keyword`.
+   */
   public get fromKeyword(): TerminalNode {
     return this.fetch().fromKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `path`.
+   */
   public get path(): StringLiteral {
     return this.fetch().path;
   }
 }
 
+/**
+ * This node represents a `ImportDeconstructionSymbol` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportDeconstructionSymbol = (* name: *) IDENTIFIER
+ *                              (* alias: *) ImportAlias?;
+ * ```
+ */
 export class ImportDeconstructionSymbol {
   private readonly fetch = once(() => {
-    const [$name, $alias] = generated.ast.Selectors.sequence(this.cst);
+    const [$name, $alias] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       name: $name as TerminalNode,
@@ -305,22 +583,44 @@ export class ImportDeconstructionSymbol {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportDeconstructionSymbol`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportDeconstructionSymbol`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportDeconstructionSymbol);
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `alias`.
+   */
   public get alias(): ImportAlias | undefined {
     return this.fetch().alias;
   }
 }
 
+/**
+ * This node represents a `ImportAlias` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportAlias = (* as_keyword: *) AS_KEYWORD
+ *               (* identifier: *) IDENTIFIER;
+ * ```
+ */
 export class ImportAlias {
   private readonly fetch = once(() => {
-    const [$asKeyword, $identifier] = generated.ast.Selectors.sequence(this.cst);
+    const [$asKeyword, $identifier] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       asKeyword: $asKeyword as TerminalNode,
@@ -328,22 +628,48 @@ export class ImportAlias {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportAlias`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportAlias`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportAlias);
   }
 
+  /**
+   * Returns the child node that has the label `as_keyword`.
+   */
   public get asKeyword(): TerminalNode {
     return this.fetch().asKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `identifier`.
+   */
   public get identifier(): TerminalNode {
     return this.fetch().identifier;
   }
 }
 
+/**
+ * This node represents a `UsingDirective` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * UsingDirective = (* using_keyword: *) USING_KEYWORD
+ *                  (* clause: *) UsingClause
+ *                  (* for_keyword: *) FOR_KEYWORD
+ *                  (* target: *) UsingTarget
+ *                  (* global_keyword: *) GLOBAL_KEYWORD? (* Introduced in 0.8.13 *)
+ *                  (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class UsingDirective {
   private readonly fetch = once(() => {
-    const [$usingKeyword, $clause, $forKeyword, $target, $globalKeyword, $semicolon] = generated.ast.Selectors.sequence(
+    const [$usingKeyword, $clause, $forKeyword, $target, $globalKeyword, $semicolon] = wasm.ast.Selectors.sequence(
       this.cst,
     );
 
@@ -357,38 +683,74 @@ export class UsingDirective {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingDirective`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingDirective`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingDirective);
   }
 
+  /**
+   * Returns the child node that has the label `using_keyword`.
+   */
   public get usingKeyword(): TerminalNode {
     return this.fetch().usingKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `clause`.
+   */
   public get clause(): UsingClause {
     return this.fetch().clause;
   }
 
+  /**
+   * Returns the child node that has the label `for_keyword`.
+   */
   public get forKeyword(): TerminalNode {
     return this.fetch().forKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `target`.
+   */
   public get target(): UsingTarget {
     return this.fetch().target;
   }
 
+  /**
+   * Returns the child node that has the label `global_keyword`.
+   */
   public get globalKeyword(): TerminalNode | undefined {
     return this.fetch().globalKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `UsingDeconstruction` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.13 *)
+ * UsingDeconstruction = (* open_brace: *) OPEN_BRACE
+ *                       (* symbols: *) UsingDeconstructionSymbols
+ *                       (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class UsingDeconstruction {
   private readonly fetch = once(() => {
-    const [$openBrace, $symbols, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBrace, $symbols, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBrace: $openBrace as TerminalNode,
@@ -397,26 +759,52 @@ export class UsingDeconstruction {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingDeconstruction`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingDeconstruction`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingDeconstruction);
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `symbols`.
+   */
   public get symbols(): UsingDeconstructionSymbols {
     return this.fetch().symbols;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `UsingDeconstructionSymbol` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.13 *)
+ * UsingDeconstructionSymbol = (* name: *) IdentifierPath
+ *                             (* alias: *) UsingAlias?; (* Introduced in 0.8.19 *)
+ * ```
+ */
 export class UsingDeconstructionSymbol {
   private readonly fetch = once(() => {
-    const [$name, $alias] = generated.ast.Selectors.sequence(this.cst);
+    const [$name, $alias] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       name: new IdentifierPath($name as NonterminalNode),
@@ -424,22 +812,45 @@ export class UsingDeconstructionSymbol {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingDeconstructionSymbol`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingDeconstructionSymbol`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingDeconstructionSymbol);
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): IdentifierPath {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `alias`.
+   */
   public get alias(): UsingAlias | undefined {
     return this.fetch().alias;
   }
 }
 
+/**
+ * This node represents a `UsingAlias` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.19 *)
+ * UsingAlias = (* as_keyword: *) AS_KEYWORD
+ *              (* operator: *) UsingOperator;
+ * ```
+ */
 export class UsingAlias {
   private readonly fetch = once(() => {
-    const [$asKeyword, $operator] = generated.ast.Selectors.sequence(this.cst);
+    const [$asKeyword, $operator] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       asKeyword: $asKeyword as TerminalNode,
@@ -447,23 +858,50 @@ export class UsingAlias {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingAlias`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingAlias`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingAlias);
   }
 
+  /**
+   * Returns the child node that has the label `as_keyword`.
+   */
   public get asKeyword(): TerminalNode {
     return this.fetch().asKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): UsingOperator {
     return this.fetch().operator;
   }
 }
 
+/**
+ * This node represents a `ContractDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ContractDefinition = (* abstract_keyword: *) ABSTRACT_KEYWORD? (* Introduced in 0.6.0 *)
+ *                      (* contract_keyword: *) CONTRACT_KEYWORD
+ *                      (* name: *) IDENTIFIER
+ *                      (* inheritance: *) InheritanceSpecifier?
+ *                      (* open_brace: *) OPEN_BRACE
+ *                      (* members: *) ContractMembers
+ *                      (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class ContractDefinition {
   private readonly fetch = once(() => {
     const [$abstractKeyword, $contractKeyword, $name, $inheritance, $openBrace, $members, $closeBrace] =
-      generated.ast.Selectors.sequence(this.cst);
+      wasm.ast.Selectors.sequence(this.cst);
 
     return {
       abstractKeyword: $abstractKeyword === undefined ? undefined : ($abstractKeyword as TerminalNode),
@@ -476,42 +914,79 @@ export class ContractDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ContractDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ContractDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ContractDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `abstract_keyword`.
+   */
   public get abstractKeyword(): TerminalNode | undefined {
     return this.fetch().abstractKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `contract_keyword`.
+   */
   public get contractKeyword(): TerminalNode {
     return this.fetch().contractKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `inheritance`.
+   */
   public get inheritance(): InheritanceSpecifier | undefined {
     return this.fetch().inheritance;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): ContractMembers {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `InheritanceSpecifier` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * InheritanceSpecifier = (* is_keyword: *) IS_KEYWORD
+ *                        (* types: *) InheritanceTypes;
+ * ```
+ */
 export class InheritanceSpecifier {
   private readonly fetch = once(() => {
-    const [$isKeyword, $types] = generated.ast.Selectors.sequence(this.cst);
+    const [$isKeyword, $types] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       isKeyword: $isKeyword as TerminalNode,
@@ -519,22 +994,44 @@ export class InheritanceSpecifier {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `InheritanceSpecifier`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `InheritanceSpecifier`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.InheritanceSpecifier);
   }
 
+  /**
+   * Returns the child node that has the label `is_keyword`.
+   */
   public get isKeyword(): TerminalNode {
     return this.fetch().isKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `types`.
+   */
   public get types(): InheritanceTypes {
     return this.fetch().types;
   }
 }
 
+/**
+ * This node represents a `InheritanceType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * InheritanceType = (* type_name: *) IdentifierPath
+ *                   (* arguments: *) ArgumentsDeclaration?;
+ * ```
+ */
 export class InheritanceType {
   private readonly fetch = once(() => {
-    const [$typeName, $arguments] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $arguments] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new IdentifierPath($typeName as NonterminalNode),
@@ -542,23 +1039,50 @@ export class InheritanceType {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `InheritanceType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `InheritanceType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.InheritanceType);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): IdentifierPath {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): ArgumentsDeclaration | undefined {
     return this.fetch().arguments;
   }
 }
 
+/**
+ * This node represents a `InterfaceDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * InterfaceDefinition = (* interface_keyword: *) INTERFACE_KEYWORD
+ *                       (* name: *) IDENTIFIER
+ *                       (* inheritance: *) InheritanceSpecifier?
+ *                       (* open_brace: *) OPEN_BRACE
+ *                       (* members: *) InterfaceMembers
+ *                       (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class InterfaceDefinition {
   private readonly fetch = once(() => {
-    const [$interfaceKeyword, $name, $inheritance, $openBrace, $members, $closeBrace] =
-      generated.ast.Selectors.sequence(this.cst);
+    const [$interfaceKeyword, $name, $inheritance, $openBrace, $members, $closeBrace] = wasm.ast.Selectors.sequence(
+      this.cst,
+    );
 
     return {
       interfaceKeyword: $interfaceKeyword as TerminalNode,
@@ -570,38 +1094,75 @@ export class InterfaceDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `InterfaceDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `InterfaceDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.InterfaceDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `interface_keyword`.
+   */
   public get interfaceKeyword(): TerminalNode {
     return this.fetch().interfaceKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `inheritance`.
+   */
   public get inheritance(): InheritanceSpecifier | undefined {
     return this.fetch().inheritance;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): InterfaceMembers {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `LibraryDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * LibraryDefinition = (* library_keyword: *) LIBRARY_KEYWORD
+ *                     (* name: *) IDENTIFIER
+ *                     (* open_brace: *) OPEN_BRACE
+ *                     (* members: *) LibraryMembers
+ *                     (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class LibraryDefinition {
   private readonly fetch = once(() => {
-    const [$libraryKeyword, $name, $openBrace, $members, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$libraryKeyword, $name, $openBrace, $members, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       libraryKeyword: $libraryKeyword as TerminalNode,
@@ -612,34 +1173,68 @@ export class LibraryDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `LibraryDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `LibraryDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.LibraryDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `library_keyword`.
+   */
   public get libraryKeyword(): TerminalNode {
     return this.fetch().libraryKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): LibraryMembers {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `StructDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StructDefinition = (* struct_keyword: *) STRUCT_KEYWORD
+ *                    (* name: *) IDENTIFIER
+ *                    (* open_brace: *) OPEN_BRACE
+ *                    (* members: *) StructMembers
+ *                    (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class StructDefinition {
   private readonly fetch = once(() => {
-    const [$structKeyword, $name, $openBrace, $members, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$structKeyword, $name, $openBrace, $members, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       structKeyword: $structKeyword as TerminalNode,
@@ -650,34 +1245,66 @@ export class StructDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StructDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StructDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StructDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `struct_keyword`.
+   */
   public get structKeyword(): TerminalNode {
     return this.fetch().structKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): StructMembers {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `StructMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StructMember = (* type_name: *) TypeName
+ *                (* name: *) IDENTIFIER
+ *                (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class StructMember {
   private readonly fetch = once(() => {
-    const [$typeName, $name, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $name, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -686,26 +1313,54 @@ export class StructMember {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StructMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StructMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StructMember);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `EnumDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EnumDefinition = (* enum_keyword: *) ENUM_KEYWORD
+ *                  (* name: *) IDENTIFIER
+ *                  (* open_brace: *) OPEN_BRACE
+ *                  (* members: *) EnumMembers
+ *                  (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class EnumDefinition {
   private readonly fetch = once(() => {
-    const [$enumKeyword, $name, $openBrace, $members, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$enumKeyword, $name, $openBrace, $members, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       enumKeyword: $enumKeyword as TerminalNode,
@@ -716,34 +1371,70 @@ export class EnumDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EnumDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EnumDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EnumDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `enum_keyword`.
+   */
   public get enumKeyword(): TerminalNode {
     return this.fetch().enumKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): EnumMembers {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `ConstantDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.7.4 *)
+ * ConstantDefinition = (* type_name: *) TypeName
+ *                      (* constant_keyword: *) CONSTANT_KEYWORD
+ *                      (* name: *) IDENTIFIER
+ *                      (* equal: *) EQUAL
+ *                      (* value: *) Expression
+ *                      (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ConstantDefinition {
   private readonly fetch = once(() => {
-    const [$typeName, $constantKeyword, $name, $equal, $value, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $constantKeyword, $name, $equal, $value, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -755,38 +1446,75 @@ export class ConstantDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ConstantDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ConstantDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ConstantDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `constant_keyword`.
+   */
   public get constantKeyword(): TerminalNode {
     return this.fetch().constantKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): Expression {
     return this.fetch().value;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `StateVariableDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StateVariableDefinition = (* type_name: *) TypeName
+ *                           (* attributes: *) StateVariableAttributes
+ *                           (* name: *) IDENTIFIER
+ *                           (* value: *) StateVariableDefinitionValue?
+ *                           (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class StateVariableDefinition {
   private readonly fetch = once(() => {
-    const [$typeName, $attributes, $name, $value, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $attributes, $name, $value, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -797,34 +1525,65 @@ export class StateVariableDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StateVariableDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StateVariableDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StateVariableDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): StateVariableAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): StateVariableDefinitionValue | undefined {
     return this.fetch().value;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `StateVariableDefinitionValue` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StateVariableDefinitionValue = (* equal: *) EQUAL
+ *                                (* value: *) Expression;
+ * ```
+ */
 export class StateVariableDefinitionValue {
   private readonly fetch = once(() => {
-    const [$equal, $value] = generated.ast.Selectors.sequence(this.cst);
+    const [$equal, $value] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       equal: $equal as TerminalNode,
@@ -832,24 +1591,48 @@ export class StateVariableDefinitionValue {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StateVariableDefinitionValue`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StateVariableDefinitionValue`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StateVariableDefinitionValue);
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): Expression {
     return this.fetch().value;
   }
 }
 
+/**
+ * This node represents a `FunctionDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
+ *                      (* name: *) FunctionName
+ *                      (* parameters: *) ParametersDeclaration
+ *                      (* attributes: *) FunctionAttributes
+ *                      (* returns: *) ReturnsDeclaration?
+ *                      (* body: *) FunctionBody;
+ * ```
+ */
 export class FunctionDefinition {
   private readonly fetch = once(() => {
-    const [$functionKeyword, $name, $parameters, $attributes, $returns, $body] = generated.ast.Selectors.sequence(
-      this.cst,
-    );
+    const [$functionKeyword, $name, $parameters, $attributes, $returns, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       functionKeyword: $functionKeyword as TerminalNode,
@@ -861,38 +1644,73 @@ export class FunctionDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `function_keyword`.
+   */
   public get functionKeyword(): TerminalNode {
     return this.fetch().functionKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): FunctionName {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): FunctionAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `returns`.
+   */
   public get returns(): ReturnsDeclaration | undefined {
     return this.fetch().returns;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): FunctionBody {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `ParametersDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ParametersDeclaration = (* open_paren: *) OPEN_PAREN
+ *                         (* parameters: *) Parameters
+ *                         (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class ParametersDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $parameters, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $parameters, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -901,26 +1719,52 @@ export class ParametersDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ParametersDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ParametersDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ParametersDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): Parameters {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `Parameter` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Parameter = (* type_name: *) TypeName
+ *             (* storage_location: *) StorageLocation?
+ *             (* name: *) IDENTIFIER?;
+ * ```
+ */
 export class Parameter {
   private readonly fetch = once(() => {
-    const [$typeName, $storageLocation, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $storageLocation, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -930,26 +1774,52 @@ export class Parameter {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Parameter`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Parameter`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Parameter);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `storage_location`.
+   */
   public get storageLocation(): StorageLocation | undefined {
     return this.fetch().storageLocation;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `OverrideSpecifier` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * OverrideSpecifier = (* override_keyword: *) OVERRIDE_KEYWORD
+ *                     (* overridden: *) OverridePathsDeclaration?;
+ * ```
+ */
 export class OverrideSpecifier {
   private readonly fetch = once(() => {
-    const [$overrideKeyword, $overridden] = generated.ast.Selectors.sequence(this.cst);
+    const [$overrideKeyword, $overridden] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       overrideKeyword: $overrideKeyword as TerminalNode,
@@ -957,22 +1827,46 @@ export class OverrideSpecifier {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `OverrideSpecifier`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `OverrideSpecifier`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.OverrideSpecifier);
   }
 
+  /**
+   * Returns the child node that has the label `override_keyword`.
+   */
   public get overrideKeyword(): TerminalNode {
     return this.fetch().overrideKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `overridden`.
+   */
   public get overridden(): OverridePathsDeclaration | undefined {
     return this.fetch().overridden;
   }
 }
 
+/**
+ * This node represents a `OverridePathsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * OverridePathsDeclaration = (* open_paren: *) OPEN_PAREN
+ *                            (* paths: *) OverridePaths
+ *                            (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class OverridePathsDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $paths, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $paths, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -981,26 +1875,51 @@ export class OverridePathsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `OverridePathsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `OverridePathsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.OverridePathsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `paths`.
+   */
   public get paths(): OverridePaths {
     return this.fetch().paths;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `ReturnsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ReturnsDeclaration = (* returns_keyword: *) RETURNS_KEYWORD
+ *                      (* variables: *) ParametersDeclaration;
+ * ```
+ */
 export class ReturnsDeclaration {
   private readonly fetch = once(() => {
-    const [$returnsKeyword, $variables] = generated.ast.Selectors.sequence(this.cst);
+    const [$returnsKeyword, $variables] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       returnsKeyword: $returnsKeyword as TerminalNode,
@@ -1008,22 +1927,47 @@ export class ReturnsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ReturnsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ReturnsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ReturnsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `returns_keyword`.
+   */
   public get returnsKeyword(): TerminalNode {
     return this.fetch().returnsKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `variables`.
+   */
   public get variables(): ParametersDeclaration {
     return this.fetch().variables;
   }
 }
 
+/**
+ * This node represents a `ConstructorDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.4.22 *)
+ * ConstructorDefinition = (* constructor_keyword: *) CONSTRUCTOR_KEYWORD
+ *                         (* parameters: *) ParametersDeclaration
+ *                         (* attributes: *) ConstructorAttributes
+ *                         (* body: *) Block;
+ * ```
+ */
 export class ConstructorDefinition {
   private readonly fetch = once(() => {
-    const [$constructorKeyword, $parameters, $attributes, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$constructorKeyword, $parameters, $attributes, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       constructorKeyword: $constructorKeyword as TerminalNode,
@@ -1033,30 +1977,61 @@ export class ConstructorDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ConstructorDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ConstructorDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ConstructorDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `constructor_keyword`.
+   */
   public get constructorKeyword(): TerminalNode {
     return this.fetch().constructorKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): ConstructorAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Block {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `UnnamedFunctionDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.6.0 *)
+ * UnnamedFunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
+ *                             (* parameters: *) ParametersDeclaration
+ *                             (* attributes: *) UnnamedFunctionAttributes
+ *                             (* body: *) FunctionBody;
+ * ```
+ */
 export class UnnamedFunctionDefinition {
   private readonly fetch = once(() => {
-    const [$functionKeyword, $parameters, $attributes, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$functionKeyword, $parameters, $attributes, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       functionKeyword: $functionKeyword as TerminalNode,
@@ -1066,30 +2041,62 @@ export class UnnamedFunctionDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UnnamedFunctionDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UnnamedFunctionDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UnnamedFunctionDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `function_keyword`.
+   */
   public get functionKeyword(): TerminalNode {
     return this.fetch().functionKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): UnnamedFunctionAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): FunctionBody {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `FallbackFunctionDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * FallbackFunctionDefinition = (* fallback_keyword: *) FALLBACK_KEYWORD
+ *                              (* parameters: *) ParametersDeclaration
+ *                              (* attributes: *) FallbackFunctionAttributes
+ *                              (* returns: *) ReturnsDeclaration?
+ *                              (* body: *) FunctionBody;
+ * ```
+ */
 export class FallbackFunctionDefinition {
   private readonly fetch = once(() => {
-    const [$fallbackKeyword, $parameters, $attributes, $returns, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$fallbackKeyword, $parameters, $attributes, $returns, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       fallbackKeyword: $fallbackKeyword as TerminalNode,
@@ -1100,34 +2107,68 @@ export class FallbackFunctionDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FallbackFunctionDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FallbackFunctionDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FallbackFunctionDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `fallback_keyword`.
+   */
   public get fallbackKeyword(): TerminalNode {
     return this.fetch().fallbackKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): FallbackFunctionAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `returns`.
+   */
   public get returns(): ReturnsDeclaration | undefined {
     return this.fetch().returns;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): FunctionBody {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `ReceiveFunctionDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * ReceiveFunctionDefinition = (* receive_keyword: *) RECEIVE_KEYWORD
+ *                             (* parameters: *) ParametersDeclaration
+ *                             (* attributes: *) ReceiveFunctionAttributes
+ *                             (* body: *) FunctionBody;
+ * ```
+ */
 export class ReceiveFunctionDefinition {
   private readonly fetch = once(() => {
-    const [$receiveKeyword, $parameters, $attributes, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$receiveKeyword, $parameters, $attributes, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       receiveKeyword: $receiveKeyword as TerminalNode,
@@ -1137,30 +2178,61 @@ export class ReceiveFunctionDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ReceiveFunctionDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ReceiveFunctionDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ReceiveFunctionDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `receive_keyword`.
+   */
   public get receiveKeyword(): TerminalNode {
     return this.fetch().receiveKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): ReceiveFunctionAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): FunctionBody {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `ModifierDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ModifierDefinition = (* modifier_keyword: *) MODIFIER_KEYWORD
+ *                      (* name: *) IDENTIFIER
+ *                      (* parameters: *) ParametersDeclaration?
+ *                      (* attributes: *) ModifierAttributes
+ *                      (* body: *) FunctionBody;
+ * ```
+ */
 export class ModifierDefinition {
   private readonly fetch = once(() => {
-    const [$modifierKeyword, $name, $parameters, $attributes, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$modifierKeyword, $name, $parameters, $attributes, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       modifierKeyword: $modifierKeyword as TerminalNode,
@@ -1171,34 +2243,65 @@ export class ModifierDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ModifierDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ModifierDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ModifierDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `modifier_keyword`.
+   */
   public get modifierKeyword(): TerminalNode {
     return this.fetch().modifierKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration | undefined {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): ModifierAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): FunctionBody {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `ModifierInvocation` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ModifierInvocation = (* name: *) IdentifierPath
+ *                      (* arguments: *) ArgumentsDeclaration?;
+ * ```
+ */
 export class ModifierInvocation {
   private readonly fetch = once(() => {
-    const [$name, $arguments] = generated.ast.Selectors.sequence(this.cst);
+    const [$name, $arguments] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       name: new IdentifierPath($name as NonterminalNode),
@@ -1206,24 +2309,47 @@ export class ModifierInvocation {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ModifierInvocation`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ModifierInvocation`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ModifierInvocation);
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): IdentifierPath {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): ArgumentsDeclaration | undefined {
     return this.fetch().arguments;
   }
 }
 
+/**
+ * This node represents a `EventDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EventDefinition = (* event_keyword: *) EVENT_KEYWORD
+ *                   (* name: *) IDENTIFIER
+ *                   (* parameters: *) EventParametersDeclaration
+ *                   (* anonymous_keyword: *) ANONYMOUS_KEYWORD?
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class EventDefinition {
   private readonly fetch = once(() => {
-    const [$eventKeyword, $name, $parameters, $anonymousKeyword, $semicolon] = generated.ast.Selectors.sequence(
-      this.cst,
-    );
+    const [$eventKeyword, $name, $parameters, $anonymousKeyword, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       eventKeyword: $eventKeyword as TerminalNode,
@@ -1234,34 +2360,66 @@ export class EventDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EventDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EventDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EventDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `event_keyword`.
+   */
   public get eventKeyword(): TerminalNode {
     return this.fetch().eventKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): EventParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `anonymous_keyword`.
+   */
   public get anonymousKeyword(): TerminalNode | undefined {
     return this.fetch().anonymousKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `EventParametersDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EventParametersDeclaration = (* open_paren: *) OPEN_PAREN
+ *                              (* parameters: *) EventParameters
+ *                              (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class EventParametersDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $parameters, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $parameters, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -1270,26 +2428,52 @@ export class EventParametersDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EventParametersDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EventParametersDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EventParametersDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): EventParameters {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `EventParameter` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EventParameter = (* type_name: *) TypeName
+ *                  (* indexed_keyword: *) INDEXED_KEYWORD?
+ *                  (* name: *) IDENTIFIER?;
+ * ```
+ */
 export class EventParameter {
   private readonly fetch = once(() => {
-    const [$typeName, $indexedKeyword, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $indexedKeyword, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -1298,26 +2482,55 @@ export class EventParameter {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EventParameter`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EventParameter`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EventParameter);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `indexed_keyword`.
+   */
   public get indexedKeyword(): TerminalNode | undefined {
     return this.fetch().indexedKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `UserDefinedValueTypeDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.8 *)
+ * UserDefinedValueTypeDefinition = (* type_keyword: *) TYPE_KEYWORD
+ *                                  (* name: *) IDENTIFIER
+ *                                  (* is_keyword: *) IS_KEYWORD
+ *                                  (* value_type: *) ElementaryType
+ *                                  (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class UserDefinedValueTypeDefinition {
   private readonly fetch = once(() => {
-    const [$typeKeyword, $name, $isKeyword, $valueType, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeKeyword, $name, $isKeyword, $valueType, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeKeyword: $typeKeyword as TerminalNode,
@@ -1328,34 +2541,68 @@ export class UserDefinedValueTypeDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UserDefinedValueTypeDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UserDefinedValueTypeDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UserDefinedValueTypeDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `type_keyword`.
+   */
   public get typeKeyword(): TerminalNode {
     return this.fetch().typeKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `is_keyword`.
+   */
   public get isKeyword(): TerminalNode {
     return this.fetch().isKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `value_type`.
+   */
   public get valueType(): ElementaryType {
     return this.fetch().valueType;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `ErrorDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.4 *)
+ * ErrorDefinition = (* error_keyword: *) ERROR_KEYWORD
+ *                   (* name: *) IDENTIFIER
+ *                   (* members: *) ErrorParametersDeclaration
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ErrorDefinition {
   private readonly fetch = once(() => {
-    const [$errorKeyword, $name, $members, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$errorKeyword, $name, $members, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       errorKeyword: $errorKeyword as TerminalNode,
@@ -1365,30 +2612,60 @@ export class ErrorDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ErrorDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ErrorDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ErrorDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `error_keyword`.
+   */
   public get errorKeyword(): TerminalNode {
     return this.fetch().errorKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): ErrorParametersDeclaration {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `ErrorParametersDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.4 *)
+ * ErrorParametersDeclaration = (* open_paren: *) OPEN_PAREN
+ *                              (* parameters: *) ErrorParameters
+ *                              (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class ErrorParametersDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $parameters, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $parameters, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -1397,26 +2674,52 @@ export class ErrorParametersDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ErrorParametersDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ErrorParametersDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ErrorParametersDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ErrorParameters {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `ErrorParameter` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.4 *)
+ * ErrorParameter = (* type_name: *) TypeName
+ *                  (* name: *) IDENTIFIER?;
+ * ```
+ */
 export class ErrorParameter {
   private readonly fetch = once(() => {
-    const [$typeName, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -1424,22 +2727,47 @@ export class ErrorParameter {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ErrorParameter`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ErrorParameter`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ErrorParameter);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `ArrayTypeName` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * ArrayTypeName = (* operand: *) TypeName
+ *                 (* open_bracket: *) OPEN_BRACKET
+ *                 (* index: *) Expression?
+ *                 (* close_bracket: *) CLOSE_BRACKET;
+ * ```
+ */
 export class ArrayTypeName {
   private readonly fetch = once(() => {
-    const [$operand, $openBracket, $index, $closeBracket] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $openBracket, $index, $closeBracket] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new TypeName($operand as NonterminalNode),
@@ -1449,30 +2777,60 @@ export class ArrayTypeName {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ArrayTypeName`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ArrayTypeName`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ArrayTypeName);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): TypeName {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `open_bracket`.
+   */
   public get openBracket(): TerminalNode {
     return this.fetch().openBracket;
   }
 
+  /**
+   * Returns the child node that has the label `index`.
+   */
   public get index(): Expression | undefined {
     return this.fetch().index;
   }
 
+  /**
+   * Returns the child node that has the label `close_bracket`.
+   */
   public get closeBracket(): TerminalNode {
     return this.fetch().closeBracket;
   }
 }
 
+/**
+ * This node represents a `FunctionType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionType = (* function_keyword: *) FUNCTION_KEYWORD
+ *                (* parameters: *) ParametersDeclaration
+ *                (* attributes: *) FunctionTypeAttributes
+ *                (* returns: *) ReturnsDeclaration?;
+ * ```
+ */
 export class FunctionType {
   private readonly fetch = once(() => {
-    const [$functionKeyword, $parameters, $attributes, $returns] = generated.ast.Selectors.sequence(this.cst);
+    const [$functionKeyword, $parameters, $attributes, $returns] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       functionKeyword: $functionKeyword as TerminalNode,
@@ -1482,31 +2840,63 @@ export class FunctionType {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionType);
   }
 
+  /**
+   * Returns the child node that has the label `function_keyword`.
+   */
   public get functionKeyword(): TerminalNode {
     return this.fetch().functionKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `attributes`.
+   */
   public get attributes(): FunctionTypeAttributes {
     return this.fetch().attributes;
   }
 
+  /**
+   * Returns the child node that has the label `returns`.
+   */
   public get returns(): ReturnsDeclaration | undefined {
     return this.fetch().returns;
   }
 }
 
+/**
+ * This node represents a `MappingType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * MappingType = (* mapping_keyword: *) MAPPING_KEYWORD
+ *               (* open_paren: *) OPEN_PAREN
+ *               (* key_type: *) MappingKey
+ *               (* equal_greater_than: *) EQUAL_GREATER_THAN
+ *               (* value_type: *) MappingValue
+ *               (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class MappingType {
   private readonly fetch = once(() => {
     const [$mappingKeyword, $openParen, $keyType, $equalGreaterThan, $valueType, $closeParen] =
-      generated.ast.Selectors.sequence(this.cst);
+      wasm.ast.Selectors.sequence(this.cst);
 
     return {
       mappingKeyword: $mappingKeyword as TerminalNode,
@@ -1518,38 +2908,72 @@ export class MappingType {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MappingType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MappingType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MappingType);
   }
 
+  /**
+   * Returns the child node that has the label `mapping_keyword`.
+   */
   public get mappingKeyword(): TerminalNode {
     return this.fetch().mappingKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `key_type`.
+   */
   public get keyType(): MappingKey {
     return this.fetch().keyType;
   }
 
+  /**
+   * Returns the child node that has the label `equal_greater_than`.
+   */
   public get equalGreaterThan(): TerminalNode {
     return this.fetch().equalGreaterThan;
   }
 
+  /**
+   * Returns the child node that has the label `value_type`.
+   */
   public get valueType(): MappingValue {
     return this.fetch().valueType;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `MappingKey` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * MappingKey = (* key_type: *) MappingKeyType
+ *              (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
+ * ```
+ */
 export class MappingKey {
   private readonly fetch = once(() => {
-    const [$keyType, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$keyType, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       keyType: new MappingKeyType($keyType as NonterminalNode),
@@ -1557,22 +2981,44 @@ export class MappingKey {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MappingKey`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MappingKey`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MappingKey);
   }
 
+  /**
+   * Returns the child node that has the label `key_type`.
+   */
   public get keyType(): MappingKeyType {
     return this.fetch().keyType;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `MappingValue` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * MappingValue = (* type_name: *) TypeName
+ *                (* name: *) IDENTIFIER?; (* Introduced in 0.8.18 *)
+ * ```
+ */
 export class MappingValue {
   private readonly fetch = once(() => {
-    const [$typeName, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -1580,22 +3026,44 @@ export class MappingValue {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MappingValue`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MappingValue`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MappingValue);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `AddressType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * AddressType = (* address_keyword: *) ADDRESS_KEYWORD
+ *               (* payable_keyword: *) PAYABLE_KEYWORD?;
+ * ```
+ */
 export class AddressType {
   private readonly fetch = once(() => {
-    const [$addressKeyword, $payableKeyword] = generated.ast.Selectors.sequence(this.cst);
+    const [$addressKeyword, $payableKeyword] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       addressKeyword: $addressKeyword as TerminalNode,
@@ -1603,22 +3071,45 @@ export class AddressType {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AddressType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AddressType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AddressType);
   }
 
+  /**
+   * Returns the child node that has the label `address_keyword`.
+   */
   public get addressKeyword(): TerminalNode {
     return this.fetch().addressKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `payable_keyword`.
+   */
   public get payableKeyword(): TerminalNode | undefined {
     return this.fetch().payableKeyword;
   }
 }
 
+/**
+ * This node represents a `Block` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Block = (* open_brace: *) OPEN_BRACE
+ *         (* statements: *) Statements
+ *         (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class Block {
   private readonly fetch = once(() => {
-    const [$openBrace, $statements, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBrace, $statements, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBrace: $openBrace as TerminalNode,
@@ -1627,26 +3118,52 @@ export class Block {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Block`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Block`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Block);
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `statements`.
+   */
   public get statements(): Statements {
     return this.fetch().statements;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `UncheckedBlock` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.0 *)
+ * UncheckedBlock = (* unchecked_keyword: *) UNCHECKED_KEYWORD
+ *                  (* block: *) Block;
+ * ```
+ */
 export class UncheckedBlock {
   private readonly fetch = once(() => {
-    const [$uncheckedKeyword, $block] = generated.ast.Selectors.sequence(this.cst);
+    const [$uncheckedKeyword, $block] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       uncheckedKeyword: $uncheckedKeyword as TerminalNode,
@@ -1654,22 +3171,44 @@ export class UncheckedBlock {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UncheckedBlock`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UncheckedBlock`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UncheckedBlock);
   }
 
+  /**
+   * Returns the child node that has the label `unchecked_keyword`.
+   */
   public get uncheckedKeyword(): TerminalNode {
     return this.fetch().uncheckedKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `block`.
+   */
   public get block(): Block {
     return this.fetch().block;
   }
 }
 
+/**
+ * This node represents a `ExpressionStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ExpressionStatement = (* expression: *) Expression
+ *                       (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ExpressionStatement {
   private readonly fetch = once(() => {
-    const [$expression, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$expression, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       expression: new Expression($expression as NonterminalNode),
@@ -1677,22 +3216,46 @@ export class ExpressionStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ExpressionStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ExpressionStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ExpressionStatement);
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression {
     return this.fetch().expression;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `AssemblyStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * AssemblyStatement = (* assembly_keyword: *) ASSEMBLY_KEYWORD
+ *                     (* label: *) StringLiteral?
+ *                     (* flags: *) AssemblyFlagsDeclaration?
+ *                     (* body: *) YulBlock;
+ * ```
+ */
 export class AssemblyStatement {
   private readonly fetch = once(() => {
-    const [$assemblyKeyword, $label, $flags, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$assemblyKeyword, $label, $flags, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       assemblyKeyword: $assemblyKeyword as TerminalNode,
@@ -1702,30 +3265,59 @@ export class AssemblyStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AssemblyStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AssemblyStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AssemblyStatement);
   }
 
+  /**
+   * Returns the child node that has the label `assembly_keyword`.
+   */
   public get assemblyKeyword(): TerminalNode {
     return this.fetch().assemblyKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `label`.
+   */
   public get label(): StringLiteral | undefined {
     return this.fetch().label;
   }
 
+  /**
+   * Returns the child node that has the label `flags`.
+   */
   public get flags(): AssemblyFlagsDeclaration | undefined {
     return this.fetch().flags;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `AssemblyFlagsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * AssemblyFlagsDeclaration = (* open_paren: *) OPEN_PAREN
+ *                            (* flags: *) AssemblyFlags
+ *                            (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class AssemblyFlagsDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $flags, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $flags, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -1734,27 +3326,57 @@ export class AssemblyFlagsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AssemblyFlagsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AssemblyFlagsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AssemblyFlagsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `flags`.
+   */
   public get flags(): AssemblyFlags {
     return this.fetch().flags;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `TupleDeconstructionStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleDeconstructionStatement = (* var_keyword: *) VAR_KEYWORD? (* Deprecated in 0.5.0 *)
+ *                                (* open_paren: *) OPEN_PAREN
+ *                                (* elements: *) TupleDeconstructionElements
+ *                                (* close_paren: *) CLOSE_PAREN
+ *                                (* equal: *) EQUAL
+ *                                (* expression: *) Expression
+ *                                (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class TupleDeconstructionStatement {
   private readonly fetch = once(() => {
     const [$varKeyword, $openParen, $elements, $closeParen, $equal, $expression, $semicolon] =
-      generated.ast.Selectors.sequence(this.cst);
+      wasm.ast.Selectors.sequence(this.cst);
 
     return {
       varKeyword: $varKeyword === undefined ? undefined : ($varKeyword as TerminalNode),
@@ -1767,60 +3389,116 @@ export class TupleDeconstructionStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleDeconstructionStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleDeconstructionStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleDeconstructionStatement);
   }
 
+  /**
+   * Returns the child node that has the label `var_keyword`.
+   */
   public get varKeyword(): TerminalNode | undefined {
     return this.fetch().varKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `elements`.
+   */
   public get elements(): TupleDeconstructionElements {
     return this.fetch().elements;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression {
     return this.fetch().expression;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `TupleDeconstructionElement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleDeconstructionElement = (* member: *) TupleMember?;
+ * ```
+ */
 export class TupleDeconstructionElement {
   private readonly fetch = once(() => {
-    const [$member] = generated.ast.Selectors.sequence(this.cst);
+    const [$member] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       member: $member === undefined ? undefined : new TupleMember($member as NonterminalNode),
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleDeconstructionElement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleDeconstructionElement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleDeconstructionElement);
   }
 
+  /**
+   * Returns the child node that has the label `member`.
+   */
   public get member(): TupleMember | undefined {
     return this.fetch().member;
   }
 }
 
+/**
+ * This node represents a `TypedTupleMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TypedTupleMember = (* type_name: *) TypeName
+ *                    (* storage_location: *) StorageLocation?
+ *                    (* name: *) IDENTIFIER;
+ * ```
+ */
 export class TypedTupleMember {
   private readonly fetch = once(() => {
-    const [$typeName, $storageLocation, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeName, $storageLocation, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeName: new TypeName($typeName as NonterminalNode),
@@ -1830,26 +3508,51 @@ export class TypedTupleMember {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TypedTupleMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TypedTupleMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TypedTupleMember);
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `storage_location`.
+   */
   public get storageLocation(): StorageLocation | undefined {
     return this.fetch().storageLocation;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `UntypedTupleMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * UntypedTupleMember = (* storage_location: *) StorageLocation?
+ *                      (* name: *) IDENTIFIER;
+ * ```
+ */
 export class UntypedTupleMember {
   private readonly fetch = once(() => {
-    const [$storageLocation, $name] = generated.ast.Selectors.sequence(this.cst);
+    const [$storageLocation, $name] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       storageLocation:
@@ -1858,22 +3561,47 @@ export class UntypedTupleMember {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UntypedTupleMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UntypedTupleMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UntypedTupleMember);
   }
 
+  /**
+   * Returns the child node that has the label `storage_location`.
+   */
   public get storageLocation(): StorageLocation | undefined {
     return this.fetch().storageLocation;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 }
 
+/**
+ * This node represents a `VariableDeclarationStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VariableDeclarationStatement = (* variable_type: *) VariableDeclarationType
+ *                                (* storage_location: *) StorageLocation?
+ *                                (* name: *) IDENTIFIER
+ *                                (* value: *) VariableDeclarationValue?
+ *                                (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class VariableDeclarationStatement {
   private readonly fetch = once(() => {
-    const [$variableType, $storageLocation, $name, $value, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$variableType, $storageLocation, $name, $value, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       variableType: new VariableDeclarationType($variableType as NonterminalNode),
@@ -1885,34 +3613,65 @@ export class VariableDeclarationStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VariableDeclarationStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VariableDeclarationStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VariableDeclarationStatement);
   }
 
+  /**
+   * Returns the child node that has the label `variable_type`.
+   */
   public get variableType(): VariableDeclarationType {
     return this.fetch().variableType;
   }
 
+  /**
+   * Returns the child node that has the label `storage_location`.
+   */
   public get storageLocation(): StorageLocation | undefined {
     return this.fetch().storageLocation;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): VariableDeclarationValue | undefined {
     return this.fetch().value;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `VariableDeclarationValue` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VariableDeclarationValue = (* equal: *) EQUAL
+ *                            (* expression: *) Expression;
+ * ```
+ */
 export class VariableDeclarationValue {
   private readonly fetch = once(() => {
-    const [$equal, $expression] = generated.ast.Selectors.sequence(this.cst);
+    const [$equal, $expression] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       equal: $equal as TerminalNode,
@@ -1920,24 +3679,48 @@ export class VariableDeclarationValue {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VariableDeclarationValue`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VariableDeclarationValue`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VariableDeclarationValue);
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression {
     return this.fetch().expression;
   }
 }
 
+/**
+ * This node represents a `IfStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * IfStatement = (* if_keyword: *) IF_KEYWORD
+ *               (* open_paren: *) OPEN_PAREN
+ *               (* condition: *) Expression
+ *               (* close_paren: *) CLOSE_PAREN
+ *               (* body: *) Statement
+ *               (* else_branch: *) ElseBranch?;
+ * ```
+ */
 export class IfStatement {
   private readonly fetch = once(() => {
-    const [$ifKeyword, $openParen, $condition, $closeParen, $body, $elseBranch] = generated.ast.Selectors.sequence(
-      this.cst,
-    );
+    const [$ifKeyword, $openParen, $condition, $closeParen, $body, $elseBranch] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       ifKeyword: $ifKeyword as TerminalNode,
@@ -1949,38 +3732,72 @@ export class IfStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `IfStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `IfStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.IfStatement);
   }
 
+  /**
+   * Returns the child node that has the label `if_keyword`.
+   */
   public get ifKeyword(): TerminalNode {
     return this.fetch().ifKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): Expression {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Statement {
     return this.fetch().body;
   }
 
+  /**
+   * Returns the child node that has the label `else_branch`.
+   */
   public get elseBranch(): ElseBranch | undefined {
     return this.fetch().elseBranch;
   }
 }
 
+/**
+ * This node represents a `ElseBranch` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ElseBranch = (* else_keyword: *) ELSE_KEYWORD
+ *              (* body: *) Statement;
+ * ```
+ */
 export class ElseBranch {
   private readonly fetch = once(() => {
-    const [$elseKeyword, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$elseKeyword, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       elseKeyword: $elseKeyword as TerminalNode,
@@ -1988,23 +3805,50 @@ export class ElseBranch {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ElseBranch`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ElseBranch`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ElseBranch);
   }
 
+  /**
+   * Returns the child node that has the label `else_keyword`.
+   */
   public get elseKeyword(): TerminalNode {
     return this.fetch().elseKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Statement {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `ForStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ForStatement = (* for_keyword: *) FOR_KEYWORD
+ *                (* open_paren: *) OPEN_PAREN
+ *                (* initialization: *) ForStatementInitialization
+ *                (* condition: *) ForStatementCondition
+ *                (* iterator: *) Expression?
+ *                (* close_paren: *) CLOSE_PAREN
+ *                (* body: *) Statement;
+ * ```
+ */
 export class ForStatement {
   private readonly fetch = once(() => {
     const [$forKeyword, $openParen, $initialization, $condition, $iterator, $closeParen, $body] =
-      generated.ast.Selectors.sequence(this.cst);
+      wasm.ast.Selectors.sequence(this.cst);
 
     return {
       forKeyword: $forKeyword as TerminalNode,
@@ -2017,42 +3861,82 @@ export class ForStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ForStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ForStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ForStatement);
   }
 
+  /**
+   * Returns the child node that has the label `for_keyword`.
+   */
   public get forKeyword(): TerminalNode {
     return this.fetch().forKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `initialization`.
+   */
   public get initialization(): ForStatementInitialization {
     return this.fetch().initialization;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): ForStatementCondition {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `iterator`.
+   */
   public get iterator(): Expression | undefined {
     return this.fetch().iterator;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Statement {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `WhileStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * WhileStatement = (* while_keyword: *) WHILE_KEYWORD
+ *                  (* open_paren: *) OPEN_PAREN
+ *                  (* condition: *) Expression
+ *                  (* close_paren: *) CLOSE_PAREN
+ *                  (* body: *) Statement;
+ * ```
+ */
 export class WhileStatement {
   private readonly fetch = once(() => {
-    const [$whileKeyword, $openParen, $condition, $closeParen, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$whileKeyword, $openParen, $condition, $closeParen, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       whileKeyword: $whileKeyword as TerminalNode,
@@ -2063,35 +3947,71 @@ export class WhileStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `WhileStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `WhileStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.WhileStatement);
   }
 
+  /**
+   * Returns the child node that has the label `while_keyword`.
+   */
   public get whileKeyword(): TerminalNode {
     return this.fetch().whileKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): Expression {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Statement {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `DoWhileStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * DoWhileStatement = (* do_keyword: *) DO_KEYWORD
+ *                    (* body: *) Statement
+ *                    (* while_keyword: *) WHILE_KEYWORD
+ *                    (* open_paren: *) OPEN_PAREN
+ *                    (* condition: *) Expression
+ *                    (* close_paren: *) CLOSE_PAREN
+ *                    (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class DoWhileStatement {
   private readonly fetch = once(() => {
     const [$doKeyword, $body, $whileKeyword, $openParen, $condition, $closeParen, $semicolon] =
-      generated.ast.Selectors.sequence(this.cst);
+      wasm.ast.Selectors.sequence(this.cst);
 
     return {
       doKeyword: $doKeyword as TerminalNode,
@@ -2104,42 +4024,79 @@ export class DoWhileStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `DoWhileStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `DoWhileStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.DoWhileStatement);
   }
 
+  /**
+   * Returns the child node that has the label `do_keyword`.
+   */
   public get doKeyword(): TerminalNode {
     return this.fetch().doKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Statement {
     return this.fetch().body;
   }
 
+  /**
+   * Returns the child node that has the label `while_keyword`.
+   */
   public get whileKeyword(): TerminalNode {
     return this.fetch().whileKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): Expression {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `ContinueStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ContinueStatement = (* continue_keyword: *) CONTINUE_KEYWORD
+ *                     (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ContinueStatement {
   private readonly fetch = once(() => {
-    const [$continueKeyword, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$continueKeyword, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       continueKeyword: $continueKeyword as TerminalNode,
@@ -2147,22 +4104,44 @@ export class ContinueStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ContinueStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ContinueStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ContinueStatement);
   }
 
+  /**
+   * Returns the child node that has the label `continue_keyword`.
+   */
   public get continueKeyword(): TerminalNode {
     return this.fetch().continueKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `BreakStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * BreakStatement = (* break_keyword: *) BREAK_KEYWORD
+ *                  (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class BreakStatement {
   private readonly fetch = once(() => {
-    const [$breakKeyword, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$breakKeyword, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       breakKeyword: $breakKeyword as TerminalNode,
@@ -2170,22 +4149,45 @@ export class BreakStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `BreakStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `BreakStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.BreakStatement);
   }
 
+  /**
+   * Returns the child node that has the label `break_keyword`.
+   */
   public get breakKeyword(): TerminalNode {
     return this.fetch().breakKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `ReturnStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ReturnStatement = (* return_keyword: *) RETURN_KEYWORD
+ *                   (* expression: *) Expression?
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ReturnStatement {
   private readonly fetch = once(() => {
-    const [$returnKeyword, $expression, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$returnKeyword, $expression, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       returnKeyword: $returnKeyword as TerminalNode,
@@ -2194,26 +4196,54 @@ export class ReturnStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ReturnStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ReturnStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ReturnStatement);
   }
 
+  /**
+   * Returns the child node that has the label `return_keyword`.
+   */
   public get returnKeyword(): TerminalNode {
     return this.fetch().returnKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression | undefined {
     return this.fetch().expression;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `EmitStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.4.21 *)
+ * EmitStatement = (* emit_keyword: *) EMIT_KEYWORD
+ *                 (* event: *) IdentifierPath
+ *                 (* arguments: *) ArgumentsDeclaration
+ *                 (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class EmitStatement {
   private readonly fetch = once(() => {
-    const [$emitKeyword, $event, $arguments, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$emitKeyword, $event, $arguments, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       emitKeyword: $emitKeyword as TerminalNode,
@@ -2223,30 +4253,62 @@ export class EmitStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EmitStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EmitStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EmitStatement);
   }
 
+  /**
+   * Returns the child node that has the label `emit_keyword`.
+   */
   public get emitKeyword(): TerminalNode {
     return this.fetch().emitKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `event`.
+   */
   public get event(): IdentifierPath {
     return this.fetch().event;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): ArgumentsDeclaration {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `TryStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * TryStatement = (* try_keyword: *) TRY_KEYWORD
+ *                (* expression: *) Expression
+ *                (* returns: *) ReturnsDeclaration?
+ *                (* body: *) Block
+ *                (* catch_clauses: *) CatchClauses;
+ * ```
+ */
 export class TryStatement {
   private readonly fetch = once(() => {
-    const [$tryKeyword, $expression, $returns, $body, $catchClauses] = generated.ast.Selectors.sequence(this.cst);
+    const [$tryKeyword, $expression, $returns, $body, $catchClauses] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       tryKeyword: $tryKeyword as TerminalNode,
@@ -2257,34 +4319,67 @@ export class TryStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TryStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TryStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TryStatement);
   }
 
+  /**
+   * Returns the child node that has the label `try_keyword`.
+   */
   public get tryKeyword(): TerminalNode {
     return this.fetch().tryKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression {
     return this.fetch().expression;
   }
 
+  /**
+   * Returns the child node that has the label `returns`.
+   */
   public get returns(): ReturnsDeclaration | undefined {
     return this.fetch().returns;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Block {
     return this.fetch().body;
   }
 
+  /**
+   * Returns the child node that has the label `catch_clauses`.
+   */
   public get catchClauses(): CatchClauses {
     return this.fetch().catchClauses;
   }
 }
 
+/**
+ * This node represents a `CatchClause` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * CatchClause = (* catch_keyword: *) CATCH_KEYWORD
+ *               (* error: *) CatchClauseError?
+ *               (* body: *) Block;
+ * ```
+ */
 export class CatchClause {
   private readonly fetch = once(() => {
-    const [$catchKeyword, $error, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$catchKeyword, $error, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       catchKeyword: $catchKeyword as TerminalNode,
@@ -2293,26 +4388,52 @@ export class CatchClause {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `CatchClause`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `CatchClause`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.CatchClause);
   }
 
+  /**
+   * Returns the child node that has the label `catch_keyword`.
+   */
   public get catchKeyword(): TerminalNode {
     return this.fetch().catchKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `error`.
+   */
   public get error(): CatchClauseError | undefined {
     return this.fetch().error;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): Block {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `CatchClauseError` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * CatchClauseError = (* name: *) IDENTIFIER?
+ *                    (* parameters: *) ParametersDeclaration;
+ * ```
+ */
 export class CatchClauseError {
   private readonly fetch = once(() => {
-    const [$name, $parameters] = generated.ast.Selectors.sequence(this.cst);
+    const [$name, $parameters] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       name: $name === undefined ? undefined : ($name as TerminalNode),
@@ -2320,22 +4441,47 @@ export class CatchClauseError {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `CatchClauseError`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `CatchClauseError`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.CatchClauseError);
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): ParametersDeclaration {
     return this.fetch().parameters;
   }
 }
 
+/**
+ * This node represents a `RevertStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.4 *)
+ * RevertStatement = (* revert_keyword: *) REVERT_KEYWORD
+ *                   (* error: *) IdentifierPath?
+ *                   (* arguments: *) ArgumentsDeclaration
+ *                   (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class RevertStatement {
   private readonly fetch = once(() => {
-    const [$revertKeyword, $error, $arguments, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$revertKeyword, $error, $arguments, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       revertKeyword: $revertKeyword as TerminalNode,
@@ -2345,30 +4491,59 @@ export class RevertStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `RevertStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `RevertStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.RevertStatement);
   }
 
+  /**
+   * Returns the child node that has the label `revert_keyword`.
+   */
   public get revertKeyword(): TerminalNode {
     return this.fetch().revertKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `error`.
+   */
   public get error(): IdentifierPath | undefined {
     return this.fetch().error;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): ArgumentsDeclaration {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `ThrowStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.0 *)
+ * ThrowStatement = (* throw_keyword: *) THROW_KEYWORD
+ *                  (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class ThrowStatement {
   private readonly fetch = once(() => {
-    const [$throwKeyword, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$throwKeyword, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       throwKeyword: $throwKeyword as TerminalNode,
@@ -2376,22 +4551,101 @@ export class ThrowStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ThrowStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ThrowStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ThrowStatement);
   }
 
+  /**
+   * Returns the child node that has the label `throw_keyword`.
+   */
   public get throwKeyword(): TerminalNode {
     return this.fetch().throwKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `AssignmentExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) BAR_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) PLUS_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) MINUS_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) CARET_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) SLASH_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) PERCENT_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) ASTERISK_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) AMPERSAND_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) LESS_THAN_LESS_THAN_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) GREATER_THAN_GREATER_THAN_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AssignmentExpression = (* left_operand: *) Expression
+ *                        (* operator: *) GREATER_THAN_GREATER_THAN_GREATER_THAN_EQUAL
+ *                        (* right_operand: *) Expression;
+ * ```
+ */
 export class AssignmentExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2400,28 +4654,55 @@ export class AssignmentExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AssignmentExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AssignmentExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AssignmentExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `ConditionalExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * ConditionalExpression = (* operand: *) Expression
+ *                         (* question_mark: *) QUESTION_MARK
+ *                         (* true_expression: *) Expression
+ *                         (* colon: *) COLON
+ *                         (* false_expression: *) Expression;
+ * ```
+ */
 export class ConditionalExpression {
   private readonly fetch = once(() => {
-    const [$operand, $questionMark, $trueExpression, $colon, $falseExpression] = generated.ast.Selectors.sequence(
-      this.cst,
-    );
+    const [$operand, $questionMark, $trueExpression, $colon, $falseExpression] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2432,34 +4713,67 @@ export class ConditionalExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ConditionalExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ConditionalExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ConditionalExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `question_mark`.
+   */
   public get questionMark(): TerminalNode {
     return this.fetch().questionMark;
   }
 
+  /**
+   * Returns the child node that has the label `true_expression`.
+   */
   public get trueExpression(): Expression {
     return this.fetch().trueExpression;
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 
+  /**
+   * Returns the child node that has the label `false_expression`.
+   */
   public get falseExpression(): Expression {
     return this.fetch().falseExpression;
   }
 }
 
+/**
+ * This node represents a `OrExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * OrExpression = (* left_operand: *) Expression
+ *                (* operator: *) BAR_BAR
+ *                (* right_operand: *) Expression;
+ * ```
+ */
 export class OrExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2468,26 +4782,53 @@ export class OrExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `OrExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `OrExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.OrExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `AndExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * AndExpression = (* left_operand: *) Expression
+ *                 (* operator: *) AMPERSAND_AMPERSAND
+ *                 (* right_operand: *) Expression;
+ * ```
+ */
 export class AndExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2496,26 +4837,58 @@ export class AndExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AndExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AndExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AndExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `EqualityExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * EqualityExpression = (* left_operand: *) Expression
+ *                      (* operator: *) EQUAL_EQUAL
+ *                      (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * EqualityExpression = (* left_operand: *) Expression
+ *                      (* operator: *) BANG_EQUAL
+ *                      (* right_operand: *) Expression;
+ * ```
+ */
 export class EqualityExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2524,26 +4897,68 @@ export class EqualityExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EqualityExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EqualityExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EqualityExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `ComparisonExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * ComparisonExpression = (* left_operand: *) Expression
+ *                        (* operator: *) LESS_THAN
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * ComparisonExpression = (* left_operand: *) Expression
+ *                        (* operator: *) GREATER_THAN
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * ComparisonExpression = (* left_operand: *) Expression
+ *                        (* operator: *) LESS_THAN_EQUAL
+ *                        (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * ComparisonExpression = (* left_operand: *) Expression
+ *                        (* operator: *) GREATER_THAN_EQUAL
+ *                        (* right_operand: *) Expression;
+ * ```
+ */
 export class ComparisonExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2552,26 +4967,53 @@ export class ComparisonExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ComparisonExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ComparisonExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ComparisonExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `BitwiseOrExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * BitwiseOrExpression = (* left_operand: *) Expression
+ *                       (* operator: *) BAR
+ *                       (* right_operand: *) Expression;
+ * ```
+ */
 export class BitwiseOrExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2580,26 +5022,53 @@ export class BitwiseOrExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `BitwiseOrExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `BitwiseOrExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.BitwiseOrExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `BitwiseXorExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * BitwiseXorExpression = (* left_operand: *) Expression
+ *                        (* operator: *) CARET
+ *                        (* right_operand: *) Expression;
+ * ```
+ */
 export class BitwiseXorExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2608,26 +5077,53 @@ export class BitwiseXorExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `BitwiseXorExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `BitwiseXorExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.BitwiseXorExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `BitwiseAndExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * BitwiseAndExpression = (* left_operand: *) Expression
+ *                        (* operator: *) AMPERSAND
+ *                        (* right_operand: *) Expression;
+ * ```
+ */
 export class BitwiseAndExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2636,26 +5132,63 @@ export class BitwiseAndExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `BitwiseAndExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `BitwiseAndExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.BitwiseAndExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `ShiftExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * ShiftExpression = (* left_operand: *) Expression
+ *                   (* operator: *) LESS_THAN_LESS_THAN
+ *                   (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * ShiftExpression = (* left_operand: *) Expression
+ *                   (* operator: *) GREATER_THAN_GREATER_THAN
+ *                   (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * ShiftExpression = (* left_operand: *) Expression
+ *                   (* operator: *) GREATER_THAN_GREATER_THAN_GREATER_THAN
+ *                   (* right_operand: *) Expression;
+ * ```
+ */
 export class ShiftExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2664,26 +5197,58 @@ export class ShiftExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ShiftExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ShiftExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ShiftExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `AdditiveExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * AdditiveExpression = (* left_operand: *) Expression
+ *                      (* operator: *) PLUS
+ *                      (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * AdditiveExpression = (* left_operand: *) Expression
+ *                      (* operator: *) MINUS
+ *                      (* right_operand: *) Expression;
+ * ```
+ */
 export class AdditiveExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2692,26 +5257,63 @@ export class AdditiveExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AdditiveExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AdditiveExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AdditiveExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `MultiplicativeExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * MultiplicativeExpression = (* left_operand: *) Expression
+ *                            (* operator: *) ASTERISK
+ *                            (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * MultiplicativeExpression = (* left_operand: *) Expression
+ *                            (* operator: *) SLASH
+ *                            (* right_operand: *) Expression;
+ *
+ * (* Left-associative binary operator *)
+ * MultiplicativeExpression = (* left_operand: *) Expression
+ *                            (* operator: *) PERCENT
+ *                            (* right_operand: *) Expression;
+ * ```
+ */
 export class MultiplicativeExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2720,26 +5322,60 @@ export class MultiplicativeExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MultiplicativeExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MultiplicativeExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MultiplicativeExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `ExponentiationExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * (* Deprecated in 0.8.0 *)
+ * ExponentiationExpression = (* left_operand: *) Expression
+ *                            (* operator: *) ASTERISK_ASTERISK
+ *                            (* right_operand: *) Expression;
+ *
+ * (* Right-associative binary operator *)
+ * (* Introduced in 0.8.0 *)
+ * ExponentiationExpression = (* left_operand: *) Expression
+ *                            (* operator: *) ASTERISK_ASTERISK
+ *                            (* right_operand: *) Expression;
+ * ```
+ */
 export class ExponentiationExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -2748,26 +5384,56 @@ export class ExponentiationExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ExponentiationExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ExponentiationExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ExponentiationExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `PostfixExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * PostfixExpression = (* operand: *) Expression
+ *                     (* operator: *) PLUS_PLUS;
+ *
+ * (* Postfix unary operator *)
+ * PostfixExpression = (* operand: *) Expression
+ *                     (* operator: *) MINUS_MINUS;
+ * ```
+ */
 export class PostfixExpression {
   private readonly fetch = once(() => {
-    const [$operand, $operator] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $operator] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2775,22 +5441,70 @@ export class PostfixExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PostfixExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PostfixExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PostfixExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 }
 
+/**
+ * This node represents a `PrefixExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) PLUS_PLUS
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) MINUS_MINUS
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) TILDE
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) BANG
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) MINUS
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * (* Deprecated in 0.5.0 *)
+ * PrefixExpression = (* operator: *) PLUS
+ *                    (* operand: *) Expression;
+ *
+ * (* Prefix unary operator *)
+ * PrefixExpression = (* operator: *) DELETE_KEYWORD
+ *                    (* operand: *) Expression;
+ * ```
+ */
 export class PrefixExpression {
   private readonly fetch = once(() => {
-    const [$operator, $operand] = generated.ast.Selectors.sequence(this.cst);
+    const [$operator, $operand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operator: $operator as TerminalNode,
@@ -2798,22 +5512,45 @@ export class PrefixExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PrefixExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PrefixExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PrefixExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 }
 
+/**
+ * This node represents a `FunctionCallExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * FunctionCallExpression = (* operand: *) Expression
+ *                          (* arguments: *) ArgumentsDeclaration;
+ * ```
+ */
 export class FunctionCallExpression {
   private readonly fetch = once(() => {
-    const [$operand, $arguments] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $arguments] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2821,22 +5558,48 @@ export class FunctionCallExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionCallExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionCallExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionCallExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): ArgumentsDeclaration {
     return this.fetch().arguments;
   }
 }
 
+/**
+ * This node represents a `CallOptionsExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * (* Introduced in 0.6.2 *)
+ * CallOptionsExpression = (* operand: *) Expression
+ *                         (* open_brace: *) OPEN_BRACE
+ *                         (* options: *) CallOptions
+ *                         (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class CallOptionsExpression {
   private readonly fetch = once(() => {
-    const [$operand, $openBrace, $options, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $openBrace, $options, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2846,30 +5609,60 @@ export class CallOptionsExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `CallOptionsExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `CallOptionsExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.CallOptionsExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `options`.
+   */
   public get options(): CallOptions {
     return this.fetch().options;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `MemberAccessExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * MemberAccessExpression = (* operand: *) Expression
+ *                          (* period: *) PERIOD
+ *                          (* member: *) IDENTIFIER;
+ * ```
+ */
 export class MemberAccessExpression {
   private readonly fetch = once(() => {
-    const [$operand, $period, $member] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $period, $member] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2878,26 +5671,55 @@ export class MemberAccessExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MemberAccessExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MemberAccessExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MemberAccessExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `period`.
+   */
   public get period(): TerminalNode {
     return this.fetch().period;
   }
 
+  /**
+   * Returns the child node that has the label `member`.
+   */
   public get member(): TerminalNode {
     return this.fetch().member;
   }
 }
 
+/**
+ * This node represents a `IndexAccessExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * IndexAccessExpression = (* operand: *) Expression
+ *                         (* open_bracket: *) OPEN_BRACKET
+ *                         (* start: *) Expression?
+ *                         (* end: *) IndexAccessEnd?
+ *                         (* close_bracket: *) CLOSE_BRACKET;
+ * ```
+ */
 export class IndexAccessExpression {
   private readonly fetch = once(() => {
-    const [$operand, $openBracket, $start, $end, $closeBracket] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $openBracket, $start, $end, $closeBracket] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -2908,34 +5730,65 @@ export class IndexAccessExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `IndexAccessExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `IndexAccessExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.IndexAccessExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `open_bracket`.
+   */
   public get openBracket(): TerminalNode {
     return this.fetch().openBracket;
   }
 
+  /**
+   * Returns the child node that has the label `start`.
+   */
   public get start(): Expression | undefined {
     return this.fetch().start;
   }
 
+  /**
+   * Returns the child node that has the label `end`.
+   */
   public get end(): IndexAccessEnd | undefined {
     return this.fetch().end;
   }
 
+  /**
+   * Returns the child node that has the label `close_bracket`.
+   */
   public get closeBracket(): TerminalNode {
     return this.fetch().closeBracket;
   }
 }
 
+/**
+ * This node represents a `IndexAccessEnd` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * IndexAccessEnd = (* colon: *) COLON
+ *                  (* end: *) Expression?;
+ * ```
+ */
 export class IndexAccessEnd {
   private readonly fetch = once(() => {
-    const [$colon, $end] = generated.ast.Selectors.sequence(this.cst);
+    const [$colon, $end] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       colon: $colon as TerminalNode,
@@ -2943,22 +5796,45 @@ export class IndexAccessEnd {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `IndexAccessEnd`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `IndexAccessEnd`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.IndexAccessEnd);
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 
+  /**
+   * Returns the child node that has the label `end`.
+   */
   public get end(): Expression | undefined {
     return this.fetch().end;
   }
 }
 
+/**
+ * This node represents a `PositionalArgumentsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * PositionalArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
+ *                                  (* arguments: *) PositionalArguments
+ *                                  (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class PositionalArgumentsDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $arguments, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $arguments, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -2967,26 +5843,52 @@ export class PositionalArgumentsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PositionalArgumentsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PositionalArgumentsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PositionalArgumentsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): PositionalArguments {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `NamedArgumentsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NamedArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
+ *                             (* arguments: *) NamedArgumentGroup?
+ *                             (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class NamedArgumentsDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $arguments, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $arguments, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -2995,26 +5897,52 @@ export class NamedArgumentsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NamedArgumentsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NamedArgumentsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NamedArgumentsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): NamedArgumentGroup | undefined {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `NamedArgumentGroup` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NamedArgumentGroup = (* open_brace: *) OPEN_BRACE
+ *                      (* arguments: *) NamedArguments
+ *                      (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class NamedArgumentGroup {
   private readonly fetch = once(() => {
-    const [$openBrace, $arguments, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBrace, $arguments, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBrace: $openBrace as TerminalNode,
@@ -3023,26 +5951,52 @@ export class NamedArgumentGroup {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NamedArgumentGroup`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NamedArgumentGroup`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NamedArgumentGroup);
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): NamedArguments {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `NamedArgument` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NamedArgument = (* name: *) IDENTIFIER
+ *                 (* colon: *) COLON
+ *                 (* value: *) Expression;
+ * ```
+ */
 export class NamedArgument {
   private readonly fetch = once(() => {
-    const [$name, $colon, $value] = generated.ast.Selectors.sequence(this.cst);
+    const [$name, $colon, $value] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       name: $name as TerminalNode,
@@ -3051,26 +6005,54 @@ export class NamedArgument {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NamedArgument`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NamedArgument`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NamedArgument);
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): Expression {
     return this.fetch().value;
   }
 }
 
+/**
+ * This node represents a `TypeExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.5.3 *)
+ * TypeExpression = (* type_keyword: *) TYPE_KEYWORD
+ *                  (* open_paren: *) OPEN_PAREN
+ *                  (* type_name: *) TypeName
+ *                  (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class TypeExpression {
   private readonly fetch = once(() => {
-    const [$typeKeyword, $openParen, $typeName, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$typeKeyword, $openParen, $typeName, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       typeKeyword: $typeKeyword as TerminalNode,
@@ -3080,30 +6062,58 @@ export class TypeExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TypeExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TypeExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TypeExpression);
   }
 
+  /**
+   * Returns the child node that has the label `type_keyword`.
+   */
   public get typeKeyword(): TerminalNode {
     return this.fetch().typeKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `NewExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NewExpression = (* new_keyword: *) NEW_KEYWORD
+ *                 (* type_name: *) TypeName;
+ * ```
+ */
 export class NewExpression {
   private readonly fetch = once(() => {
-    const [$newKeyword, $typeName] = generated.ast.Selectors.sequence(this.cst);
+    const [$newKeyword, $typeName] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       newKeyword: $newKeyword as TerminalNode,
@@ -3111,22 +6121,45 @@ export class NewExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NewExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NewExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NewExpression);
   }
 
+  /**
+   * Returns the child node that has the label `new_keyword`.
+   */
   public get newKeyword(): TerminalNode {
     return this.fetch().newKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `type_name`.
+   */
   public get typeName(): TypeName {
     return this.fetch().typeName;
   }
 }
 
+/**
+ * This node represents a `TupleExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleExpression = (* open_paren: *) OPEN_PAREN
+ *                   (* items: *) TupleValues
+ *                   (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class TupleExpression {
   private readonly fetch = once(() => {
-    const [$openParen, $items, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $items, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -3135,44 +6168,88 @@ export class TupleExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleExpression);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `items`.
+   */
   public get items(): TupleValues {
     return this.fetch().items;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `TupleValue` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleValue = (* expression: *) Expression?;
+ * ```
+ */
 export class TupleValue {
   private readonly fetch = once(() => {
-    const [$expression] = generated.ast.Selectors.sequence(this.cst);
+    const [$expression] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       expression: $expression === undefined ? undefined : new Expression($expression as NonterminalNode),
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleValue`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleValue`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleValue);
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): Expression | undefined {
     return this.fetch().expression;
   }
 }
 
+/**
+ * This node represents a `ArrayExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ArrayExpression = (* open_bracket: *) OPEN_BRACKET
+ *                   (* items: *) ArrayValues
+ *                   (* close_bracket: *) CLOSE_BRACKET;
+ * ```
+ */
 export class ArrayExpression {
   private readonly fetch = once(() => {
-    const [$openBracket, $items, $closeBracket] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBracket, $items, $closeBracket] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBracket: $openBracket as TerminalNode,
@@ -3181,26 +6258,51 @@ export class ArrayExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ArrayExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ArrayExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ArrayExpression);
   }
 
+  /**
+   * Returns the child node that has the label `open_bracket`.
+   */
   public get openBracket(): TerminalNode {
     return this.fetch().openBracket;
   }
 
+  /**
+   * Returns the child node that has the label `items`.
+   */
   public get items(): ArrayValues {
     return this.fetch().items;
   }
 
+  /**
+   * Returns the child node that has the label `close_bracket`.
+   */
   public get closeBracket(): TerminalNode {
     return this.fetch().closeBracket;
   }
 }
 
+/**
+ * This node represents a `HexNumberExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * HexNumberExpression = (* literal: *) HEX_LITERAL
+ *                       (* unit: *) NumberUnit?; (* Deprecated in 0.5.0 *)
+ * ```
+ */
 export class HexNumberExpression {
   private readonly fetch = once(() => {
-    const [$literal, $unit] = generated.ast.Selectors.sequence(this.cst);
+    const [$literal, $unit] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       literal: $literal as TerminalNode,
@@ -3208,22 +6310,44 @@ export class HexNumberExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `HexNumberExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `HexNumberExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.HexNumberExpression);
   }
 
+  /**
+   * Returns the child node that has the label `literal`.
+   */
   public get literal(): TerminalNode {
     return this.fetch().literal;
   }
 
+  /**
+   * Returns the child node that has the label `unit`.
+   */
   public get unit(): NumberUnit | undefined {
     return this.fetch().unit;
   }
 }
 
+/**
+ * This node represents a `DecimalNumberExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * DecimalNumberExpression = (* literal: *) DECIMAL_LITERAL
+ *                           (* unit: *) NumberUnit?;
+ * ```
+ */
 export class DecimalNumberExpression {
   private readonly fetch = once(() => {
-    const [$literal, $unit] = generated.ast.Selectors.sequence(this.cst);
+    const [$literal, $unit] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       literal: $literal as TerminalNode,
@@ -3231,22 +6355,45 @@ export class DecimalNumberExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `DecimalNumberExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `DecimalNumberExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.DecimalNumberExpression);
   }
 
+  /**
+   * Returns the child node that has the label `literal`.
+   */
   public get literal(): TerminalNode {
     return this.fetch().literal;
   }
 
+  /**
+   * Returns the child node that has the label `unit`.
+   */
   public get unit(): NumberUnit | undefined {
     return this.fetch().unit;
   }
 }
 
+/**
+ * This node represents a `YulBlock` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulBlock = (* open_brace: *) OPEN_BRACE
+ *            (* statements: *) YulStatements
+ *            (* close_brace: *) CLOSE_BRACE;
+ * ```
+ */
 export class YulBlock {
   private readonly fetch = once(() => {
-    const [$openBrace, $statements, $closeBrace] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBrace, $statements, $closeBrace] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBrace: $openBrace as TerminalNode,
@@ -3255,26 +6402,54 @@ export class YulBlock {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulBlock`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulBlock`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulBlock);
   }
 
+  /**
+   * Returns the child node that has the label `open_brace`.
+   */
   public get openBrace(): TerminalNode {
     return this.fetch().openBrace;
   }
 
+  /**
+   * Returns the child node that has the label `statements`.
+   */
   public get statements(): YulStatements {
     return this.fetch().statements;
   }
 
+  /**
+   * Returns the child node that has the label `close_brace`.
+   */
   public get closeBrace(): TerminalNode {
     return this.fetch().closeBrace;
   }
 }
 
+/**
+ * This node represents a `YulFunctionDefinition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulFunctionDefinition = (* function_keyword: *) YUL_FUNCTION_KEYWORD
+ *                         (* name: *) YUL_IDENTIFIER
+ *                         (* parameters: *) YulParametersDeclaration
+ *                         (* returns: *) YulReturnsDeclaration?
+ *                         (* body: *) YulBlock;
+ * ```
+ */
 export class YulFunctionDefinition {
   private readonly fetch = once(() => {
-    const [$functionKeyword, $name, $parameters, $returns, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$functionKeyword, $name, $parameters, $returns, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       functionKeyword: $functionKeyword as TerminalNode,
@@ -3285,34 +6460,66 @@ export class YulFunctionDefinition {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulFunctionDefinition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulFunctionDefinition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulFunctionDefinition);
   }
 
+  /**
+   * Returns the child node that has the label `function_keyword`.
+   */
   public get functionKeyword(): TerminalNode {
     return this.fetch().functionKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): YulParametersDeclaration {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `returns`.
+   */
   public get returns(): YulReturnsDeclaration | undefined {
     return this.fetch().returns;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `YulParametersDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulParametersDeclaration = (* open_paren: *) OPEN_PAREN
+ *                            (* parameters: *) YulParameters
+ *                            (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class YulParametersDeclaration {
   private readonly fetch = once(() => {
-    const [$openParen, $parameters, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$openParen, $parameters, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openParen: $openParen as TerminalNode,
@@ -3321,26 +6528,51 @@ export class YulParametersDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulParametersDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulParametersDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulParametersDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `parameters`.
+   */
   public get parameters(): YulParameters {
     return this.fetch().parameters;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
+/**
+ * This node represents a `YulReturnsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulReturnsDeclaration = (* minus_greater_than: *) MINUS_GREATER_THAN
+ *                         (* variables: *) YulVariableNames;
+ * ```
+ */
 export class YulReturnsDeclaration {
   private readonly fetch = once(() => {
-    const [$minusGreaterThan, $variables] = generated.ast.Selectors.sequence(this.cst);
+    const [$minusGreaterThan, $variables] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       minusGreaterThan: $minusGreaterThan as TerminalNode,
@@ -3348,22 +6580,45 @@ export class YulReturnsDeclaration {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulReturnsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulReturnsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulReturnsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `minus_greater_than`.
+   */
   public get minusGreaterThan(): TerminalNode {
     return this.fetch().minusGreaterThan;
   }
 
+  /**
+   * Returns the child node that has the label `variables`.
+   */
   public get variables(): YulVariableNames {
     return this.fetch().variables;
   }
 }
 
+/**
+ * This node represents a `YulVariableDeclarationStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulVariableDeclarationStatement = (* let_keyword: *) YUL_LET_KEYWORD
+ *                                   (* variables: *) YulVariableNames
+ *                                   (* value: *) YulVariableDeclarationValue?;
+ * ```
+ */
 export class YulVariableDeclarationStatement {
   private readonly fetch = once(() => {
-    const [$letKeyword, $variables, $value] = generated.ast.Selectors.sequence(this.cst);
+    const [$letKeyword, $variables, $value] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       letKeyword: $letKeyword as TerminalNode,
@@ -3372,26 +6627,51 @@ export class YulVariableDeclarationStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulVariableDeclarationStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulVariableDeclarationStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulVariableDeclarationStatement);
   }
 
+  /**
+   * Returns the child node that has the label `let_keyword`.
+   */
   public get letKeyword(): TerminalNode {
     return this.fetch().letKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `variables`.
+   */
   public get variables(): YulVariableNames {
     return this.fetch().variables;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): YulVariableDeclarationValue | undefined {
     return this.fetch().value;
   }
 }
 
+/**
+ * This node represents a `YulVariableDeclarationValue` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulVariableDeclarationValue = (* assignment: *) YulAssignmentOperator
+ *                               (* expression: *) YulExpression;
+ * ```
+ */
 export class YulVariableDeclarationValue {
   private readonly fetch = once(() => {
-    const [$assignment, $expression] = generated.ast.Selectors.sequence(this.cst);
+    const [$assignment, $expression] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       assignment: new YulAssignmentOperator($assignment as NonterminalNode),
@@ -3399,22 +6679,45 @@ export class YulVariableDeclarationValue {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulVariableDeclarationValue`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulVariableDeclarationValue`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulVariableDeclarationValue);
   }
 
+  /**
+   * Returns the child node that has the label `assignment`.
+   */
   public get assignment(): YulAssignmentOperator {
     return this.fetch().assignment;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): YulExpression {
     return this.fetch().expression;
   }
 }
 
+/**
+ * This node represents a `YulVariableAssignmentStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulVariableAssignmentStatement = (* variables: *) YulPaths
+ *                                  (* assignment: *) YulAssignmentOperator
+ *                                  (* expression: *) YulExpression;
+ * ```
+ */
 export class YulVariableAssignmentStatement {
   private readonly fetch = once(() => {
-    const [$variables, $assignment, $expression] = generated.ast.Selectors.sequence(this.cst);
+    const [$variables, $assignment, $expression] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       variables: new YulPaths($variables as NonterminalNode),
@@ -3423,26 +6726,52 @@ export class YulVariableAssignmentStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulVariableAssignmentStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulVariableAssignmentStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulVariableAssignmentStatement);
   }
 
+  /**
+   * Returns the child node that has the label `variables`.
+   */
   public get variables(): YulPaths {
     return this.fetch().variables;
   }
 
+  /**
+   * Returns the child node that has the label `assignment`.
+   */
   public get assignment(): YulAssignmentOperator {
     return this.fetch().assignment;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): YulExpression {
     return this.fetch().expression;
   }
 }
 
+/**
+ * This node represents a `YulColonAndEqual` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.5 *)
+ * YulColonAndEqual = (* colon: *) COLON
+ *                    (* equal: *) EQUAL;
+ * ```
+ */
 export class YulColonAndEqual {
   private readonly fetch = once(() => {
-    const [$colon, $equal] = generated.ast.Selectors.sequence(this.cst);
+    const [$colon, $equal] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       colon: $colon as TerminalNode,
@@ -3450,22 +6779,45 @@ export class YulColonAndEqual {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulColonAndEqual`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulColonAndEqual`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulColonAndEqual);
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 }
 
+/**
+ * This node represents a `YulStackAssignmentStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.0 *)
+ * YulStackAssignmentStatement = (* assignment: *) YulStackAssignmentOperator
+ *                               (* variable: *) YUL_IDENTIFIER;
+ * ```
+ */
 export class YulStackAssignmentStatement {
   private readonly fetch = once(() => {
-    const [$assignment, $variable] = generated.ast.Selectors.sequence(this.cst);
+    const [$assignment, $variable] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       assignment: new YulStackAssignmentOperator($assignment as NonterminalNode),
@@ -3473,22 +6825,45 @@ export class YulStackAssignmentStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulStackAssignmentStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulStackAssignmentStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulStackAssignmentStatement);
   }
 
+  /**
+   * Returns the child node that has the label `assignment`.
+   */
   public get assignment(): YulStackAssignmentOperator {
     return this.fetch().assignment;
   }
 
+  /**
+   * Returns the child node that has the label `variable`.
+   */
   public get variable(): TerminalNode {
     return this.fetch().variable;
   }
 }
 
+/**
+ * This node represents a `YulEqualAndColon` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.0 *)
+ * YulEqualAndColon = (* equal: *) EQUAL
+ *                    (* colon: *) COLON;
+ * ```
+ */
 export class YulEqualAndColon {
   private readonly fetch = once(() => {
-    const [$equal, $colon] = generated.ast.Selectors.sequence(this.cst);
+    const [$equal, $colon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       equal: $equal as TerminalNode,
@@ -3496,22 +6871,45 @@ export class YulEqualAndColon {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulEqualAndColon`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulEqualAndColon`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulEqualAndColon);
   }
 
+  /**
+   * Returns the child node that has the label `equal`.
+   */
   public get equal(): TerminalNode {
     return this.fetch().equal;
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 }
 
+/**
+ * This node represents a `YulIfStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulIfStatement = (* if_keyword: *) YUL_IF_KEYWORD
+ *                  (* condition: *) YulExpression
+ *                  (* body: *) YulBlock;
+ * ```
+ */
 export class YulIfStatement {
   private readonly fetch = once(() => {
-    const [$ifKeyword, $condition, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$ifKeyword, $condition, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       ifKeyword: $ifKeyword as TerminalNode,
@@ -3520,26 +6918,54 @@ export class YulIfStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulIfStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulIfStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulIfStatement);
   }
 
+  /**
+   * Returns the child node that has the label `if_keyword`.
+   */
   public get ifKeyword(): TerminalNode {
     return this.fetch().ifKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): YulExpression {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `YulForStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulForStatement = (* for_keyword: *) YUL_FOR_KEYWORD
+ *                   (* initialization: *) YulBlock
+ *                   (* condition: *) YulExpression
+ *                   (* iterator: *) YulBlock
+ *                   (* body: *) YulBlock;
+ * ```
+ */
 export class YulForStatement {
   private readonly fetch = once(() => {
-    const [$forKeyword, $initialization, $condition, $iterator, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$forKeyword, $initialization, $condition, $iterator, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       forKeyword: $forKeyword as TerminalNode,
@@ -3550,34 +6976,66 @@ export class YulForStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulForStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulForStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulForStatement);
   }
 
+  /**
+   * Returns the child node that has the label `for_keyword`.
+   */
   public get forKeyword(): TerminalNode {
     return this.fetch().forKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `initialization`.
+   */
   public get initialization(): YulBlock {
     return this.fetch().initialization;
   }
 
+  /**
+   * Returns the child node that has the label `condition`.
+   */
   public get condition(): YulExpression {
     return this.fetch().condition;
   }
 
+  /**
+   * Returns the child node that has the label `iterator`.
+   */
   public get iterator(): YulBlock {
     return this.fetch().iterator;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `YulSwitchStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulSwitchStatement = (* switch_keyword: *) YUL_SWITCH_KEYWORD
+ *                      (* expression: *) YulExpression
+ *                      (* cases: *) YulSwitchCases;
+ * ```
+ */
 export class YulSwitchStatement {
   private readonly fetch = once(() => {
-    const [$switchKeyword, $expression, $cases] = generated.ast.Selectors.sequence(this.cst);
+    const [$switchKeyword, $expression, $cases] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       switchKeyword: $switchKeyword as TerminalNode,
@@ -3586,26 +7044,51 @@ export class YulSwitchStatement {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulSwitchStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulSwitchStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulSwitchStatement);
   }
 
+  /**
+   * Returns the child node that has the label `switch_keyword`.
+   */
   public get switchKeyword(): TerminalNode {
     return this.fetch().switchKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `expression`.
+   */
   public get expression(): YulExpression {
     return this.fetch().expression;
   }
 
+  /**
+   * Returns the child node that has the label `cases`.
+   */
   public get cases(): YulSwitchCases {
     return this.fetch().cases;
   }
 }
 
+/**
+ * This node represents a `YulDefaultCase` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulDefaultCase = (* default_keyword: *) YUL_DEFAULT_KEYWORD
+ *                  (* body: *) YulBlock;
+ * ```
+ */
 export class YulDefaultCase {
   private readonly fetch = once(() => {
-    const [$defaultKeyword, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$defaultKeyword, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       defaultKeyword: $defaultKeyword as TerminalNode,
@@ -3613,22 +7096,45 @@ export class YulDefaultCase {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulDefaultCase`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulDefaultCase`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulDefaultCase);
   }
 
+  /**
+   * Returns the child node that has the label `default_keyword`.
+   */
   public get defaultKeyword(): TerminalNode {
     return this.fetch().defaultKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `YulValueCase` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulValueCase = (* case_keyword: *) YUL_CASE_KEYWORD
+ *                (* value: *) YulLiteral
+ *                (* body: *) YulBlock;
+ * ```
+ */
 export class YulValueCase {
   private readonly fetch = once(() => {
-    const [$caseKeyword, $value, $body] = generated.ast.Selectors.sequence(this.cst);
+    const [$caseKeyword, $value, $body] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       caseKeyword: $caseKeyword as TerminalNode,
@@ -3637,80 +7143,161 @@ export class YulValueCase {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulValueCase`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulValueCase`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulValueCase);
   }
 
+  /**
+   * Returns the child node that has the label `case_keyword`.
+   */
   public get caseKeyword(): TerminalNode {
     return this.fetch().caseKeyword;
   }
 
+  /**
+   * Returns the child node that has the label `value`.
+   */
   public get value(): YulLiteral {
     return this.fetch().value;
   }
 
+  /**
+   * Returns the child node that has the label `body`.
+   */
   public get body(): YulBlock {
     return this.fetch().body;
   }
 }
 
+/**
+ * This node represents a `YulLeaveStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * YulLeaveStatement = (* leave_keyword: *) YUL_LEAVE_KEYWORD;
+ * ```
+ */
 export class YulLeaveStatement {
   private readonly fetch = once(() => {
-    const [$leaveKeyword] = generated.ast.Selectors.sequence(this.cst);
+    const [$leaveKeyword] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leaveKeyword: $leaveKeyword as TerminalNode,
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulLeaveStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulLeaveStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulLeaveStatement);
   }
 
+  /**
+   * Returns the child node that has the label `leave_keyword`.
+   */
   public get leaveKeyword(): TerminalNode {
     return this.fetch().leaveKeyword;
   }
 }
 
+/**
+ * This node represents a `YulBreakStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulBreakStatement = (* break_keyword: *) YUL_BREAK_KEYWORD;
+ * ```
+ */
 export class YulBreakStatement {
   private readonly fetch = once(() => {
-    const [$breakKeyword] = generated.ast.Selectors.sequence(this.cst);
+    const [$breakKeyword] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       breakKeyword: $breakKeyword as TerminalNode,
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulBreakStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulBreakStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulBreakStatement);
   }
 
+  /**
+   * Returns the child node that has the label `break_keyword`.
+   */
   public get breakKeyword(): TerminalNode {
     return this.fetch().breakKeyword;
   }
 }
 
+/**
+ * This node represents a `YulContinueStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulContinueStatement = (* continue_keyword: *) YUL_CONTINUE_KEYWORD;
+ * ```
+ */
 export class YulContinueStatement {
   private readonly fetch = once(() => {
-    const [$continueKeyword] = generated.ast.Selectors.sequence(this.cst);
+    const [$continueKeyword] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       continueKeyword: $continueKeyword as TerminalNode,
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulContinueStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulContinueStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulContinueStatement);
   }
 
+  /**
+   * Returns the child node that has the label `continue_keyword`.
+   */
   public get continueKeyword(): TerminalNode {
     return this.fetch().continueKeyword;
   }
 }
 
+/**
+ * This node represents a `YulLabel` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.0 *)
+ * YulLabel = (* label: *) YUL_IDENTIFIER
+ *            (* colon: *) COLON;
+ * ```
+ */
 export class YulLabel {
   private readonly fetch = once(() => {
-    const [$label, $colon] = generated.ast.Selectors.sequence(this.cst);
+    const [$label, $colon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       label: $label as TerminalNode,
@@ -3718,22 +7305,47 @@ export class YulLabel {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulLabel`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulLabel`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulLabel);
   }
 
+  /**
+   * Returns the child node that has the label `label`.
+   */
   public get label(): TerminalNode {
     return this.fetch().label;
   }
 
+  /**
+   * Returns the child node that has the label `colon`.
+   */
   public get colon(): TerminalNode {
     return this.fetch().colon;
   }
 }
 
+/**
+ * This node represents a `YulFunctionCallExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * YulFunctionCallExpression = (* operand: *) YulExpression
+ *                             (* open_paren: *) OPEN_PAREN
+ *                             (* arguments: *) YulArguments
+ *                             (* close_paren: *) CLOSE_PAREN;
+ * ```
+ */
 export class YulFunctionCallExpression {
   private readonly fetch = once(() => {
-    const [$operand, $openParen, $arguments, $closeParen] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $openParen, $arguments, $closeParen] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new YulExpression($operand as NonterminalNode),
@@ -3743,31 +7355,70 @@ export class YulFunctionCallExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulFunctionCallExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulFunctionCallExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulFunctionCallExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): YulExpression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `open_paren`.
+   */
   public get openParen(): TerminalNode {
     return this.fetch().openParen;
   }
 
+  /**
+   * Returns the child node that has the label `arguments`.
+   */
   public get arguments(): YulArguments {
     return this.fetch().arguments;
   }
 
+  /**
+   * Returns the child node that has the label `close_paren`.
+   */
   public get closeParen(): TerminalNode {
     return this.fetch().closeParen;
   }
 }
 
-/*
- * Choices:
- */
+//
+// Choices:
+//
 
+/**
+ * This node represents a `SourceUnitMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnitMember = (* variant: *) PragmaDirective
+ *                  | (* variant: *) ImportDirective
+ *                  | (* variant: *) ContractDefinition
+ *                  | (* variant: *) InterfaceDefinition
+ *                  | (* variant: *) LibraryDefinition
+ *                  | (* variant: *) StructDefinition (* Introduced in 0.6.0 *)
+ *                  | (* variant: *) EnumDefinition (* Introduced in 0.6.0 *)
+ *                  | (* variant: *) FunctionDefinition (* Introduced in 0.7.1 *)
+ *                  | (* variant: *) ErrorDefinition (* Introduced in 0.8.4 *)
+ *                  | (* variant: *) UserDefinedValueTypeDefinition (* Introduced in 0.8.8 *)
+ *                  | (* variant: *) UsingDirective (* Introduced in 0.8.13 *)
+ *                  | (* variant: *) EventDefinition (* Introduced in 0.8.22 *)
+ *                  | (* variant: *) ConstantDefinition; (* Introduced in 0.7.4 *)
+ * ```
+ */
 export class SourceUnitMember {
   private readonly fetch: () =>
     | PragmaDirective
@@ -3783,7 +7434,7 @@ export class SourceUnitMember {
     | UsingDirective
     | EventDefinition
     | ConstantDefinition = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.PragmaDirective:
@@ -3818,10 +7469,21 @@ export class SourceUnitMember {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnitMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnitMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnitMember);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | PragmaDirective
     | ImportDirective
@@ -3840,9 +7502,18 @@ export class SourceUnitMember {
   }
 }
 
+/**
+ * This node represents a `Pragma` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Pragma = (* variant: *) AbicoderPragma
+ *        | (* variant: *) ExperimentalPragma
+ *        | (* variant: *) VersionPragma;
+ * ```
+ */
 export class Pragma {
   private readonly fetch: () => AbicoderPragma | ExperimentalPragma | VersionPragma = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.AbicoderPragma:
@@ -3857,18 +7528,37 @@ export class Pragma {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Pragma`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Pragma`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Pragma);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): AbicoderPragma | ExperimentalPragma | VersionPragma {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ExperimentalFeature` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ExperimentalFeature = (* variant: *) IDENTIFIER
+ *                     | (* variant: *) StringLiteral;
+ * ```
+ */
 export class ExperimentalFeature {
   private readonly fetch: () => StringLiteral | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -3883,18 +7573,37 @@ export class ExperimentalFeature {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ExperimentalFeature`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ExperimentalFeature`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ExperimentalFeature);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): StringLiteral | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `VersionExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionExpression = (* variant: *) VersionRange
+ *                   | (* variant: *) VersionTerm;
+ * ```
+ */
 export class VersionExpression {
   private readonly fetch: () => VersionRange | VersionTerm = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.VersionRange:
@@ -3907,34 +7616,78 @@ export class VersionExpression {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionExpression);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): VersionRange | VersionTerm {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `VersionOperator` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionOperator = (* variant: *) CARET
+ *                 | (* variant: *) TILDE
+ *                 | (* variant: *) EQUAL
+ *                 | (* variant: *) LESS_THAN
+ *                 | (* variant: *) GREATER_THAN
+ *                 | (* variant: *) LESS_THAN_EQUAL
+ *                 | (* variant: *) GREATER_THAN_EQUAL;
+ * ```
+ */
 export class VersionOperator {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionOperator`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionOperator`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionOperator);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `VersionLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionLiteral = (* variant: *) SimpleVersionLiteral
+ *                | (* variant: *) SINGLE_QUOTED_VERSION_LITERAL
+ *                | (* variant: *) DOUBLE_QUOTED_VERSION_LITERAL;
+ * ```
+ */
 export class VersionLiteral {
   private readonly fetch: () => SimpleVersionLiteral | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -3949,18 +7702,38 @@ export class VersionLiteral {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionLiteral);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): SimpleVersionLiteral | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ImportClause` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportClause = (* variant: *) PathImport
+ *              | (* variant: *) NamedImport
+ *              | (* variant: *) ImportDeconstruction;
+ * ```
+ */
 export class ImportClause {
   private readonly fetch: () => PathImport | NamedImport | ImportDeconstruction = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.PathImport:
@@ -3975,18 +7748,37 @@ export class ImportClause {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportClause`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportClause`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportClause);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): PathImport | NamedImport | ImportDeconstruction {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UsingClause` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * UsingClause = (* variant: *) IdentifierPath
+ *             | (* variant: *) UsingDeconstruction; (* Introduced in 0.8.13 *)
+ * ```
+ */
 export class UsingClause {
   private readonly fetch: () => IdentifierPath | UsingDeconstruction = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.IdentifierPath:
@@ -3999,34 +7791,86 @@ export class UsingClause {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingClause`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingClause`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingClause);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): IdentifierPath | UsingDeconstruction {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UsingOperator` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.19 *)
+ * UsingOperator = (* variant: *) AMPERSAND
+ *               | (* variant: *) ASTERISK
+ *               | (* variant: *) BANG_EQUAL
+ *               | (* variant: *) BAR
+ *               | (* variant: *) CARET
+ *               | (* variant: *) EQUAL_EQUAL
+ *               | (* variant: *) GREATER_THAN
+ *               | (* variant: *) GREATER_THAN_EQUAL
+ *               | (* variant: *) LESS_THAN
+ *               | (* variant: *) LESS_THAN_EQUAL
+ *               | (* variant: *) MINUS
+ *               | (* variant: *) PERCENT
+ *               | (* variant: *) PLUS
+ *               | (* variant: *) SLASH
+ *               | (* variant: *) TILDE;
+ * ```
+ */
 export class UsingOperator {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingOperator`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingOperator`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingOperator);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UsingTarget` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * UsingTarget = (* variant: *) TypeName
+ *             | (* variant: *) ASTERISK;
+ * ```
+ */
 export class UsingTarget {
   private readonly fetch: () => TypeName | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4041,15 +7885,45 @@ export class UsingTarget {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingTarget`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingTarget`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingTarget);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TypeName | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ContractMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ContractMember = (* variant: *) UsingDirective
+ *                | (* variant: *) FunctionDefinition
+ *                | (* variant: *) ConstructorDefinition (* Introduced in 0.4.22 *)
+ *                | (* variant: *) ReceiveFunctionDefinition (* Introduced in 0.6.0 *)
+ *                | (* variant: *) FallbackFunctionDefinition (* Introduced in 0.6.0 *)
+ *                | (* variant: *) UnnamedFunctionDefinition (* Deprecated in 0.6.0 *)
+ *                | (* variant: *) ModifierDefinition
+ *                | (* variant: *) StructDefinition
+ *                | (* variant: *) EnumDefinition
+ *                | (* variant: *) EventDefinition
+ *                | (* variant: *) ErrorDefinition (* Introduced in 0.8.4 *)
+ *                | (* variant: *) UserDefinedValueTypeDefinition (* Introduced in 0.8.8 *)
+ *                | (* variant: *) StateVariableDefinition;
+ * ```
+ */
 export class ContractMember {
   private readonly fetch: () =>
     | UsingDirective
@@ -4065,7 +7939,7 @@ export class ContractMember {
     | ErrorDefinition
     | UserDefinedValueTypeDefinition
     | StateVariableDefinition = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.UsingDirective:
@@ -4100,10 +7974,21 @@ export class ContractMember {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ContractMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ContractMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ContractMember);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | UsingDirective
     | FunctionDefinition
@@ -4122,9 +8007,22 @@ export class ContractMember {
   }
 }
 
+/**
+ * This node represents a `StateVariableAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StateVariableAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
+ *                        | (* variant: *) CONSTANT_KEYWORD
+ *                        | (* variant: *) INTERNAL_KEYWORD
+ *                        | (* variant: *) PRIVATE_KEYWORD
+ *                        | (* variant: *) PUBLIC_KEYWORD
+ *                        | (* variant: *) IMMUTABLE_KEYWORD (* Introduced in 0.6.5 *)
+ *                        | (* variant: *) TRANSIENT_KEYWORD; (* Introduced in 0.8.27 *)
+ * ```
+ */
 export class StateVariableAttribute {
   private readonly fetch: () => OverrideSpecifier | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4139,34 +8037,82 @@ export class StateVariableAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StateVariableAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StateVariableAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StateVariableAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): OverrideSpecifier | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionName` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionName = (* variant: *) IDENTIFIER
+ *              | (* variant: *) FALLBACK_KEYWORD
+ *              | (* variant: *) RECEIVE_KEYWORD;
+ * ```
+ */
 export class FunctionName {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionName`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionName`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionName);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionAttribute = (* variant: *) ModifierInvocation
+ *                   | (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
+ *                   | (* variant: *) CONSTANT_KEYWORD (* Deprecated in 0.5.0 *)
+ *                   | (* variant: *) EXTERNAL_KEYWORD
+ *                   | (* variant: *) INTERNAL_KEYWORD
+ *                   | (* variant: *) PAYABLE_KEYWORD
+ *                   | (* variant: *) PRIVATE_KEYWORD
+ *                   | (* variant: *) PUBLIC_KEYWORD
+ *                   | (* variant: *) PURE_KEYWORD (* Introduced in 0.4.16 *)
+ *                   | (* variant: *) VIEW_KEYWORD (* Introduced in 0.4.16 *)
+ *                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
+ * ```
+ */
 export class FunctionAttribute {
   private readonly fetch: () => ModifierInvocation | OverrideSpecifier | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4183,18 +8129,37 @@ export class FunctionAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ModifierInvocation | OverrideSpecifier | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionBody` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionBody = (* variant: *) Block
+ *              | (* variant: *) SEMICOLON;
+ * ```
+ */
 export class FunctionBody {
   private readonly fetch: () => Block | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4209,18 +8174,42 @@ export class FunctionBody {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionBody`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionBody`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionBody);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): Block | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ConstructorAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.4.22 *)
+ * ConstructorAttribute = (* variant: *) ModifierInvocation
+ *                      | (* variant: *) INTERNAL_KEYWORD
+ *                      | (* variant: *) OVERRIDE_KEYWORD (* Introduced in 0.6.0 and deprecated in 0.6.7. *)
+ *                      | (* variant: *) PAYABLE_KEYWORD
+ *                      | (* variant: *) PUBLIC_KEYWORD
+ *                      | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 and deprecated in 0.6.7. *)
+ * ```
+ */
 export class ConstructorAttribute {
   private readonly fetch: () => ModifierInvocation | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4235,18 +8224,45 @@ export class ConstructorAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ConstructorAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ConstructorAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ConstructorAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ModifierInvocation | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UnnamedFunctionAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.6.0 *)
+ * UnnamedFunctionAttribute = (* variant: *) ModifierInvocation
+ *                          | (* variant: *) CONSTANT_KEYWORD (* Deprecated in 0.5.0 *)
+ *                          | (* variant: *) EXTERNAL_KEYWORD
+ *                          | (* variant: *) INTERNAL_KEYWORD (* Deprecated in 0.5.0 *)
+ *                          | (* variant: *) PAYABLE_KEYWORD
+ *                          | (* variant: *) PRIVATE_KEYWORD (* Deprecated in 0.5.0 *)
+ *                          | (* variant: *) PUBLIC_KEYWORD (* Deprecated in 0.5.0 *)
+ *                          | (* variant: *) PURE_KEYWORD (* Introduced in 0.4.16 and deprecated in 0.6.0. *)
+ *                          | (* variant: *) VIEW_KEYWORD; (* Introduced in 0.4.16 and deprecated in 0.6.0. *)
+ * ```
+ */
 export class UnnamedFunctionAttribute {
   private readonly fetch: () => ModifierInvocation | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4261,18 +8277,43 @@ export class UnnamedFunctionAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UnnamedFunctionAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UnnamedFunctionAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UnnamedFunctionAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ModifierInvocation | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FallbackFunctionAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * FallbackFunctionAttribute = (* variant: *) ModifierInvocation
+ *                           | (* variant: *) OverrideSpecifier
+ *                           | (* variant: *) EXTERNAL_KEYWORD
+ *                           | (* variant: *) PAYABLE_KEYWORD
+ *                           | (* variant: *) PURE_KEYWORD
+ *                           | (* variant: *) VIEW_KEYWORD
+ *                           | (* variant: *) VIRTUAL_KEYWORD;
+ * ```
+ */
 export class FallbackFunctionAttribute {
   private readonly fetch: () => ModifierInvocation | OverrideSpecifier | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4289,18 +8330,41 @@ export class FallbackFunctionAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FallbackFunctionAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FallbackFunctionAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FallbackFunctionAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ModifierInvocation | OverrideSpecifier | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ReceiveFunctionAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * ReceiveFunctionAttribute = (* variant: *) ModifierInvocation
+ *                          | (* variant: *) OverrideSpecifier
+ *                          | (* variant: *) EXTERNAL_KEYWORD
+ *                          | (* variant: *) PAYABLE_KEYWORD
+ *                          | (* variant: *) VIRTUAL_KEYWORD;
+ * ```
+ */
 export class ReceiveFunctionAttribute {
   private readonly fetch: () => ModifierInvocation | OverrideSpecifier | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4317,18 +8381,37 @@ export class ReceiveFunctionAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ReceiveFunctionAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ReceiveFunctionAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ReceiveFunctionAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ModifierInvocation | OverrideSpecifier | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ModifierAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ModifierAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
+ *                   | (* variant: *) VIRTUAL_KEYWORD; (* Introduced in 0.6.0 *)
+ * ```
+ */
 export class ModifierAttribute {
   private readonly fetch: () => OverrideSpecifier | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4343,19 +8426,41 @@ export class ModifierAttribute {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ModifierAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ModifierAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ModifierAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): OverrideSpecifier | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `TypeName` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TypeName = (* variant: *) ArrayTypeName
+ *          | (* variant: *) FunctionType
+ *          | (* variant: *) MappingType
+ *          | (* variant: *) ElementaryType
+ *          | (* variant: *) IdentifierPath;
+ * ```
+ */
 export class TypeName {
   private readonly fetch: () => ArrayTypeName | FunctionType | MappingType | ElementaryType | IdentifierPath = once(
     () => {
-      const variant = generated.ast.Selectors.choice(this.cst);
+      const variant = wasm.ast.Selectors.choice(this.cst);
 
       switch (variant.kind) {
         case NonterminalKind.ArrayTypeName:
@@ -4375,34 +8480,78 @@ export class TypeName {
     },
   );
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TypeName`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TypeName`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TypeName);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ArrayTypeName | FunctionType | MappingType | ElementaryType | IdentifierPath {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionTypeAttribute` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionTypeAttribute = (* variant: *) INTERNAL_KEYWORD
+ *                       | (* variant: *) EXTERNAL_KEYWORD
+ *                       | (* variant: *) PRIVATE_KEYWORD
+ *                       | (* variant: *) PUBLIC_KEYWORD
+ *                       | (* variant: *) CONSTANT_KEYWORD (* Deprecated in 0.5.0 *)
+ *                       | (* variant: *) PURE_KEYWORD (* Introduced in 0.4.16 *)
+ *                       | (* variant: *) VIEW_KEYWORD (* Introduced in 0.4.16 *)
+ *                       | (* variant: *) PAYABLE_KEYWORD;
+ * ```
+ */
 export class FunctionTypeAttribute {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionTypeAttribute`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionTypeAttribute`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionTypeAttribute);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `MappingKeyType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * MappingKeyType = (* variant: *) ElementaryType
+ *                | (* variant: *) IdentifierPath;
+ * ```
+ */
 export class MappingKeyType {
   private readonly fetch: () => ElementaryType | IdentifierPath = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.ElementaryType:
@@ -4415,18 +8564,44 @@ export class MappingKeyType {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MappingKeyType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MappingKeyType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MappingKeyType);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ElementaryType | IdentifierPath {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ElementaryType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ElementaryType = (* variant: *) BOOL_KEYWORD
+ *                | (* variant: *) BYTE_KEYWORD (* Deprecated in 0.8.0 *)
+ *                | (* variant: *) STRING_KEYWORD
+ *                | (* variant: *) AddressType
+ *                | (* variant: *) BYTES_KEYWORD
+ *                | (* variant: *) INT_KEYWORD
+ *                | (* variant: *) UINT_KEYWORD
+ *                | (* variant: *) FIXED_KEYWORD
+ *                | (* variant: *) UFIXED_KEYWORD;
+ * ```
+ */
 export class ElementaryType {
   private readonly fetch: () => AddressType | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4441,15 +8616,49 @@ export class ElementaryType {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ElementaryType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ElementaryType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ElementaryType);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): AddressType | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `Statement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Statement = (* variant: *) IfStatement
+ *           | (* variant: *) ForStatement
+ *           | (* variant: *) WhileStatement
+ *           | (* variant: *) DoWhileStatement
+ *           | (* variant: *) ContinueStatement
+ *           | (* variant: *) BreakStatement
+ *           | (* variant: *) ReturnStatement
+ *           | (* variant: *) ThrowStatement (* Deprecated in 0.5.0 *)
+ *           | (* variant: *) EmitStatement (* Introduced in 0.4.21 *)
+ *           | (* variant: *) TryStatement (* Introduced in 0.6.0 *)
+ *           | (* variant: *) RevertStatement (* Introduced in 0.8.4 *)
+ *           | (* variant: *) AssemblyStatement
+ *           | (* variant: *) Block
+ *           | (* variant: *) UncheckedBlock (* Introduced in 0.8.0 *)
+ *           | (* variant: *) TupleDeconstructionStatement
+ *           | (* variant: *) VariableDeclarationStatement
+ *           | (* variant: *) ExpressionStatement;
+ * ```
+ */
 export class Statement {
   private readonly fetch: () =>
     | IfStatement
@@ -4469,7 +8678,7 @@ export class Statement {
     | TupleDeconstructionStatement
     | VariableDeclarationStatement
     | ExpressionStatement = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.IfStatement:
@@ -4512,10 +8721,21 @@ export class Statement {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Statement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Statement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Statement);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | IfStatement
     | ForStatement
@@ -4538,9 +8758,17 @@ export class Statement {
   }
 }
 
+/**
+ * This node represents a `TupleMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleMember = (* variant: *) TypedTupleMember
+ *             | (* variant: *) UntypedTupleMember;
+ * ```
+ */
 export class TupleMember {
   private readonly fetch: () => TypedTupleMember | UntypedTupleMember = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.TypedTupleMember:
@@ -4553,18 +8781,37 @@ export class TupleMember {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleMember);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TypedTupleMember | UntypedTupleMember {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `VariableDeclarationType` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VariableDeclarationType = (* variant: *) TypeName
+ *                         | (* variant: *) VAR_KEYWORD; (* Deprecated in 0.5.0 *)
+ * ```
+ */
 export class VariableDeclarationType {
   private readonly fetch: () => TypeName | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4579,38 +8826,79 @@ export class VariableDeclarationType {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VariableDeclarationType`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VariableDeclarationType`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VariableDeclarationType);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TypeName | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StorageLocation` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StorageLocation = (* variant: *) MEMORY_KEYWORD
+ *                 | (* variant: *) STORAGE_KEYWORD
+ *                 | (* variant: *) CALL_DATA_KEYWORD; (* Introduced in 0.5.0 *)
+ * ```
+ */
 export class StorageLocation {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StorageLocation`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StorageLocation`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StorageLocation);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ForStatementInitialization` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ForStatementInitialization = (* variant: *) TupleDeconstructionStatement
+ *                            | (* variant: *) VariableDeclarationStatement
+ *                            | (* variant: *) ExpressionStatement
+ *                            | (* variant: *) SEMICOLON;
+ * ```
+ */
 export class ForStatementInitialization {
   private readonly fetch: () =>
     | TupleDeconstructionStatement
     | VariableDeclarationStatement
     | ExpressionStatement
     | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4629,10 +8917,21 @@ export class ForStatementInitialization {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ForStatementInitialization`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ForStatementInitialization`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ForStatementInitialization);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | TupleDeconstructionStatement
     | VariableDeclarationStatement
@@ -4642,9 +8941,17 @@ export class ForStatementInitialization {
   }
 }
 
+/**
+ * This node represents a `ForStatementCondition` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ForStatementCondition = (* variant: *) ExpressionStatement
+ *                       | (* variant: *) SEMICOLON;
+ * ```
+ */
 export class ForStatementCondition {
   private readonly fetch: () => ExpressionStatement | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4659,15 +8966,65 @@ export class ForStatementCondition {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ForStatementCondition`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ForStatementCondition`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ForStatementCondition);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): ExpressionStatement | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `Expression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Expression = (* variant: *) AssignmentExpression
+ *            | (* variant: *) ConditionalExpression
+ *            | (* variant: *) OrExpression
+ *            | (* variant: *) AndExpression
+ *            | (* variant: *) EqualityExpression
+ *            | (* variant: *) ComparisonExpression
+ *            | (* variant: *) BitwiseOrExpression
+ *            | (* variant: *) BitwiseXorExpression
+ *            | (* variant: *) BitwiseAndExpression
+ *            | (* variant: *) ShiftExpression
+ *            | (* variant: *) AdditiveExpression
+ *            | (* variant: *) MultiplicativeExpression
+ *            | (* variant: *) ExponentiationExpression
+ *            | (* variant: *) PostfixExpression
+ *            | (* variant: *) PrefixExpression
+ *            | (* variant: *) FunctionCallExpression
+ *            | (* variant: *) CallOptionsExpression
+ *            | (* variant: *) MemberAccessExpression
+ *            | (* variant: *) IndexAccessExpression
+ *            | (* variant: *) NewExpression
+ *            | (* variant: *) TupleExpression
+ *            | (* variant: *) TypeExpression (* Introduced in 0.5.3 *)
+ *            | (* variant: *) ArrayExpression
+ *            | (* variant: *) HexNumberExpression
+ *            | (* variant: *) DecimalNumberExpression
+ *            | (* variant: *) StringExpression
+ *            | (* variant: *) ElementaryType
+ *            | (* variant: *) PAYABLE_KEYWORD (* Introduced in 0.6.0 *)
+ *            | (* variant: *) THIS_KEYWORD
+ *            | (* variant: *) SUPER_KEYWORD
+ *            | (* variant: *) TRUE_KEYWORD
+ *            | (* variant: *) FALSE_KEYWORD
+ *            | (* variant: *) IDENTIFIER;
+ * ```
+ */
 export class Expression {
   private readonly fetch: () =>
     | AssignmentExpression
@@ -4698,7 +9055,7 @@ export class Expression {
     | StringExpression
     | ElementaryType
     | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -4765,10 +9122,21 @@ export class Expression {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Expression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Expression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Expression);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | AssignmentExpression
     | ConditionalExpression
@@ -4802,9 +9170,17 @@ export class Expression {
   }
 }
 
+/**
+ * This node represents a `ArgumentsDeclaration` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ArgumentsDeclaration = (* variant: *) PositionalArgumentsDeclaration
+ *                      | (* variant: *) NamedArgumentsDeclaration;
+ * ```
+ */
 export class ArgumentsDeclaration {
   private readonly fetch: () => PositionalArgumentsDeclaration | NamedArgumentsDeclaration = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.PositionalArgumentsDeclaration:
@@ -4817,31 +9193,81 @@ export class ArgumentsDeclaration {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ArgumentsDeclaration`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ArgumentsDeclaration`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ArgumentsDeclaration);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): PositionalArgumentsDeclaration | NamedArgumentsDeclaration {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `NumberUnit` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NumberUnit = (* variant: *) WEI_KEYWORD
+ *            | (* variant: *) GWEI_KEYWORD (* Introduced in 0.6.11 *)
+ *            | (* variant: *) SZABO_KEYWORD (* Deprecated in 0.7.0 *)
+ *            | (* variant: *) FINNEY_KEYWORD (* Deprecated in 0.7.0 *)
+ *            | (* variant: *) ETHER_KEYWORD
+ *            | (* variant: *) SECONDS_KEYWORD
+ *            | (* variant: *) MINUTES_KEYWORD
+ *            | (* variant: *) HOURS_KEYWORD
+ *            | (* variant: *) DAYS_KEYWORD
+ *            | (* variant: *) WEEKS_KEYWORD
+ *            | (* variant: *) YEARS_KEYWORD; (* Deprecated in 0.5.0 *)
+ * ```
+ */
 export class NumberUnit {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NumberUnit`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NumberUnit`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NumberUnit);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StringExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StringExpression = (* variant: *) StringLiteral (* Deprecated in 0.5.14 *)
+ *                  | (* variant: *) StringLiterals (* Introduced in 0.5.14 *)
+ *                  | (* variant: *) HexStringLiteral (* Deprecated in 0.5.14 *)
+ *                  | (* variant: *) HexStringLiterals (* Introduced in 0.5.14 *)
+ *                  | (* variant: *) UnicodeStringLiterals; (* Introduced in 0.7.0 *)
+ * ```
+ */
 export class StringExpression {
   private readonly fetch: () =>
     | StringLiteral
@@ -4849,7 +9275,7 @@ export class StringExpression {
     | HexStringLiteral
     | HexStringLiterals
     | UnicodeStringLiterals = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.StringLiteral:
@@ -4868,63 +9294,151 @@ export class StringExpression {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StringExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StringExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StringExpression);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): StringLiteral | StringLiterals | HexStringLiteral | HexStringLiterals | UnicodeStringLiterals {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StringLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StringLiteral = (* variant: *) SINGLE_QUOTED_STRING_LITERAL
+ *               | (* variant: *) DOUBLE_QUOTED_STRING_LITERAL;
+ * ```
+ */
 export class StringLiteral {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StringLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StringLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StringLiteral);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `HexStringLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * HexStringLiteral = (* variant: *) SINGLE_QUOTED_HEX_STRING_LITERAL
+ *                  | (* variant: *) DOUBLE_QUOTED_HEX_STRING_LITERAL;
+ * ```
+ */
 export class HexStringLiteral {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `HexStringLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `HexStringLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.HexStringLiteral);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UnicodeStringLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.7.0 *)
+ * UnicodeStringLiteral = (* variant: *) SINGLE_QUOTED_UNICODE_STRING_LITERAL
+ *                      | (* variant: *) DOUBLE_QUOTED_UNICODE_STRING_LITERAL;
+ * ```
+ */
 export class UnicodeStringLiteral {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UnicodeStringLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UnicodeStringLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UnicodeStringLiteral);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulStatement` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulStatement = (* variant: *) YulBlock
+ *              | (* variant: *) YulFunctionDefinition
+ *              | (* variant: *) YulStackAssignmentStatement (* Deprecated in 0.5.0 *)
+ *              | (* variant: *) YulIfStatement
+ *              | (* variant: *) YulForStatement
+ *              | (* variant: *) YulSwitchStatement
+ *              | (* variant: *) YulLeaveStatement (* Introduced in 0.6.0 *)
+ *              | (* variant: *) YulBreakStatement
+ *              | (* variant: *) YulContinueStatement
+ *              | (* variant: *) YulVariableAssignmentStatement
+ *              | (* variant: *) YulLabel (* Deprecated in 0.5.0 *)
+ *              | (* variant: *) YulVariableDeclarationStatement
+ *              | (* variant: *) YulExpression;
+ * ```
+ */
 export class YulStatement {
   private readonly fetch: () =>
     | YulBlock
@@ -4940,7 +9454,7 @@ export class YulStatement {
     | YulLabel
     | YulVariableDeclarationStatement
     | YulExpression = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.YulBlock:
@@ -4975,10 +9489,21 @@ export class YulStatement {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulStatement`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulStatement`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulStatement);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant():
     | YulBlock
     | YulFunctionDefinition
@@ -4997,9 +9522,17 @@ export class YulStatement {
   }
 }
 
+/**
+ * This node represents a `YulAssignmentOperator` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulAssignmentOperator = (* variant: *) COLON_EQUAL
+ *                       | (* variant: *) YulColonAndEqual; (* Deprecated in 0.5.5 *)
+ * ```
+ */
 export class YulAssignmentOperator {
   private readonly fetch: () => YulColonAndEqual | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -5014,18 +9547,38 @@ export class YulAssignmentOperator {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulAssignmentOperator`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulAssignmentOperator`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulAssignmentOperator);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): YulColonAndEqual | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulStackAssignmentOperator` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.5.0 *)
+ * YulStackAssignmentOperator = (* variant: *) EQUAL_COLON
+ *                            | (* variant: *) YulEqualAndColon;
+ * ```
+ */
 export class YulStackAssignmentOperator {
   private readonly fetch: () => YulEqualAndColon | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -5040,18 +9593,37 @@ export class YulStackAssignmentOperator {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulStackAssignmentOperator`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulStackAssignmentOperator`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulStackAssignmentOperator);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): YulEqualAndColon | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulSwitchCase` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulSwitchCase = (* variant: *) YulDefaultCase
+ *               | (* variant: *) YulValueCase;
+ * ```
+ */
 export class YulSwitchCase {
   private readonly fetch: () => YulDefaultCase | YulValueCase = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.YulDefaultCase:
@@ -5064,18 +9636,39 @@ export class YulSwitchCase {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulSwitchCase`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulSwitchCase`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulSwitchCase);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): YulDefaultCase | YulValueCase {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulExpression = (* variant: *) YulFunctionCallExpression
+ *               | (* variant: *) YulLiteral
+ *               | (* variant: *) YulBuiltInFunction
+ *               | (* variant: *) YulPath;
+ * ```
+ */
 export class YulExpression {
   private readonly fetch: () => YulFunctionCallExpression | YulLiteral | YulBuiltInFunction | YulPath = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.YulFunctionCallExpression:
@@ -5092,34 +9685,157 @@ export class YulExpression {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulExpression);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): YulFunctionCallExpression | YulLiteral | YulBuiltInFunction | YulPath {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulBuiltInFunction` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulBuiltInFunction = (* variant: *) YUL_ADD_KEYWORD
+ *                    | (* variant: *) YUL_ADD_MOD_KEYWORD
+ *                    | (* variant: *) YUL_ADDRESS_KEYWORD
+ *                    | (* variant: *) YUL_AND_KEYWORD
+ *                    | (* variant: *) YUL_BALANCE_KEYWORD
+ *                    | (* variant: *) YUL_BLOCK_HASH_KEYWORD
+ *                    | (* variant: *) YUL_BYTE_KEYWORD
+ *                    | (* variant: *) YUL_CALL_CODE_KEYWORD
+ *                    | (* variant: *) YUL_CALL_DATA_COPY_KEYWORD
+ *                    | (* variant: *) YUL_CALL_DATA_LOAD_KEYWORD
+ *                    | (* variant: *) YUL_CALL_DATA_SIZE_KEYWORD
+ *                    | (* variant: *) YUL_CALLER_KEYWORD
+ *                    | (* variant: *) YUL_CALL_KEYWORD
+ *                    | (* variant: *) YUL_CALL_VALUE_KEYWORD
+ *                    | (* variant: *) YUL_COIN_BASE_KEYWORD
+ *                    | (* variant: *) YUL_CREATE_KEYWORD
+ *                    | (* variant: *) YUL_DELEGATE_CALL_KEYWORD
+ *                    | (* variant: *) YUL_DIV_KEYWORD
+ *                    | (* variant: *) YUL_EQ_KEYWORD
+ *                    | (* variant: *) YUL_EXP_KEYWORD
+ *                    | (* variant: *) YUL_EXT_CODE_COPY_KEYWORD
+ *                    | (* variant: *) YUL_EXT_CODE_SIZE_KEYWORD
+ *                    | (* variant: *) YUL_GAS_KEYWORD
+ *                    | (* variant: *) YUL_GAS_LIMIT_KEYWORD
+ *                    | (* variant: *) YUL_GAS_PRICE_KEYWORD
+ *                    | (* variant: *) YUL_GT_KEYWORD
+ *                    | (* variant: *) YUL_INVALID_KEYWORD
+ *                    | (* variant: *) YUL_IS_ZERO_KEYWORD
+ *                    | (* variant: *) YUL_JUMP_KEYWORD (* Deprecated in 0.5.0 *)
+ *                    | (* variant: *) YUL_JUMPI_KEYWORD (* Deprecated in 0.5.0 *)
+ *                    | (* variant: *) YUL_LOG_0_KEYWORD
+ *                    | (* variant: *) YUL_LOG_1_KEYWORD
+ *                    | (* variant: *) YUL_LOG_2_KEYWORD
+ *                    | (* variant: *) YUL_LOG_3_KEYWORD
+ *                    | (* variant: *) YUL_LOG_4_KEYWORD
+ *                    | (* variant: *) YUL_LT_KEYWORD
+ *                    | (* variant: *) YUL_M_LOAD_KEYWORD
+ *                    | (* variant: *) YUL_MOD_KEYWORD
+ *                    | (* variant: *) YUL_M_SIZE_KEYWORD
+ *                    | (* variant: *) YUL_M_STORE_8_KEYWORD
+ *                    | (* variant: *) YUL_M_STORE_KEYWORD
+ *                    | (* variant: *) YUL_MUL_KEYWORD
+ *                    | (* variant: *) YUL_MUL_MOD_KEYWORD
+ *                    | (* variant: *) YUL_NOT_KEYWORD
+ *                    | (* variant: *) YUL_NUMBER_KEYWORD
+ *                    | (* variant: *) YUL_ORIGIN_KEYWORD
+ *                    | (* variant: *) YUL_OR_KEYWORD
+ *                    | (* variant: *) YUL_POP_KEYWORD
+ *                    | (* variant: *) YUL_RETURN_KEYWORD
+ *                    | (* variant: *) YUL_REVERT_KEYWORD
+ *                    | (* variant: *) YUL_S_DIV_KEYWORD
+ *                    | (* variant: *) YUL_SELF_DESTRUCT_KEYWORD
+ *                    | (* variant: *) YUL_SGT_KEYWORD
+ *                    | (* variant: *) YUL_SIGN_EXTEND_KEYWORD
+ *                    | (* variant: *) YUL_S_LOAD_KEYWORD
+ *                    | (* variant: *) YUL_SLT_KEYWORD
+ *                    | (* variant: *) YUL_S_MOD_KEYWORD
+ *                    | (* variant: *) YUL_S_STORE_KEYWORD
+ *                    | (* variant: *) YUL_STOP_KEYWORD
+ *                    | (* variant: *) YUL_SUB_KEYWORD
+ *                    | (* variant: *) YUL_TIMESTAMP_KEYWORD
+ *                    | (* variant: *) YUL_XOR_KEYWORD
+ *                    | (* variant: *) YUL_KECCAK_256_KEYWORD (* Introduced in 0.4.12 *)
+ *                    | (* variant: *) YUL_SHA_3_KEYWORD (* Deprecated in 0.5.0 *)
+ *                    | (* variant: *) YUL_SUICIDE_KEYWORD (* Deprecated in 0.5.0 *)
+ *                    | (* variant: *) YUL_RETURN_DATA_COPY_KEYWORD (* Introduced in 0.4.12 *)
+ *                    | (* variant: *) YUL_RETURN_DATA_SIZE_KEYWORD (* Introduced in 0.4.12 *)
+ *                    | (* variant: *) YUL_STATIC_CALL_KEYWORD (* Introduced in 0.4.12 *)
+ *                    | (* variant: *) YUL_CREATE_2_KEYWORD (* Introduced in 0.4.12 *)
+ *                    | (* variant: *) YUL_EXT_CODE_HASH_KEYWORD (* Introduced in 0.5.0 *)
+ *                    | (* variant: *) YUL_SAR_KEYWORD
+ *                    | (* variant: *) YUL_SHL_KEYWORD
+ *                    | (* variant: *) YUL_SHR_KEYWORD
+ *                    | (* variant: *) YUL_CHAIN_ID_KEYWORD
+ *                    | (* variant: *) YUL_SELF_BALANCE_KEYWORD
+ *                    | (* variant: *) YUL_BASE_FEE_KEYWORD (* Introduced in 0.8.7 *)
+ *                    | (* variant: *) YUL_DIFFICULTY_KEYWORD (* Deprecated in 0.8.18 *)
+ *                    | (* variant: *) YUL_PREV_RANDAO_KEYWORD (* Introduced in 0.8.18 *)
+ *                    | (* variant: *) YUL_BLOB_BASE_FEE_KEYWORD (* Introduced in 0.8.24 *)
+ *                    | (* variant: *) YUL_BLOB_HASH_KEYWORD (* Introduced in 0.8.24 *)
+ *                    | (* variant: *) YUL_T_LOAD_KEYWORD (* Introduced in 0.8.24 *)
+ *                    | (* variant: *) YUL_T_STORE_KEYWORD (* Introduced in 0.8.24 *)
+ *                    | (* variant: *) YUL_M_COPY_KEYWORD; (* Introduced in 0.8.24 *)
+ * ```
+ */
 export class YulBuiltInFunction {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulBuiltInFunction`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulBuiltInFunction`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulBuiltInFunction);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulLiteral = (* variant: *) YUL_TRUE_KEYWORD
+ *            | (* variant: *) YUL_FALSE_KEYWORD
+ *            | (* variant: *) YUL_DECIMAL_LITERAL
+ *            | (* variant: *) YUL_HEX_LITERAL
+ *            | (* variant: *) HexStringLiteral
+ *            | (* variant: *) StringLiteral;
+ * ```
+ */
 export class YulLiteral {
   private readonly fetch: () => HexStringLiteral | StringLiteral | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -5136,341 +9852,745 @@ export class YulLiteral {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulLiteral);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): HexStringLiteral | StringLiteral | TerminalNode {
     return this.fetch();
   }
 }
 
-/*
- * Repeated:
- */
+//
+// Repeated:
+//
 
+/**
+ * This node represents a `SourceUnitMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnitMembers = (* item: *) SourceUnitMember*;
+ * ```
+ */
 export class SourceUnitMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new SourceUnitMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnitMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnitMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnitMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly SourceUnitMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `VersionExpressionSet` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionExpressionSet = (* item: *) VersionExpression+;
+ * ```
+ */
 export class VersionExpressionSet {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new VersionExpression(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionExpressionSet`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionExpressionSet`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionExpressionSet);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly VersionExpression[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ContractMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ContractMembers = (* item: *) ContractMember*;
+ * ```
+ */
 export class ContractMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ContractMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ContractMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ContractMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ContractMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ContractMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `InterfaceMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * InterfaceMembers = (* item: *) ContractMember*;
+ * ```
+ */
 export class InterfaceMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ContractMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `InterfaceMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `InterfaceMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.InterfaceMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ContractMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `LibraryMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * LibraryMembers = (* item: *) ContractMember*;
+ * ```
+ */
 export class LibraryMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ContractMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `LibraryMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `LibraryMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.LibraryMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ContractMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StructMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StructMembers = (* item: *) StructMember*;
+ * ```
+ */
 export class StructMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new StructMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StructMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StructMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StructMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly StructMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StateVariableAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * StateVariableAttributes = (* item: *) StateVariableAttribute*;
+ * ```
+ */
 export class StateVariableAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new StateVariableAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StateVariableAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StateVariableAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StateVariableAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly StateVariableAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionAttributes = (* item: *) FunctionAttribute*;
+ * ```
+ */
 export class FunctionAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new FunctionAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly FunctionAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ConstructorAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.4.22 *)
+ * ConstructorAttributes = (* item: *) ConstructorAttribute*;
+ * ```
+ */
 export class ConstructorAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ConstructorAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ConstructorAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ConstructorAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ConstructorAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ConstructorAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UnnamedFunctionAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Deprecated in 0.6.0 *)
+ * UnnamedFunctionAttributes = (* item: *) UnnamedFunctionAttribute*;
+ * ```
+ */
 export class UnnamedFunctionAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new UnnamedFunctionAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UnnamedFunctionAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UnnamedFunctionAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UnnamedFunctionAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly UnnamedFunctionAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FallbackFunctionAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * FallbackFunctionAttributes = (* item: *) FallbackFunctionAttribute*;
+ * ```
+ */
 export class FallbackFunctionAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new FallbackFunctionAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FallbackFunctionAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FallbackFunctionAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FallbackFunctionAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly FallbackFunctionAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ReceiveFunctionAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * ReceiveFunctionAttributes = (* item: *) ReceiveFunctionAttribute*;
+ * ```
+ */
 export class ReceiveFunctionAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ReceiveFunctionAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ReceiveFunctionAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ReceiveFunctionAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ReceiveFunctionAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ReceiveFunctionAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `ModifierAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ModifierAttributes = (* item: *) ModifierAttribute*;
+ * ```
+ */
 export class ModifierAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new ModifierAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ModifierAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ModifierAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ModifierAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ModifierAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `FunctionTypeAttributes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * FunctionTypeAttributes = (* item: *) FunctionTypeAttribute*;
+ * ```
+ */
 export class FunctionTypeAttributes {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new FunctionTypeAttribute(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `FunctionTypeAttributes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `FunctionTypeAttributes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.FunctionTypeAttributes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly FunctionTypeAttribute[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `Statements` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Statements = (* item: *) Statement*;
+ * ```
+ */
 export class Statements {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new Statement(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Statements`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Statements`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Statements);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly Statement[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `CatchClauses` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * CatchClauses = (* item: *) CatchClause+;
+ * ```
+ */
 export class CatchClauses {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new CatchClause(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `CatchClauses`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `CatchClauses`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.CatchClauses);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly CatchClause[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `StringLiterals` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.5.14 *)
+ * StringLiterals = (* item: *) StringLiteral+;
+ * ```
+ */
 export class StringLiterals {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new StringLiteral(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `StringLiterals`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `StringLiterals`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.StringLiterals);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly StringLiteral[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `HexStringLiterals` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.5.14 *)
+ * HexStringLiterals = (* item: *) HexStringLiteral+;
+ * ```
+ */
 export class HexStringLiterals {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new HexStringLiteral(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `HexStringLiterals`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `HexStringLiterals`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.HexStringLiterals);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly HexStringLiteral[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `UnicodeStringLiterals` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.7.0 *)
+ * UnicodeStringLiterals = (* item: *) UnicodeStringLiteral+;
+ * ```
+ */
 export class UnicodeStringLiterals {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new UnicodeStringLiteral(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UnicodeStringLiterals`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UnicodeStringLiterals`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UnicodeStringLiterals);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly UnicodeStringLiteral[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulStatements` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulStatements = (* item: *) YulStatement*;
+ * ```
+ */
 export class YulStatements {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new YulStatement(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulStatements`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulStatements`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulStatements);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly YulStatement[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `YulSwitchCases` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulSwitchCases = (* item: *) YulSwitchCase+;
+ * ```
+ */
 export class YulSwitchCases {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new YulSwitchCase(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulSwitchCases`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulSwitchCases`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulSwitchCases);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly YulSwitchCase[] {
     return this.fetch();
   }
 }
 
-/*
- * Separated:
- */
+//
+// Separated:
+//
 
+/**
+ * This node represents a `VersionExpressionSets` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * VersionExpressionSets = (* item: *) VersionExpressionSet ((* separator: *) BAR_BAR (* item: *) VersionExpressionSet)*;
+ * ```
+ */
 export class VersionExpressionSets {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new VersionExpressionSet(item as NonterminalNode)),
@@ -5478,42 +10598,84 @@ export class VersionExpressionSets {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `VersionExpressionSets`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `VersionExpressionSets`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.VersionExpressionSets);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly VersionExpressionSet[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `SimpleVersionLiteral` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SimpleVersionLiteral = (* item: *) VERSION_SPECIFIER ((* separator: *) PERIOD (* item: *) VERSION_SPECIFIER)*;
+ * ```
+ */
 export class SimpleVersionLiteral {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SimpleVersionLiteral`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SimpleVersionLiteral`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SimpleVersionLiteral);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `ImportDeconstructionSymbols` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ImportDeconstructionSymbols = (* item: *) ImportDeconstructionSymbol ((* separator: *) COMMA (* item: *) ImportDeconstructionSymbol)*;
+ * ```
+ */
 export class ImportDeconstructionSymbols {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new ImportDeconstructionSymbol(item as NonterminalNode)),
@@ -5521,22 +10683,44 @@ export class ImportDeconstructionSymbols {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ImportDeconstructionSymbols`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ImportDeconstructionSymbols`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ImportDeconstructionSymbols);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ImportDeconstructionSymbol[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `UsingDeconstructionSymbols` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.13 *)
+ * UsingDeconstructionSymbols = (* item: *) UsingDeconstructionSymbol ((* separator: *) COMMA (* item: *) UsingDeconstructionSymbol)*;
+ * ```
+ */
 export class UsingDeconstructionSymbols {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new UsingDeconstructionSymbol(item as NonterminalNode)),
@@ -5544,22 +10728,43 @@ export class UsingDeconstructionSymbols {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `UsingDeconstructionSymbols`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `UsingDeconstructionSymbols`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.UsingDeconstructionSymbols);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly UsingDeconstructionSymbol[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `InheritanceTypes` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * InheritanceTypes = (* item: *) InheritanceType ((* separator: *) COMMA (* item: *) InheritanceType)*;
+ * ```
+ */
 export class InheritanceTypes {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new InheritanceType(item as NonterminalNode)),
@@ -5567,42 +10772,84 @@ export class InheritanceTypes {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `InheritanceTypes`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `InheritanceTypes`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.InheritanceTypes);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly InheritanceType[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `EnumMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EnumMembers = ((* item: *) IDENTIFIER ((* separator: *) COMMA (* item: *) IDENTIFIER)*)?;
+ * ```
+ */
 export class EnumMembers {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EnumMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EnumMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EnumMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `Parameters` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Parameters = ((* item: *) Parameter ((* separator: *) COMMA (* item: *) Parameter)*)?;
+ * ```
+ */
 export class Parameters {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new Parameter(item as NonterminalNode)),
@@ -5610,22 +10857,44 @@ export class Parameters {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Parameters`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Parameters`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Parameters);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly Parameter[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `OverridePaths` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.0 *)
+ * OverridePaths = (* item: *) IdentifierPath ((* separator: *) COMMA (* item: *) IdentifierPath)*;
+ * ```
+ */
 export class OverridePaths {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new IdentifierPath(item as NonterminalNode)),
@@ -5633,22 +10902,43 @@ export class OverridePaths {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `OverridePaths`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `OverridePaths`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.OverridePaths);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly IdentifierPath[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `EventParameters` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * EventParameters = ((* item: *) EventParameter ((* separator: *) COMMA (* item: *) EventParameter)*)?;
+ * ```
+ */
 export class EventParameters {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new EventParameter(item as NonterminalNode)),
@@ -5656,22 +10946,44 @@ export class EventParameters {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `EventParameters`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `EventParameters`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.EventParameters);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly EventParameter[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `ErrorParameters` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.8.4 *)
+ * ErrorParameters = ((* item: *) ErrorParameter ((* separator: *) COMMA (* item: *) ErrorParameter)*)?;
+ * ```
+ */
 export class ErrorParameters {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new ErrorParameter(item as NonterminalNode)),
@@ -5679,22 +10991,43 @@ export class ErrorParameters {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ErrorParameters`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ErrorParameters`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ErrorParameters);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly ErrorParameter[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `AssemblyFlags` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * AssemblyFlags = (* item: *) StringLiteral ((* separator: *) COMMA (* item: *) StringLiteral)*;
+ * ```
+ */
 export class AssemblyFlags {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new StringLiteral(item as NonterminalNode)),
@@ -5702,22 +11035,43 @@ export class AssemblyFlags {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AssemblyFlags`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AssemblyFlags`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AssemblyFlags);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly StringLiteral[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `TupleDeconstructionElements` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleDeconstructionElements = (* item: *) TupleDeconstructionElement ((* separator: *) COMMA (* item: *) TupleDeconstructionElement)*;
+ * ```
+ */
 export class TupleDeconstructionElements {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new TupleDeconstructionElement(item as NonterminalNode)),
@@ -5725,22 +11079,43 @@ export class TupleDeconstructionElements {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleDeconstructionElements`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleDeconstructionElements`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleDeconstructionElements);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TupleDeconstructionElement[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `PositionalArguments` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * PositionalArguments = ((* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*)?;
+ * ```
+ */
 export class PositionalArguments {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new Expression(item as NonterminalNode)),
@@ -5748,22 +11123,43 @@ export class PositionalArguments {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `PositionalArguments`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `PositionalArguments`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.PositionalArguments);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly Expression[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `NamedArguments` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * NamedArguments = ((* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*)?;
+ * ```
+ */
 export class NamedArguments {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new NamedArgument(item as NonterminalNode)),
@@ -5771,22 +11167,44 @@ export class NamedArguments {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NamedArguments`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NamedArguments`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NamedArguments);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly NamedArgument[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `CallOptions` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 0.6.2 *)
+ * CallOptions = (* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*;
+ * ```
+ */
 export class CallOptions {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new NamedArgument(item as NonterminalNode)),
@@ -5794,22 +11212,43 @@ export class CallOptions {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `CallOptions`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `CallOptions`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.CallOptions);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly NamedArgument[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `TupleValues` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TupleValues = (* item: *) TupleValue ((* separator: *) COMMA (* item: *) TupleValue)*;
+ * ```
+ */
 export class TupleValues {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new TupleValue(item as NonterminalNode)),
@@ -5817,22 +11256,43 @@ export class TupleValues {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TupleValues`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TupleValues`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TupleValues);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TupleValue[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `ArrayValues` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * ArrayValues = (* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*;
+ * ```
+ */
 export class ArrayValues {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new Expression(item as NonterminalNode)),
@@ -5840,82 +11300,166 @@ export class ArrayValues {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `ArrayValues`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `ArrayValues`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.ArrayValues);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly Expression[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `IdentifierPath` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * IdentifierPath = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
+ * ```
+ */
 export class IdentifierPath {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `IdentifierPath`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `IdentifierPath`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.IdentifierPath);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `YulParameters` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulParameters = ((* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*)?;
+ * ```
+ */
 export class YulParameters {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulParameters`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulParameters`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulParameters);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `YulVariableNames` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulVariableNames = (* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*;
+ * ```
+ */
 export class YulVariableNames {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulVariableNames`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulVariableNames`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulVariableNames);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `YulArguments` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulArguments = ((* item: *) YulExpression ((* separator: *) COMMA (* item: *) YulExpression)*)?;
+ * ```
+ */
 export class YulArguments {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new YulExpression(item as NonterminalNode)),
@@ -5923,22 +11467,43 @@ export class YulArguments {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulArguments`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulArguments`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulArguments);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly YulExpression[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `YulPaths` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulPaths = (* item: *) YulPath ((* separator: *) COMMA (* item: *) YulPath)*;
+ * ```
+ */
 export class YulPaths {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return {
       items: items!.map((item) => new YulPath(item as NonterminalNode)),
@@ -5946,42 +11511,73 @@ export class YulPaths {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulPaths`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulPaths`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulPaths);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly YulPath[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
 
+/**
+ * This node represents a `YulPath` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * YulPath = (* item: *) YUL_IDENTIFIER ((* separator: *) PERIOD (* item: *) YUL_IDENTIFIER)*;
+ * ```
+ */
 export class YulPath {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `YulPath`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `YulPath`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.YulPath);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
-
-/*
- * Helpers:
- */
 
 function once<T>(factory: () => T): () => T {
   let value: T | undefined;

--- a/crates/solidity/outputs/npm/package/src/generated/bindings/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/bindings/index.mts
@@ -1,23 +1,36 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const BindingGraph = generated.bindings.BindingGraph;
-export type BindingGraph = generated.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export const BindingGraph = wasm.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export type BindingGraph = wasm.bindings.BindingGraph;
 
-export const Definition = generated.bindings.Definition;
-export type Definition = generated.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export const Definition = wasm.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export type Definition = wasm.bindings.Definition;
 
-export const Reference = generated.bindings.Reference;
-export type Reference = generated.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export const Reference = wasm.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export type Reference = wasm.bindings.Reference;
 
-export type BindingLocation = generated.bindings.BindingLocation;
+/** {@inheritDoc wasm.bindings.BindingLocation} */
+export type BindingLocation = wasm.bindings.BindingLocation;
 
-export const BindingLocationType = generated.bindings.BindingLocationType;
-export type BindingLocationType = generated.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export const BindingLocationType = wasm.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export type BindingLocationType = wasm.bindings.BindingLocationType;
 
-export const UserFileLocation = generated.bindings.UserFileLocation;
-export type UserFileLocation = generated.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export const UserFileLocation = wasm.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export type UserFileLocation = wasm.bindings.UserFileLocation;
 
-export const BuiltInLocation = generated.bindings.BuiltInLocation;
-export type BuiltInLocation = generated.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export const BuiltInLocation = wasm.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export type BuiltInLocation = wasm.bindings.BuiltInLocation;

--- a/crates/solidity/outputs/npm/package/src/generated/compilation/builder.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/compilation/builder.mts
@@ -3,10 +3,7 @@
 import { Cursor } from "../cst/index.mjs";
 import { CompilationUnit } from "./index.mjs";
 
-import * as generated from "../../../wasm/index.mjs";
-
-const InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
-type InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
+import * as wasm from "../../../wasm/index.mjs";
 
 /**
  * User-provided options and callbacks necessary for the `CompilationBuilder` class to perform its job.
@@ -51,7 +48,7 @@ export class CompilationBuilder {
   private readonly seenFiles: Set<string> = new Set();
 
   private constructor(
-    private readonly internalBuilder: InternalCompilationBuilder,
+    private readonly internalBuilder: wasm.compilation.InternalCompilationBuilder,
 
     /**
      * The user-supplied configuration.
@@ -63,7 +60,7 @@ export class CompilationBuilder {
    * Creates a new compilation builder for the specified language version.
    */
   public static create(config: CompilationBuilderConfig): CompilationBuilder {
-    const internalBuilder = InternalCompilationBuilder.create(config.languageVersion);
+    const internalBuilder = wasm.compilation.InternalCompilationBuilder.create(config.languageVersion);
     return new CompilationBuilder(internalBuilder, config);
   }
 

--- a/crates/solidity/outputs/npm/package/src/generated/compilation/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/compilation/index.mts
@@ -1,16 +1,15 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
-import * as builder from "./builder.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-// This is a wrapper around 'generated.compilation.InternalCompilationBuilder':
-export const CompilationBuilder = builder.CompilationBuilder;
-export type CompilationBuilder = builder.CompilationBuilder;
+export { CompilationBuilder, CompilationBuilderConfig } from "./builder.mjs";
 
-export type CompilationBuilderConfig = builder.CompilationBuilderConfig;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export const CompilationUnit = wasm.compilation.CompilationUnit;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export type CompilationUnit = wasm.compilation.CompilationUnit;
 
-export const CompilationUnit = generated.compilation.CompilationUnit;
-export type CompilationUnit = generated.compilation.CompilationUnit;
-
-export const File = generated.compilation.File;
-export type File = generated.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export const File = wasm.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export type File = wasm.compilation.File;

--- a/crates/solidity/outputs/npm/package/src/generated/cst/assertions.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/cst/assertions.mts
@@ -1,0 +1,41 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+import { NonterminalKind, NonterminalNode, TerminalKind, TerminalNode } from "./index.mjs";
+
+/**
+ * Asserts that this node is a `NonterminalNode` with the provided kind and text.
+ */
+export function assertIsNonterminalNode(
+  node: unknown,
+  kind?: NonterminalKind,
+  text?: string,
+): asserts node is NonterminalNode {
+  if (!(node instanceof NonterminalNode)) {
+    throw new Error("Node provided is not a NonterminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}
+
+/**
+ * Asserts that this node is a `TerminalKind` with the provided kind and text.
+ */
+export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
+  if (!(node instanceof TerminalNode)) {
+    throw new Error("Node provided is not a TerminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}

--- a/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
@@ -1,89 +1,83 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const NonterminalKind = generated.cst.NonterminalKind;
-export type NonterminalKind = generated.cst.NonterminalKind;
+export * from "./assertions.mjs";
 
-export const TerminalKind = generated.cst.TerminalKind;
-export type TerminalKind = generated.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export const NonterminalKind = wasm.cst.NonterminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export type NonterminalKind = wasm.cst.NonterminalKind;
 
-export const TerminalKindExtensions = generated.cst.TerminalKindExtensions;
-export type TerminalKindExtensions = generated.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export const TerminalKind = wasm.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export type TerminalKind = wasm.cst.TerminalKind;
 
-export const EdgeLabel = generated.cst.EdgeLabel;
-export type EdgeLabel = generated.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export const TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export type TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
 
-export type Node = generated.cst.Node;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export const EdgeLabel = wasm.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export type EdgeLabel = wasm.cst.EdgeLabel;
 
-export const NodeType = generated.cst.NodeType;
-export type NodeType = generated.cst.NodeType;
+/** {@inheritDoc wasm.cst.Node} */
+export type Node = wasm.cst.Node;
 
-export const NonterminalNode = generated.cst.NonterminalNode;
-export type NonterminalNode = generated.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NodeType} */
+export const NodeType = wasm.cst.NodeType;
+/** {@inheritDoc wasm.cst.NodeType} */
+export type NodeType = wasm.cst.NodeType;
 
-export const TerminalNode = generated.cst.TerminalNode;
-export type TerminalNode = generated.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export const NonterminalNode = wasm.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export type NonterminalNode = wasm.cst.NonterminalNode;
 
-export type Edge = generated.cst.Edge;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export const TerminalNode = wasm.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export type TerminalNode = wasm.cst.TerminalNode;
 
-export const Cursor = generated.cst.Cursor;
-export type Cursor = generated.cst.Cursor;
+/** {@inheritDoc wasm.cst.Edge} */
+export type Edge = wasm.cst.Edge;
 
-export const CursorIterator = generated.cst.CursorIterator;
-export type CursorIterator = generated.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.Cursor} */
+export const Cursor = wasm.cst.Cursor;
+/** {@inheritDoc wasm.cst.Cursor} */
+export type Cursor = wasm.cst.Cursor;
 
-export const AncestorsIterator = generated.cst.AncestorsIterator;
-export type AncestorsIterator = generated.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export const CursorIterator = wasm.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export type CursorIterator = wasm.cst.CursorIterator;
 
-export const Query = generated.cst.Query;
-export type Query = generated.cst.Query;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export const AncestorsIterator = wasm.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export type AncestorsIterator = wasm.cst.AncestorsIterator;
 
-export type QueryError = generated.cst.QueryError;
+/** {@inheritDoc wasm.cst.Query} */
+export const Query = wasm.cst.Query;
+/** {@inheritDoc wasm.cst.Query} */
+export type Query = wasm.cst.Query;
 
-export type QueryMatch = generated.cst.QueryMatch;
+/** {@inheritDoc wasm.cst.QueryError} */
+export type QueryError = wasm.cst.QueryError;
 
-export const QueryMatchIterator = generated.cst.QueryMatchIterator;
-export type QueryMatchIterator = generated.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatch} */
+export type QueryMatch = wasm.cst.QueryMatch;
 
-export type TextIndex = generated.cst.TextIndex;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export const QueryMatchIterator = wasm.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export type QueryMatchIterator = wasm.cst.QueryMatchIterator;
 
-export type TextRange = generated.cst.TextRange;
+/** {@inheritDoc wasm.cst.TextIndex} */
+export type TextIndex = wasm.cst.TextIndex;
 
-/**
- * Asserts that this node is a `NonterminalNode` with the provided kind and text.
- */
-export function assertIsNonterminalNode(
-  node: unknown,
-  kind?: NonterminalKind,
-  text?: string,
-): asserts node is NonterminalNode {
-  if (!(node instanceof NonterminalNode)) {
-    throw new Error("Node provided is not a NonterminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
-
-/**
- * Asserts that this node is a `TerminalKind` with the provided kind and text.
- */
-export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
-  if (!(node instanceof TerminalNode)) {
-    throw new Error("Node provided is not a TerminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
+/** {@inheritDoc wasm.cst.TextRange} */
+export type TextRange = wasm.cst.TextRange;

--- a/crates/solidity/outputs/npm/package/src/generated/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/index.mts
@@ -1,5 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+/*
+ * __SLANG_NPM_PACKAGE_EXPORTS__ (keep in sync)
+ */
 export * as ast from "./ast/index.mjs";
 export * as bindings from "./bindings/index.mjs";
 export * as compilation from "./compilation/index.mjs";

--- a/crates/solidity/outputs/npm/package/src/generated/parser/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/parser/index.mts
@@ -1,12 +1,18 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const Parser = generated.parser.Parser;
-export type Parser = generated.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export const Parser = wasm.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export type Parser = wasm.parser.Parser;
 
-export const ParseError = generated.parser.ParseError;
-export type ParseError = generated.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export const ParseError = wasm.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export type ParseError = wasm.parser.ParseError;
 
-export const ParseOutput = generated.parser.ParseOutput;
-export type ParseOutput = generated.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export const ParseOutput = wasm.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export type ParseOutput = wasm.parser.ParseOutput;

--- a/crates/solidity/outputs/npm/package/src/generated/utils/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/utils/index.mts
@@ -1,6 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const LanguageFacts = generated.utils.LanguageFacts;
-export type LanguageFacts = generated.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export const LanguageFacts = wasm.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export type LanguageFacts = wasm.utils.LanguageFacts;

--- a/crates/solidity/outputs/npm/package/typedoc.mjs
+++ b/crates/solidity/outputs/npm/package/typedoc.mjs
@@ -1,0 +1,53 @@
+/** @type {Partial<import("typedoc").TypeDocOptions>} */
+const config = {
+  /*
+   * https://typedoc.org/documents/Options.html
+   */
+
+  basePath: ".",
+  entryPointStrategy: "expand",
+  entryPoints: [
+    "src/generated/index.mts",
+    // __SLANG_NPM_PACKAGE_EXPORTS__ (keep in sync)
+    "src/generated/ast/index.mts",
+    "src/generated/bindings/index.mts",
+    "src/generated/compilation/index.mts",
+    "src/generated/cst/index.mts",
+    "src/generated/parser/index.mts",
+    "src/generated/utils/index.mts",
+    // WASM-generated APIs:
+    "wasm/index.d.mts",
+  ],
+
+  emit: "none",
+
+  readme: "none", // we already have a site-wide README...
+  disableSources: true, // links won't be persistant between commits...
+  skipErrorChecking: true, // already dne by 'tsc'...
+  treatWarningsAsErrors: true,
+  excludeInternal: true,
+
+  requiredToBeDocumented: [
+    "Enum",
+    "EnumMember",
+    "Variable",
+    "Function",
+    "Class",
+    "Interface",
+    "Constructor",
+    "Property",
+    "Method",
+    "Accessor",
+    "TypeAlias",
+  ],
+
+  validation: {
+    notExported: true,
+    invalidLink: true,
+    rewrittenLink: true,
+    notDocumented: true,
+    unusedMergeModuleWith: true,
+  },
+};
+
+export default config;

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
@@ -7,6 +7,10 @@ import type { Node } from "./nomic-foundation-slang-cst.js";
 export { Node };
 import type { NonterminalNode } from "./nomic-foundation-slang-cst.js";
 export { NonterminalNode };
+
+/**
+ * @internal
+ */
 export class Selectors {
   static sequence(node: NonterminalNode): (Node | undefined)[];
   static choice(node: NonterminalNode): Node;

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
@@ -16,8 +16,19 @@ export { Cursor };
  * It can either be in a user file, or a built-in in the language.
  */
 export type BindingLocation = UserFileLocation | BuiltInLocation;
+
+/**
+ * Enumerates different variants of the `BindingLocation` type.
+ */
 export enum BindingLocationType {
+  /**
+   * Represents a variant of type `UserFileLocation`.
+   */
   UserFileLocation = "UserFileLocation",
+
+  /**
+   * Represents a variant of type `BuiltInLocation`.
+   */
   BuiltInLocation = "BuiltInLocation",
 }
 

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
@@ -77,6 +77,8 @@ export class File {
  *
  * This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
  * This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+ *
+ * @internal
  */
 export class InternalCompilationBuilder {
   /**

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -21,7 +21,7 @@ export namespace NomicFoundationSlangCst {
  */
 export declare enum NonterminalKind {
   /**
-   * This kind represents a `AbicoderPragma` node, with the following structure:
+   * Represents a node with kind `AbicoderPragma`, having the following structure:
    *
    * ```ebnf
    * AbicoderPragma = (* abicoder_keyword: *) ABICODER_KEYWORD
@@ -30,7 +30,7 @@ export declare enum NonterminalKind {
    */
   AbicoderPragma = "AbicoderPragma",
   /**
-   * This kind represents a `AdditiveExpression` node, with the following structure:
+   * Represents a node with kind `AdditiveExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -46,7 +46,7 @@ export declare enum NonterminalKind {
    */
   AdditiveExpression = "AdditiveExpression",
   /**
-   * This kind represents a `AddressType` node, with the following structure:
+   * Represents a node with kind `AddressType`, having the following structure:
    *
    * ```ebnf
    * AddressType = (* address_keyword: *) ADDRESS_KEYWORD
@@ -55,7 +55,7 @@ export declare enum NonterminalKind {
    */
   AddressType = "AddressType",
   /**
-   * This kind represents a `AndExpression` node, with the following structure:
+   * Represents a node with kind `AndExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -66,7 +66,7 @@ export declare enum NonterminalKind {
    */
   AndExpression = "AndExpression",
   /**
-   * This kind represents a `ArgumentsDeclaration` node, with the following structure:
+   * Represents a node with kind `ArgumentsDeclaration`, having the following structure:
    *
    * ```ebnf
    * ArgumentsDeclaration = (* variant: *) PositionalArgumentsDeclaration
@@ -75,7 +75,7 @@ export declare enum NonterminalKind {
    */
   ArgumentsDeclaration = "ArgumentsDeclaration",
   /**
-   * This kind represents a `ArrayExpression` node, with the following structure:
+   * Represents a node with kind `ArrayExpression`, having the following structure:
    *
    * ```ebnf
    * ArrayExpression = (* open_bracket: *) OPEN_BRACKET
@@ -85,7 +85,7 @@ export declare enum NonterminalKind {
    */
   ArrayExpression = "ArrayExpression",
   /**
-   * This kind represents a `ArrayTypeName` node, with the following structure:
+   * Represents a node with kind `ArrayTypeName`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -97,7 +97,7 @@ export declare enum NonterminalKind {
    */
   ArrayTypeName = "ArrayTypeName",
   /**
-   * This kind represents a `ArrayValues` node, with the following structure:
+   * Represents a node with kind `ArrayValues`, having the following structure:
    *
    * ```ebnf
    * ArrayValues = (* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*;
@@ -105,7 +105,7 @@ export declare enum NonterminalKind {
    */
   ArrayValues = "ArrayValues",
   /**
-   * This kind represents a `AssemblyFlags` node, with the following structure:
+   * Represents a node with kind `AssemblyFlags`, having the following structure:
    *
    * ```ebnf
    * AssemblyFlags = (* item: *) StringLiteral ((* separator: *) COMMA (* item: *) StringLiteral)*;
@@ -113,7 +113,7 @@ export declare enum NonterminalKind {
    */
   AssemblyFlags = "AssemblyFlags",
   /**
-   * This kind represents a `AssemblyFlagsDeclaration` node, with the following structure:
+   * Represents a node with kind `AssemblyFlagsDeclaration`, having the following structure:
    *
    * ```ebnf
    * AssemblyFlagsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -123,7 +123,7 @@ export declare enum NonterminalKind {
    */
   AssemblyFlagsDeclaration = "AssemblyFlagsDeclaration",
   /**
-   * This kind represents a `AssemblyStatement` node, with the following structure:
+   * Represents a node with kind `AssemblyStatement`, having the following structure:
    *
    * ```ebnf
    * AssemblyStatement = (* assembly_keyword: *) ASSEMBLY_KEYWORD
@@ -134,7 +134,7 @@ export declare enum NonterminalKind {
    */
   AssemblyStatement = "AssemblyStatement",
   /**
-   * This kind represents a `AssignmentExpression` node, with the following structure:
+   * Represents a node with kind `AssignmentExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -200,7 +200,7 @@ export declare enum NonterminalKind {
    */
   AssignmentExpression = "AssignmentExpression",
   /**
-   * This kind represents a `BitwiseAndExpression` node, with the following structure:
+   * Represents a node with kind `BitwiseAndExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -211,7 +211,7 @@ export declare enum NonterminalKind {
    */
   BitwiseAndExpression = "BitwiseAndExpression",
   /**
-   * This kind represents a `BitwiseOrExpression` node, with the following structure:
+   * Represents a node with kind `BitwiseOrExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -222,7 +222,7 @@ export declare enum NonterminalKind {
    */
   BitwiseOrExpression = "BitwiseOrExpression",
   /**
-   * This kind represents a `BitwiseXorExpression` node, with the following structure:
+   * Represents a node with kind `BitwiseXorExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -233,7 +233,7 @@ export declare enum NonterminalKind {
    */
   BitwiseXorExpression = "BitwiseXorExpression",
   /**
-   * This kind represents a `Block` node, with the following structure:
+   * Represents a node with kind `Block`, having the following structure:
    *
    * ```ebnf
    * Block = (* open_brace: *) OPEN_BRACE
@@ -243,7 +243,7 @@ export declare enum NonterminalKind {
    */
   Block = "Block",
   /**
-   * This kind represents a `BreakStatement` node, with the following structure:
+   * Represents a node with kind `BreakStatement`, having the following structure:
    *
    * ```ebnf
    * BreakStatement = (* break_keyword: *) BREAK_KEYWORD
@@ -252,7 +252,7 @@ export declare enum NonterminalKind {
    */
   BreakStatement = "BreakStatement",
   /**
-   * This kind represents a `CallOptions` node, with the following structure:
+   * Represents a node with kind `CallOptions`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.2 *)
@@ -261,7 +261,7 @@ export declare enum NonterminalKind {
    */
   CallOptions = "CallOptions",
   /**
-   * This kind represents a `CallOptionsExpression` node, with the following structure:
+   * Represents a node with kind `CallOptionsExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -274,7 +274,7 @@ export declare enum NonterminalKind {
    */
   CallOptionsExpression = "CallOptionsExpression",
   /**
-   * This kind represents a `CatchClause` node, with the following structure:
+   * Represents a node with kind `CatchClause`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -285,7 +285,7 @@ export declare enum NonterminalKind {
    */
   CatchClause = "CatchClause",
   /**
-   * This kind represents a `CatchClauseError` node, with the following structure:
+   * Represents a node with kind `CatchClauseError`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -295,7 +295,7 @@ export declare enum NonterminalKind {
    */
   CatchClauseError = "CatchClauseError",
   /**
-   * This kind represents a `CatchClauses` node, with the following structure:
+   * Represents a node with kind `CatchClauses`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -304,7 +304,7 @@ export declare enum NonterminalKind {
    */
   CatchClauses = "CatchClauses",
   /**
-   * This kind represents a `ComparisonExpression` node, with the following structure:
+   * Represents a node with kind `ComparisonExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -330,7 +330,7 @@ export declare enum NonterminalKind {
    */
   ComparisonExpression = "ComparisonExpression",
   /**
-   * This kind represents a `ConditionalExpression` node, with the following structure:
+   * Represents a node with kind `ConditionalExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -343,7 +343,7 @@ export declare enum NonterminalKind {
    */
   ConditionalExpression = "ConditionalExpression",
   /**
-   * This kind represents a `ConstantDefinition` node, with the following structure:
+   * Represents a node with kind `ConstantDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.7.4 *)
@@ -357,7 +357,7 @@ export declare enum NonterminalKind {
    */
   ConstantDefinition = "ConstantDefinition",
   /**
-   * This kind represents a `ConstructorAttribute` node, with the following structure:
+   * Represents a node with kind `ConstructorAttribute`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.22 *)
@@ -371,7 +371,7 @@ export declare enum NonterminalKind {
    */
   ConstructorAttribute = "ConstructorAttribute",
   /**
-   * This kind represents a `ConstructorAttributes` node, with the following structure:
+   * Represents a node with kind `ConstructorAttributes`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.22 *)
@@ -380,7 +380,7 @@ export declare enum NonterminalKind {
    */
   ConstructorAttributes = "ConstructorAttributes",
   /**
-   * This kind represents a `ConstructorDefinition` node, with the following structure:
+   * Represents a node with kind `ConstructorDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.22 *)
@@ -392,7 +392,7 @@ export declare enum NonterminalKind {
    */
   ConstructorDefinition = "ConstructorDefinition",
   /**
-   * This kind represents a `ContinueStatement` node, with the following structure:
+   * Represents a node with kind `ContinueStatement`, having the following structure:
    *
    * ```ebnf
    * ContinueStatement = (* continue_keyword: *) CONTINUE_KEYWORD
@@ -401,7 +401,7 @@ export declare enum NonterminalKind {
    */
   ContinueStatement = "ContinueStatement",
   /**
-   * This kind represents a `ContractDefinition` node, with the following structure:
+   * Represents a node with kind `ContractDefinition`, having the following structure:
    *
    * ```ebnf
    * ContractDefinition = (* abstract_keyword: *) ABSTRACT_KEYWORD? (* Introduced in 0.6.0 *)
@@ -415,7 +415,7 @@ export declare enum NonterminalKind {
    */
   ContractDefinition = "ContractDefinition",
   /**
-   * This kind represents a `ContractMember` node, with the following structure:
+   * Represents a node with kind `ContractMember`, having the following structure:
    *
    * ```ebnf
    * ContractMember = (* variant: *) UsingDirective
@@ -435,7 +435,7 @@ export declare enum NonterminalKind {
    */
   ContractMember = "ContractMember",
   /**
-   * This kind represents a `ContractMembers` node, with the following structure:
+   * Represents a node with kind `ContractMembers`, having the following structure:
    *
    * ```ebnf
    * ContractMembers = (* item: *) ContractMember*;
@@ -443,7 +443,7 @@ export declare enum NonterminalKind {
    */
   ContractMembers = "ContractMembers",
   /**
-   * This kind represents a `DecimalNumberExpression` node, with the following structure:
+   * Represents a node with kind `DecimalNumberExpression`, having the following structure:
    *
    * ```ebnf
    * DecimalNumberExpression = (* literal: *) DECIMAL_LITERAL
@@ -452,7 +452,7 @@ export declare enum NonterminalKind {
    */
   DecimalNumberExpression = "DecimalNumberExpression",
   /**
-   * This kind represents a `DoWhileStatement` node, with the following structure:
+   * Represents a node with kind `DoWhileStatement`, having the following structure:
    *
    * ```ebnf
    * DoWhileStatement = (* do_keyword: *) DO_KEYWORD
@@ -466,7 +466,7 @@ export declare enum NonterminalKind {
    */
   DoWhileStatement = "DoWhileStatement",
   /**
-   * This kind represents a `ElementaryType` node, with the following structure:
+   * Represents a node with kind `ElementaryType`, having the following structure:
    *
    * ```ebnf
    * ElementaryType = (* variant: *) BOOL_KEYWORD
@@ -482,7 +482,7 @@ export declare enum NonterminalKind {
    */
   ElementaryType = "ElementaryType",
   /**
-   * This kind represents a `ElseBranch` node, with the following structure:
+   * Represents a node with kind `ElseBranch`, having the following structure:
    *
    * ```ebnf
    * ElseBranch = (* else_keyword: *) ELSE_KEYWORD
@@ -491,7 +491,7 @@ export declare enum NonterminalKind {
    */
   ElseBranch = "ElseBranch",
   /**
-   * This kind represents a `EmitStatement` node, with the following structure:
+   * Represents a node with kind `EmitStatement`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.21 *)
@@ -503,7 +503,7 @@ export declare enum NonterminalKind {
    */
   EmitStatement = "EmitStatement",
   /**
-   * This kind represents a `EnumDefinition` node, with the following structure:
+   * Represents a node with kind `EnumDefinition`, having the following structure:
    *
    * ```ebnf
    * EnumDefinition = (* enum_keyword: *) ENUM_KEYWORD
@@ -515,7 +515,7 @@ export declare enum NonterminalKind {
    */
   EnumDefinition = "EnumDefinition",
   /**
-   * This kind represents a `EnumMembers` node, with the following structure:
+   * Represents a node with kind `EnumMembers`, having the following structure:
    *
    * ```ebnf
    * EnumMembers = ((* item: *) IDENTIFIER ((* separator: *) COMMA (* item: *) IDENTIFIER)*)?;
@@ -523,7 +523,7 @@ export declare enum NonterminalKind {
    */
   EnumMembers = "EnumMembers",
   /**
-   * This kind represents a `EqualityExpression` node, with the following structure:
+   * Represents a node with kind `EqualityExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -539,7 +539,7 @@ export declare enum NonterminalKind {
    */
   EqualityExpression = "EqualityExpression",
   /**
-   * This kind represents a `ErrorDefinition` node, with the following structure:
+   * Represents a node with kind `ErrorDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -551,7 +551,7 @@ export declare enum NonterminalKind {
    */
   ErrorDefinition = "ErrorDefinition",
   /**
-   * This kind represents a `ErrorParameter` node, with the following structure:
+   * Represents a node with kind `ErrorParameter`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -561,7 +561,7 @@ export declare enum NonterminalKind {
    */
   ErrorParameter = "ErrorParameter",
   /**
-   * This kind represents a `ErrorParameters` node, with the following structure:
+   * Represents a node with kind `ErrorParameters`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -570,7 +570,7 @@ export declare enum NonterminalKind {
    */
   ErrorParameters = "ErrorParameters",
   /**
-   * This kind represents a `ErrorParametersDeclaration` node, with the following structure:
+   * Represents a node with kind `ErrorParametersDeclaration`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -581,7 +581,7 @@ export declare enum NonterminalKind {
    */
   ErrorParametersDeclaration = "ErrorParametersDeclaration",
   /**
-   * This kind represents a `EventDefinition` node, with the following structure:
+   * Represents a node with kind `EventDefinition`, having the following structure:
    *
    * ```ebnf
    * EventDefinition = (* event_keyword: *) EVENT_KEYWORD
@@ -593,7 +593,7 @@ export declare enum NonterminalKind {
    */
   EventDefinition = "EventDefinition",
   /**
-   * This kind represents a `EventParameter` node, with the following structure:
+   * Represents a node with kind `EventParameter`, having the following structure:
    *
    * ```ebnf
    * EventParameter = (* type_name: *) TypeName
@@ -603,7 +603,7 @@ export declare enum NonterminalKind {
    */
   EventParameter = "EventParameter",
   /**
-   * This kind represents a `EventParameters` node, with the following structure:
+   * Represents a node with kind `EventParameters`, having the following structure:
    *
    * ```ebnf
    * EventParameters = ((* item: *) EventParameter ((* separator: *) COMMA (* item: *) EventParameter)*)?;
@@ -611,7 +611,7 @@ export declare enum NonterminalKind {
    */
   EventParameters = "EventParameters",
   /**
-   * This kind represents a `EventParametersDeclaration` node, with the following structure:
+   * Represents a node with kind `EventParametersDeclaration`, having the following structure:
    *
    * ```ebnf
    * EventParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -621,7 +621,7 @@ export declare enum NonterminalKind {
    */
   EventParametersDeclaration = "EventParametersDeclaration",
   /**
-   * This kind represents a `ExperimentalFeature` node, with the following structure:
+   * Represents a node with kind `ExperimentalFeature`, having the following structure:
    *
    * ```ebnf
    * ExperimentalFeature = (* variant: *) IDENTIFIER
@@ -630,7 +630,7 @@ export declare enum NonterminalKind {
    */
   ExperimentalFeature = "ExperimentalFeature",
   /**
-   * This kind represents a `ExperimentalPragma` node, with the following structure:
+   * Represents a node with kind `ExperimentalPragma`, having the following structure:
    *
    * ```ebnf
    * ExperimentalPragma = (* experimental_keyword: *) EXPERIMENTAL_KEYWORD
@@ -639,7 +639,7 @@ export declare enum NonterminalKind {
    */
   ExperimentalPragma = "ExperimentalPragma",
   /**
-   * This kind represents a `ExponentiationExpression` node, with the following structure:
+   * Represents a node with kind `ExponentiationExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -657,7 +657,7 @@ export declare enum NonterminalKind {
    */
   ExponentiationExpression = "ExponentiationExpression",
   /**
-   * This kind represents a `Expression` node, with the following structure:
+   * Represents a node with kind `Expression`, having the following structure:
    *
    * ```ebnf
    * Expression = (* variant: *) AssignmentExpression
@@ -697,7 +697,7 @@ export declare enum NonterminalKind {
    */
   Expression = "Expression",
   /**
-   * This kind represents a `ExpressionStatement` node, with the following structure:
+   * Represents a node with kind `ExpressionStatement`, having the following structure:
    *
    * ```ebnf
    * ExpressionStatement = (* expression: *) Expression
@@ -706,7 +706,7 @@ export declare enum NonterminalKind {
    */
   ExpressionStatement = "ExpressionStatement",
   /**
-   * This kind represents a `FallbackFunctionAttribute` node, with the following structure:
+   * Represents a node with kind `FallbackFunctionAttribute`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -721,7 +721,7 @@ export declare enum NonterminalKind {
    */
   FallbackFunctionAttribute = "FallbackFunctionAttribute",
   /**
-   * This kind represents a `FallbackFunctionAttributes` node, with the following structure:
+   * Represents a node with kind `FallbackFunctionAttributes`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -730,7 +730,7 @@ export declare enum NonterminalKind {
    */
   FallbackFunctionAttributes = "FallbackFunctionAttributes",
   /**
-   * This kind represents a `FallbackFunctionDefinition` node, with the following structure:
+   * Represents a node with kind `FallbackFunctionDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -743,7 +743,7 @@ export declare enum NonterminalKind {
    */
   FallbackFunctionDefinition = "FallbackFunctionDefinition",
   /**
-   * This kind represents a `ForStatement` node, with the following structure:
+   * Represents a node with kind `ForStatement`, having the following structure:
    *
    * ```ebnf
    * ForStatement = (* for_keyword: *) FOR_KEYWORD
@@ -757,7 +757,7 @@ export declare enum NonterminalKind {
    */
   ForStatement = "ForStatement",
   /**
-   * This kind represents a `ForStatementCondition` node, with the following structure:
+   * Represents a node with kind `ForStatementCondition`, having the following structure:
    *
    * ```ebnf
    * ForStatementCondition = (* variant: *) ExpressionStatement
@@ -766,7 +766,7 @@ export declare enum NonterminalKind {
    */
   ForStatementCondition = "ForStatementCondition",
   /**
-   * This kind represents a `ForStatementInitialization` node, with the following structure:
+   * Represents a node with kind `ForStatementInitialization`, having the following structure:
    *
    * ```ebnf
    * ForStatementInitialization = (* variant: *) TupleDeconstructionStatement
@@ -777,7 +777,7 @@ export declare enum NonterminalKind {
    */
   ForStatementInitialization = "ForStatementInitialization",
   /**
-   * This kind represents a `FunctionAttribute` node, with the following structure:
+   * Represents a node with kind `FunctionAttribute`, having the following structure:
    *
    * ```ebnf
    * FunctionAttribute = (* variant: *) ModifierInvocation
@@ -795,7 +795,7 @@ export declare enum NonterminalKind {
    */
   FunctionAttribute = "FunctionAttribute",
   /**
-   * This kind represents a `FunctionAttributes` node, with the following structure:
+   * Represents a node with kind `FunctionAttributes`, having the following structure:
    *
    * ```ebnf
    * FunctionAttributes = (* item: *) FunctionAttribute*;
@@ -803,7 +803,7 @@ export declare enum NonterminalKind {
    */
   FunctionAttributes = "FunctionAttributes",
   /**
-   * This kind represents a `FunctionBody` node, with the following structure:
+   * Represents a node with kind `FunctionBody`, having the following structure:
    *
    * ```ebnf
    * FunctionBody = (* variant: *) Block
@@ -812,7 +812,7 @@ export declare enum NonterminalKind {
    */
   FunctionBody = "FunctionBody",
   /**
-   * This kind represents a `FunctionCallExpression` node, with the following structure:
+   * Represents a node with kind `FunctionCallExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -822,7 +822,7 @@ export declare enum NonterminalKind {
    */
   FunctionCallExpression = "FunctionCallExpression",
   /**
-   * This kind represents a `FunctionDefinition` node, with the following structure:
+   * Represents a node with kind `FunctionDefinition`, having the following structure:
    *
    * ```ebnf
    * FunctionDefinition = (* function_keyword: *) FUNCTION_KEYWORD
@@ -835,7 +835,7 @@ export declare enum NonterminalKind {
    */
   FunctionDefinition = "FunctionDefinition",
   /**
-   * This kind represents a `FunctionName` node, with the following structure:
+   * Represents a node with kind `FunctionName`, having the following structure:
    *
    * ```ebnf
    * FunctionName = (* variant: *) IDENTIFIER
@@ -845,7 +845,7 @@ export declare enum NonterminalKind {
    */
   FunctionName = "FunctionName",
   /**
-   * This kind represents a `FunctionType` node, with the following structure:
+   * Represents a node with kind `FunctionType`, having the following structure:
    *
    * ```ebnf
    * FunctionType = (* function_keyword: *) FUNCTION_KEYWORD
@@ -856,7 +856,7 @@ export declare enum NonterminalKind {
    */
   FunctionType = "FunctionType",
   /**
-   * This kind represents a `FunctionTypeAttribute` node, with the following structure:
+   * Represents a node with kind `FunctionTypeAttribute`, having the following structure:
    *
    * ```ebnf
    * FunctionTypeAttribute = (* variant: *) INTERNAL_KEYWORD
@@ -871,7 +871,7 @@ export declare enum NonterminalKind {
    */
   FunctionTypeAttribute = "FunctionTypeAttribute",
   /**
-   * This kind represents a `FunctionTypeAttributes` node, with the following structure:
+   * Represents a node with kind `FunctionTypeAttributes`, having the following structure:
    *
    * ```ebnf
    * FunctionTypeAttributes = (* item: *) FunctionTypeAttribute*;
@@ -879,7 +879,7 @@ export declare enum NonterminalKind {
    */
   FunctionTypeAttributes = "FunctionTypeAttributes",
   /**
-   * This kind represents a `HexNumberExpression` node, with the following structure:
+   * Represents a node with kind `HexNumberExpression`, having the following structure:
    *
    * ```ebnf
    * HexNumberExpression = (* literal: *) HEX_LITERAL
@@ -888,7 +888,7 @@ export declare enum NonterminalKind {
    */
   HexNumberExpression = "HexNumberExpression",
   /**
-   * This kind represents a `HexStringLiteral` node, with the following structure:
+   * Represents a node with kind `HexStringLiteral`, having the following structure:
    *
    * ```ebnf
    * HexStringLiteral = (* variant: *) SINGLE_QUOTED_HEX_STRING_LITERAL
@@ -897,7 +897,7 @@ export declare enum NonterminalKind {
    */
   HexStringLiteral = "HexStringLiteral",
   /**
-   * This kind represents a `HexStringLiterals` node, with the following structure:
+   * Represents a node with kind `HexStringLiterals`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.14 *)
@@ -906,7 +906,7 @@ export declare enum NonterminalKind {
    */
   HexStringLiterals = "HexStringLiterals",
   /**
-   * This kind represents a `IdentifierPath` node, with the following structure:
+   * Represents a node with kind `IdentifierPath`, having the following structure:
    *
    * ```ebnf
    * IdentifierPath = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
@@ -914,7 +914,7 @@ export declare enum NonterminalKind {
    */
   IdentifierPath = "IdentifierPath",
   /**
-   * This kind represents a `IfStatement` node, with the following structure:
+   * Represents a node with kind `IfStatement`, having the following structure:
    *
    * ```ebnf
    * IfStatement = (* if_keyword: *) IF_KEYWORD
@@ -927,7 +927,7 @@ export declare enum NonterminalKind {
    */
   IfStatement = "IfStatement",
   /**
-   * This kind represents a `ImportAlias` node, with the following structure:
+   * Represents a node with kind `ImportAlias`, having the following structure:
    *
    * ```ebnf
    * ImportAlias = (* as_keyword: *) AS_KEYWORD
@@ -936,7 +936,7 @@ export declare enum NonterminalKind {
    */
   ImportAlias = "ImportAlias",
   /**
-   * This kind represents a `ImportClause` node, with the following structure:
+   * Represents a node with kind `ImportClause`, having the following structure:
    *
    * ```ebnf
    * ImportClause = (* variant: *) PathImport
@@ -946,7 +946,7 @@ export declare enum NonterminalKind {
    */
   ImportClause = "ImportClause",
   /**
-   * This kind represents a `ImportDeconstruction` node, with the following structure:
+   * Represents a node with kind `ImportDeconstruction`, having the following structure:
    *
    * ```ebnf
    * ImportDeconstruction = (* open_brace: *) OPEN_BRACE
@@ -958,7 +958,7 @@ export declare enum NonterminalKind {
    */
   ImportDeconstruction = "ImportDeconstruction",
   /**
-   * This kind represents a `ImportDeconstructionSymbol` node, with the following structure:
+   * Represents a node with kind `ImportDeconstructionSymbol`, having the following structure:
    *
    * ```ebnf
    * ImportDeconstructionSymbol = (* name: *) IDENTIFIER
@@ -967,7 +967,7 @@ export declare enum NonterminalKind {
    */
   ImportDeconstructionSymbol = "ImportDeconstructionSymbol",
   /**
-   * This kind represents a `ImportDeconstructionSymbols` node, with the following structure:
+   * Represents a node with kind `ImportDeconstructionSymbols`, having the following structure:
    *
    * ```ebnf
    * ImportDeconstructionSymbols = (* item: *) ImportDeconstructionSymbol ((* separator: *) COMMA (* item: *) ImportDeconstructionSymbol)*;
@@ -975,7 +975,7 @@ export declare enum NonterminalKind {
    */
   ImportDeconstructionSymbols = "ImportDeconstructionSymbols",
   /**
-   * This kind represents a `ImportDirective` node, with the following structure:
+   * Represents a node with kind `ImportDirective`, having the following structure:
    *
    * ```ebnf
    * ImportDirective = (* import_keyword: *) IMPORT_KEYWORD
@@ -985,7 +985,7 @@ export declare enum NonterminalKind {
    */
   ImportDirective = "ImportDirective",
   /**
-   * This kind represents a `IndexAccessEnd` node, with the following structure:
+   * Represents a node with kind `IndexAccessEnd`, having the following structure:
    *
    * ```ebnf
    * IndexAccessEnd = (* colon: *) COLON
@@ -994,7 +994,7 @@ export declare enum NonterminalKind {
    */
   IndexAccessEnd = "IndexAccessEnd",
   /**
-   * This kind represents a `IndexAccessExpression` node, with the following structure:
+   * Represents a node with kind `IndexAccessExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -1007,7 +1007,7 @@ export declare enum NonterminalKind {
    */
   IndexAccessExpression = "IndexAccessExpression",
   /**
-   * This kind represents a `InheritanceSpecifier` node, with the following structure:
+   * Represents a node with kind `InheritanceSpecifier`, having the following structure:
    *
    * ```ebnf
    * InheritanceSpecifier = (* is_keyword: *) IS_KEYWORD
@@ -1016,7 +1016,7 @@ export declare enum NonterminalKind {
    */
   InheritanceSpecifier = "InheritanceSpecifier",
   /**
-   * This kind represents a `InheritanceType` node, with the following structure:
+   * Represents a node with kind `InheritanceType`, having the following structure:
    *
    * ```ebnf
    * InheritanceType = (* type_name: *) IdentifierPath
@@ -1025,7 +1025,7 @@ export declare enum NonterminalKind {
    */
   InheritanceType = "InheritanceType",
   /**
-   * This kind represents a `InheritanceTypes` node, with the following structure:
+   * Represents a node with kind `InheritanceTypes`, having the following structure:
    *
    * ```ebnf
    * InheritanceTypes = (* item: *) InheritanceType ((* separator: *) COMMA (* item: *) InheritanceType)*;
@@ -1033,7 +1033,7 @@ export declare enum NonterminalKind {
    */
   InheritanceTypes = "InheritanceTypes",
   /**
-   * This kind represents a `InterfaceDefinition` node, with the following structure:
+   * Represents a node with kind `InterfaceDefinition`, having the following structure:
    *
    * ```ebnf
    * InterfaceDefinition = (* interface_keyword: *) INTERFACE_KEYWORD
@@ -1046,7 +1046,7 @@ export declare enum NonterminalKind {
    */
   InterfaceDefinition = "InterfaceDefinition",
   /**
-   * This kind represents a `InterfaceMembers` node, with the following structure:
+   * Represents a node with kind `InterfaceMembers`, having the following structure:
    *
    * ```ebnf
    * InterfaceMembers = (* item: *) ContractMember*;
@@ -1054,7 +1054,7 @@ export declare enum NonterminalKind {
    */
   InterfaceMembers = "InterfaceMembers",
   /**
-   * This kind represents a `LibraryDefinition` node, with the following structure:
+   * Represents a node with kind `LibraryDefinition`, having the following structure:
    *
    * ```ebnf
    * LibraryDefinition = (* library_keyword: *) LIBRARY_KEYWORD
@@ -1066,7 +1066,7 @@ export declare enum NonterminalKind {
    */
   LibraryDefinition = "LibraryDefinition",
   /**
-   * This kind represents a `LibraryMembers` node, with the following structure:
+   * Represents a node with kind `LibraryMembers`, having the following structure:
    *
    * ```ebnf
    * LibraryMembers = (* item: *) ContractMember*;
@@ -1074,7 +1074,7 @@ export declare enum NonterminalKind {
    */
   LibraryMembers = "LibraryMembers",
   /**
-   * This kind represents a `MappingKey` node, with the following structure:
+   * Represents a node with kind `MappingKey`, having the following structure:
    *
    * ```ebnf
    * MappingKey = (* key_type: *) MappingKeyType
@@ -1083,7 +1083,7 @@ export declare enum NonterminalKind {
    */
   MappingKey = "MappingKey",
   /**
-   * This kind represents a `MappingKeyType` node, with the following structure:
+   * Represents a node with kind `MappingKeyType`, having the following structure:
    *
    * ```ebnf
    * MappingKeyType = (* variant: *) ElementaryType
@@ -1092,7 +1092,7 @@ export declare enum NonterminalKind {
    */
   MappingKeyType = "MappingKeyType",
   /**
-   * This kind represents a `MappingType` node, with the following structure:
+   * Represents a node with kind `MappingType`, having the following structure:
    *
    * ```ebnf
    * MappingType = (* mapping_keyword: *) MAPPING_KEYWORD
@@ -1105,7 +1105,7 @@ export declare enum NonterminalKind {
    */
   MappingType = "MappingType",
   /**
-   * This kind represents a `MappingValue` node, with the following structure:
+   * Represents a node with kind `MappingValue`, having the following structure:
    *
    * ```ebnf
    * MappingValue = (* type_name: *) TypeName
@@ -1114,7 +1114,7 @@ export declare enum NonterminalKind {
    */
   MappingValue = "MappingValue",
   /**
-   * This kind represents a `MemberAccessExpression` node, with the following structure:
+   * Represents a node with kind `MemberAccessExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -1125,7 +1125,7 @@ export declare enum NonterminalKind {
    */
   MemberAccessExpression = "MemberAccessExpression",
   /**
-   * This kind represents a `ModifierAttribute` node, with the following structure:
+   * Represents a node with kind `ModifierAttribute`, having the following structure:
    *
    * ```ebnf
    * ModifierAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
@@ -1134,7 +1134,7 @@ export declare enum NonterminalKind {
    */
   ModifierAttribute = "ModifierAttribute",
   /**
-   * This kind represents a `ModifierAttributes` node, with the following structure:
+   * Represents a node with kind `ModifierAttributes`, having the following structure:
    *
    * ```ebnf
    * ModifierAttributes = (* item: *) ModifierAttribute*;
@@ -1142,7 +1142,7 @@ export declare enum NonterminalKind {
    */
   ModifierAttributes = "ModifierAttributes",
   /**
-   * This kind represents a `ModifierDefinition` node, with the following structure:
+   * Represents a node with kind `ModifierDefinition`, having the following structure:
    *
    * ```ebnf
    * ModifierDefinition = (* modifier_keyword: *) MODIFIER_KEYWORD
@@ -1154,7 +1154,7 @@ export declare enum NonterminalKind {
    */
   ModifierDefinition = "ModifierDefinition",
   /**
-   * This kind represents a `ModifierInvocation` node, with the following structure:
+   * Represents a node with kind `ModifierInvocation`, having the following structure:
    *
    * ```ebnf
    * ModifierInvocation = (* name: *) IdentifierPath
@@ -1163,7 +1163,7 @@ export declare enum NonterminalKind {
    */
   ModifierInvocation = "ModifierInvocation",
   /**
-   * This kind represents a `MultiplicativeExpression` node, with the following structure:
+   * Represents a node with kind `MultiplicativeExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -1184,7 +1184,7 @@ export declare enum NonterminalKind {
    */
   MultiplicativeExpression = "MultiplicativeExpression",
   /**
-   * This kind represents a `NamedArgument` node, with the following structure:
+   * Represents a node with kind `NamedArgument`, having the following structure:
    *
    * ```ebnf
    * NamedArgument = (* name: *) IDENTIFIER
@@ -1194,7 +1194,7 @@ export declare enum NonterminalKind {
    */
   NamedArgument = "NamedArgument",
   /**
-   * This kind represents a `NamedArgumentGroup` node, with the following structure:
+   * Represents a node with kind `NamedArgumentGroup`, having the following structure:
    *
    * ```ebnf
    * NamedArgumentGroup = (* open_brace: *) OPEN_BRACE
@@ -1204,7 +1204,7 @@ export declare enum NonterminalKind {
    */
   NamedArgumentGroup = "NamedArgumentGroup",
   /**
-   * This kind represents a `NamedArguments` node, with the following structure:
+   * Represents a node with kind `NamedArguments`, having the following structure:
    *
    * ```ebnf
    * NamedArguments = ((* item: *) NamedArgument ((* separator: *) COMMA (* item: *) NamedArgument)*)?;
@@ -1212,7 +1212,7 @@ export declare enum NonterminalKind {
    */
   NamedArguments = "NamedArguments",
   /**
-   * This kind represents a `NamedArgumentsDeclaration` node, with the following structure:
+   * Represents a node with kind `NamedArgumentsDeclaration`, having the following structure:
    *
    * ```ebnf
    * NamedArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1222,7 +1222,7 @@ export declare enum NonterminalKind {
    */
   NamedArgumentsDeclaration = "NamedArgumentsDeclaration",
   /**
-   * This kind represents a `NamedImport` node, with the following structure:
+   * Represents a node with kind `NamedImport`, having the following structure:
    *
    * ```ebnf
    * NamedImport = (* asterisk: *) ASTERISK
@@ -1233,7 +1233,7 @@ export declare enum NonterminalKind {
    */
   NamedImport = "NamedImport",
   /**
-   * This kind represents a `NewExpression` node, with the following structure:
+   * Represents a node with kind `NewExpression`, having the following structure:
    *
    * ```ebnf
    * NewExpression = (* new_keyword: *) NEW_KEYWORD
@@ -1242,7 +1242,7 @@ export declare enum NonterminalKind {
    */
   NewExpression = "NewExpression",
   /**
-   * This kind represents a `NumberUnit` node, with the following structure:
+   * Represents a node with kind `NumberUnit`, having the following structure:
    *
    * ```ebnf
    * NumberUnit = (* variant: *) WEI_KEYWORD
@@ -1260,7 +1260,7 @@ export declare enum NonterminalKind {
    */
   NumberUnit = "NumberUnit",
   /**
-   * This kind represents a `OrExpression` node, with the following structure:
+   * Represents a node with kind `OrExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -1271,7 +1271,7 @@ export declare enum NonterminalKind {
    */
   OrExpression = "OrExpression",
   /**
-   * This kind represents a `OverridePaths` node, with the following structure:
+   * Represents a node with kind `OverridePaths`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1280,7 +1280,7 @@ export declare enum NonterminalKind {
    */
   OverridePaths = "OverridePaths",
   /**
-   * This kind represents a `OverridePathsDeclaration` node, with the following structure:
+   * Represents a node with kind `OverridePathsDeclaration`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1291,7 +1291,7 @@ export declare enum NonterminalKind {
    */
   OverridePathsDeclaration = "OverridePathsDeclaration",
   /**
-   * This kind represents a `OverrideSpecifier` node, with the following structure:
+   * Represents a node with kind `OverrideSpecifier`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1301,7 +1301,7 @@ export declare enum NonterminalKind {
    */
   OverrideSpecifier = "OverrideSpecifier",
   /**
-   * This kind represents a `Parameter` node, with the following structure:
+   * Represents a node with kind `Parameter`, having the following structure:
    *
    * ```ebnf
    * Parameter = (* type_name: *) TypeName
@@ -1311,7 +1311,7 @@ export declare enum NonterminalKind {
    */
   Parameter = "Parameter",
   /**
-   * This kind represents a `Parameters` node, with the following structure:
+   * Represents a node with kind `Parameters`, having the following structure:
    *
    * ```ebnf
    * Parameters = ((* item: *) Parameter ((* separator: *) COMMA (* item: *) Parameter)*)?;
@@ -1319,7 +1319,7 @@ export declare enum NonterminalKind {
    */
   Parameters = "Parameters",
   /**
-   * This kind represents a `ParametersDeclaration` node, with the following structure:
+   * Represents a node with kind `ParametersDeclaration`, having the following structure:
    *
    * ```ebnf
    * ParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1329,7 +1329,7 @@ export declare enum NonterminalKind {
    */
   ParametersDeclaration = "ParametersDeclaration",
   /**
-   * This kind represents a `PathImport` node, with the following structure:
+   * Represents a node with kind `PathImport`, having the following structure:
    *
    * ```ebnf
    * PathImport = (* path: *) StringLiteral
@@ -1338,7 +1338,7 @@ export declare enum NonterminalKind {
    */
   PathImport = "PathImport",
   /**
-   * This kind represents a `PositionalArguments` node, with the following structure:
+   * Represents a node with kind `PositionalArguments`, having the following structure:
    *
    * ```ebnf
    * PositionalArguments = ((* item: *) Expression ((* separator: *) COMMA (* item: *) Expression)*)?;
@@ -1346,7 +1346,7 @@ export declare enum NonterminalKind {
    */
   PositionalArguments = "PositionalArguments",
   /**
-   * This kind represents a `PositionalArgumentsDeclaration` node, with the following structure:
+   * Represents a node with kind `PositionalArgumentsDeclaration`, having the following structure:
    *
    * ```ebnf
    * PositionalArgumentsDeclaration = (* open_paren: *) OPEN_PAREN
@@ -1356,7 +1356,7 @@ export declare enum NonterminalKind {
    */
   PositionalArgumentsDeclaration = "PositionalArgumentsDeclaration",
   /**
-   * This kind represents a `PostfixExpression` node, with the following structure:
+   * Represents a node with kind `PostfixExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -1370,7 +1370,7 @@ export declare enum NonterminalKind {
    */
   PostfixExpression = "PostfixExpression",
   /**
-   * This kind represents a `Pragma` node, with the following structure:
+   * Represents a node with kind `Pragma`, having the following structure:
    *
    * ```ebnf
    * Pragma = (* variant: *) AbicoderPragma
@@ -1380,7 +1380,7 @@ export declare enum NonterminalKind {
    */
   Pragma = "Pragma",
   /**
-   * This kind represents a `PragmaDirective` node, with the following structure:
+   * Represents a node with kind `PragmaDirective`, having the following structure:
    *
    * ```ebnf
    * PragmaDirective = (* pragma_keyword: *) PRAGMA_KEYWORD
@@ -1390,7 +1390,7 @@ export declare enum NonterminalKind {
    */
   PragmaDirective = "PragmaDirective",
   /**
-   * This kind represents a `PrefixExpression` node, with the following structure:
+   * Represents a node with kind `PrefixExpression`, having the following structure:
    *
    * ```ebnf
    * (* Prefix unary operator *)
@@ -1425,7 +1425,7 @@ export declare enum NonterminalKind {
    */
   PrefixExpression = "PrefixExpression",
   /**
-   * This kind represents a `ReceiveFunctionAttribute` node, with the following structure:
+   * Represents a node with kind `ReceiveFunctionAttribute`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1438,7 +1438,7 @@ export declare enum NonterminalKind {
    */
   ReceiveFunctionAttribute = "ReceiveFunctionAttribute",
   /**
-   * This kind represents a `ReceiveFunctionAttributes` node, with the following structure:
+   * Represents a node with kind `ReceiveFunctionAttributes`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1447,7 +1447,7 @@ export declare enum NonterminalKind {
    */
   ReceiveFunctionAttributes = "ReceiveFunctionAttributes",
   /**
-   * This kind represents a `ReceiveFunctionDefinition` node, with the following structure:
+   * Represents a node with kind `ReceiveFunctionDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1459,7 +1459,7 @@ export declare enum NonterminalKind {
    */
   ReceiveFunctionDefinition = "ReceiveFunctionDefinition",
   /**
-   * This kind represents a `ReturnStatement` node, with the following structure:
+   * Represents a node with kind `ReturnStatement`, having the following structure:
    *
    * ```ebnf
    * ReturnStatement = (* return_keyword: *) RETURN_KEYWORD
@@ -1469,7 +1469,7 @@ export declare enum NonterminalKind {
    */
   ReturnStatement = "ReturnStatement",
   /**
-   * This kind represents a `ReturnsDeclaration` node, with the following structure:
+   * Represents a node with kind `ReturnsDeclaration`, having the following structure:
    *
    * ```ebnf
    * ReturnsDeclaration = (* returns_keyword: *) RETURNS_KEYWORD
@@ -1478,7 +1478,7 @@ export declare enum NonterminalKind {
    */
   ReturnsDeclaration = "ReturnsDeclaration",
   /**
-   * This kind represents a `RevertStatement` node, with the following structure:
+   * Represents a node with kind `RevertStatement`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -1490,7 +1490,7 @@ export declare enum NonterminalKind {
    */
   RevertStatement = "RevertStatement",
   /**
-   * This kind represents a `ShiftExpression` node, with the following structure:
+   * Represents a node with kind `ShiftExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -1511,7 +1511,7 @@ export declare enum NonterminalKind {
    */
   ShiftExpression = "ShiftExpression",
   /**
-   * This kind represents a `SimpleVersionLiteral` node, with the following structure:
+   * Represents a node with kind `SimpleVersionLiteral`, having the following structure:
    *
    * ```ebnf
    * SimpleVersionLiteral = (* item: *) VERSION_SPECIFIER ((* separator: *) PERIOD (* item: *) VERSION_SPECIFIER)*;
@@ -1519,7 +1519,7 @@ export declare enum NonterminalKind {
    */
   SimpleVersionLiteral = "SimpleVersionLiteral",
   /**
-   * This kind represents a `SourceUnit` node, with the following structure:
+   * Represents a node with kind `SourceUnit`, having the following structure:
    *
    * ```ebnf
    * SourceUnit = (* members: *) SourceUnitMembers;
@@ -1527,7 +1527,7 @@ export declare enum NonterminalKind {
    */
   SourceUnit = "SourceUnit",
   /**
-   * This kind represents a `SourceUnitMember` node, with the following structure:
+   * Represents a node with kind `SourceUnitMember`, having the following structure:
    *
    * ```ebnf
    * SourceUnitMember = (* variant: *) PragmaDirective
@@ -1547,7 +1547,7 @@ export declare enum NonterminalKind {
    */
   SourceUnitMember = "SourceUnitMember",
   /**
-   * This kind represents a `SourceUnitMembers` node, with the following structure:
+   * Represents a node with kind `SourceUnitMembers`, having the following structure:
    *
    * ```ebnf
    * SourceUnitMembers = (* item: *) SourceUnitMember*;
@@ -1555,7 +1555,7 @@ export declare enum NonterminalKind {
    */
   SourceUnitMembers = "SourceUnitMembers",
   /**
-   * This kind represents a `StateVariableAttribute` node, with the following structure:
+   * Represents a node with kind `StateVariableAttribute`, having the following structure:
    *
    * ```ebnf
    * StateVariableAttribute = (* variant: *) OverrideSpecifier (* Introduced in 0.6.0 *)
@@ -1569,7 +1569,7 @@ export declare enum NonterminalKind {
    */
   StateVariableAttribute = "StateVariableAttribute",
   /**
-   * This kind represents a `StateVariableAttributes` node, with the following structure:
+   * Represents a node with kind `StateVariableAttributes`, having the following structure:
    *
    * ```ebnf
    * StateVariableAttributes = (* item: *) StateVariableAttribute*;
@@ -1577,7 +1577,7 @@ export declare enum NonterminalKind {
    */
   StateVariableAttributes = "StateVariableAttributes",
   /**
-   * This kind represents a `StateVariableDefinition` node, with the following structure:
+   * Represents a node with kind `StateVariableDefinition`, having the following structure:
    *
    * ```ebnf
    * StateVariableDefinition = (* type_name: *) TypeName
@@ -1589,7 +1589,7 @@ export declare enum NonterminalKind {
    */
   StateVariableDefinition = "StateVariableDefinition",
   /**
-   * This kind represents a `StateVariableDefinitionValue` node, with the following structure:
+   * Represents a node with kind `StateVariableDefinitionValue`, having the following structure:
    *
    * ```ebnf
    * StateVariableDefinitionValue = (* equal: *) EQUAL
@@ -1598,7 +1598,7 @@ export declare enum NonterminalKind {
    */
   StateVariableDefinitionValue = "StateVariableDefinitionValue",
   /**
-   * This kind represents a `Statement` node, with the following structure:
+   * Represents a node with kind `Statement`, having the following structure:
    *
    * ```ebnf
    * Statement = (* variant: *) IfStatement
@@ -1622,7 +1622,7 @@ export declare enum NonterminalKind {
    */
   Statement = "Statement",
   /**
-   * This kind represents a `Statements` node, with the following structure:
+   * Represents a node with kind `Statements`, having the following structure:
    *
    * ```ebnf
    * Statements = (* item: *) Statement*;
@@ -1630,7 +1630,7 @@ export declare enum NonterminalKind {
    */
   Statements = "Statements",
   /**
-   * This kind represents a `StorageLocation` node, with the following structure:
+   * Represents a node with kind `StorageLocation`, having the following structure:
    *
    * ```ebnf
    * StorageLocation = (* variant: *) MEMORY_KEYWORD
@@ -1640,7 +1640,7 @@ export declare enum NonterminalKind {
    */
   StorageLocation = "StorageLocation",
   /**
-   * This kind represents a `StringExpression` node, with the following structure:
+   * Represents a node with kind `StringExpression`, having the following structure:
    *
    * ```ebnf
    * StringExpression = (* variant: *) StringLiteral (* Deprecated in 0.5.14 *)
@@ -1652,7 +1652,7 @@ export declare enum NonterminalKind {
    */
   StringExpression = "StringExpression",
   /**
-   * This kind represents a `StringLiteral` node, with the following structure:
+   * Represents a node with kind `StringLiteral`, having the following structure:
    *
    * ```ebnf
    * StringLiteral = (* variant: *) SINGLE_QUOTED_STRING_LITERAL
@@ -1661,7 +1661,7 @@ export declare enum NonterminalKind {
    */
   StringLiteral = "StringLiteral",
   /**
-   * This kind represents a `StringLiterals` node, with the following structure:
+   * Represents a node with kind `StringLiterals`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.14 *)
@@ -1670,7 +1670,7 @@ export declare enum NonterminalKind {
    */
   StringLiterals = "StringLiterals",
   /**
-   * This kind represents a `StructDefinition` node, with the following structure:
+   * Represents a node with kind `StructDefinition`, having the following structure:
    *
    * ```ebnf
    * StructDefinition = (* struct_keyword: *) STRUCT_KEYWORD
@@ -1682,7 +1682,7 @@ export declare enum NonterminalKind {
    */
   StructDefinition = "StructDefinition",
   /**
-   * This kind represents a `StructMember` node, with the following structure:
+   * Represents a node with kind `StructMember`, having the following structure:
    *
    * ```ebnf
    * StructMember = (* type_name: *) TypeName
@@ -1692,7 +1692,7 @@ export declare enum NonterminalKind {
    */
   StructMember = "StructMember",
   /**
-   * This kind represents a `StructMembers` node, with the following structure:
+   * Represents a node with kind `StructMembers`, having the following structure:
    *
    * ```ebnf
    * StructMembers = (* item: *) StructMember*;
@@ -1700,7 +1700,7 @@ export declare enum NonterminalKind {
    */
   StructMembers = "StructMembers",
   /**
-   * This kind represents a `ThrowStatement` node, with the following structure:
+   * Represents a node with kind `ThrowStatement`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -1710,7 +1710,7 @@ export declare enum NonterminalKind {
    */
   ThrowStatement = "ThrowStatement",
   /**
-   * This kind represents a `TryStatement` node, with the following structure:
+   * Represents a node with kind `TryStatement`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -1723,7 +1723,7 @@ export declare enum NonterminalKind {
    */
   TryStatement = "TryStatement",
   /**
-   * This kind represents a `TupleDeconstructionElement` node, with the following structure:
+   * Represents a node with kind `TupleDeconstructionElement`, having the following structure:
    *
    * ```ebnf
    * TupleDeconstructionElement = (* member: *) TupleMember?;
@@ -1731,7 +1731,7 @@ export declare enum NonterminalKind {
    */
   TupleDeconstructionElement = "TupleDeconstructionElement",
   /**
-   * This kind represents a `TupleDeconstructionElements` node, with the following structure:
+   * Represents a node with kind `TupleDeconstructionElements`, having the following structure:
    *
    * ```ebnf
    * TupleDeconstructionElements = (* item: *) TupleDeconstructionElement ((* separator: *) COMMA (* item: *) TupleDeconstructionElement)*;
@@ -1739,7 +1739,7 @@ export declare enum NonterminalKind {
    */
   TupleDeconstructionElements = "TupleDeconstructionElements",
   /**
-   * This kind represents a `TupleDeconstructionStatement` node, with the following structure:
+   * Represents a node with kind `TupleDeconstructionStatement`, having the following structure:
    *
    * ```ebnf
    * TupleDeconstructionStatement = (* var_keyword: *) VAR_KEYWORD? (* Deprecated in 0.5.0 *)
@@ -1753,7 +1753,7 @@ export declare enum NonterminalKind {
    */
   TupleDeconstructionStatement = "TupleDeconstructionStatement",
   /**
-   * This kind represents a `TupleExpression` node, with the following structure:
+   * Represents a node with kind `TupleExpression`, having the following structure:
    *
    * ```ebnf
    * TupleExpression = (* open_paren: *) OPEN_PAREN
@@ -1763,7 +1763,7 @@ export declare enum NonterminalKind {
    */
   TupleExpression = "TupleExpression",
   /**
-   * This kind represents a `TupleMember` node, with the following structure:
+   * Represents a node with kind `TupleMember`, having the following structure:
    *
    * ```ebnf
    * TupleMember = (* variant: *) TypedTupleMember
@@ -1772,7 +1772,7 @@ export declare enum NonterminalKind {
    */
   TupleMember = "TupleMember",
   /**
-   * This kind represents a `TupleValue` node, with the following structure:
+   * Represents a node with kind `TupleValue`, having the following structure:
    *
    * ```ebnf
    * TupleValue = (* expression: *) Expression?;
@@ -1780,7 +1780,7 @@ export declare enum NonterminalKind {
    */
   TupleValue = "TupleValue",
   /**
-   * This kind represents a `TupleValues` node, with the following structure:
+   * Represents a node with kind `TupleValues`, having the following structure:
    *
    * ```ebnf
    * TupleValues = (* item: *) TupleValue ((* separator: *) COMMA (* item: *) TupleValue)*;
@@ -1788,7 +1788,7 @@ export declare enum NonterminalKind {
    */
   TupleValues = "TupleValues",
   /**
-   * This kind represents a `TypeExpression` node, with the following structure:
+   * Represents a node with kind `TypeExpression`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.3 *)
@@ -1800,7 +1800,7 @@ export declare enum NonterminalKind {
    */
   TypeExpression = "TypeExpression",
   /**
-   * This kind represents a `TypeName` node, with the following structure:
+   * Represents a node with kind `TypeName`, having the following structure:
    *
    * ```ebnf
    * TypeName = (* variant: *) ArrayTypeName
@@ -1812,7 +1812,7 @@ export declare enum NonterminalKind {
    */
   TypeName = "TypeName",
   /**
-   * This kind represents a `TypedTupleMember` node, with the following structure:
+   * Represents a node with kind `TypedTupleMember`, having the following structure:
    *
    * ```ebnf
    * TypedTupleMember = (* type_name: *) TypeName
@@ -1822,7 +1822,7 @@ export declare enum NonterminalKind {
    */
   TypedTupleMember = "TypedTupleMember",
   /**
-   * This kind represents a `UncheckedBlock` node, with the following structure:
+   * Represents a node with kind `UncheckedBlock`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.0 *)
@@ -1832,7 +1832,7 @@ export declare enum NonterminalKind {
    */
   UncheckedBlock = "UncheckedBlock",
   /**
-   * This kind represents a `UnicodeStringLiteral` node, with the following structure:
+   * Represents a node with kind `UnicodeStringLiteral`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.7.0 *)
@@ -1842,7 +1842,7 @@ export declare enum NonterminalKind {
    */
   UnicodeStringLiteral = "UnicodeStringLiteral",
   /**
-   * This kind represents a `UnicodeStringLiterals` node, with the following structure:
+   * Represents a node with kind `UnicodeStringLiterals`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.7.0 *)
@@ -1851,7 +1851,7 @@ export declare enum NonterminalKind {
    */
   UnicodeStringLiterals = "UnicodeStringLiterals",
   /**
-   * This kind represents a `UnnamedFunctionAttribute` node, with the following structure:
+   * Represents a node with kind `UnnamedFunctionAttribute`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.6.0 *)
@@ -1868,7 +1868,7 @@ export declare enum NonterminalKind {
    */
   UnnamedFunctionAttribute = "UnnamedFunctionAttribute",
   /**
-   * This kind represents a `UnnamedFunctionAttributes` node, with the following structure:
+   * Represents a node with kind `UnnamedFunctionAttributes`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.6.0 *)
@@ -1877,7 +1877,7 @@ export declare enum NonterminalKind {
    */
   UnnamedFunctionAttributes = "UnnamedFunctionAttributes",
   /**
-   * This kind represents a `UnnamedFunctionDefinition` node, with the following structure:
+   * Represents a node with kind `UnnamedFunctionDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.6.0 *)
@@ -1889,7 +1889,7 @@ export declare enum NonterminalKind {
    */
   UnnamedFunctionDefinition = "UnnamedFunctionDefinition",
   /**
-   * This kind represents a `UntypedTupleMember` node, with the following structure:
+   * Represents a node with kind `UntypedTupleMember`, having the following structure:
    *
    * ```ebnf
    * UntypedTupleMember = (* storage_location: *) StorageLocation?
@@ -1898,7 +1898,7 @@ export declare enum NonterminalKind {
    */
   UntypedTupleMember = "UntypedTupleMember",
   /**
-   * This kind represents a `UserDefinedValueTypeDefinition` node, with the following structure:
+   * Represents a node with kind `UserDefinedValueTypeDefinition`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.8 *)
@@ -1911,7 +1911,7 @@ export declare enum NonterminalKind {
    */
   UserDefinedValueTypeDefinition = "UserDefinedValueTypeDefinition",
   /**
-   * This kind represents a `UsingAlias` node, with the following structure:
+   * Represents a node with kind `UsingAlias`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.19 *)
@@ -1921,7 +1921,7 @@ export declare enum NonterminalKind {
    */
   UsingAlias = "UsingAlias",
   /**
-   * This kind represents a `UsingClause` node, with the following structure:
+   * Represents a node with kind `UsingClause`, having the following structure:
    *
    * ```ebnf
    * UsingClause = (* variant: *) IdentifierPath
@@ -1930,7 +1930,7 @@ export declare enum NonterminalKind {
    */
   UsingClause = "UsingClause",
   /**
-   * This kind represents a `UsingDeconstruction` node, with the following structure:
+   * Represents a node with kind `UsingDeconstruction`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.13 *)
@@ -1941,7 +1941,7 @@ export declare enum NonterminalKind {
    */
   UsingDeconstruction = "UsingDeconstruction",
   /**
-   * This kind represents a `UsingDeconstructionSymbol` node, with the following structure:
+   * Represents a node with kind `UsingDeconstructionSymbol`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.13 *)
@@ -1951,7 +1951,7 @@ export declare enum NonterminalKind {
    */
   UsingDeconstructionSymbol = "UsingDeconstructionSymbol",
   /**
-   * This kind represents a `UsingDeconstructionSymbols` node, with the following structure:
+   * Represents a node with kind `UsingDeconstructionSymbols`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.13 *)
@@ -1960,7 +1960,7 @@ export declare enum NonterminalKind {
    */
   UsingDeconstructionSymbols = "UsingDeconstructionSymbols",
   /**
-   * This kind represents a `UsingDirective` node, with the following structure:
+   * Represents a node with kind `UsingDirective`, having the following structure:
    *
    * ```ebnf
    * UsingDirective = (* using_keyword: *) USING_KEYWORD
@@ -1973,7 +1973,7 @@ export declare enum NonterminalKind {
    */
   UsingDirective = "UsingDirective",
   /**
-   * This kind represents a `UsingOperator` node, with the following structure:
+   * Represents a node with kind `UsingOperator`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.19 *)
@@ -1996,7 +1996,7 @@ export declare enum NonterminalKind {
    */
   UsingOperator = "UsingOperator",
   /**
-   * This kind represents a `UsingTarget` node, with the following structure:
+   * Represents a node with kind `UsingTarget`, having the following structure:
    *
    * ```ebnf
    * UsingTarget = (* variant: *) TypeName
@@ -2005,7 +2005,7 @@ export declare enum NonterminalKind {
    */
   UsingTarget = "UsingTarget",
   /**
-   * This kind represents a `VariableDeclarationStatement` node, with the following structure:
+   * Represents a node with kind `VariableDeclarationStatement`, having the following structure:
    *
    * ```ebnf
    * VariableDeclarationStatement = (* variable_type: *) VariableDeclarationType
@@ -2017,7 +2017,7 @@ export declare enum NonterminalKind {
    */
   VariableDeclarationStatement = "VariableDeclarationStatement",
   /**
-   * This kind represents a `VariableDeclarationType` node, with the following structure:
+   * Represents a node with kind `VariableDeclarationType`, having the following structure:
    *
    * ```ebnf
    * VariableDeclarationType = (* variant: *) TypeName
@@ -2026,7 +2026,7 @@ export declare enum NonterminalKind {
    */
   VariableDeclarationType = "VariableDeclarationType",
   /**
-   * This kind represents a `VariableDeclarationValue` node, with the following structure:
+   * Represents a node with kind `VariableDeclarationValue`, having the following structure:
    *
    * ```ebnf
    * VariableDeclarationValue = (* equal: *) EQUAL
@@ -2035,7 +2035,7 @@ export declare enum NonterminalKind {
    */
   VariableDeclarationValue = "VariableDeclarationValue",
   /**
-   * This kind represents a `VersionExpression` node, with the following structure:
+   * Represents a node with kind `VersionExpression`, having the following structure:
    *
    * ```ebnf
    * VersionExpression = (* variant: *) VersionRange
@@ -2044,7 +2044,7 @@ export declare enum NonterminalKind {
    */
   VersionExpression = "VersionExpression",
   /**
-   * This kind represents a `VersionExpressionSet` node, with the following structure:
+   * Represents a node with kind `VersionExpressionSet`, having the following structure:
    *
    * ```ebnf
    * VersionExpressionSet = (* item: *) VersionExpression+;
@@ -2052,7 +2052,7 @@ export declare enum NonterminalKind {
    */
   VersionExpressionSet = "VersionExpressionSet",
   /**
-   * This kind represents a `VersionExpressionSets` node, with the following structure:
+   * Represents a node with kind `VersionExpressionSets`, having the following structure:
    *
    * ```ebnf
    * VersionExpressionSets = (* item: *) VersionExpressionSet ((* separator: *) BAR_BAR (* item: *) VersionExpressionSet)*;
@@ -2060,7 +2060,7 @@ export declare enum NonterminalKind {
    */
   VersionExpressionSets = "VersionExpressionSets",
   /**
-   * This kind represents a `VersionLiteral` node, with the following structure:
+   * Represents a node with kind `VersionLiteral`, having the following structure:
    *
    * ```ebnf
    * VersionLiteral = (* variant: *) SimpleVersionLiteral
@@ -2070,7 +2070,7 @@ export declare enum NonterminalKind {
    */
   VersionLiteral = "VersionLiteral",
   /**
-   * This kind represents a `VersionOperator` node, with the following structure:
+   * Represents a node with kind `VersionOperator`, having the following structure:
    *
    * ```ebnf
    * VersionOperator = (* variant: *) CARET
@@ -2084,7 +2084,7 @@ export declare enum NonterminalKind {
    */
   VersionOperator = "VersionOperator",
   /**
-   * This kind represents a `VersionPragma` node, with the following structure:
+   * Represents a node with kind `VersionPragma`, having the following structure:
    *
    * ```ebnf
    * VersionPragma = (* solidity_keyword: *) SOLIDITY_KEYWORD
@@ -2093,7 +2093,7 @@ export declare enum NonterminalKind {
    */
   VersionPragma = "VersionPragma",
   /**
-   * This kind represents a `VersionRange` node, with the following structure:
+   * Represents a node with kind `VersionRange`, having the following structure:
    *
    * ```ebnf
    * VersionRange = (* start: *) VersionLiteral
@@ -2103,7 +2103,7 @@ export declare enum NonterminalKind {
    */
   VersionRange = "VersionRange",
   /**
-   * This kind represents a `VersionTerm` node, with the following structure:
+   * Represents a node with kind `VersionTerm`, having the following structure:
    *
    * ```ebnf
    * VersionTerm = (* operator: *) VersionOperator?
@@ -2112,7 +2112,7 @@ export declare enum NonterminalKind {
    */
   VersionTerm = "VersionTerm",
   /**
-   * This kind represents a `WhileStatement` node, with the following structure:
+   * Represents a node with kind `WhileStatement`, having the following structure:
    *
    * ```ebnf
    * WhileStatement = (* while_keyword: *) WHILE_KEYWORD
@@ -2124,7 +2124,7 @@ export declare enum NonterminalKind {
    */
   WhileStatement = "WhileStatement",
   /**
-   * This kind represents a `YulArguments` node, with the following structure:
+   * Represents a node with kind `YulArguments`, having the following structure:
    *
    * ```ebnf
    * YulArguments = ((* item: *) YulExpression ((* separator: *) COMMA (* item: *) YulExpression)*)?;
@@ -2132,7 +2132,7 @@ export declare enum NonterminalKind {
    */
   YulArguments = "YulArguments",
   /**
-   * This kind represents a `YulAssignmentOperator` node, with the following structure:
+   * Represents a node with kind `YulAssignmentOperator`, having the following structure:
    *
    * ```ebnf
    * YulAssignmentOperator = (* variant: *) COLON_EQUAL
@@ -2141,7 +2141,7 @@ export declare enum NonterminalKind {
    */
   YulAssignmentOperator = "YulAssignmentOperator",
   /**
-   * This kind represents a `YulBlock` node, with the following structure:
+   * Represents a node with kind `YulBlock`, having the following structure:
    *
    * ```ebnf
    * YulBlock = (* open_brace: *) OPEN_BRACE
@@ -2151,7 +2151,7 @@ export declare enum NonterminalKind {
    */
   YulBlock = "YulBlock",
   /**
-   * This kind represents a `YulBreakStatement` node, with the following structure:
+   * Represents a node with kind `YulBreakStatement`, having the following structure:
    *
    * ```ebnf
    * YulBreakStatement = (* break_keyword: *) YUL_BREAK_KEYWORD;
@@ -2159,7 +2159,7 @@ export declare enum NonterminalKind {
    */
   YulBreakStatement = "YulBreakStatement",
   /**
-   * This kind represents a `YulBuiltInFunction` node, with the following structure:
+   * Represents a node with kind `YulBuiltInFunction`, having the following structure:
    *
    * ```ebnf
    * YulBuiltInFunction = (* variant: *) YUL_ADD_KEYWORD
@@ -2249,7 +2249,7 @@ export declare enum NonterminalKind {
    */
   YulBuiltInFunction = "YulBuiltInFunction",
   /**
-   * This kind represents a `YulColonAndEqual` node, with the following structure:
+   * Represents a node with kind `YulColonAndEqual`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.5 *)
@@ -2259,7 +2259,7 @@ export declare enum NonterminalKind {
    */
   YulColonAndEqual = "YulColonAndEqual",
   /**
-   * This kind represents a `YulContinueStatement` node, with the following structure:
+   * Represents a node with kind `YulContinueStatement`, having the following structure:
    *
    * ```ebnf
    * YulContinueStatement = (* continue_keyword: *) YUL_CONTINUE_KEYWORD;
@@ -2267,7 +2267,7 @@ export declare enum NonterminalKind {
    */
   YulContinueStatement = "YulContinueStatement",
   /**
-   * This kind represents a `YulDefaultCase` node, with the following structure:
+   * Represents a node with kind `YulDefaultCase`, having the following structure:
    *
    * ```ebnf
    * YulDefaultCase = (* default_keyword: *) YUL_DEFAULT_KEYWORD
@@ -2276,7 +2276,7 @@ export declare enum NonterminalKind {
    */
   YulDefaultCase = "YulDefaultCase",
   /**
-   * This kind represents a `YulEqualAndColon` node, with the following structure:
+   * Represents a node with kind `YulEqualAndColon`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -2286,7 +2286,7 @@ export declare enum NonterminalKind {
    */
   YulEqualAndColon = "YulEqualAndColon",
   /**
-   * This kind represents a `YulExpression` node, with the following structure:
+   * Represents a node with kind `YulExpression`, having the following structure:
    *
    * ```ebnf
    * YulExpression = (* variant: *) YulFunctionCallExpression
@@ -2297,7 +2297,7 @@ export declare enum NonterminalKind {
    */
   YulExpression = "YulExpression",
   /**
-   * This kind represents a `YulForStatement` node, with the following structure:
+   * Represents a node with kind `YulForStatement`, having the following structure:
    *
    * ```ebnf
    * YulForStatement = (* for_keyword: *) YUL_FOR_KEYWORD
@@ -2309,7 +2309,7 @@ export declare enum NonterminalKind {
    */
   YulForStatement = "YulForStatement",
   /**
-   * This kind represents a `YulFunctionCallExpression` node, with the following structure:
+   * Represents a node with kind `YulFunctionCallExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -2321,7 +2321,7 @@ export declare enum NonterminalKind {
    */
   YulFunctionCallExpression = "YulFunctionCallExpression",
   /**
-   * This kind represents a `YulFunctionDefinition` node, with the following structure:
+   * Represents a node with kind `YulFunctionDefinition`, having the following structure:
    *
    * ```ebnf
    * YulFunctionDefinition = (* function_keyword: *) YUL_FUNCTION_KEYWORD
@@ -2333,7 +2333,7 @@ export declare enum NonterminalKind {
    */
   YulFunctionDefinition = "YulFunctionDefinition",
   /**
-   * This kind represents a `YulIfStatement` node, with the following structure:
+   * Represents a node with kind `YulIfStatement`, having the following structure:
    *
    * ```ebnf
    * YulIfStatement = (* if_keyword: *) YUL_IF_KEYWORD
@@ -2343,7 +2343,7 @@ export declare enum NonterminalKind {
    */
   YulIfStatement = "YulIfStatement",
   /**
-   * This kind represents a `YulLabel` node, with the following structure:
+   * Represents a node with kind `YulLabel`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -2353,7 +2353,7 @@ export declare enum NonterminalKind {
    */
   YulLabel = "YulLabel",
   /**
-   * This kind represents a `YulLeaveStatement` node, with the following structure:
+   * Represents a node with kind `YulLeaveStatement`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -2362,7 +2362,7 @@ export declare enum NonterminalKind {
    */
   YulLeaveStatement = "YulLeaveStatement",
   /**
-   * This kind represents a `YulLiteral` node, with the following structure:
+   * Represents a node with kind `YulLiteral`, having the following structure:
    *
    * ```ebnf
    * YulLiteral = (* variant: *) YUL_TRUE_KEYWORD
@@ -2375,7 +2375,7 @@ export declare enum NonterminalKind {
    */
   YulLiteral = "YulLiteral",
   /**
-   * This kind represents a `YulParameters` node, with the following structure:
+   * Represents a node with kind `YulParameters`, having the following structure:
    *
    * ```ebnf
    * YulParameters = ((* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*)?;
@@ -2383,7 +2383,7 @@ export declare enum NonterminalKind {
    */
   YulParameters = "YulParameters",
   /**
-   * This kind represents a `YulParametersDeclaration` node, with the following structure:
+   * Represents a node with kind `YulParametersDeclaration`, having the following structure:
    *
    * ```ebnf
    * YulParametersDeclaration = (* open_paren: *) OPEN_PAREN
@@ -2393,7 +2393,7 @@ export declare enum NonterminalKind {
    */
   YulParametersDeclaration = "YulParametersDeclaration",
   /**
-   * This kind represents a `YulPath` node, with the following structure:
+   * Represents a node with kind `YulPath`, having the following structure:
    *
    * ```ebnf
    * YulPath = (* item: *) YUL_IDENTIFIER ((* separator: *) PERIOD (* item: *) YUL_IDENTIFIER)*;
@@ -2401,7 +2401,7 @@ export declare enum NonterminalKind {
    */
   YulPath = "YulPath",
   /**
-   * This kind represents a `YulPaths` node, with the following structure:
+   * Represents a node with kind `YulPaths`, having the following structure:
    *
    * ```ebnf
    * YulPaths = (* item: *) YulPath ((* separator: *) COMMA (* item: *) YulPath)*;
@@ -2409,7 +2409,7 @@ export declare enum NonterminalKind {
    */
   YulPaths = "YulPaths",
   /**
-   * This kind represents a `YulReturnsDeclaration` node, with the following structure:
+   * Represents a node with kind `YulReturnsDeclaration`, having the following structure:
    *
    * ```ebnf
    * YulReturnsDeclaration = (* minus_greater_than: *) MINUS_GREATER_THAN
@@ -2418,7 +2418,7 @@ export declare enum NonterminalKind {
    */
   YulReturnsDeclaration = "YulReturnsDeclaration",
   /**
-   * This kind represents a `YulStackAssignmentOperator` node, with the following structure:
+   * Represents a node with kind `YulStackAssignmentOperator`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -2428,7 +2428,7 @@ export declare enum NonterminalKind {
    */
   YulStackAssignmentOperator = "YulStackAssignmentOperator",
   /**
-   * This kind represents a `YulStackAssignmentStatement` node, with the following structure:
+   * Represents a node with kind `YulStackAssignmentStatement`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -2438,7 +2438,7 @@ export declare enum NonterminalKind {
    */
   YulStackAssignmentStatement = "YulStackAssignmentStatement",
   /**
-   * This kind represents a `YulStatement` node, with the following structure:
+   * Represents a node with kind `YulStatement`, having the following structure:
    *
    * ```ebnf
    * YulStatement = (* variant: *) YulBlock
@@ -2458,7 +2458,7 @@ export declare enum NonterminalKind {
    */
   YulStatement = "YulStatement",
   /**
-   * This kind represents a `YulStatements` node, with the following structure:
+   * Represents a node with kind `YulStatements`, having the following structure:
    *
    * ```ebnf
    * YulStatements = (* item: *) YulStatement*;
@@ -2466,7 +2466,7 @@ export declare enum NonterminalKind {
    */
   YulStatements = "YulStatements",
   /**
-   * This kind represents a `YulSwitchCase` node, with the following structure:
+   * Represents a node with kind `YulSwitchCase`, having the following structure:
    *
    * ```ebnf
    * YulSwitchCase = (* variant: *) YulDefaultCase
@@ -2475,7 +2475,7 @@ export declare enum NonterminalKind {
    */
   YulSwitchCase = "YulSwitchCase",
   /**
-   * This kind represents a `YulSwitchCases` node, with the following structure:
+   * Represents a node with kind `YulSwitchCases`, having the following structure:
    *
    * ```ebnf
    * YulSwitchCases = (* item: *) YulSwitchCase+;
@@ -2483,7 +2483,7 @@ export declare enum NonterminalKind {
    */
   YulSwitchCases = "YulSwitchCases",
   /**
-   * This kind represents a `YulSwitchStatement` node, with the following structure:
+   * Represents a node with kind `YulSwitchStatement`, having the following structure:
    *
    * ```ebnf
    * YulSwitchStatement = (* switch_keyword: *) YUL_SWITCH_KEYWORD
@@ -2493,7 +2493,7 @@ export declare enum NonterminalKind {
    */
   YulSwitchStatement = "YulSwitchStatement",
   /**
-   * This kind represents a `YulValueCase` node, with the following structure:
+   * Represents a node with kind `YulValueCase`, having the following structure:
    *
    * ```ebnf
    * YulValueCase = (* case_keyword: *) YUL_CASE_KEYWORD
@@ -2503,7 +2503,7 @@ export declare enum NonterminalKind {
    */
   YulValueCase = "YulValueCase",
   /**
-   * This kind represents a `YulVariableAssignmentStatement` node, with the following structure:
+   * Represents a node with kind `YulVariableAssignmentStatement`, having the following structure:
    *
    * ```ebnf
    * YulVariableAssignmentStatement = (* variables: *) YulPaths
@@ -2513,7 +2513,7 @@ export declare enum NonterminalKind {
    */
   YulVariableAssignmentStatement = "YulVariableAssignmentStatement",
   /**
-   * This kind represents a `YulVariableDeclarationStatement` node, with the following structure:
+   * Represents a node with kind `YulVariableDeclarationStatement`, having the following structure:
    *
    * ```ebnf
    * YulVariableDeclarationStatement = (* let_keyword: *) YUL_LET_KEYWORD
@@ -2523,7 +2523,7 @@ export declare enum NonterminalKind {
    */
   YulVariableDeclarationStatement = "YulVariableDeclarationStatement",
   /**
-   * This kind represents a `YulVariableDeclarationValue` node, with the following structure:
+   * Represents a node with kind `YulVariableDeclarationValue`, having the following structure:
    *
    * ```ebnf
    * YulVariableDeclarationValue = (* assignment: *) YulAssignmentOperator
@@ -2532,7 +2532,7 @@ export declare enum NonterminalKind {
    */
   YulVariableDeclarationValue = "YulVariableDeclarationValue",
   /**
-   * This kind represents a `YulVariableNames` node, with the following structure:
+   * Represents a node with kind `YulVariableNames`, having the following structure:
    *
    * ```ebnf
    * YulVariableNames = (* item: *) YUL_IDENTIFIER ((* separator: *) COMMA (* item: *) YUL_IDENTIFIER)*;
@@ -2556,7 +2556,7 @@ export declare enum TerminalKind {
    */
   Missing = "Missing",
   /**
-   * This kind represents a `AbicoderKeyword` node, with the following structure:
+   * Represents a node with kind `AbicoderKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -2565,7 +2565,7 @@ export declare enum TerminalKind {
    */
   AbicoderKeyword = "AbicoderKeyword",
   /**
-   * This kind represents a `AbstractKeyword` node, with the following structure:
+   * Represents a node with kind `AbstractKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -2574,7 +2574,7 @@ export declare enum TerminalKind {
    */
   AbstractKeyword = "AbstractKeyword",
   /**
-   * This kind represents a `AddressKeyword` node, with the following structure:
+   * Represents a node with kind `AddressKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -2583,7 +2583,7 @@ export declare enum TerminalKind {
    */
   AddressKeyword = "AddressKeyword",
   /**
-   * This kind represents a `AfterKeyword` node, with the following structure:
+   * Represents a node with kind `AfterKeyword`, having the following structure:
    *
    * ```ebnf
    * AFTER_KEYWORD = "after";
@@ -2591,7 +2591,7 @@ export declare enum TerminalKind {
    */
   AfterKeyword = "AfterKeyword",
   /**
-   * This kind represents a `AliasKeyword` node, with the following structure:
+   * Represents a node with kind `AliasKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -2600,7 +2600,7 @@ export declare enum TerminalKind {
    */
   AliasKeyword = "AliasKeyword",
   /**
-   * This kind represents a `Ampersand` node, with the following structure:
+   * Represents a node with kind `Ampersand`, having the following structure:
    *
    * ```ebnf
    * AMPERSAND = "&";
@@ -2608,7 +2608,7 @@ export declare enum TerminalKind {
    */
   Ampersand = "Ampersand",
   /**
-   * This kind represents a `AmpersandAmpersand` node, with the following structure:
+   * Represents a node with kind `AmpersandAmpersand`, having the following structure:
    *
    * ```ebnf
    * AMPERSAND_AMPERSAND = "&&";
@@ -2616,7 +2616,7 @@ export declare enum TerminalKind {
    */
   AmpersandAmpersand = "AmpersandAmpersand",
   /**
-   * This kind represents a `AmpersandEqual` node, with the following structure:
+   * Represents a node with kind `AmpersandEqual`, having the following structure:
    *
    * ```ebnf
    * AMPERSAND_EQUAL = "&=";
@@ -2624,7 +2624,7 @@ export declare enum TerminalKind {
    */
   AmpersandEqual = "AmpersandEqual",
   /**
-   * This kind represents a `AnonymousKeyword` node, with the following structure:
+   * Represents a node with kind `AnonymousKeyword`, having the following structure:
    *
    * ```ebnf
    * ANONYMOUS_KEYWORD = "anonymous";
@@ -2632,7 +2632,7 @@ export declare enum TerminalKind {
    */
   AnonymousKeyword = "AnonymousKeyword",
   /**
-   * This kind represents a `ApplyKeyword` node, with the following structure:
+   * Represents a node with kind `ApplyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -2641,7 +2641,7 @@ export declare enum TerminalKind {
    */
   ApplyKeyword = "ApplyKeyword",
   /**
-   * This kind represents a `AsKeyword` node, with the following structure:
+   * Represents a node with kind `AsKeyword`, having the following structure:
    *
    * ```ebnf
    * AS_KEYWORD = "as";
@@ -2649,7 +2649,7 @@ export declare enum TerminalKind {
    */
   AsKeyword = "AsKeyword",
   /**
-   * This kind represents a `AssemblyKeyword` node, with the following structure:
+   * Represents a node with kind `AssemblyKeyword`, having the following structure:
    *
    * ```ebnf
    * ASSEMBLY_KEYWORD = "assembly";
@@ -2657,7 +2657,7 @@ export declare enum TerminalKind {
    */
   AssemblyKeyword = "AssemblyKeyword",
   /**
-   * This kind represents a `Asterisk` node, with the following structure:
+   * Represents a node with kind `Asterisk`, having the following structure:
    *
    * ```ebnf
    * ASTERISK = "*";
@@ -2665,7 +2665,7 @@ export declare enum TerminalKind {
    */
   Asterisk = "Asterisk",
   /**
-   * This kind represents a `AsteriskAsterisk` node, with the following structure:
+   * Represents a node with kind `AsteriskAsterisk`, having the following structure:
    *
    * ```ebnf
    * ASTERISK_ASTERISK = "**";
@@ -2673,7 +2673,7 @@ export declare enum TerminalKind {
    */
   AsteriskAsterisk = "AsteriskAsterisk",
   /**
-   * This kind represents a `AsteriskEqual` node, with the following structure:
+   * Represents a node with kind `AsteriskEqual`, having the following structure:
    *
    * ```ebnf
    * ASTERISK_EQUAL = "*=";
@@ -2681,7 +2681,7 @@ export declare enum TerminalKind {
    */
   AsteriskEqual = "AsteriskEqual",
   /**
-   * This kind represents a `AutoKeyword` node, with the following structure:
+   * Represents a node with kind `AutoKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -2690,7 +2690,7 @@ export declare enum TerminalKind {
    */
   AutoKeyword = "AutoKeyword",
   /**
-   * This kind represents a `Bang` node, with the following structure:
+   * Represents a node with kind `Bang`, having the following structure:
    *
    * ```ebnf
    * BANG = "!";
@@ -2698,7 +2698,7 @@ export declare enum TerminalKind {
    */
   Bang = "Bang",
   /**
-   * This kind represents a `BangEqual` node, with the following structure:
+   * Represents a node with kind `BangEqual`, having the following structure:
    *
    * ```ebnf
    * BANG_EQUAL = "!=";
@@ -2706,7 +2706,7 @@ export declare enum TerminalKind {
    */
   BangEqual = "BangEqual",
   /**
-   * This kind represents a `Bar` node, with the following structure:
+   * Represents a node with kind `Bar`, having the following structure:
    *
    * ```ebnf
    * BAR = "|";
@@ -2714,7 +2714,7 @@ export declare enum TerminalKind {
    */
   Bar = "Bar",
   /**
-   * This kind represents a `BarBar` node, with the following structure:
+   * Represents a node with kind `BarBar`, having the following structure:
    *
    * ```ebnf
    * BAR_BAR = "||";
@@ -2722,7 +2722,7 @@ export declare enum TerminalKind {
    */
   BarBar = "BarBar",
   /**
-   * This kind represents a `BarEqual` node, with the following structure:
+   * Represents a node with kind `BarEqual`, having the following structure:
    *
    * ```ebnf
    * BAR_EQUAL = "|=";
@@ -2730,7 +2730,7 @@ export declare enum TerminalKind {
    */
   BarEqual = "BarEqual",
   /**
-   * This kind represents a `BoolKeyword` node, with the following structure:
+   * Represents a node with kind `BoolKeyword`, having the following structure:
    *
    * ```ebnf
    * BOOL_KEYWORD = "bool";
@@ -2738,7 +2738,7 @@ export declare enum TerminalKind {
    */
   BoolKeyword = "BoolKeyword",
   /**
-   * This kind represents a `BreakKeyword` node, with the following structure:
+   * Represents a node with kind `BreakKeyword`, having the following structure:
    *
    * ```ebnf
    * BREAK_KEYWORD = "break";
@@ -2746,7 +2746,7 @@ export declare enum TerminalKind {
    */
   BreakKeyword = "BreakKeyword",
   /**
-   * This kind represents a `ByteKeyword` node, with the following structure:
+   * Represents a node with kind `ByteKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.8.0 *)
@@ -2755,7 +2755,7 @@ export declare enum TerminalKind {
    */
   ByteKeyword = "ByteKeyword",
   /**
-   * This kind represents a `BytesKeyword` node, with the following structure:
+   * Represents a node with kind `BytesKeyword`, having the following structure:
    *
    * ```ebnf
    * BYTES_KEYWORD = "bytes" ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32")?;
@@ -2763,7 +2763,7 @@ export declare enum TerminalKind {
    */
   BytesKeyword = "BytesKeyword",
   /**
-   * This kind represents a `CallDataKeyword` node, with the following structure:
+   * Represents a node with kind `CallDataKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.0 *)
@@ -2773,7 +2773,7 @@ export declare enum TerminalKind {
    */
   CallDataKeyword = "CallDataKeyword",
   /**
-   * This kind represents a `Caret` node, with the following structure:
+   * Represents a node with kind `Caret`, having the following structure:
    *
    * ```ebnf
    * CARET = "^";
@@ -2781,7 +2781,7 @@ export declare enum TerminalKind {
    */
   Caret = "Caret",
   /**
-   * This kind represents a `CaretEqual` node, with the following structure:
+   * Represents a node with kind `CaretEqual`, having the following structure:
    *
    * ```ebnf
    * CARET_EQUAL = "^=";
@@ -2789,7 +2789,7 @@ export declare enum TerminalKind {
    */
   CaretEqual = "CaretEqual",
   /**
-   * This kind represents a `CaseKeyword` node, with the following structure:
+   * Represents a node with kind `CaseKeyword`, having the following structure:
    *
    * ```ebnf
    * CASE_KEYWORD = "case";
@@ -2797,7 +2797,7 @@ export declare enum TerminalKind {
    */
   CaseKeyword = "CaseKeyword",
   /**
-   * This kind represents a `CatchKeyword` node, with the following structure:
+   * Represents a node with kind `CatchKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -2806,7 +2806,7 @@ export declare enum TerminalKind {
    */
   CatchKeyword = "CatchKeyword",
   /**
-   * This kind represents a `CloseBrace` node, with the following structure:
+   * Represents a node with kind `CloseBrace`, having the following structure:
    *
    * ```ebnf
    * CLOSE_BRACE = "}";
@@ -2814,7 +2814,7 @@ export declare enum TerminalKind {
    */
   CloseBrace = "CloseBrace",
   /**
-   * This kind represents a `CloseBracket` node, with the following structure:
+   * Represents a node with kind `CloseBracket`, having the following structure:
    *
    * ```ebnf
    * CLOSE_BRACKET = "]";
@@ -2822,7 +2822,7 @@ export declare enum TerminalKind {
    */
   CloseBracket = "CloseBracket",
   /**
-   * This kind represents a `CloseParen` node, with the following structure:
+   * Represents a node with kind `CloseParen`, having the following structure:
    *
    * ```ebnf
    * CLOSE_PAREN = ")";
@@ -2830,7 +2830,7 @@ export declare enum TerminalKind {
    */
   CloseParen = "CloseParen",
   /**
-   * This kind represents a `Colon` node, with the following structure:
+   * Represents a node with kind `Colon`, having the following structure:
    *
    * ```ebnf
    * COLON = ":";
@@ -2838,7 +2838,7 @@ export declare enum TerminalKind {
    */
   Colon = "Colon",
   /**
-   * This kind represents a `ColonEqual` node, with the following structure:
+   * Represents a node with kind `ColonEqual`, having the following structure:
    *
    * ```ebnf
    * COLON_EQUAL = ":=";
@@ -2846,7 +2846,7 @@ export declare enum TerminalKind {
    */
   ColonEqual = "ColonEqual",
   /**
-   * This kind represents a `Comma` node, with the following structure:
+   * Represents a node with kind `Comma`, having the following structure:
    *
    * ```ebnf
    * COMMA = ",";
@@ -2854,7 +2854,7 @@ export declare enum TerminalKind {
    */
   Comma = "Comma",
   /**
-   * This kind represents a `ConstantKeyword` node, with the following structure:
+   * Represents a node with kind `ConstantKeyword`, having the following structure:
    *
    * ```ebnf
    * CONSTANT_KEYWORD = "constant";
@@ -2862,7 +2862,7 @@ export declare enum TerminalKind {
    */
   ConstantKeyword = "ConstantKeyword",
   /**
-   * This kind represents a `ConstructorKeyword` node, with the following structure:
+   * Represents a node with kind `ConstructorKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.22 *)
@@ -2872,7 +2872,7 @@ export declare enum TerminalKind {
    */
   ConstructorKeyword = "ConstructorKeyword",
   /**
-   * This kind represents a `ContinueKeyword` node, with the following structure:
+   * Represents a node with kind `ContinueKeyword`, having the following structure:
    *
    * ```ebnf
    * CONTINUE_KEYWORD = "continue";
@@ -2880,7 +2880,7 @@ export declare enum TerminalKind {
    */
   ContinueKeyword = "ContinueKeyword",
   /**
-   * This kind represents a `ContractKeyword` node, with the following structure:
+   * Represents a node with kind `ContractKeyword`, having the following structure:
    *
    * ```ebnf
    * CONTRACT_KEYWORD = "contract";
@@ -2888,7 +2888,7 @@ export declare enum TerminalKind {
    */
   ContractKeyword = "ContractKeyword",
   /**
-   * This kind represents a `CopyOfKeyword` node, with the following structure:
+   * Represents a node with kind `CopyOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -2897,7 +2897,7 @@ export declare enum TerminalKind {
    */
   CopyOfKeyword = "CopyOfKeyword",
   /**
-   * This kind represents a `DaysKeyword` node, with the following structure:
+   * Represents a node with kind `DaysKeyword`, having the following structure:
    *
    * ```ebnf
    * DAYS_KEYWORD = "days";
@@ -2905,7 +2905,7 @@ export declare enum TerminalKind {
    */
   DaysKeyword = "DaysKeyword",
   /**
-   * This kind represents a `DecimalLiteral` node, with the following structure:
+   * Represents a node with kind `DecimalLiteral`, having the following structure:
    *
    * ```ebnf
    * DECIMAL_LITERAL = "." «DECIMAL_DIGITS» «DECIMAL_EXPONENT»?;
@@ -2924,7 +2924,7 @@ export declare enum TerminalKind {
    */
   DecimalLiteral = "DecimalLiteral",
   /**
-   * This kind represents a `DefaultKeyword` node, with the following structure:
+   * Represents a node with kind `DefaultKeyword`, having the following structure:
    *
    * ```ebnf
    * DEFAULT_KEYWORD = "default";
@@ -2932,7 +2932,7 @@ export declare enum TerminalKind {
    */
   DefaultKeyword = "DefaultKeyword",
   /**
-   * This kind represents a `DefineKeyword` node, with the following structure:
+   * Represents a node with kind `DefineKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -2941,7 +2941,7 @@ export declare enum TerminalKind {
    */
   DefineKeyword = "DefineKeyword",
   /**
-   * This kind represents a `DeleteKeyword` node, with the following structure:
+   * Represents a node with kind `DeleteKeyword`, having the following structure:
    *
    * ```ebnf
    * DELETE_KEYWORD = "delete";
@@ -2949,7 +2949,7 @@ export declare enum TerminalKind {
    */
   DeleteKeyword = "DeleteKeyword",
   /**
-   * This kind represents a `DoKeyword` node, with the following structure:
+   * Represents a node with kind `DoKeyword`, having the following structure:
    *
    * ```ebnf
    * DO_KEYWORD = "do";
@@ -2957,7 +2957,7 @@ export declare enum TerminalKind {
    */
   DoKeyword = "DoKeyword",
   /**
-   * This kind represents a `DoubleQuotedHexStringLiteral` node, with the following structure:
+   * Represents a node with kind `DoubleQuotedHexStringLiteral`, having the following structure:
    *
    * ```ebnf
    * DOUBLE_QUOTED_HEX_STRING_LITERAL = 'hex"' «HEX_STRING_CONTENTS»? '"';
@@ -2965,7 +2965,7 @@ export declare enum TerminalKind {
    */
   DoubleQuotedHexStringLiteral = "DoubleQuotedHexStringLiteral",
   /**
-   * This kind represents a `DoubleQuotedStringLiteral` node, with the following structure:
+   * Represents a node with kind `DoubleQuotedStringLiteral`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.4.25 *)
@@ -2979,7 +2979,7 @@ export declare enum TerminalKind {
    */
   DoubleQuotedStringLiteral = "DoubleQuotedStringLiteral",
   /**
-   * This kind represents a `DoubleQuotedUnicodeStringLiteral` node, with the following structure:
+   * Represents a node with kind `DoubleQuotedUnicodeStringLiteral`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.7.0 *)
@@ -2988,7 +2988,7 @@ export declare enum TerminalKind {
    */
   DoubleQuotedUnicodeStringLiteral = "DoubleQuotedUnicodeStringLiteral",
   /**
-   * This kind represents a `DoubleQuotedVersionLiteral` node, with the following structure:
+   * Represents a node with kind `DoubleQuotedVersionLiteral`, having the following structure:
    *
    * ```ebnf
    * DOUBLE_QUOTED_VERSION_LITERAL = '"' «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* '"';
@@ -2996,7 +2996,7 @@ export declare enum TerminalKind {
    */
   DoubleQuotedVersionLiteral = "DoubleQuotedVersionLiteral",
   /**
-   * This kind represents a `ElseKeyword` node, with the following structure:
+   * Represents a node with kind `ElseKeyword`, having the following structure:
    *
    * ```ebnf
    * ELSE_KEYWORD = "else";
@@ -3004,7 +3004,7 @@ export declare enum TerminalKind {
    */
   ElseKeyword = "ElseKeyword",
   /**
-   * This kind represents a `EmitKeyword` node, with the following structure:
+   * Represents a node with kind `EmitKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.21 *)
@@ -3014,7 +3014,7 @@ export declare enum TerminalKind {
    */
   EmitKeyword = "EmitKeyword",
   /**
-   * This kind represents a `EndOfLine` node, with the following structure:
+   * Represents a node with kind `EndOfLine`, having the following structure:
    *
    * ```ebnf
    * END_OF_LINE = "\n" | ("\r" "\n"?);
@@ -3022,7 +3022,7 @@ export declare enum TerminalKind {
    */
   EndOfLine = "EndOfLine",
   /**
-   * This kind represents a `EnumKeyword` node, with the following structure:
+   * Represents a node with kind `EnumKeyword`, having the following structure:
    *
    * ```ebnf
    * ENUM_KEYWORD = "enum";
@@ -3030,7 +3030,7 @@ export declare enum TerminalKind {
    */
   EnumKeyword = "EnumKeyword",
   /**
-   * This kind represents a `Equal` node, with the following structure:
+   * Represents a node with kind `Equal`, having the following structure:
    *
    * ```ebnf
    * EQUAL = "=";
@@ -3038,7 +3038,7 @@ export declare enum TerminalKind {
    */
   Equal = "Equal",
   /**
-   * This kind represents a `EqualColon` node, with the following structure:
+   * Represents a node with kind `EqualColon`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -3047,7 +3047,7 @@ export declare enum TerminalKind {
    */
   EqualColon = "EqualColon",
   /**
-   * This kind represents a `EqualEqual` node, with the following structure:
+   * Represents a node with kind `EqualEqual`, having the following structure:
    *
    * ```ebnf
    * EQUAL_EQUAL = "==";
@@ -3055,7 +3055,7 @@ export declare enum TerminalKind {
    */
   EqualEqual = "EqualEqual",
   /**
-   * This kind represents a `EqualGreaterThan` node, with the following structure:
+   * Represents a node with kind `EqualGreaterThan`, having the following structure:
    *
    * ```ebnf
    * EQUAL_GREATER_THAN = "=>";
@@ -3063,7 +3063,7 @@ export declare enum TerminalKind {
    */
   EqualGreaterThan = "EqualGreaterThan",
   /**
-   * This kind represents a `ErrorKeyword` node, with the following structure:
+   * Represents a node with kind `ErrorKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -3073,7 +3073,7 @@ export declare enum TerminalKind {
    */
   ErrorKeyword = "ErrorKeyword",
   /**
-   * This kind represents a `EtherKeyword` node, with the following structure:
+   * Represents a node with kind `EtherKeyword`, having the following structure:
    *
    * ```ebnf
    * ETHER_KEYWORD = "ether";
@@ -3081,7 +3081,7 @@ export declare enum TerminalKind {
    */
   EtherKeyword = "EtherKeyword",
   /**
-   * This kind represents a `EventKeyword` node, with the following structure:
+   * Represents a node with kind `EventKeyword`, having the following structure:
    *
    * ```ebnf
    * EVENT_KEYWORD = "event";
@@ -3089,7 +3089,7 @@ export declare enum TerminalKind {
    */
   EventKeyword = "EventKeyword",
   /**
-   * This kind represents a `ExperimentalKeyword` node, with the following structure:
+   * Represents a node with kind `ExperimentalKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -3098,7 +3098,7 @@ export declare enum TerminalKind {
    */
   ExperimentalKeyword = "ExperimentalKeyword",
   /**
-   * This kind represents a `ExternalKeyword` node, with the following structure:
+   * Represents a node with kind `ExternalKeyword`, having the following structure:
    *
    * ```ebnf
    * EXTERNAL_KEYWORD = "external";
@@ -3106,7 +3106,7 @@ export declare enum TerminalKind {
    */
   ExternalKeyword = "ExternalKeyword",
   /**
-   * This kind represents a `FallbackKeyword` node, with the following structure:
+   * Represents a node with kind `FallbackKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.6.0 *)
@@ -3115,7 +3115,7 @@ export declare enum TerminalKind {
    */
   FallbackKeyword = "FallbackKeyword",
   /**
-   * This kind represents a `FalseKeyword` node, with the following structure:
+   * Represents a node with kind `FalseKeyword`, having the following structure:
    *
    * ```ebnf
    * FALSE_KEYWORD = "false";
@@ -3123,7 +3123,7 @@ export declare enum TerminalKind {
    */
   FalseKeyword = "FalseKeyword",
   /**
-   * This kind represents a `FinalKeyword` node, with the following structure:
+   * Represents a node with kind `FinalKeyword`, having the following structure:
    *
    * ```ebnf
    * FINAL_KEYWORD = "final";
@@ -3131,7 +3131,7 @@ export declare enum TerminalKind {
    */
   FinalKeyword = "FinalKeyword",
   /**
-   * This kind represents a `FinneyKeyword` node, with the following structure:
+   * Represents a node with kind `FinneyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.7.0 *)
@@ -3141,7 +3141,7 @@ export declare enum TerminalKind {
    */
   FinneyKeyword = "FinneyKeyword",
   /**
-   * This kind represents a `FixedKeyword` node, with the following structure:
+   * Represents a node with kind `FixedKeyword`, having the following structure:
    *
    * ```ebnf
    * FIXED_KEYWORD = "fixed";
@@ -3159,7 +3159,7 @@ export declare enum TerminalKind {
    */
   FixedKeyword = "FixedKeyword",
   /**
-   * This kind represents a `ForKeyword` node, with the following structure:
+   * Represents a node with kind `ForKeyword`, having the following structure:
    *
    * ```ebnf
    * FOR_KEYWORD = "for";
@@ -3167,7 +3167,7 @@ export declare enum TerminalKind {
    */
   ForKeyword = "ForKeyword",
   /**
-   * This kind represents a `FromKeyword` node, with the following structure:
+   * Represents a node with kind `FromKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -3176,7 +3176,7 @@ export declare enum TerminalKind {
    */
   FromKeyword = "FromKeyword",
   /**
-   * This kind represents a `FunctionKeyword` node, with the following structure:
+   * Represents a node with kind `FunctionKeyword`, having the following structure:
    *
    * ```ebnf
    * FUNCTION_KEYWORD = "function";
@@ -3184,7 +3184,7 @@ export declare enum TerminalKind {
    */
   FunctionKeyword = "FunctionKeyword",
   /**
-   * This kind represents a `GlobalKeyword` node, with the following structure:
+   * Represents a node with kind `GlobalKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.13 *)
@@ -3194,7 +3194,7 @@ export declare enum TerminalKind {
    */
   GlobalKeyword = "GlobalKeyword",
   /**
-   * This kind represents a `GreaterThan` node, with the following structure:
+   * Represents a node with kind `GreaterThan`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN = ">";
@@ -3202,7 +3202,7 @@ export declare enum TerminalKind {
    */
   GreaterThan = "GreaterThan",
   /**
-   * This kind represents a `GreaterThanEqual` node, with the following structure:
+   * Represents a node with kind `GreaterThanEqual`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN_EQUAL = ">=";
@@ -3210,7 +3210,7 @@ export declare enum TerminalKind {
    */
   GreaterThanEqual = "GreaterThanEqual",
   /**
-   * This kind represents a `GreaterThanGreaterThan` node, with the following structure:
+   * Represents a node with kind `GreaterThanGreaterThan`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN_GREATER_THAN = ">>";
@@ -3218,7 +3218,7 @@ export declare enum TerminalKind {
    */
   GreaterThanGreaterThan = "GreaterThanGreaterThan",
   /**
-   * This kind represents a `GreaterThanGreaterThanEqual` node, with the following structure:
+   * Represents a node with kind `GreaterThanGreaterThanEqual`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN_GREATER_THAN_EQUAL = ">>=";
@@ -3226,7 +3226,7 @@ export declare enum TerminalKind {
    */
   GreaterThanGreaterThanEqual = "GreaterThanGreaterThanEqual",
   /**
-   * This kind represents a `GreaterThanGreaterThanGreaterThan` node, with the following structure:
+   * Represents a node with kind `GreaterThanGreaterThanGreaterThan`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN_GREATER_THAN_GREATER_THAN = ">>>";
@@ -3234,7 +3234,7 @@ export declare enum TerminalKind {
    */
   GreaterThanGreaterThanGreaterThan = "GreaterThanGreaterThanGreaterThan",
   /**
-   * This kind represents a `GreaterThanGreaterThanGreaterThanEqual` node, with the following structure:
+   * Represents a node with kind `GreaterThanGreaterThanGreaterThanEqual`, having the following structure:
    *
    * ```ebnf
    * GREATER_THAN_GREATER_THAN_GREATER_THAN_EQUAL = ">>>=";
@@ -3242,7 +3242,7 @@ export declare enum TerminalKind {
    */
   GreaterThanGreaterThanGreaterThanEqual = "GreaterThanGreaterThanGreaterThanEqual",
   /**
-   * This kind represents a `GweiKeyword` node, with the following structure:
+   * Represents a node with kind `GweiKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.11 *)
@@ -3252,7 +3252,7 @@ export declare enum TerminalKind {
    */
   GweiKeyword = "GweiKeyword",
   /**
-   * This kind represents a `HexKeyword` node, with the following structure:
+   * Represents a node with kind `HexKeyword`, having the following structure:
    *
    * ```ebnf
    * HEX_KEYWORD = "hex";
@@ -3260,7 +3260,7 @@ export declare enum TerminalKind {
    */
   HexKeyword = "HexKeyword",
   /**
-   * This kind represents a `HexLiteral` node, with the following structure:
+   * Represents a node with kind `HexLiteral`, having the following structure:
    *
    * ```ebnf
    * HEX_LITERAL = "0x" «HEX_CHARACTER»+ ("_" «HEX_CHARACTER»+)*;
@@ -3271,7 +3271,7 @@ export declare enum TerminalKind {
    */
   HexLiteral = "HexLiteral",
   /**
-   * This kind represents a `HoursKeyword` node, with the following structure:
+   * Represents a node with kind `HoursKeyword`, having the following structure:
    *
    * ```ebnf
    * HOURS_KEYWORD = "hours";
@@ -3279,7 +3279,7 @@ export declare enum TerminalKind {
    */
   HoursKeyword = "HoursKeyword",
   /**
-   * This kind represents a `Identifier` node, with the following structure:
+   * Represents a node with kind `Identifier`, having the following structure:
    *
    * ```ebnf
    * IDENTIFIER = «IDENTIFIER_START» «IDENTIFIER_PART»*;
@@ -3287,7 +3287,7 @@ export declare enum TerminalKind {
    */
   Identifier = "Identifier",
   /**
-   * This kind represents a `IfKeyword` node, with the following structure:
+   * Represents a node with kind `IfKeyword`, having the following structure:
    *
    * ```ebnf
    * IF_KEYWORD = "if";
@@ -3295,7 +3295,7 @@ export declare enum TerminalKind {
    */
   IfKeyword = "IfKeyword",
   /**
-   * This kind represents a `ImmutableKeyword` node, with the following structure:
+   * Represents a node with kind `ImmutableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.5 *)
@@ -3305,7 +3305,7 @@ export declare enum TerminalKind {
    */
   ImmutableKeyword = "ImmutableKeyword",
   /**
-   * This kind represents a `ImplementsKeyword` node, with the following structure:
+   * Represents a node with kind `ImplementsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3314,7 +3314,7 @@ export declare enum TerminalKind {
    */
   ImplementsKeyword = "ImplementsKeyword",
   /**
-   * This kind represents a `ImportKeyword` node, with the following structure:
+   * Represents a node with kind `ImportKeyword`, having the following structure:
    *
    * ```ebnf
    * IMPORT_KEYWORD = "import";
@@ -3322,7 +3322,7 @@ export declare enum TerminalKind {
    */
   ImportKeyword = "ImportKeyword",
   /**
-   * This kind represents a `InKeyword` node, with the following structure:
+   * Represents a node with kind `InKeyword`, having the following structure:
    *
    * ```ebnf
    * IN_KEYWORD = "in";
@@ -3330,7 +3330,7 @@ export declare enum TerminalKind {
    */
   InKeyword = "InKeyword",
   /**
-   * This kind represents a `IndexedKeyword` node, with the following structure:
+   * Represents a node with kind `IndexedKeyword`, having the following structure:
    *
    * ```ebnf
    * INDEXED_KEYWORD = "indexed";
@@ -3338,7 +3338,7 @@ export declare enum TerminalKind {
    */
   IndexedKeyword = "IndexedKeyword",
   /**
-   * This kind represents a `InlineKeyword` node, with the following structure:
+   * Represents a node with kind `InlineKeyword`, having the following structure:
    *
    * ```ebnf
    * INLINE_KEYWORD = "inline";
@@ -3346,7 +3346,7 @@ export declare enum TerminalKind {
    */
   InlineKeyword = "InlineKeyword",
   /**
-   * This kind represents a `IntKeyword` node, with the following structure:
+   * Represents a node with kind `IntKeyword`, having the following structure:
    *
    * ```ebnf
    * INT_KEYWORD = "int" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
@@ -3354,7 +3354,7 @@ export declare enum TerminalKind {
    */
   IntKeyword = "IntKeyword",
   /**
-   * This kind represents a `InterfaceKeyword` node, with the following structure:
+   * Represents a node with kind `InterfaceKeyword`, having the following structure:
    *
    * ```ebnf
    * INTERFACE_KEYWORD = "interface";
@@ -3362,7 +3362,7 @@ export declare enum TerminalKind {
    */
   InterfaceKeyword = "InterfaceKeyword",
   /**
-   * This kind represents a `InternalKeyword` node, with the following structure:
+   * Represents a node with kind `InternalKeyword`, having the following structure:
    *
    * ```ebnf
    * INTERNAL_KEYWORD = "internal";
@@ -3370,7 +3370,7 @@ export declare enum TerminalKind {
    */
   InternalKeyword = "InternalKeyword",
   /**
-   * This kind represents a `IsKeyword` node, with the following structure:
+   * Represents a node with kind `IsKeyword`, having the following structure:
    *
    * ```ebnf
    * IS_KEYWORD = "is";
@@ -3378,7 +3378,7 @@ export declare enum TerminalKind {
    */
   IsKeyword = "IsKeyword",
   /**
-   * This kind represents a `LessThan` node, with the following structure:
+   * Represents a node with kind `LessThan`, having the following structure:
    *
    * ```ebnf
    * LESS_THAN = "<";
@@ -3386,7 +3386,7 @@ export declare enum TerminalKind {
    */
   LessThan = "LessThan",
   /**
-   * This kind represents a `LessThanEqual` node, with the following structure:
+   * Represents a node with kind `LessThanEqual`, having the following structure:
    *
    * ```ebnf
    * LESS_THAN_EQUAL = "<=";
@@ -3394,7 +3394,7 @@ export declare enum TerminalKind {
    */
   LessThanEqual = "LessThanEqual",
   /**
-   * This kind represents a `LessThanLessThan` node, with the following structure:
+   * Represents a node with kind `LessThanLessThan`, having the following structure:
    *
    * ```ebnf
    * LESS_THAN_LESS_THAN = "<<";
@@ -3402,7 +3402,7 @@ export declare enum TerminalKind {
    */
   LessThanLessThan = "LessThanLessThan",
   /**
-   * This kind represents a `LessThanLessThanEqual` node, with the following structure:
+   * Represents a node with kind `LessThanLessThanEqual`, having the following structure:
    *
    * ```ebnf
    * LESS_THAN_LESS_THAN_EQUAL = "<<=";
@@ -3410,7 +3410,7 @@ export declare enum TerminalKind {
    */
   LessThanLessThanEqual = "LessThanLessThanEqual",
   /**
-   * This kind represents a `LetKeyword` node, with the following structure:
+   * Represents a node with kind `LetKeyword`, having the following structure:
    *
    * ```ebnf
    * LET_KEYWORD = "let";
@@ -3418,7 +3418,7 @@ export declare enum TerminalKind {
    */
   LetKeyword = "LetKeyword",
   /**
-   * This kind represents a `LibraryKeyword` node, with the following structure:
+   * Represents a node with kind `LibraryKeyword`, having the following structure:
    *
    * ```ebnf
    * LIBRARY_KEYWORD = "library";
@@ -3426,7 +3426,7 @@ export declare enum TerminalKind {
    */
   LibraryKeyword = "LibraryKeyword",
   /**
-   * This kind represents a `MacroKeyword` node, with the following structure:
+   * Represents a node with kind `MacroKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3435,7 +3435,7 @@ export declare enum TerminalKind {
    */
   MacroKeyword = "MacroKeyword",
   /**
-   * This kind represents a `MappingKeyword` node, with the following structure:
+   * Represents a node with kind `MappingKeyword`, having the following structure:
    *
    * ```ebnf
    * MAPPING_KEYWORD = "mapping";
@@ -3443,7 +3443,7 @@ export declare enum TerminalKind {
    */
   MappingKeyword = "MappingKeyword",
   /**
-   * This kind represents a `MatchKeyword` node, with the following structure:
+   * Represents a node with kind `MatchKeyword`, having the following structure:
    *
    * ```ebnf
    * MATCH_KEYWORD = "match";
@@ -3451,7 +3451,7 @@ export declare enum TerminalKind {
    */
   MatchKeyword = "MatchKeyword",
   /**
-   * This kind represents a `MemoryKeyword` node, with the following structure:
+   * Represents a node with kind `MemoryKeyword`, having the following structure:
    *
    * ```ebnf
    * MEMORY_KEYWORD = "memory";
@@ -3459,7 +3459,7 @@ export declare enum TerminalKind {
    */
   MemoryKeyword = "MemoryKeyword",
   /**
-   * This kind represents a `Minus` node, with the following structure:
+   * Represents a node with kind `Minus`, having the following structure:
    *
    * ```ebnf
    * MINUS = "-";
@@ -3467,7 +3467,7 @@ export declare enum TerminalKind {
    */
   Minus = "Minus",
   /**
-   * This kind represents a `MinusEqual` node, with the following structure:
+   * Represents a node with kind `MinusEqual`, having the following structure:
    *
    * ```ebnf
    * MINUS_EQUAL = "-=";
@@ -3475,7 +3475,7 @@ export declare enum TerminalKind {
    */
   MinusEqual = "MinusEqual",
   /**
-   * This kind represents a `MinusGreaterThan` node, with the following structure:
+   * Represents a node with kind `MinusGreaterThan`, having the following structure:
    *
    * ```ebnf
    * MINUS_GREATER_THAN = "->";
@@ -3483,7 +3483,7 @@ export declare enum TerminalKind {
    */
   MinusGreaterThan = "MinusGreaterThan",
   /**
-   * This kind represents a `MinusMinus` node, with the following structure:
+   * Represents a node with kind `MinusMinus`, having the following structure:
    *
    * ```ebnf
    * MINUS_MINUS = "--";
@@ -3491,7 +3491,7 @@ export declare enum TerminalKind {
    */
   MinusMinus = "MinusMinus",
   /**
-   * This kind represents a `MinutesKeyword` node, with the following structure:
+   * Represents a node with kind `MinutesKeyword`, having the following structure:
    *
    * ```ebnf
    * MINUTES_KEYWORD = "minutes";
@@ -3499,7 +3499,7 @@ export declare enum TerminalKind {
    */
   MinutesKeyword = "MinutesKeyword",
   /**
-   * This kind represents a `ModifierKeyword` node, with the following structure:
+   * Represents a node with kind `ModifierKeyword`, having the following structure:
    *
    * ```ebnf
    * MODIFIER_KEYWORD = "modifier";
@@ -3507,7 +3507,7 @@ export declare enum TerminalKind {
    */
   ModifierKeyword = "ModifierKeyword",
   /**
-   * This kind represents a `MultiLineComment` node, with the following structure:
+   * Represents a node with kind `MultiLineComment`, having the following structure:
    *
    * ```ebnf
    * MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*\/";
@@ -3515,7 +3515,7 @@ export declare enum TerminalKind {
    */
   MultiLineComment = "MultiLineComment",
   /**
-   * This kind represents a `MultiLineNatSpecComment` node, with the following structure:
+   * Represents a node with kind `MultiLineNatSpecComment`, having the following structure:
    *
    * ```ebnf
    * MULTI_LINE_NAT_SPEC_COMMENT = "/**" (!"*" | "*")* "*\/";
@@ -3523,7 +3523,7 @@ export declare enum TerminalKind {
    */
   MultiLineNatSpecComment = "MultiLineNatSpecComment",
   /**
-   * This kind represents a `MutableKeyword` node, with the following structure:
+   * Represents a node with kind `MutableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3532,7 +3532,7 @@ export declare enum TerminalKind {
    */
   MutableKeyword = "MutableKeyword",
   /**
-   * This kind represents a `NewKeyword` node, with the following structure:
+   * Represents a node with kind `NewKeyword`, having the following structure:
    *
    * ```ebnf
    * NEW_KEYWORD = "new";
@@ -3540,7 +3540,7 @@ export declare enum TerminalKind {
    */
   NewKeyword = "NewKeyword",
   /**
-   * This kind represents a `NullKeyword` node, with the following structure:
+   * Represents a node with kind `NullKeyword`, having the following structure:
    *
    * ```ebnf
    * NULL_KEYWORD = "null";
@@ -3548,7 +3548,7 @@ export declare enum TerminalKind {
    */
   NullKeyword = "NullKeyword",
   /**
-   * This kind represents a `OfKeyword` node, with the following structure:
+   * Represents a node with kind `OfKeyword`, having the following structure:
    *
    * ```ebnf
    * OF_KEYWORD = "of";
@@ -3556,7 +3556,7 @@ export declare enum TerminalKind {
    */
   OfKeyword = "OfKeyword",
   /**
-   * This kind represents a `OpenBrace` node, with the following structure:
+   * Represents a node with kind `OpenBrace`, having the following structure:
    *
    * ```ebnf
    * OPEN_BRACE = "{";
@@ -3564,7 +3564,7 @@ export declare enum TerminalKind {
    */
   OpenBrace = "OpenBrace",
   /**
-   * This kind represents a `OpenBracket` node, with the following structure:
+   * Represents a node with kind `OpenBracket`, having the following structure:
    *
    * ```ebnf
    * OPEN_BRACKET = "[";
@@ -3572,7 +3572,7 @@ export declare enum TerminalKind {
    */
   OpenBracket = "OpenBracket",
   /**
-   * This kind represents a `OpenParen` node, with the following structure:
+   * Represents a node with kind `OpenParen`, having the following structure:
    *
    * ```ebnf
    * OPEN_PAREN = "(";
@@ -3580,7 +3580,7 @@ export declare enum TerminalKind {
    */
   OpenParen = "OpenParen",
   /**
-   * This kind represents a `OverrideKeyword` node, with the following structure:
+   * Represents a node with kind `OverrideKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -3590,7 +3590,7 @@ export declare enum TerminalKind {
    */
   OverrideKeyword = "OverrideKeyword",
   /**
-   * This kind represents a `PartialKeyword` node, with the following structure:
+   * Represents a node with kind `PartialKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3599,7 +3599,7 @@ export declare enum TerminalKind {
    */
   PartialKeyword = "PartialKeyword",
   /**
-   * This kind represents a `PayableKeyword` node, with the following structure:
+   * Represents a node with kind `PayableKeyword`, having the following structure:
    *
    * ```ebnf
    * PAYABLE_KEYWORD = "payable";
@@ -3607,7 +3607,7 @@ export declare enum TerminalKind {
    */
   PayableKeyword = "PayableKeyword",
   /**
-   * This kind represents a `Percent` node, with the following structure:
+   * Represents a node with kind `Percent`, having the following structure:
    *
    * ```ebnf
    * PERCENT = "%";
@@ -3615,7 +3615,7 @@ export declare enum TerminalKind {
    */
   Percent = "Percent",
   /**
-   * This kind represents a `PercentEqual` node, with the following structure:
+   * Represents a node with kind `PercentEqual`, having the following structure:
    *
    * ```ebnf
    * PERCENT_EQUAL = "%=";
@@ -3623,7 +3623,7 @@ export declare enum TerminalKind {
    */
   PercentEqual = "PercentEqual",
   /**
-   * This kind represents a `Period` node, with the following structure:
+   * Represents a node with kind `Period`, having the following structure:
    *
    * ```ebnf
    * PERIOD = ".";
@@ -3631,7 +3631,7 @@ export declare enum TerminalKind {
    */
   Period = "Period",
   /**
-   * This kind represents a `Plus` node, with the following structure:
+   * Represents a node with kind `Plus`, having the following structure:
    *
    * ```ebnf
    * PLUS = "+";
@@ -3639,7 +3639,7 @@ export declare enum TerminalKind {
    */
   Plus = "Plus",
   /**
-   * This kind represents a `PlusEqual` node, with the following structure:
+   * Represents a node with kind `PlusEqual`, having the following structure:
    *
    * ```ebnf
    * PLUS_EQUAL = "+=";
@@ -3647,7 +3647,7 @@ export declare enum TerminalKind {
    */
   PlusEqual = "PlusEqual",
   /**
-   * This kind represents a `PlusPlus` node, with the following structure:
+   * Represents a node with kind `PlusPlus`, having the following structure:
    *
    * ```ebnf
    * PLUS_PLUS = "++";
@@ -3655,7 +3655,7 @@ export declare enum TerminalKind {
    */
   PlusPlus = "PlusPlus",
   /**
-   * This kind represents a `PragmaKeyword` node, with the following structure:
+   * Represents a node with kind `PragmaKeyword`, having the following structure:
    *
    * ```ebnf
    * PRAGMA_KEYWORD = "pragma";
@@ -3663,7 +3663,7 @@ export declare enum TerminalKind {
    */
   PragmaKeyword = "PragmaKeyword",
   /**
-   * This kind represents a `PrivateKeyword` node, with the following structure:
+   * Represents a node with kind `PrivateKeyword`, having the following structure:
    *
    * ```ebnf
    * PRIVATE_KEYWORD = "private";
@@ -3671,7 +3671,7 @@ export declare enum TerminalKind {
    */
   PrivateKeyword = "PrivateKeyword",
   /**
-   * This kind represents a `PromiseKeyword` node, with the following structure:
+   * Represents a node with kind `PromiseKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3680,7 +3680,7 @@ export declare enum TerminalKind {
    */
   PromiseKeyword = "PromiseKeyword",
   /**
-   * This kind represents a `PublicKeyword` node, with the following structure:
+   * Represents a node with kind `PublicKeyword`, having the following structure:
    *
    * ```ebnf
    * PUBLIC_KEYWORD = "public";
@@ -3688,7 +3688,7 @@ export declare enum TerminalKind {
    */
   PublicKeyword = "PublicKeyword",
   /**
-   * This kind represents a `PureKeyword` node, with the following structure:
+   * Represents a node with kind `PureKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.16 *)
@@ -3697,7 +3697,7 @@ export declare enum TerminalKind {
    */
   PureKeyword = "PureKeyword",
   /**
-   * This kind represents a `QuestionMark` node, with the following structure:
+   * Represents a node with kind `QuestionMark`, having the following structure:
    *
    * ```ebnf
    * QUESTION_MARK = "?";
@@ -3705,7 +3705,7 @@ export declare enum TerminalKind {
    */
   QuestionMark = "QuestionMark",
   /**
-   * This kind represents a `ReceiveKeyword` node, with the following structure:
+   * Represents a node with kind `ReceiveKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.6.0 *)
@@ -3714,7 +3714,7 @@ export declare enum TerminalKind {
    */
   ReceiveKeyword = "ReceiveKeyword",
   /**
-   * This kind represents a `ReferenceKeyword` node, with the following structure:
+   * Represents a node with kind `ReferenceKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3723,7 +3723,7 @@ export declare enum TerminalKind {
    */
   ReferenceKeyword = "ReferenceKeyword",
   /**
-   * This kind represents a `RelocatableKeyword` node, with the following structure:
+   * Represents a node with kind `RelocatableKeyword`, having the following structure:
    *
    * ```ebnf
    * RELOCATABLE_KEYWORD = "relocatable";
@@ -3731,7 +3731,7 @@ export declare enum TerminalKind {
    */
   RelocatableKeyword = "RelocatableKeyword",
   /**
-   * This kind represents a `ReturnKeyword` node, with the following structure:
+   * Represents a node with kind `ReturnKeyword`, having the following structure:
    *
    * ```ebnf
    * RETURN_KEYWORD = "return";
@@ -3739,7 +3739,7 @@ export declare enum TerminalKind {
    */
   ReturnKeyword = "ReturnKeyword",
   /**
-   * This kind represents a `ReturnsKeyword` node, with the following structure:
+   * Represents a node with kind `ReturnsKeyword`, having the following structure:
    *
    * ```ebnf
    * RETURNS_KEYWORD = "returns";
@@ -3747,7 +3747,7 @@ export declare enum TerminalKind {
    */
   ReturnsKeyword = "ReturnsKeyword",
   /**
-   * This kind represents a `RevertKeyword` node, with the following structure:
+   * Represents a node with kind `RevertKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.4 *)
@@ -3757,7 +3757,7 @@ export declare enum TerminalKind {
    */
   RevertKeyword = "RevertKeyword",
   /**
-   * This kind represents a `SealedKeyword` node, with the following structure:
+   * Represents a node with kind `SealedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3766,7 +3766,7 @@ export declare enum TerminalKind {
    */
   SealedKeyword = "SealedKeyword",
   /**
-   * This kind represents a `SecondsKeyword` node, with the following structure:
+   * Represents a node with kind `SecondsKeyword`, having the following structure:
    *
    * ```ebnf
    * SECONDS_KEYWORD = "seconds";
@@ -3774,7 +3774,7 @@ export declare enum TerminalKind {
    */
   SecondsKeyword = "SecondsKeyword",
   /**
-   * This kind represents a `Semicolon` node, with the following structure:
+   * Represents a node with kind `Semicolon`, having the following structure:
    *
    * ```ebnf
    * SEMICOLON = ";";
@@ -3782,7 +3782,7 @@ export declare enum TerminalKind {
    */
   Semicolon = "Semicolon",
   /**
-   * This kind represents a `SingleLineComment` node, with the following structure:
+   * Represents a node with kind `SingleLineComment`, having the following structure:
    *
    * ```ebnf
    * SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
@@ -3790,7 +3790,7 @@ export declare enum TerminalKind {
    */
   SingleLineComment = "SingleLineComment",
   /**
-   * This kind represents a `SingleLineNatSpecComment` node, with the following structure:
+   * Represents a node with kind `SingleLineNatSpecComment`, having the following structure:
    *
    * ```ebnf
    * SINGLE_LINE_NAT_SPEC_COMMENT = "///" (!("\r" "\n"))*;
@@ -3798,7 +3798,7 @@ export declare enum TerminalKind {
    */
   SingleLineNatSpecComment = "SingleLineNatSpecComment",
   /**
-   * This kind represents a `SingleQuotedHexStringLiteral` node, with the following structure:
+   * Represents a node with kind `SingleQuotedHexStringLiteral`, having the following structure:
    *
    * ```ebnf
    * SINGLE_QUOTED_HEX_STRING_LITERAL = "hex'" «HEX_STRING_CONTENTS»? "'";
@@ -3806,7 +3806,7 @@ export declare enum TerminalKind {
    */
   SingleQuotedHexStringLiteral = "SingleQuotedHexStringLiteral",
   /**
-   * This kind represents a `SingleQuotedStringLiteral` node, with the following structure:
+   * Represents a node with kind `SingleQuotedStringLiteral`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.4.25 *)
@@ -3820,7 +3820,7 @@ export declare enum TerminalKind {
    */
   SingleQuotedStringLiteral = "SingleQuotedStringLiteral",
   /**
-   * This kind represents a `SingleQuotedUnicodeStringLiteral` node, with the following structure:
+   * Represents a node with kind `SingleQuotedUnicodeStringLiteral`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.7.0 *)
@@ -3829,7 +3829,7 @@ export declare enum TerminalKind {
    */
   SingleQuotedUnicodeStringLiteral = "SingleQuotedUnicodeStringLiteral",
   /**
-   * This kind represents a `SingleQuotedVersionLiteral` node, with the following structure:
+   * Represents a node with kind `SingleQuotedVersionLiteral`, having the following structure:
    *
    * ```ebnf
    * SINGLE_QUOTED_VERSION_LITERAL = "'" «VERSION_SPECIFIER_FRAGMENT» ("." «VERSION_SPECIFIER_FRAGMENT»)* "'";
@@ -3837,7 +3837,7 @@ export declare enum TerminalKind {
    */
   SingleQuotedVersionLiteral = "SingleQuotedVersionLiteral",
   /**
-   * This kind represents a `SizeOfKeyword` node, with the following structure:
+   * Represents a node with kind `SizeOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3846,7 +3846,7 @@ export declare enum TerminalKind {
    */
   SizeOfKeyword = "SizeOfKeyword",
   /**
-   * This kind represents a `Slash` node, with the following structure:
+   * Represents a node with kind `Slash`, having the following structure:
    *
    * ```ebnf
    * SLASH = "/";
@@ -3854,7 +3854,7 @@ export declare enum TerminalKind {
    */
   Slash = "Slash",
   /**
-   * This kind represents a `SlashEqual` node, with the following structure:
+   * Represents a node with kind `SlashEqual`, having the following structure:
    *
    * ```ebnf
    * SLASH_EQUAL = "/=";
@@ -3862,7 +3862,7 @@ export declare enum TerminalKind {
    */
   SlashEqual = "SlashEqual",
   /**
-   * This kind represents a `SolidityKeyword` node, with the following structure:
+   * Represents a node with kind `SolidityKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -3871,7 +3871,7 @@ export declare enum TerminalKind {
    */
   SolidityKeyword = "SolidityKeyword",
   /**
-   * This kind represents a `StaticKeyword` node, with the following structure:
+   * Represents a node with kind `StaticKeyword`, having the following structure:
    *
    * ```ebnf
    * STATIC_KEYWORD = "static";
@@ -3879,7 +3879,7 @@ export declare enum TerminalKind {
    */
   StaticKeyword = "StaticKeyword",
   /**
-   * This kind represents a `StorageKeyword` node, with the following structure:
+   * Represents a node with kind `StorageKeyword`, having the following structure:
    *
    * ```ebnf
    * STORAGE_KEYWORD = "storage";
@@ -3887,7 +3887,7 @@ export declare enum TerminalKind {
    */
   StorageKeyword = "StorageKeyword",
   /**
-   * This kind represents a `StringKeyword` node, with the following structure:
+   * Represents a node with kind `StringKeyword`, having the following structure:
    *
    * ```ebnf
    * STRING_KEYWORD = "string";
@@ -3895,7 +3895,7 @@ export declare enum TerminalKind {
    */
   StringKeyword = "StringKeyword",
   /**
-   * This kind represents a `StructKeyword` node, with the following structure:
+   * Represents a node with kind `StructKeyword`, having the following structure:
    *
    * ```ebnf
    * STRUCT_KEYWORD = "struct";
@@ -3903,7 +3903,7 @@ export declare enum TerminalKind {
    */
   StructKeyword = "StructKeyword",
   /**
-   * This kind represents a `SuperKeyword` node, with the following structure:
+   * Represents a node with kind `SuperKeyword`, having the following structure:
    *
    * ```ebnf
    * SUPER_KEYWORD = "super";
@@ -3911,7 +3911,7 @@ export declare enum TerminalKind {
    */
   SuperKeyword = "SuperKeyword",
   /**
-   * This kind represents a `SupportsKeyword` node, with the following structure:
+   * Represents a node with kind `SupportsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3920,7 +3920,7 @@ export declare enum TerminalKind {
    */
   SupportsKeyword = "SupportsKeyword",
   /**
-   * This kind represents a `SwitchKeyword` node, with the following structure:
+   * Represents a node with kind `SwitchKeyword`, having the following structure:
    *
    * ```ebnf
    * SWITCH_KEYWORD = "switch";
@@ -3928,7 +3928,7 @@ export declare enum TerminalKind {
    */
   SwitchKeyword = "SwitchKeyword",
   /**
-   * This kind represents a `SzaboKeyword` node, with the following structure:
+   * Represents a node with kind `SzaboKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.7.0 *)
@@ -3938,7 +3938,7 @@ export declare enum TerminalKind {
    */
   SzaboKeyword = "SzaboKeyword",
   /**
-   * This kind represents a `ThisKeyword` node, with the following structure:
+   * Represents a node with kind `ThisKeyword`, having the following structure:
    *
    * ```ebnf
    * THIS_KEYWORD = "this";
@@ -3946,7 +3946,7 @@ export declare enum TerminalKind {
    */
   ThisKeyword = "ThisKeyword",
   /**
-   * This kind represents a `ThrowKeyword` node, with the following structure:
+   * Represents a node with kind `ThrowKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -3955,7 +3955,7 @@ export declare enum TerminalKind {
    */
   ThrowKeyword = "ThrowKeyword",
   /**
-   * This kind represents a `Tilde` node, with the following structure:
+   * Represents a node with kind `Tilde`, having the following structure:
    *
    * ```ebnf
    * TILDE = "~";
@@ -3963,7 +3963,7 @@ export declare enum TerminalKind {
    */
   Tilde = "Tilde",
   /**
-   * This kind represents a `TransientKeyword` node, with the following structure:
+   * Represents a node with kind `TransientKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.27 *)
@@ -3973,7 +3973,7 @@ export declare enum TerminalKind {
    */
   TransientKeyword = "TransientKeyword",
   /**
-   * This kind represents a `TrueKeyword` node, with the following structure:
+   * Represents a node with kind `TrueKeyword`, having the following structure:
    *
    * ```ebnf
    * TRUE_KEYWORD = "true";
@@ -3981,7 +3981,7 @@ export declare enum TerminalKind {
    */
   TrueKeyword = "TrueKeyword",
   /**
-   * This kind represents a `TryKeyword` node, with the following structure:
+   * Represents a node with kind `TryKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -3990,7 +3990,7 @@ export declare enum TerminalKind {
    */
   TryKeyword = "TryKeyword",
   /**
-   * This kind represents a `TypeDefKeyword` node, with the following structure:
+   * Represents a node with kind `TypeDefKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.0 *)
@@ -3999,7 +3999,7 @@ export declare enum TerminalKind {
    */
   TypeDefKeyword = "TypeDefKeyword",
   /**
-   * This kind represents a `TypeKeyword` node, with the following structure:
+   * Represents a node with kind `TypeKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.3 *)
@@ -4008,7 +4008,7 @@ export declare enum TerminalKind {
    */
   TypeKeyword = "TypeKeyword",
   /**
-   * This kind represents a `TypeOfKeyword` node, with the following structure:
+   * Represents a node with kind `TypeOfKeyword`, having the following structure:
    *
    * ```ebnf
    * TYPE_OF_KEYWORD = "typeof";
@@ -4016,7 +4016,7 @@ export declare enum TerminalKind {
    */
   TypeOfKeyword = "TypeOfKeyword",
   /**
-   * This kind represents a `UfixedKeyword` node, with the following structure:
+   * Represents a node with kind `UfixedKeyword`, having the following structure:
    *
    * ```ebnf
    * UFIXED_KEYWORD = "ufixed";
@@ -4034,7 +4034,7 @@ export declare enum TerminalKind {
    */
   UfixedKeyword = "UfixedKeyword",
   /**
-   * This kind represents a `UintKeyword` node, with the following structure:
+   * Represents a node with kind `UintKeyword`, having the following structure:
    *
    * ```ebnf
    * UINT_KEYWORD = "uint" ("8" | "16" | "24" | "32" | "40" | "48" | "56" | "64" | "72" | "80" | "88" | "96" | "104" | "112" | "120" | "128" | "136" | "144" | "152" | "160" | "168" | "176" | "184" | "192" | "200" | "208" | "216" | "224" | "232" | "240" | "248" | "256")?;
@@ -4042,7 +4042,7 @@ export declare enum TerminalKind {
    */
   UintKeyword = "UintKeyword",
   /**
-   * This kind represents a `UncheckedKeyword` node, with the following structure:
+   * Represents a node with kind `UncheckedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.0 *)
@@ -4052,7 +4052,7 @@ export declare enum TerminalKind {
    */
   UncheckedKeyword = "UncheckedKeyword",
   /**
-   * This kind represents a `UsingKeyword` node, with the following structure:
+   * Represents a node with kind `UsingKeyword`, having the following structure:
    *
    * ```ebnf
    * USING_KEYWORD = "using";
@@ -4060,7 +4060,7 @@ export declare enum TerminalKind {
    */
   UsingKeyword = "UsingKeyword",
   /**
-   * This kind represents a `VarKeyword` node, with the following structure:
+   * Represents a node with kind `VarKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -4069,7 +4069,7 @@ export declare enum TerminalKind {
    */
   VarKeyword = "VarKeyword",
   /**
-   * This kind represents a `VersionSpecifier` node, with the following structure:
+   * Represents a node with kind `VersionSpecifier`, having the following structure:
    *
    * ```ebnf
    * VERSION_SPECIFIER = «VERSION_SPECIFIER_FRAGMENT»;
@@ -4077,7 +4077,7 @@ export declare enum TerminalKind {
    */
   VersionSpecifier = "VersionSpecifier",
   /**
-   * This kind represents a `ViewKeyword` node, with the following structure:
+   * Represents a node with kind `ViewKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.16 *)
@@ -4086,7 +4086,7 @@ export declare enum TerminalKind {
    */
   ViewKeyword = "ViewKeyword",
   /**
-   * This kind represents a `VirtualKeyword` node, with the following structure:
+   * Represents a node with kind `VirtualKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -4096,7 +4096,7 @@ export declare enum TerminalKind {
    */
   VirtualKeyword = "VirtualKeyword",
   /**
-   * This kind represents a `WeeksKeyword` node, with the following structure:
+   * Represents a node with kind `WeeksKeyword`, having the following structure:
    *
    * ```ebnf
    * WEEKS_KEYWORD = "weeks";
@@ -4104,7 +4104,7 @@ export declare enum TerminalKind {
    */
   WeeksKeyword = "WeeksKeyword",
   /**
-   * This kind represents a `WeiKeyword` node, with the following structure:
+   * Represents a node with kind `WeiKeyword`, having the following structure:
    *
    * ```ebnf
    * WEI_KEYWORD = "wei";
@@ -4112,7 +4112,7 @@ export declare enum TerminalKind {
    */
   WeiKeyword = "WeiKeyword",
   /**
-   * This kind represents a `WhileKeyword` node, with the following structure:
+   * Represents a node with kind `WhileKeyword`, having the following structure:
    *
    * ```ebnf
    * WHILE_KEYWORD = "while";
@@ -4120,7 +4120,7 @@ export declare enum TerminalKind {
    */
   WhileKeyword = "WhileKeyword",
   /**
-   * This kind represents a `Whitespace` node, with the following structure:
+   * Represents a node with kind `Whitespace`, having the following structure:
    *
    * ```ebnf
    * WHITESPACE = (" " | "\t")+;
@@ -4128,7 +4128,7 @@ export declare enum TerminalKind {
    */
   Whitespace = "Whitespace",
   /**
-   * This kind represents a `YearsKeyword` node, with the following structure:
+   * Represents a node with kind `YearsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -4137,7 +4137,7 @@ export declare enum TerminalKind {
    */
   YearsKeyword = "YearsKeyword",
   /**
-   * This kind represents a `YulAbstractKeyword` node, with the following structure:
+   * Represents a node with kind `YulAbstractKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4146,7 +4146,7 @@ export declare enum TerminalKind {
    */
   YulAbstractKeyword = "YulAbstractKeyword",
   /**
-   * This kind represents a `YulAddKeyword` node, with the following structure:
+   * Represents a node with kind `YulAddKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_ADD_KEYWORD = "add";
@@ -4154,7 +4154,7 @@ export declare enum TerminalKind {
    */
   YulAddKeyword = "YulAddKeyword",
   /**
-   * This kind represents a `YulAddModKeyword` node, with the following structure:
+   * Represents a node with kind `YulAddModKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_ADD_MOD_KEYWORD = "addmod";
@@ -4162,7 +4162,7 @@ export declare enum TerminalKind {
    */
   YulAddModKeyword = "YulAddModKeyword",
   /**
-   * This kind represents a `YulAddressKeyword` node, with the following structure:
+   * Represents a node with kind `YulAddressKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Never reserved *)
@@ -4171,7 +4171,7 @@ export declare enum TerminalKind {
    */
   YulAddressKeyword = "YulAddressKeyword",
   /**
-   * This kind represents a `YulAfterKeyword` node, with the following structure:
+   * Represents a node with kind `YulAfterKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4180,7 +4180,7 @@ export declare enum TerminalKind {
    */
   YulAfterKeyword = "YulAfterKeyword",
   /**
-   * This kind represents a `YulAliasKeyword` node, with the following structure:
+   * Represents a node with kind `YulAliasKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4189,7 +4189,7 @@ export declare enum TerminalKind {
    */
   YulAliasKeyword = "YulAliasKeyword",
   /**
-   * This kind represents a `YulAndKeyword` node, with the following structure:
+   * Represents a node with kind `YulAndKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_AND_KEYWORD = "and";
@@ -4197,7 +4197,7 @@ export declare enum TerminalKind {
    */
   YulAndKeyword = "YulAndKeyword",
   /**
-   * This kind represents a `YulAnonymousKeyword` node, with the following structure:
+   * Represents a node with kind `YulAnonymousKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4206,7 +4206,7 @@ export declare enum TerminalKind {
    */
   YulAnonymousKeyword = "YulAnonymousKeyword",
   /**
-   * This kind represents a `YulApplyKeyword` node, with the following structure:
+   * Represents a node with kind `YulApplyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4215,7 +4215,7 @@ export declare enum TerminalKind {
    */
   YulApplyKeyword = "YulApplyKeyword",
   /**
-   * This kind represents a `YulAsKeyword` node, with the following structure:
+   * Represents a node with kind `YulAsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4224,7 +4224,7 @@ export declare enum TerminalKind {
    */
   YulAsKeyword = "YulAsKeyword",
   /**
-   * This kind represents a `YulAssemblyKeyword` node, with the following structure:
+   * Represents a node with kind `YulAssemblyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4233,7 +4233,7 @@ export declare enum TerminalKind {
    */
   YulAssemblyKeyword = "YulAssemblyKeyword",
   /**
-   * This kind represents a `YulAutoKeyword` node, with the following structure:
+   * Represents a node with kind `YulAutoKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4242,7 +4242,7 @@ export declare enum TerminalKind {
    */
   YulAutoKeyword = "YulAutoKeyword",
   /**
-   * This kind represents a `YulBalanceKeyword` node, with the following structure:
+   * Represents a node with kind `YulBalanceKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_BALANCE_KEYWORD = "balance";
@@ -4250,7 +4250,7 @@ export declare enum TerminalKind {
    */
   YulBalanceKeyword = "YulBalanceKeyword",
   /**
-   * This kind represents a `YulBaseFeeKeyword` node, with the following structure:
+   * Represents a node with kind `YulBaseFeeKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.7 *)
@@ -4260,7 +4260,7 @@ export declare enum TerminalKind {
    */
   YulBaseFeeKeyword = "YulBaseFeeKeyword",
   /**
-   * This kind represents a `YulBlobBaseFeeKeyword` node, with the following structure:
+   * Represents a node with kind `YulBlobBaseFeeKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.24 *)
@@ -4270,7 +4270,7 @@ export declare enum TerminalKind {
    */
   YulBlobBaseFeeKeyword = "YulBlobBaseFeeKeyword",
   /**
-   * This kind represents a `YulBlobHashKeyword` node, with the following structure:
+   * Represents a node with kind `YulBlobHashKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.24 *)
@@ -4280,7 +4280,7 @@ export declare enum TerminalKind {
    */
   YulBlobHashKeyword = "YulBlobHashKeyword",
   /**
-   * This kind represents a `YulBlockHashKeyword` node, with the following structure:
+   * Represents a node with kind `YulBlockHashKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_BLOCK_HASH_KEYWORD = "blockhash";
@@ -4288,7 +4288,7 @@ export declare enum TerminalKind {
    */
   YulBlockHashKeyword = "YulBlockHashKeyword",
   /**
-   * This kind represents a `YulBoolKeyword` node, with the following structure:
+   * Represents a node with kind `YulBoolKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.5.10 *)
@@ -4297,7 +4297,7 @@ export declare enum TerminalKind {
    */
   YulBoolKeyword = "YulBoolKeyword",
   /**
-   * This kind represents a `YulBreakKeyword` node, with the following structure:
+   * Represents a node with kind `YulBreakKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_BREAK_KEYWORD = "break";
@@ -4305,7 +4305,7 @@ export declare enum TerminalKind {
    */
   YulBreakKeyword = "YulBreakKeyword",
   /**
-   * This kind represents a `YulByteKeyword` node, with the following structure:
+   * Represents a node with kind `YulByteKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_BYTE_KEYWORD = "byte";
@@ -4313,7 +4313,7 @@ export declare enum TerminalKind {
    */
   YulByteKeyword = "YulByteKeyword",
   /**
-   * This kind represents a `YulBytesKeyword` node, with the following structure:
+   * Represents a node with kind `YulBytesKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4322,7 +4322,7 @@ export declare enum TerminalKind {
    */
   YulBytesKeyword = "YulBytesKeyword",
   /**
-   * This kind represents a `YulCallCodeKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallCodeKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_CODE_KEYWORD = "callcode";
@@ -4330,7 +4330,7 @@ export declare enum TerminalKind {
    */
   YulCallCodeKeyword = "YulCallCodeKeyword",
   /**
-   * This kind represents a `YulCallDataCopyKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallDataCopyKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_DATA_COPY_KEYWORD = "calldatacopy";
@@ -4338,7 +4338,7 @@ export declare enum TerminalKind {
    */
   YulCallDataCopyKeyword = "YulCallDataCopyKeyword",
   /**
-   * This kind represents a `YulCallDataKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallDataKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4347,7 +4347,7 @@ export declare enum TerminalKind {
    */
   YulCallDataKeyword = "YulCallDataKeyword",
   /**
-   * This kind represents a `YulCallDataLoadKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallDataLoadKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_DATA_LOAD_KEYWORD = "calldataload";
@@ -4355,7 +4355,7 @@ export declare enum TerminalKind {
    */
   YulCallDataLoadKeyword = "YulCallDataLoadKeyword",
   /**
-   * This kind represents a `YulCallDataSizeKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallDataSizeKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_DATA_SIZE_KEYWORD = "calldatasize";
@@ -4363,7 +4363,7 @@ export declare enum TerminalKind {
    */
   YulCallDataSizeKeyword = "YulCallDataSizeKeyword",
   /**
-   * This kind represents a `YulCallKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_KEYWORD = "call";
@@ -4371,7 +4371,7 @@ export declare enum TerminalKind {
    */
   YulCallKeyword = "YulCallKeyword",
   /**
-   * This kind represents a `YulCallValueKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallValueKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALL_VALUE_KEYWORD = "callvalue";
@@ -4379,7 +4379,7 @@ export declare enum TerminalKind {
    */
   YulCallValueKeyword = "YulCallValueKeyword",
   /**
-   * This kind represents a `YulCallerKeyword` node, with the following structure:
+   * Represents a node with kind `YulCallerKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CALLER_KEYWORD = "caller";
@@ -4387,7 +4387,7 @@ export declare enum TerminalKind {
    */
   YulCallerKeyword = "YulCallerKeyword",
   /**
-   * This kind represents a `YulCaseKeyword` node, with the following structure:
+   * Represents a node with kind `YulCaseKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CASE_KEYWORD = "case";
@@ -4395,7 +4395,7 @@ export declare enum TerminalKind {
    */
   YulCaseKeyword = "YulCaseKeyword",
   /**
-   * This kind represents a `YulCatchKeyword` node, with the following structure:
+   * Represents a node with kind `YulCatchKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4404,7 +4404,7 @@ export declare enum TerminalKind {
    */
   YulCatchKeyword = "YulCatchKeyword",
   /**
-   * This kind represents a `YulChainIdKeyword` node, with the following structure:
+   * Represents a node with kind `YulChainIdKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.12 *)
@@ -4413,7 +4413,7 @@ export declare enum TerminalKind {
    */
   YulChainIdKeyword = "YulChainIdKeyword",
   /**
-   * This kind represents a `YulCoinBaseKeyword` node, with the following structure:
+   * Represents a node with kind `YulCoinBaseKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_COIN_BASE_KEYWORD = "coinbase";
@@ -4421,7 +4421,7 @@ export declare enum TerminalKind {
    */
   YulCoinBaseKeyword = "YulCoinBaseKeyword",
   /**
-   * This kind represents a `YulConstantKeyword` node, with the following structure:
+   * Represents a node with kind `YulConstantKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4430,7 +4430,7 @@ export declare enum TerminalKind {
    */
   YulConstantKeyword = "YulConstantKeyword",
   /**
-   * This kind represents a `YulConstructorKeyword` node, with the following structure:
+   * Represents a node with kind `YulConstructorKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4439,7 +4439,7 @@ export declare enum TerminalKind {
    */
   YulConstructorKeyword = "YulConstructorKeyword",
   /**
-   * This kind represents a `YulContinueKeyword` node, with the following structure:
+   * Represents a node with kind `YulContinueKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CONTINUE_KEYWORD = "continue";
@@ -4447,7 +4447,7 @@ export declare enum TerminalKind {
    */
   YulContinueKeyword = "YulContinueKeyword",
   /**
-   * This kind represents a `YulContractKeyword` node, with the following structure:
+   * Represents a node with kind `YulContractKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4456,7 +4456,7 @@ export declare enum TerminalKind {
    */
   YulContractKeyword = "YulContractKeyword",
   /**
-   * This kind represents a `YulCopyOfKeyword` node, with the following structure:
+   * Represents a node with kind `YulCopyOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4465,7 +4465,7 @@ export declare enum TerminalKind {
    */
   YulCopyOfKeyword = "YulCopyOfKeyword",
   /**
-   * This kind represents a `YulCreate2Keyword` node, with the following structure:
+   * Represents a node with kind `YulCreate2Keyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.12 *)
@@ -4475,7 +4475,7 @@ export declare enum TerminalKind {
    */
   YulCreate2Keyword = "YulCreate2Keyword",
   /**
-   * This kind represents a `YulCreateKeyword` node, with the following structure:
+   * Represents a node with kind `YulCreateKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_CREATE_KEYWORD = "create";
@@ -4483,7 +4483,7 @@ export declare enum TerminalKind {
    */
   YulCreateKeyword = "YulCreateKeyword",
   /**
-   * This kind represents a `YulDaysKeyword` node, with the following structure:
+   * Represents a node with kind `YulDaysKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4492,7 +4492,7 @@ export declare enum TerminalKind {
    */
   YulDaysKeyword = "YulDaysKeyword",
   /**
-   * This kind represents a `YulDecimalLiteral` node, with the following structure:
+   * Represents a node with kind `YulDecimalLiteral`, having the following structure:
    *
    * ```ebnf
    * YUL_DECIMAL_LITERAL = "0" | (("1"…"9") ("0"…"9")*);
@@ -4500,7 +4500,7 @@ export declare enum TerminalKind {
    */
   YulDecimalLiteral = "YulDecimalLiteral",
   /**
-   * This kind represents a `YulDefaultKeyword` node, with the following structure:
+   * Represents a node with kind `YulDefaultKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_DEFAULT_KEYWORD = "default";
@@ -4508,7 +4508,7 @@ export declare enum TerminalKind {
    */
   YulDefaultKeyword = "YulDefaultKeyword",
   /**
-   * This kind represents a `YulDefineKeyword` node, with the following structure:
+   * Represents a node with kind `YulDefineKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4517,7 +4517,7 @@ export declare enum TerminalKind {
    */
   YulDefineKeyword = "YulDefineKeyword",
   /**
-   * This kind represents a `YulDelegateCallKeyword` node, with the following structure:
+   * Represents a node with kind `YulDelegateCallKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_DELEGATE_CALL_KEYWORD = "delegatecall";
@@ -4525,7 +4525,7 @@ export declare enum TerminalKind {
    */
   YulDelegateCallKeyword = "YulDelegateCallKeyword",
   /**
-   * This kind represents a `YulDeleteKeyword` node, with the following structure:
+   * Represents a node with kind `YulDeleteKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4534,7 +4534,7 @@ export declare enum TerminalKind {
    */
   YulDeleteKeyword = "YulDeleteKeyword",
   /**
-   * This kind represents a `YulDifficultyKeyword` node, with the following structure:
+   * Represents a node with kind `YulDifficultyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.8.18 *)
@@ -4543,7 +4543,7 @@ export declare enum TerminalKind {
    */
   YulDifficultyKeyword = "YulDifficultyKeyword",
   /**
-   * This kind represents a `YulDivKeyword` node, with the following structure:
+   * Represents a node with kind `YulDivKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_DIV_KEYWORD = "div";
@@ -4551,7 +4551,7 @@ export declare enum TerminalKind {
    */
   YulDivKeyword = "YulDivKeyword",
   /**
-   * This kind represents a `YulDoKeyword` node, with the following structure:
+   * Represents a node with kind `YulDoKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4560,7 +4560,7 @@ export declare enum TerminalKind {
    */
   YulDoKeyword = "YulDoKeyword",
   /**
-   * This kind represents a `YulElseKeyword` node, with the following structure:
+   * Represents a node with kind `YulElseKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4569,7 +4569,7 @@ export declare enum TerminalKind {
    */
   YulElseKeyword = "YulElseKeyword",
   /**
-   * This kind represents a `YulEmitKeyword` node, with the following structure:
+   * Represents a node with kind `YulEmitKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4578,7 +4578,7 @@ export declare enum TerminalKind {
    */
   YulEmitKeyword = "YulEmitKeyword",
   /**
-   * This kind represents a `YulEnumKeyword` node, with the following structure:
+   * Represents a node with kind `YulEnumKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4587,7 +4587,7 @@ export declare enum TerminalKind {
    */
   YulEnumKeyword = "YulEnumKeyword",
   /**
-   * This kind represents a `YulEqKeyword` node, with the following structure:
+   * Represents a node with kind `YulEqKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_EQ_KEYWORD = "eq";
@@ -4595,7 +4595,7 @@ export declare enum TerminalKind {
    */
   YulEqKeyword = "YulEqKeyword",
   /**
-   * This kind represents a `YulEtherKeyword` node, with the following structure:
+   * Represents a node with kind `YulEtherKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4604,7 +4604,7 @@ export declare enum TerminalKind {
    */
   YulEtherKeyword = "YulEtherKeyword",
   /**
-   * This kind represents a `YulEventKeyword` node, with the following structure:
+   * Represents a node with kind `YulEventKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4613,7 +4613,7 @@ export declare enum TerminalKind {
    */
   YulEventKeyword = "YulEventKeyword",
   /**
-   * This kind represents a `YulExpKeyword` node, with the following structure:
+   * Represents a node with kind `YulExpKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_EXP_KEYWORD = "exp";
@@ -4621,7 +4621,7 @@ export declare enum TerminalKind {
    */
   YulExpKeyword = "YulExpKeyword",
   /**
-   * This kind represents a `YulExtCodeCopyKeyword` node, with the following structure:
+   * Represents a node with kind `YulExtCodeCopyKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_EXT_CODE_COPY_KEYWORD = "extcodecopy";
@@ -4629,7 +4629,7 @@ export declare enum TerminalKind {
    */
   YulExtCodeCopyKeyword = "YulExtCodeCopyKeyword",
   /**
-   * This kind represents a `YulExtCodeHashKeyword` node, with the following structure:
+   * Represents a node with kind `YulExtCodeHashKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.0 *)
@@ -4639,7 +4639,7 @@ export declare enum TerminalKind {
    */
   YulExtCodeHashKeyword = "YulExtCodeHashKeyword",
   /**
-   * This kind represents a `YulExtCodeSizeKeyword` node, with the following structure:
+   * Represents a node with kind `YulExtCodeSizeKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_EXT_CODE_SIZE_KEYWORD = "extcodesize";
@@ -4647,7 +4647,7 @@ export declare enum TerminalKind {
    */
   YulExtCodeSizeKeyword = "YulExtCodeSizeKeyword",
   /**
-   * This kind represents a `YulExternalKeyword` node, with the following structure:
+   * Represents a node with kind `YulExternalKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4656,7 +4656,7 @@ export declare enum TerminalKind {
    */
   YulExternalKeyword = "YulExternalKeyword",
   /**
-   * This kind represents a `YulFallbackKeyword` node, with the following structure:
+   * Represents a node with kind `YulFallbackKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.6.0 until 0.7.1 *)
@@ -4665,7 +4665,7 @@ export declare enum TerminalKind {
    */
   YulFallbackKeyword = "YulFallbackKeyword",
   /**
-   * This kind represents a `YulFalseKeyword` node, with the following structure:
+   * Represents a node with kind `YulFalseKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_FALSE_KEYWORD = "false";
@@ -4673,7 +4673,7 @@ export declare enum TerminalKind {
    */
   YulFalseKeyword = "YulFalseKeyword",
   /**
-   * This kind represents a `YulFinalKeyword` node, with the following structure:
+   * Represents a node with kind `YulFinalKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4682,7 +4682,7 @@ export declare enum TerminalKind {
    */
   YulFinalKeyword = "YulFinalKeyword",
   /**
-   * This kind represents a `YulFinneyKeyword` node, with the following structure:
+   * Represents a node with kind `YulFinneyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.0 *)
@@ -4691,7 +4691,7 @@ export declare enum TerminalKind {
    */
   YulFinneyKeyword = "YulFinneyKeyword",
   /**
-   * This kind represents a `YulFixedKeyword` node, with the following structure:
+   * Represents a node with kind `YulFixedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4712,7 +4712,7 @@ export declare enum TerminalKind {
    */
   YulFixedKeyword = "YulFixedKeyword",
   /**
-   * This kind represents a `YulForKeyword` node, with the following structure:
+   * Represents a node with kind `YulForKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_FOR_KEYWORD = "for";
@@ -4720,7 +4720,7 @@ export declare enum TerminalKind {
    */
   YulForKeyword = "YulForKeyword",
   /**
-   * This kind represents a `YulFunctionKeyword` node, with the following structure:
+   * Represents a node with kind `YulFunctionKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_FUNCTION_KEYWORD = "function";
@@ -4728,7 +4728,7 @@ export declare enum TerminalKind {
    */
   YulFunctionKeyword = "YulFunctionKeyword",
   /**
-   * This kind represents a `YulGasKeyword` node, with the following structure:
+   * Represents a node with kind `YulGasKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_GAS_KEYWORD = "gas";
@@ -4736,7 +4736,7 @@ export declare enum TerminalKind {
    */
   YulGasKeyword = "YulGasKeyword",
   /**
-   * This kind represents a `YulGasLimitKeyword` node, with the following structure:
+   * Represents a node with kind `YulGasLimitKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_GAS_LIMIT_KEYWORD = "gaslimit";
@@ -4744,7 +4744,7 @@ export declare enum TerminalKind {
    */
   YulGasLimitKeyword = "YulGasLimitKeyword",
   /**
-   * This kind represents a `YulGasPriceKeyword` node, with the following structure:
+   * Represents a node with kind `YulGasPriceKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_GAS_PRICE_KEYWORD = "gasprice";
@@ -4752,7 +4752,7 @@ export declare enum TerminalKind {
    */
   YulGasPriceKeyword = "YulGasPriceKeyword",
   /**
-   * This kind represents a `YulGtKeyword` node, with the following structure:
+   * Represents a node with kind `YulGtKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_GT_KEYWORD = "gt";
@@ -4760,7 +4760,7 @@ export declare enum TerminalKind {
    */
   YulGtKeyword = "YulGtKeyword",
   /**
-   * This kind represents a `YulGweiKeyword` node, with the following structure:
+   * Represents a node with kind `YulGweiKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.7.0 until 0.7.1 *)
@@ -4769,7 +4769,7 @@ export declare enum TerminalKind {
    */
   YulGweiKeyword = "YulGweiKeyword",
   /**
-   * This kind represents a `YulHexKeyword` node, with the following structure:
+   * Represents a node with kind `YulHexKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_HEX_KEYWORD = "hex";
@@ -4777,7 +4777,7 @@ export declare enum TerminalKind {
    */
   YulHexKeyword = "YulHexKeyword",
   /**
-   * This kind represents a `YulHexLiteral` node, with the following structure:
+   * Represents a node with kind `YulHexLiteral`, having the following structure:
    *
    * ```ebnf
    * YUL_HEX_LITERAL = "0x" «HEX_CHARACTER»+;
@@ -4785,7 +4785,7 @@ export declare enum TerminalKind {
    */
   YulHexLiteral = "YulHexLiteral",
   /**
-   * This kind represents a `YulHoursKeyword` node, with the following structure:
+   * Represents a node with kind `YulHoursKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4794,7 +4794,7 @@ export declare enum TerminalKind {
    */
   YulHoursKeyword = "YulHoursKeyword",
   /**
-   * This kind represents a `YulIdentifier` node, with the following structure:
+   * Represents a node with kind `YulIdentifier`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.5.8 and deprecated in 0.7.0. *)
@@ -4805,7 +4805,7 @@ export declare enum TerminalKind {
    */
   YulIdentifier = "YulIdentifier",
   /**
-   * This kind represents a `YulIfKeyword` node, with the following structure:
+   * Represents a node with kind `YulIfKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_IF_KEYWORD = "if";
@@ -4813,7 +4813,7 @@ export declare enum TerminalKind {
    */
   YulIfKeyword = "YulIfKeyword",
   /**
-   * This kind represents a `YulImmutableKeyword` node, with the following structure:
+   * Represents a node with kind `YulImmutableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4822,7 +4822,7 @@ export declare enum TerminalKind {
    */
   YulImmutableKeyword = "YulImmutableKeyword",
   /**
-   * This kind represents a `YulImplementsKeyword` node, with the following structure:
+   * Represents a node with kind `YulImplementsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -4831,7 +4831,7 @@ export declare enum TerminalKind {
    */
   YulImplementsKeyword = "YulImplementsKeyword",
   /**
-   * This kind represents a `YulImportKeyword` node, with the following structure:
+   * Represents a node with kind `YulImportKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4840,7 +4840,7 @@ export declare enum TerminalKind {
    */
   YulImportKeyword = "YulImportKeyword",
   /**
-   * This kind represents a `YulInKeyword` node, with the following structure:
+   * Represents a node with kind `YulInKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.6.8 *)
@@ -4849,7 +4849,7 @@ export declare enum TerminalKind {
    */
   YulInKeyword = "YulInKeyword",
   /**
-   * This kind represents a `YulIndexedKeyword` node, with the following structure:
+   * Represents a node with kind `YulIndexedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4858,7 +4858,7 @@ export declare enum TerminalKind {
    */
   YulIndexedKeyword = "YulIndexedKeyword",
   /**
-   * This kind represents a `YulInlineKeyword` node, with the following structure:
+   * Represents a node with kind `YulInlineKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4867,7 +4867,7 @@ export declare enum TerminalKind {
    */
   YulInlineKeyword = "YulInlineKeyword",
   /**
-   * This kind represents a `YulIntKeyword` node, with the following structure:
+   * Represents a node with kind `YulIntKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4876,7 +4876,7 @@ export declare enum TerminalKind {
    */
   YulIntKeyword = "YulIntKeyword",
   /**
-   * This kind represents a `YulInterfaceKeyword` node, with the following structure:
+   * Represents a node with kind `YulInterfaceKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4885,7 +4885,7 @@ export declare enum TerminalKind {
    */
   YulInterfaceKeyword = "YulInterfaceKeyword",
   /**
-   * This kind represents a `YulInternalKeyword` node, with the following structure:
+   * Represents a node with kind `YulInternalKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4894,7 +4894,7 @@ export declare enum TerminalKind {
    */
   YulInternalKeyword = "YulInternalKeyword",
   /**
-   * This kind represents a `YulInvalidKeyword` node, with the following structure:
+   * Represents a node with kind `YulInvalidKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_INVALID_KEYWORD = "invalid";
@@ -4902,7 +4902,7 @@ export declare enum TerminalKind {
    */
   YulInvalidKeyword = "YulInvalidKeyword",
   /**
-   * This kind represents a `YulIsKeyword` node, with the following structure:
+   * Represents a node with kind `YulIsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4911,7 +4911,7 @@ export declare enum TerminalKind {
    */
   YulIsKeyword = "YulIsKeyword",
   /**
-   * This kind represents a `YulIsZeroKeyword` node, with the following structure:
+   * Represents a node with kind `YulIsZeroKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_IS_ZERO_KEYWORD = "iszero";
@@ -4919,7 +4919,7 @@ export declare enum TerminalKind {
    */
   YulIsZeroKeyword = "YulIsZeroKeyword",
   /**
-   * This kind represents a `YulJumpKeyword` node, with the following structure:
+   * Represents a node with kind `YulJumpKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -4928,7 +4928,7 @@ export declare enum TerminalKind {
    */
   YulJumpKeyword = "YulJumpKeyword",
   /**
-   * This kind represents a `YulJumpiKeyword` node, with the following structure:
+   * Represents a node with kind `YulJumpiKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -4937,7 +4937,7 @@ export declare enum TerminalKind {
    */
   YulJumpiKeyword = "YulJumpiKeyword",
   /**
-   * This kind represents a `YulKeccak256Keyword` node, with the following structure:
+   * Represents a node with kind `YulKeccak256Keyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.12 *)
@@ -4947,7 +4947,7 @@ export declare enum TerminalKind {
    */
   YulKeccak256Keyword = "YulKeccak256Keyword",
   /**
-   * This kind represents a `YulLeaveKeyword` node, with the following structure:
+   * Represents a node with kind `YulLeaveKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.6.0 *)
@@ -4957,7 +4957,7 @@ export declare enum TerminalKind {
    */
   YulLeaveKeyword = "YulLeaveKeyword",
   /**
-   * This kind represents a `YulLetKeyword` node, with the following structure:
+   * Represents a node with kind `YulLetKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LET_KEYWORD = "let";
@@ -4965,7 +4965,7 @@ export declare enum TerminalKind {
    */
   YulLetKeyword = "YulLetKeyword",
   /**
-   * This kind represents a `YulLibraryKeyword` node, with the following structure:
+   * Represents a node with kind `YulLibraryKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -4974,7 +4974,7 @@ export declare enum TerminalKind {
    */
   YulLibraryKeyword = "YulLibraryKeyword",
   /**
-   * This kind represents a `YulLog0Keyword` node, with the following structure:
+   * Represents a node with kind `YulLog0Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LOG_0_KEYWORD = "log0";
@@ -4982,7 +4982,7 @@ export declare enum TerminalKind {
    */
   YulLog0Keyword = "YulLog0Keyword",
   /**
-   * This kind represents a `YulLog1Keyword` node, with the following structure:
+   * Represents a node with kind `YulLog1Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LOG_1_KEYWORD = "log1";
@@ -4990,7 +4990,7 @@ export declare enum TerminalKind {
    */
   YulLog1Keyword = "YulLog1Keyword",
   /**
-   * This kind represents a `YulLog2Keyword` node, with the following structure:
+   * Represents a node with kind `YulLog2Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LOG_2_KEYWORD = "log2";
@@ -4998,7 +4998,7 @@ export declare enum TerminalKind {
    */
   YulLog2Keyword = "YulLog2Keyword",
   /**
-   * This kind represents a `YulLog3Keyword` node, with the following structure:
+   * Represents a node with kind `YulLog3Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LOG_3_KEYWORD = "log3";
@@ -5006,7 +5006,7 @@ export declare enum TerminalKind {
    */
   YulLog3Keyword = "YulLog3Keyword",
   /**
-   * This kind represents a `YulLog4Keyword` node, with the following structure:
+   * Represents a node with kind `YulLog4Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LOG_4_KEYWORD = "log4";
@@ -5014,7 +5014,7 @@ export declare enum TerminalKind {
    */
   YulLog4Keyword = "YulLog4Keyword",
   /**
-   * This kind represents a `YulLtKeyword` node, with the following structure:
+   * Represents a node with kind `YulLtKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_LT_KEYWORD = "lt";
@@ -5022,7 +5022,7 @@ export declare enum TerminalKind {
    */
   YulLtKeyword = "YulLtKeyword",
   /**
-   * This kind represents a `YulMCopyKeyword` node, with the following structure:
+   * Represents a node with kind `YulMCopyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.24 *)
@@ -5032,7 +5032,7 @@ export declare enum TerminalKind {
    */
   YulMcopyKeyword = "YulMcopyKeyword",
   /**
-   * This kind represents a `YulMLoadKeyword` node, with the following structure:
+   * Represents a node with kind `YulMLoadKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_M_LOAD_KEYWORD = "mload";
@@ -5040,7 +5040,7 @@ export declare enum TerminalKind {
    */
   YulMloadKeyword = "YulMloadKeyword",
   /**
-   * This kind represents a `YulMSizeKeyword` node, with the following structure:
+   * Represents a node with kind `YulMSizeKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_M_SIZE_KEYWORD = "msize";
@@ -5048,7 +5048,7 @@ export declare enum TerminalKind {
    */
   YulMsizeKeyword = "YulMsizeKeyword",
   /**
-   * This kind represents a `YulMStore8Keyword` node, with the following structure:
+   * Represents a node with kind `YulMStore8Keyword`, having the following structure:
    *
    * ```ebnf
    * YUL_M_STORE_8_KEYWORD = "mstore8";
@@ -5056,7 +5056,7 @@ export declare enum TerminalKind {
    */
   YulMstore8Keyword = "YulMstore8Keyword",
   /**
-   * This kind represents a `YulMStoreKeyword` node, with the following structure:
+   * Represents a node with kind `YulMStoreKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_M_STORE_KEYWORD = "mstore";
@@ -5064,7 +5064,7 @@ export declare enum TerminalKind {
    */
   YulMstoreKeyword = "YulMstoreKeyword",
   /**
-   * This kind represents a `YulMacroKeyword` node, with the following structure:
+   * Represents a node with kind `YulMacroKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5073,7 +5073,7 @@ export declare enum TerminalKind {
    */
   YulMacroKeyword = "YulMacroKeyword",
   /**
-   * This kind represents a `YulMappingKeyword` node, with the following structure:
+   * Represents a node with kind `YulMappingKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5082,7 +5082,7 @@ export declare enum TerminalKind {
    */
   YulMappingKeyword = "YulMappingKeyword",
   /**
-   * This kind represents a `YulMatchKeyword` node, with the following structure:
+   * Represents a node with kind `YulMatchKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5091,7 +5091,7 @@ export declare enum TerminalKind {
    */
   YulMatchKeyword = "YulMatchKeyword",
   /**
-   * This kind represents a `YulMemoryKeyword` node, with the following structure:
+   * Represents a node with kind `YulMemoryKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5100,7 +5100,7 @@ export declare enum TerminalKind {
    */
   YulMemoryKeyword = "YulMemoryKeyword",
   /**
-   * This kind represents a `YulMinutesKeyword` node, with the following structure:
+   * Represents a node with kind `YulMinutesKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5109,7 +5109,7 @@ export declare enum TerminalKind {
    */
   YulMinutesKeyword = "YulMinutesKeyword",
   /**
-   * This kind represents a `YulModKeyword` node, with the following structure:
+   * Represents a node with kind `YulModKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_MOD_KEYWORD = "mod";
@@ -5117,7 +5117,7 @@ export declare enum TerminalKind {
    */
   YulModKeyword = "YulModKeyword",
   /**
-   * This kind represents a `YulModifierKeyword` node, with the following structure:
+   * Represents a node with kind `YulModifierKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5126,7 +5126,7 @@ export declare enum TerminalKind {
    */
   YulModifierKeyword = "YulModifierKeyword",
   /**
-   * This kind represents a `YulMulKeyword` node, with the following structure:
+   * Represents a node with kind `YulMulKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_MUL_KEYWORD = "mul";
@@ -5134,7 +5134,7 @@ export declare enum TerminalKind {
    */
   YulMulKeyword = "YulMulKeyword",
   /**
-   * This kind represents a `YulMulModKeyword` node, with the following structure:
+   * Represents a node with kind `YulMulModKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_MUL_MOD_KEYWORD = "mulmod";
@@ -5142,7 +5142,7 @@ export declare enum TerminalKind {
    */
   YulMulModKeyword = "YulMulModKeyword",
   /**
-   * This kind represents a `YulMutableKeyword` node, with the following structure:
+   * Represents a node with kind `YulMutableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5151,7 +5151,7 @@ export declare enum TerminalKind {
    */
   YulMutableKeyword = "YulMutableKeyword",
   /**
-   * This kind represents a `YulNewKeyword` node, with the following structure:
+   * Represents a node with kind `YulNewKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5160,7 +5160,7 @@ export declare enum TerminalKind {
    */
   YulNewKeyword = "YulNewKeyword",
   /**
-   * This kind represents a `YulNotKeyword` node, with the following structure:
+   * Represents a node with kind `YulNotKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_NOT_KEYWORD = "not";
@@ -5168,7 +5168,7 @@ export declare enum TerminalKind {
    */
   YulNotKeyword = "YulNotKeyword",
   /**
-   * This kind represents a `YulNullKeyword` node, with the following structure:
+   * Represents a node with kind `YulNullKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5177,7 +5177,7 @@ export declare enum TerminalKind {
    */
   YulNullKeyword = "YulNullKeyword",
   /**
-   * This kind represents a `YulNumberKeyword` node, with the following structure:
+   * Represents a node with kind `YulNumberKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_NUMBER_KEYWORD = "number";
@@ -5185,7 +5185,7 @@ export declare enum TerminalKind {
    */
   YulNumberKeyword = "YulNumberKeyword",
   /**
-   * This kind represents a `YulOfKeyword` node, with the following structure:
+   * Represents a node with kind `YulOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5194,7 +5194,7 @@ export declare enum TerminalKind {
    */
   YulOfKeyword = "YulOfKeyword",
   /**
-   * This kind represents a `YulOrKeyword` node, with the following structure:
+   * Represents a node with kind `YulOrKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_OR_KEYWORD = "or";
@@ -5202,7 +5202,7 @@ export declare enum TerminalKind {
    */
   YulOrKeyword = "YulOrKeyword",
   /**
-   * This kind represents a `YulOriginKeyword` node, with the following structure:
+   * Represents a node with kind `YulOriginKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_ORIGIN_KEYWORD = "origin";
@@ -5210,7 +5210,7 @@ export declare enum TerminalKind {
    */
   YulOriginKeyword = "YulOriginKeyword",
   /**
-   * This kind represents a `YulOverrideKeyword` node, with the following structure:
+   * Represents a node with kind `YulOverrideKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5219,7 +5219,7 @@ export declare enum TerminalKind {
    */
   YulOverrideKeyword = "YulOverrideKeyword",
   /**
-   * This kind represents a `YulPartialKeyword` node, with the following structure:
+   * Represents a node with kind `YulPartialKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5228,7 +5228,7 @@ export declare enum TerminalKind {
    */
   YulPartialKeyword = "YulPartialKeyword",
   /**
-   * This kind represents a `YulPayableKeyword` node, with the following structure:
+   * Represents a node with kind `YulPayableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5237,7 +5237,7 @@ export declare enum TerminalKind {
    */
   YulPayableKeyword = "YulPayableKeyword",
   /**
-   * This kind represents a `YulPopKeyword` node, with the following structure:
+   * Represents a node with kind `YulPopKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_POP_KEYWORD = "pop";
@@ -5245,7 +5245,7 @@ export declare enum TerminalKind {
    */
   YulPopKeyword = "YulPopKeyword",
   /**
-   * This kind represents a `YulPragmaKeyword` node, with the following structure:
+   * Represents a node with kind `YulPragmaKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5254,7 +5254,7 @@ export declare enum TerminalKind {
    */
   YulPragmaKeyword = "YulPragmaKeyword",
   /**
-   * This kind represents a `YulPrevRandaoKeyword` node, with the following structure:
+   * Represents a node with kind `YulPrevRandaoKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.18 *)
@@ -5264,7 +5264,7 @@ export declare enum TerminalKind {
    */
   YulPrevRandaoKeyword = "YulPrevRandaoKeyword",
   /**
-   * This kind represents a `YulPrivateKeyword` node, with the following structure:
+   * Represents a node with kind `YulPrivateKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5273,7 +5273,7 @@ export declare enum TerminalKind {
    */
   YulPrivateKeyword = "YulPrivateKeyword",
   /**
-   * This kind represents a `YulPromiseKeyword` node, with the following structure:
+   * Represents a node with kind `YulPromiseKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5282,7 +5282,7 @@ export declare enum TerminalKind {
    */
   YulPromiseKeyword = "YulPromiseKeyword",
   /**
-   * This kind represents a `YulPublicKeyword` node, with the following structure:
+   * Represents a node with kind `YulPublicKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5291,7 +5291,7 @@ export declare enum TerminalKind {
    */
   YulPublicKeyword = "YulPublicKeyword",
   /**
-   * This kind represents a `YulPureKeyword` node, with the following structure:
+   * Represents a node with kind `YulPureKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5300,7 +5300,7 @@ export declare enum TerminalKind {
    */
   YulPureKeyword = "YulPureKeyword",
   /**
-   * This kind represents a `YulReceiveKeyword` node, with the following structure:
+   * Represents a node with kind `YulReceiveKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.6.0 until 0.7.1 *)
@@ -5309,7 +5309,7 @@ export declare enum TerminalKind {
    */
   YulReceiveKeyword = "YulReceiveKeyword",
   /**
-   * This kind represents a `YulReferenceKeyword` node, with the following structure:
+   * Represents a node with kind `YulReferenceKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5318,7 +5318,7 @@ export declare enum TerminalKind {
    */
   YulReferenceKeyword = "YulReferenceKeyword",
   /**
-   * This kind represents a `YulRelocatableKeyword` node, with the following structure:
+   * Represents a node with kind `YulRelocatableKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5327,7 +5327,7 @@ export declare enum TerminalKind {
    */
   YulRelocatableKeyword = "YulRelocatableKeyword",
   /**
-   * This kind represents a `YulReturnDataCopyKeyword` node, with the following structure:
+   * Represents a node with kind `YulReturnDataCopyKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.12 *)
@@ -5337,7 +5337,7 @@ export declare enum TerminalKind {
    */
   YulReturnDataCopyKeyword = "YulReturnDataCopyKeyword",
   /**
-   * This kind represents a `YulReturnDataSizeKeyword` node, with the following structure:
+   * Represents a node with kind `YulReturnDataSizeKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.12 *)
@@ -5347,7 +5347,7 @@ export declare enum TerminalKind {
    */
   YulReturnDataSizeKeyword = "YulReturnDataSizeKeyword",
   /**
-   * This kind represents a `YulReturnKeyword` node, with the following structure:
+   * Represents a node with kind `YulReturnKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_RETURN_KEYWORD = "return";
@@ -5355,7 +5355,7 @@ export declare enum TerminalKind {
    */
   YulReturnKeyword = "YulReturnKeyword",
   /**
-   * This kind represents a `YulReturnsKeyword` node, with the following structure:
+   * Represents a node with kind `YulReturnsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5364,7 +5364,7 @@ export declare enum TerminalKind {
    */
   YulReturnsKeyword = "YulReturnsKeyword",
   /**
-   * This kind represents a `YulRevertKeyword` node, with the following structure:
+   * Represents a node with kind `YulRevertKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_REVERT_KEYWORD = "revert";
@@ -5372,7 +5372,7 @@ export declare enum TerminalKind {
    */
   YulRevertKeyword = "YulRevertKeyword",
   /**
-   * This kind represents a `YulSDivKeyword` node, with the following structure:
+   * Represents a node with kind `YulSDivKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_S_DIV_KEYWORD = "sdiv";
@@ -5380,7 +5380,7 @@ export declare enum TerminalKind {
    */
   YulSdivKeyword = "YulSdivKeyword",
   /**
-   * This kind represents a `YulSLoadKeyword` node, with the following structure:
+   * Represents a node with kind `YulSLoadKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_S_LOAD_KEYWORD = "sload";
@@ -5388,7 +5388,7 @@ export declare enum TerminalKind {
    */
   YulSloadKeyword = "YulSloadKeyword",
   /**
-   * This kind represents a `YulSModKeyword` node, with the following structure:
+   * Represents a node with kind `YulSModKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_S_MOD_KEYWORD = "smod";
@@ -5396,7 +5396,7 @@ export declare enum TerminalKind {
    */
   YulSmodKeyword = "YulSmodKeyword",
   /**
-   * This kind represents a `YulSStoreKeyword` node, with the following structure:
+   * Represents a node with kind `YulSStoreKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_S_STORE_KEYWORD = "sstore";
@@ -5404,7 +5404,7 @@ export declare enum TerminalKind {
    */
   YulSstoreKeyword = "YulSstoreKeyword",
   /**
-   * This kind represents a `YulSarKeyword` node, with the following structure:
+   * Represents a node with kind `YulSarKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.4.21 *)
@@ -5413,7 +5413,7 @@ export declare enum TerminalKind {
    */
   YulSarKeyword = "YulSarKeyword",
   /**
-   * This kind represents a `YulSealedKeyword` node, with the following structure:
+   * Represents a node with kind `YulSealedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5422,7 +5422,7 @@ export declare enum TerminalKind {
    */
   YulSealedKeyword = "YulSealedKeyword",
   /**
-   * This kind represents a `YulSecondsKeyword` node, with the following structure:
+   * Represents a node with kind `YulSecondsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5431,7 +5431,7 @@ export declare enum TerminalKind {
    */
   YulSecondsKeyword = "YulSecondsKeyword",
   /**
-   * This kind represents a `YulSelfBalanceKeyword` node, with the following structure:
+   * Represents a node with kind `YulSelfBalanceKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.5.12 *)
@@ -5440,7 +5440,7 @@ export declare enum TerminalKind {
    */
   YulSelfBalanceKeyword = "YulSelfBalanceKeyword",
   /**
-   * This kind represents a `YulSelfDestructKeyword` node, with the following structure:
+   * Represents a node with kind `YulSelfDestructKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SELF_DESTRUCT_KEYWORD = "selfdestruct";
@@ -5448,7 +5448,7 @@ export declare enum TerminalKind {
    */
   YulSelfDestructKeyword = "YulSelfDestructKeyword",
   /**
-   * This kind represents a `YulSgtKeyword` node, with the following structure:
+   * Represents a node with kind `YulSgtKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SGT_KEYWORD = "sgt";
@@ -5456,7 +5456,7 @@ export declare enum TerminalKind {
    */
   YulSgtKeyword = "YulSgtKeyword",
   /**
-   * This kind represents a `YulSha3Keyword` node, with the following structure:
+   * Represents a node with kind `YulSha3Keyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -5466,7 +5466,7 @@ export declare enum TerminalKind {
    */
   YulSha3Keyword = "YulSha3Keyword",
   /**
-   * This kind represents a `YulShlKeyword` node, with the following structure:
+   * Represents a node with kind `YulShlKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.4.21 *)
@@ -5475,7 +5475,7 @@ export declare enum TerminalKind {
    */
   YulShlKeyword = "YulShlKeyword",
   /**
-   * This kind represents a `YulShrKeyword` node, with the following structure:
+   * Represents a node with kind `YulShrKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved in 0.4.21 *)
@@ -5484,7 +5484,7 @@ export declare enum TerminalKind {
    */
   YulShrKeyword = "YulShrKeyword",
   /**
-   * This kind represents a `YulSignExtendKeyword` node, with the following structure:
+   * Represents a node with kind `YulSignExtendKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SIGN_EXTEND_KEYWORD = "signextend";
@@ -5492,7 +5492,7 @@ export declare enum TerminalKind {
    */
   YulSignExtendKeyword = "YulSignExtendKeyword",
   /**
-   * This kind represents a `YulSizeOfKeyword` node, with the following structure:
+   * Represents a node with kind `YulSizeOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5501,7 +5501,7 @@ export declare enum TerminalKind {
    */
   YulSizeOfKeyword = "YulSizeOfKeyword",
   /**
-   * This kind represents a `YulSltKeyword` node, with the following structure:
+   * Represents a node with kind `YulSltKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SLT_KEYWORD = "slt";
@@ -5509,7 +5509,7 @@ export declare enum TerminalKind {
    */
   YulSltKeyword = "YulSltKeyword",
   /**
-   * This kind represents a `YulStaticCallKeyword` node, with the following structure:
+   * Represents a node with kind `YulStaticCallKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.4.12 *)
@@ -5519,7 +5519,7 @@ export declare enum TerminalKind {
    */
   YulStaticCallKeyword = "YulStaticCallKeyword",
   /**
-   * This kind represents a `YulStaticKeyword` node, with the following structure:
+   * Represents a node with kind `YulStaticKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5528,7 +5528,7 @@ export declare enum TerminalKind {
    */
   YulStaticKeyword = "YulStaticKeyword",
   /**
-   * This kind represents a `YulStopKeyword` node, with the following structure:
+   * Represents a node with kind `YulStopKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_STOP_KEYWORD = "stop";
@@ -5536,7 +5536,7 @@ export declare enum TerminalKind {
    */
   YulStopKeyword = "YulStopKeyword",
   /**
-   * This kind represents a `YulStorageKeyword` node, with the following structure:
+   * Represents a node with kind `YulStorageKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5545,7 +5545,7 @@ export declare enum TerminalKind {
    */
   YulStorageKeyword = "YulStorageKeyword",
   /**
-   * This kind represents a `YulStringKeyword` node, with the following structure:
+   * Represents a node with kind `YulStringKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5554,7 +5554,7 @@ export declare enum TerminalKind {
    */
   YulStringKeyword = "YulStringKeyword",
   /**
-   * This kind represents a `YulStructKeyword` node, with the following structure:
+   * Represents a node with kind `YulStructKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5563,7 +5563,7 @@ export declare enum TerminalKind {
    */
   YulStructKeyword = "YulStructKeyword",
   /**
-   * This kind represents a `YulSubKeyword` node, with the following structure:
+   * Represents a node with kind `YulSubKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SUB_KEYWORD = "sub";
@@ -5571,7 +5571,7 @@ export declare enum TerminalKind {
    */
   YulSubKeyword = "YulSubKeyword",
   /**
-   * This kind represents a `YulSuicideKeyword` node, with the following structure:
+   * Represents a node with kind `YulSuicideKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Deprecated in 0.5.0 *)
@@ -5581,7 +5581,7 @@ export declare enum TerminalKind {
    */
   YulSuicideKeyword = "YulSuicideKeyword",
   /**
-   * This kind represents a `YulSuperKeyword` node, with the following structure:
+   * Represents a node with kind `YulSuperKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SUPER_KEYWORD = "super";
@@ -5589,7 +5589,7 @@ export declare enum TerminalKind {
    */
   YulSuperKeyword = "YulSuperKeyword",
   /**
-   * This kind represents a `YulSupportsKeyword` node, with the following structure:
+   * Represents a node with kind `YulSupportsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5598,7 +5598,7 @@ export declare enum TerminalKind {
    */
   YulSupportsKeyword = "YulSupportsKeyword",
   /**
-   * This kind represents a `YulSwitchKeyword` node, with the following structure:
+   * Represents a node with kind `YulSwitchKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_SWITCH_KEYWORD = "switch";
@@ -5606,7 +5606,7 @@ export declare enum TerminalKind {
    */
   YulSwitchKeyword = "YulSwitchKeyword",
   /**
-   * This kind represents a `YulSzaboKeyword` node, with the following structure:
+   * Represents a node with kind `YulSzaboKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.0 *)
@@ -5615,7 +5615,7 @@ export declare enum TerminalKind {
    */
   YulSzaboKeyword = "YulSzaboKeyword",
   /**
-   * This kind represents a `YulTLoadKeyword` node, with the following structure:
+   * Represents a node with kind `YulTLoadKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.24 *)
@@ -5625,7 +5625,7 @@ export declare enum TerminalKind {
    */
   YulTloadKeyword = "YulTloadKeyword",
   /**
-   * This kind represents a `YulTStoreKeyword` node, with the following structure:
+   * Represents a node with kind `YulTStoreKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 0.8.24 *)
@@ -5635,7 +5635,7 @@ export declare enum TerminalKind {
    */
   YulTstoreKeyword = "YulTstoreKeyword",
   /**
-   * This kind represents a `YulThisKeyword` node, with the following structure:
+   * Represents a node with kind `YulThisKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_THIS_KEYWORD = "this";
@@ -5643,7 +5643,7 @@ export declare enum TerminalKind {
    */
   YulThisKeyword = "YulThisKeyword",
   /**
-   * This kind represents a `YulThrowKeyword` node, with the following structure:
+   * Represents a node with kind `YulThrowKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5652,7 +5652,7 @@ export declare enum TerminalKind {
    */
   YulThrowKeyword = "YulThrowKeyword",
   /**
-   * This kind represents a `YulTimestampKeyword` node, with the following structure:
+   * Represents a node with kind `YulTimestampKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_TIMESTAMP_KEYWORD = "timestamp";
@@ -5660,7 +5660,7 @@ export declare enum TerminalKind {
    */
   YulTimestampKeyword = "YulTimestampKeyword",
   /**
-   * This kind represents a `YulTrueKeyword` node, with the following structure:
+   * Represents a node with kind `YulTrueKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_TRUE_KEYWORD = "true";
@@ -5668,7 +5668,7 @@ export declare enum TerminalKind {
    */
   YulTrueKeyword = "YulTrueKeyword",
   /**
-   * This kind represents a `YulTryKeyword` node, with the following structure:
+   * Represents a node with kind `YulTryKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5677,7 +5677,7 @@ export declare enum TerminalKind {
    */
   YulTryKeyword = "YulTryKeyword",
   /**
-   * This kind represents a `YulTypeDefKeyword` node, with the following structure:
+   * Represents a node with kind `YulTypeDefKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5686,7 +5686,7 @@ export declare enum TerminalKind {
    */
   YulTypeDefKeyword = "YulTypeDefKeyword",
   /**
-   * This kind represents a `YulTypeKeyword` node, with the following structure:
+   * Represents a node with kind `YulTypeKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5695,7 +5695,7 @@ export declare enum TerminalKind {
    */
   YulTypeKeyword = "YulTypeKeyword",
   /**
-   * This kind represents a `YulTypeOfKeyword` node, with the following structure:
+   * Represents a node with kind `YulTypeOfKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5704,7 +5704,7 @@ export declare enum TerminalKind {
    */
   YulTypeOfKeyword = "YulTypeOfKeyword",
   /**
-   * This kind represents a `YulUfixedKeyword` node, with the following structure:
+   * Represents a node with kind `YulUfixedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5725,7 +5725,7 @@ export declare enum TerminalKind {
    */
   YulUfixedKeyword = "YulUfixedKeyword",
   /**
-   * This kind represents a `YulUintKeyword` node, with the following structure:
+   * Represents a node with kind `YulUintKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5734,7 +5734,7 @@ export declare enum TerminalKind {
    */
   YulUintKeyword = "YulUintKeyword",
   /**
-   * This kind represents a `YulUncheckedKeyword` node, with the following structure:
+   * Represents a node with kind `YulUncheckedKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.5.0 until 0.7.1 *)
@@ -5743,7 +5743,7 @@ export declare enum TerminalKind {
    */
   YulUncheckedKeyword = "YulUncheckedKeyword",
   /**
-   * This kind represents a `YulUsingKeyword` node, with the following structure:
+   * Represents a node with kind `YulUsingKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5752,7 +5752,7 @@ export declare enum TerminalKind {
    */
   YulUsingKeyword = "YulUsingKeyword",
   /**
-   * This kind represents a `YulVarKeyword` node, with the following structure:
+   * Represents a node with kind `YulVarKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.6.5 *)
@@ -5761,7 +5761,7 @@ export declare enum TerminalKind {
    */
   YulVarKeyword = "YulVarKeyword",
   /**
-   * This kind represents a `YulViewKeyword` node, with the following structure:
+   * Represents a node with kind `YulViewKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5770,7 +5770,7 @@ export declare enum TerminalKind {
    */
   YulViewKeyword = "YulViewKeyword",
   /**
-   * This kind represents a `YulVirtualKeyword` node, with the following structure:
+   * Represents a node with kind `YulVirtualKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved from 0.6.0 until 0.7.1 *)
@@ -5779,7 +5779,7 @@ export declare enum TerminalKind {
    */
   YulVirtualKeyword = "YulVirtualKeyword",
   /**
-   * This kind represents a `YulWeeksKeyword` node, with the following structure:
+   * Represents a node with kind `YulWeeksKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5788,7 +5788,7 @@ export declare enum TerminalKind {
    */
   YulWeeksKeyword = "YulWeeksKeyword",
   /**
-   * This kind represents a `YulWeiKeyword` node, with the following structure:
+   * Represents a node with kind `YulWeiKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5797,7 +5797,7 @@ export declare enum TerminalKind {
    */
   YulWeiKeyword = "YulWeiKeyword",
   /**
-   * This kind represents a `YulWhileKeyword` node, with the following structure:
+   * Represents a node with kind `YulWhileKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5806,7 +5806,7 @@ export declare enum TerminalKind {
    */
   YulWhileKeyword = "YulWhileKeyword",
   /**
-   * This kind represents a `YulXorKeyword` node, with the following structure:
+   * Represents a node with kind `YulXorKeyword`, having the following structure:
    *
    * ```ebnf
    * YUL_XOR_KEYWORD = "xor";
@@ -5814,7 +5814,7 @@ export declare enum TerminalKind {
    */
   YulXorKeyword = "YulXorKeyword",
   /**
-   * This kind represents a `YulYearsKeyword` node, with the following structure:
+   * Represents a node with kind `YulYearsKeyword`, having the following structure:
    *
    * ```ebnf
    * (* Reserved until 0.7.1 *)
@@ -5827,145 +5827,552 @@ export declare enum TerminalKind {
  * Represents the different types of relationships between nodes in the syntax tree.
  */
 export declare enum EdgeLabel {
+  /**
+   * Represents a child node with the label `item`.
+   */
   Item = "Item",
+  /**
+   * Represents a child node with the label `variant`.
+   */
   Variant = "Variant",
+  /**
+   * Represents a child node with the label `separator`.
+   */
   Separator = "Separator",
+  /**
+   * Represents a child node with the label `operand`.
+   */
   Operand = "Operand",
+  /**
+   * Represents a child node with the label `left_operand`.
+   */
   LeftOperand = "LeftOperand",
+  /**
+   * Represents a child node with the label `right_operand`.
+   */
   RightOperand = "RightOperand",
+  /**
+   * Represents a child node with the label `leading_trivia`.
+   */
   LeadingTrivia = "LeadingTrivia",
+  /**
+   * Represents a child node with the label `trailing_trivia`.
+   */
   TrailingTrivia = "TrailingTrivia",
+  /**
+   * Represents a child node with the label `abicoder_keyword`.
+   */
   AbicoderKeyword = "AbicoderKeyword",
+  /**
+   * Represents a child node with the label `abstract_keyword`.
+   */
   AbstractKeyword = "AbstractKeyword",
+  /**
+   * Represents a child node with the label `address_keyword`.
+   */
   AddressKeyword = "AddressKeyword",
+  /**
+   * Represents a child node with the label `alias`.
+   */
   Alias = "Alias",
+  /**
+   * Represents a child node with the label `anonymous_keyword`.
+   */
   AnonymousKeyword = "AnonymousKeyword",
+  /**
+   * Represents a child node with the label `arguments`.
+   */
   Arguments = "Arguments",
+  /**
+   * Represents a child node with the label `as_keyword`.
+   */
   AsKeyword = "AsKeyword",
+  /**
+   * Represents a child node with the label `assembly_keyword`.
+   */
   AssemblyKeyword = "AssemblyKeyword",
+  /**
+   * Represents a child node with the label `assignment`.
+   */
   Assignment = "Assignment",
+  /**
+   * Represents a child node with the label `asterisk`.
+   */
   Asterisk = "Asterisk",
+  /**
+   * Represents a child node with the label `attributes`.
+   */
   Attributes = "Attributes",
+  /**
+   * Represents a child node with the label `block`.
+   */
   Block = "Block",
+  /**
+   * Represents a child node with the label `body`.
+   */
   Body = "Body",
+  /**
+   * Represents a child node with the label `break_keyword`.
+   */
   BreakKeyword = "BreakKeyword",
+  /**
+   * Represents a child node with the label `case_keyword`.
+   */
   CaseKeyword = "CaseKeyword",
+  /**
+   * Represents a child node with the label `cases`.
+   */
   Cases = "Cases",
+  /**
+   * Represents a child node with the label `catch_clauses`.
+   */
   CatchClauses = "CatchClauses",
+  /**
+   * Represents a child node with the label `catch_keyword`.
+   */
   CatchKeyword = "CatchKeyword",
+  /**
+   * Represents a child node with the label `clause`.
+   */
   Clause = "Clause",
+  /**
+   * Represents a child node with the label `close_brace`.
+   */
   CloseBrace = "CloseBrace",
+  /**
+   * Represents a child node with the label `close_bracket`.
+   */
   CloseBracket = "CloseBracket",
+  /**
+   * Represents a child node with the label `close_paren`.
+   */
   CloseParen = "CloseParen",
+  /**
+   * Represents a child node with the label `colon`.
+   */
   Colon = "Colon",
+  /**
+   * Represents a child node with the label `condition`.
+   */
   Condition = "Condition",
+  /**
+   * Represents a child node with the label `constant_keyword`.
+   */
   ConstantKeyword = "ConstantKeyword",
+  /**
+   * Represents a child node with the label `constructor_keyword`.
+   */
   ConstructorKeyword = "ConstructorKeyword",
+  /**
+   * Represents a child node with the label `continue_keyword`.
+   */
   ContinueKeyword = "ContinueKeyword",
+  /**
+   * Represents a child node with the label `contract_keyword`.
+   */
   ContractKeyword = "ContractKeyword",
+  /**
+   * Represents a child node with the label `default_keyword`.
+   */
   DefaultKeyword = "DefaultKeyword",
+  /**
+   * Represents a child node with the label `do_keyword`.
+   */
   DoKeyword = "DoKeyword",
+  /**
+   * Represents a child node with the label `elements`.
+   */
   Elements = "Elements",
+  /**
+   * Represents a child node with the label `else_branch`.
+   */
   ElseBranch = "ElseBranch",
+  /**
+   * Represents a child node with the label `else_keyword`.
+   */
   ElseKeyword = "ElseKeyword",
+  /**
+   * Represents a child node with the label `emit_keyword`.
+   */
   EmitKeyword = "EmitKeyword",
+  /**
+   * Represents a child node with the label `end`.
+   */
   End = "End",
+  /**
+   * Represents a child node with the label `enum_keyword`.
+   */
   EnumKeyword = "EnumKeyword",
+  /**
+   * Represents a child node with the label `equal`.
+   */
   Equal = "Equal",
+  /**
+   * Represents a child node with the label `equal_greater_than`.
+   */
   EqualGreaterThan = "EqualGreaterThan",
+  /**
+   * Represents a child node with the label `error`.
+   */
   Error = "Error",
+  /**
+   * Represents a child node with the label `error_keyword`.
+   */
   ErrorKeyword = "ErrorKeyword",
+  /**
+   * Represents a child node with the label `event`.
+   */
   Event = "Event",
+  /**
+   * Represents a child node with the label `event_keyword`.
+   */
   EventKeyword = "EventKeyword",
+  /**
+   * Represents a child node with the label `experimental_keyword`.
+   */
   ExperimentalKeyword = "ExperimentalKeyword",
+  /**
+   * Represents a child node with the label `expression`.
+   */
   Expression = "Expression",
+  /**
+   * Represents a child node with the label `fallback_keyword`.
+   */
   FallbackKeyword = "FallbackKeyword",
+  /**
+   * Represents a child node with the label `false_expression`.
+   */
   FalseExpression = "FalseExpression",
+  /**
+   * Represents a child node with the label `feature`.
+   */
   Feature = "Feature",
+  /**
+   * Represents a child node with the label `flags`.
+   */
   Flags = "Flags",
+  /**
+   * Represents a child node with the label `for_keyword`.
+   */
   ForKeyword = "ForKeyword",
+  /**
+   * Represents a child node with the label `from_keyword`.
+   */
   FromKeyword = "FromKeyword",
+  /**
+   * Represents a child node with the label `function_keyword`.
+   */
   FunctionKeyword = "FunctionKeyword",
+  /**
+   * Represents a child node with the label `global_keyword`.
+   */
   GlobalKeyword = "GlobalKeyword",
+  /**
+   * Represents a child node with the label `identifier`.
+   */
   Identifier = "Identifier",
+  /**
+   * Represents a child node with the label `if_keyword`.
+   */
   IfKeyword = "IfKeyword",
+  /**
+   * Represents a child node with the label `import_keyword`.
+   */
   ImportKeyword = "ImportKeyword",
+  /**
+   * Represents a child node with the label `index`.
+   */
   Index = "Index",
+  /**
+   * Represents a child node with the label `indexed_keyword`.
+   */
   IndexedKeyword = "IndexedKeyword",
+  /**
+   * Represents a child node with the label `inheritance`.
+   */
   Inheritance = "Inheritance",
+  /**
+   * Represents a child node with the label `initialization`.
+   */
   Initialization = "Initialization",
+  /**
+   * Represents a child node with the label `interface_keyword`.
+   */
   InterfaceKeyword = "InterfaceKeyword",
+  /**
+   * Represents a child node with the label `is_keyword`.
+   */
   IsKeyword = "IsKeyword",
+  /**
+   * Represents a child node with the label `items`.
+   */
   Items = "Items",
+  /**
+   * Represents a child node with the label `iterator`.
+   */
   Iterator = "Iterator",
+  /**
+   * Represents a child node with the label `key_type`.
+   */
   KeyType = "KeyType",
+  /**
+   * Represents a child node with the label `label`.
+   */
   Label = "Label",
+  /**
+   * Represents a child node with the label `leave_keyword`.
+   */
   LeaveKeyword = "LeaveKeyword",
+  /**
+   * Represents a child node with the label `let_keyword`.
+   */
   LetKeyword = "LetKeyword",
+  /**
+   * Represents a child node with the label `library_keyword`.
+   */
   LibraryKeyword = "LibraryKeyword",
+  /**
+   * Represents a child node with the label `literal`.
+   */
   Literal = "Literal",
+  /**
+   * Represents a child node with the label `mapping_keyword`.
+   */
   MappingKeyword = "MappingKeyword",
+  /**
+   * Represents a child node with the label `member`.
+   */
   Member = "Member",
+  /**
+   * Represents a child node with the label `members`.
+   */
   Members = "Members",
+  /**
+   * Represents a child node with the label `minus`.
+   */
   Minus = "Minus",
+  /**
+   * Represents a child node with the label `minus_greater_than`.
+   */
   MinusGreaterThan = "MinusGreaterThan",
+  /**
+   * Represents a child node with the label `modifier_keyword`.
+   */
   ModifierKeyword = "ModifierKeyword",
+  /**
+   * Represents a child node with the label `name`.
+   */
   Name = "Name",
+  /**
+   * Represents a child node with the label `new_keyword`.
+   */
   NewKeyword = "NewKeyword",
+  /**
+   * Represents a child node with the label `open_brace`.
+   */
   OpenBrace = "OpenBrace",
+  /**
+   * Represents a child node with the label `open_bracket`.
+   */
   OpenBracket = "OpenBracket",
+  /**
+   * Represents a child node with the label `open_paren`.
+   */
   OpenParen = "OpenParen",
+  /**
+   * Represents a child node with the label `operator`.
+   */
   Operator = "Operator",
+  /**
+   * Represents a child node with the label `options`.
+   */
   Options = "Options",
+  /**
+   * Represents a child node with the label `overridden`.
+   */
   Overridden = "Overridden",
+  /**
+   * Represents a child node with the label `override_keyword`.
+   */
   OverrideKeyword = "OverrideKeyword",
+  /**
+   * Represents a child node with the label `parameters`.
+   */
   Parameters = "Parameters",
+  /**
+   * Represents a child node with the label `path`.
+   */
   Path = "Path",
+  /**
+   * Represents a child node with the label `paths`.
+   */
   Paths = "Paths",
+  /**
+   * Represents a child node with the label `payable_keyword`.
+   */
   PayableKeyword = "PayableKeyword",
+  /**
+   * Represents a child node with the label `period`.
+   */
   Period = "Period",
+  /**
+   * Represents a child node with the label `pragma`.
+   */
   Pragma = "Pragma",
+  /**
+   * Represents a child node with the label `pragma_keyword`.
+   */
   PragmaKeyword = "PragmaKeyword",
+  /**
+   * Represents a child node with the label `question_mark`.
+   */
   QuestionMark = "QuestionMark",
+  /**
+   * Represents a child node with the label `receive_keyword`.
+   */
   ReceiveKeyword = "ReceiveKeyword",
+  /**
+   * Represents a child node with the label `return_keyword`.
+   */
   ReturnKeyword = "ReturnKeyword",
+  /**
+   * Represents a child node with the label `returns`.
+   */
   Returns = "Returns",
+  /**
+   * Represents a child node with the label `returns_keyword`.
+   */
   ReturnsKeyword = "ReturnsKeyword",
+  /**
+   * Represents a child node with the label `revert_keyword`.
+   */
   RevertKeyword = "RevertKeyword",
+  /**
+   * Represents a child node with the label `semicolon`.
+   */
   Semicolon = "Semicolon",
+  /**
+   * Represents a child node with the label `sets`.
+   */
   Sets = "Sets",
+  /**
+   * Represents a child node with the label `solidity_keyword`.
+   */
   SolidityKeyword = "SolidityKeyword",
+  /**
+   * Represents a child node with the label `start`.
+   */
   Start = "Start",
+  /**
+   * Represents a child node with the label `statements`.
+   */
   Statements = "Statements",
+  /**
+   * Represents a child node with the label `storage_location`.
+   */
   StorageLocation = "StorageLocation",
+  /**
+   * Represents a child node with the label `struct_keyword`.
+   */
   StructKeyword = "StructKeyword",
+  /**
+   * Represents a child node with the label `switch_keyword`.
+   */
   SwitchKeyword = "SwitchKeyword",
+  /**
+   * Represents a child node with the label `symbols`.
+   */
   Symbols = "Symbols",
+  /**
+   * Represents a child node with the label `target`.
+   */
   Target = "Target",
+  /**
+   * Represents a child node with the label `throw_keyword`.
+   */
   ThrowKeyword = "ThrowKeyword",
+  /**
+   * Represents a child node with the label `true_expression`.
+   */
   TrueExpression = "TrueExpression",
+  /**
+   * Represents a child node with the label `try_keyword`.
+   */
   TryKeyword = "TryKeyword",
+  /**
+   * Represents a child node with the label `type_keyword`.
+   */
   TypeKeyword = "TypeKeyword",
+  /**
+   * Represents a child node with the label `type_name`.
+   */
   TypeName = "TypeName",
+  /**
+   * Represents a child node with the label `types`.
+   */
   Types = "Types",
+  /**
+   * Represents a child node with the label `unchecked_keyword`.
+   */
   UncheckedKeyword = "UncheckedKeyword",
+  /**
+   * Represents a child node with the label `unit`.
+   */
   Unit = "Unit",
+  /**
+   * Represents a child node with the label `using_keyword`.
+   */
   UsingKeyword = "UsingKeyword",
+  /**
+   * Represents a child node with the label `value`.
+   */
   Value = "Value",
+  /**
+   * Represents a child node with the label `value_type`.
+   */
   ValueType = "ValueType",
+  /**
+   * Represents a child node with the label `var_keyword`.
+   */
   VarKeyword = "VarKeyword",
+  /**
+   * Represents a child node with the label `variable`.
+   */
   Variable = "Variable",
+  /**
+   * Represents a child node with the label `variable_type`.
+   */
   VariableType = "VariableType",
+  /**
+   * Represents a child node with the label `variables`.
+   */
   Variables = "Variables",
+  /**
+   * Represents a child node with the label `version`.
+   */
   Version = "Version",
+  /**
+   * Represents a child node with the label `while_keyword`.
+   */
   WhileKeyword = "WhileKeyword",
 }
 /**
  * The super type of all nodes in a tree.
  */
 export type Node = NonterminalNode | TerminalNode;
+
+/**
+ * Enumerates different variants of the `Node` type.
+ */
 export enum NodeType {
+  /**
+   * Represents a variant of type `NonterminalNode`.
+   */
   NonterminalNode = "NonterminalNode",
+
+  /**
+   * Represents a variant of type `TerminalNode`.
+   */
   TerminalNode = "TerminalNode",
 }
 /**
@@ -6059,6 +6466,9 @@ export interface TextRange {
  * Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
  */
 export class AncestorsIterator {
+  /**
+   * Returns an iterator over `NonterminalNode` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<NonterminalNode>;
   /**
    * Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
@@ -6200,6 +6610,9 @@ export class Cursor {
  * Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
  */
 export class CursorIterator {
+  /**
+   * Returns an iterator over `Edge` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<Edge>;
   /**
    * Returns the next edge in the iteration, or `undefined` if there are no more edges.
@@ -6288,6 +6701,9 @@ export class Query {
  * Iterator over query matches in the syntax tree.
  */
 export class QueryMatchIterator {
+  /**
+   * Returns an iterator over `QueryMatch` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<QueryMatch>;
   /**
    * Returns the next match or `undefined` if there are no more matches.

--- a/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/edge_label.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/edge_label.rs
@@ -16,27 +16,44 @@
 )]
 #[strum(serialize_all = "snake_case")]
 #[derive(Clone, Copy)]
+/// Represents the different types of relationships between nodes in the syntax tree.
 pub enum EdgeLabel {
-    // Built-in:
+    /// Represents a child node with the label `item`.
     Item,
+    /// Represents a child node with the label `variant`.
     Variant,
+    /// Represents a child node with the label `separator`.
     Separator,
+    /// Represents a child node with the label `operand`.
     Operand,
+    /// Represents a child node with the label `left_operand`.
     LeftOperand,
+    /// Represents a child node with the label `right_operand`.
     RightOperand,
+    /// Represents a child node with the label `leading_trivia`.
     LeadingTrivia,
+    /// Represents a child node with the label `trailing_trivia`.
     TrailingTrivia,
 
-    // Generated:
+    /// Represents a child node with the label `close_bracket`.
     CloseBracket,
+    /// Represents a child node with the label `keyword`.
     Keyword,
+    /// Represents a child node with the label `member`.
     Member,
+    /// Represents a child node with the label `members`.
     Members,
+    /// Represents a child node with the label `name`.
     Name,
+    /// Represents a child node with the label `node`.
     Node,
+    /// Represents a child node with the label `open_bracket`.
     OpenBracket,
+    /// Represents a child node with the label `operator`.
     Operator,
+    /// Represents a child node with the label `period`.
     Period,
+    /// Represents a child node with the label `semicolon`.
     Semicolon,
 }
 

--- a/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
@@ -19,6 +19,8 @@
     Copy,
 )]
 pub enum NonterminalKind {
+    /// Represents a node with kind `AdditionExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Left-associative binary operator *)
     /// AdditionExpression = (* left_operand: *) Expression
@@ -26,6 +28,8 @@ pub enum NonterminalKind {
     ///                      (* right_operand: *) Expression;
     /// ```
     AdditionExpression,
+    /// Represents a node with kind `Expression`, having the following structure:
+    ///
     /// ```ebnf
     /// Expression = (* variant: *) AdditionExpression
     ///            | (* variant: *) NegationExpression
@@ -34,10 +38,14 @@ pub enum NonterminalKind {
     ///            | (* variant: *) IDENTIFIER;
     /// ```
     Expression,
+    /// Represents a node with kind `Literal`, having the following structure:
+    ///
     /// ```ebnf
     /// Literal = (* variant: *) STRING_LITERAL;
     /// ```
     Literal,
+    /// Represents a node with kind `MemberAccessExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Postfix unary operator *)
     /// MemberAccessExpression = (* operand: *) Expression
@@ -45,21 +53,29 @@ pub enum NonterminalKind {
     ///                          (* member: *) IDENTIFIER;
     /// ```
     MemberAccessExpression,
+    /// Represents a node with kind `NegationExpression`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Prefix unary operator *)
     /// NegationExpression = (* operator: *) BANG
     ///                      (* operand: *) Expression;
     /// ```
     NegationExpression,
+    /// Represents a node with kind `SeparatedIdentifiers`, having the following structure:
+    ///
     /// ```ebnf
     /// (* Introduced in 1.0.0 *)
     /// SeparatedIdentifiers = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
     /// ```
     SeparatedIdentifiers,
+    /// Represents a node with kind `SourceUnit`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnit = (* members: *) SourceUnitMembers;
     /// ```
     SourceUnit,
+    /// Represents a node with kind `SourceUnitMember`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnitMember = (* variant: *) Tree
     ///                  | (* variant: *) Expression
@@ -67,10 +83,14 @@ pub enum NonterminalKind {
     ///                  | (* variant: *) Literal;
     /// ```
     SourceUnitMember,
+    /// Represents a node with kind `SourceUnitMembers`, having the following structure:
+    ///
     /// ```ebnf
     /// SourceUnitMembers = (* item: *) SourceUnitMember+;
     /// ```
     SourceUnitMembers,
+    /// Represents a node with kind `Tree`, having the following structure:
+    ///
     /// ```ebnf
     /// Tree = (* keyword: *) TREE_KEYWORD
     ///        (* name: *) IDENTIFIER?
@@ -78,17 +98,23 @@ pub enum NonterminalKind {
     ///        (* semicolon: *) SEMICOLON;
     /// ```
     Tree,
+    /// Represents a node with kind `TreeNode`, having the following structure:
+    ///
     /// ```ebnf
     /// TreeNode = (* open_bracket: *) OPEN_BRACKET
     ///            (* members: *) TreeNodeChildren
     ///            (* close_bracket: *) CLOSE_BRACKET;
     /// ```
     TreeNode,
+    /// Represents a node with kind `TreeNodeChild`, having the following structure:
+    ///
     /// ```ebnf
     /// TreeNodeChild = (* variant: *) TreeNode
     ///               | (* variant: *) DELIMITED_IDENTIFIER;
     /// ```
     TreeNodeChild,
+    /// Represents a node with kind `TreeNodeChildren`, having the following structure:
+    ///
     /// ```ebnf
     /// TreeNodeChildren = (* item: *) TreeNodeChild+;
     /// ```

--- a/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
@@ -20,63 +20,89 @@
 #[allow(clippy::doc_markdown)]
 #[allow(clippy::doc_link_with_quotes)]
 pub enum TerminalKind {
-    // Built-in:
     UNRECOGNIZED,
     MISSING,
 
-    // Generated:
+    /// Represents a node with kind `Bang`, having the following structure:
+    ///
     /// ```ebnf
     /// BANG = "!";
     /// ```
     Bang,
+    /// Represents a node with kind `CloseBracket`, having the following structure:
+    ///
     /// ```ebnf
     /// CLOSE_BRACKET = "]";
     /// ```
     CloseBracket,
+    /// Represents a node with kind `DelimitedIdentifier`, having the following structure:
+    ///
     /// ```ebnf
     /// DELIMITED_IDENTIFIER = «DELIMITED_IDENTIFIER_START» «DELIMITED_IDENTIFIER_PART»*;
     /// ```
     DelimitedIdentifier,
+    /// Represents a node with kind `EndOfLine`, having the following structure:
+    ///
     /// ```ebnf
     /// END_OF_LINE = "\r"? "\n";
     /// ```
     EndOfLine,
+    /// Represents a node with kind `Identifier`, having the following structure:
+    ///
     /// ```ebnf
     /// IDENTIFIER = «RAW_IDENTIFIER»;
     /// ```
     Identifier,
+    /// Represents a node with kind `MultiLineComment`, having the following structure:
+    ///
     /// ```ebnf
     /// MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*/";
     /// ```
     MultiLineComment,
+    /// Represents a node with kind `OpenBracket`, having the following structure:
+    ///
     /// ```ebnf
     /// OPEN_BRACKET = "[";
     /// ```
     OpenBracket,
+    /// Represents a node with kind `Period`, having the following structure:
+    ///
     /// ```ebnf
     /// PERIOD = ".";
     /// ```
     Period,
+    /// Represents a node with kind `Plus`, having the following structure:
+    ///
     /// ```ebnf
     /// PLUS = "+";
     /// ```
     Plus,
+    /// Represents a node with kind `Semicolon`, having the following structure:
+    ///
     /// ```ebnf
     /// SEMICOLON = ";";
     /// ```
     Semicolon,
+    /// Represents a node with kind `SingleLineComment`, having the following structure:
+    ///
     /// ```ebnf
     /// SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
     /// ```
     SingleLineComment,
+    /// Represents a node with kind `StringLiteral`, having the following structure:
+    ///
     /// ```ebnf
     /// STRING_LITERAL = '"' («ESCAPE_SEQUENCE» | !('"' "\\" "\r" "\n"))* '"';
     /// ```
     StringLiteral,
+    /// Represents a node with kind `TreeKeyword`, having the following structure:
+    ///
     /// ```ebnf
     /// TREE_KEYWORD = "tree";
     /// ```
     TreeKeyword,
+    /// Represents a node with kind `Whitespace`, having the following structure:
+    ///
     /// ```ebnf
     /// WHITESPACE = (" " | "\t")+;
     /// ```

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/ast.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/ast.wit
@@ -3,6 +3,7 @@
 interface ast {
     use cst.{node, nonterminal-node};
 
+    /// @internal
     resource selectors {
         sequence: static func(node: borrow<nonterminal-node>) -> result<list<option<node>>, string>;
         choice: static func(node: borrow<nonterminal-node>) -> result<node, string>;

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/compilation.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/compilation.wit
@@ -9,6 +9,8 @@ interface compilation {
     ///
     /// This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
     /// This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+    ///
+    /// @internal
     resource internal-compilation-builder {
         /// Creates a new compilation builder for the specified language version.
         create: static func(language-version: string) -> result<internal-compilation-builder, string>;

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -4,7 +4,7 @@ interface cst {
     /// Represents different kinds of nonterminal nodes in the syntax tree.
     /// These are nodes that can have child nodes and represent higher-level language constructs.
     enum nonterminal-kind {
-                /// This kind represents a `AdditionExpression` node, with the following structure: 
+                /// Represents a node with kind `AdditionExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Left-associative binary operator *)
@@ -13,7 +13,7 @@ interface cst {
                 ///                      (* right_operand: *) Expression;
                 /// ```
                 %addition-expression,
-                /// This kind represents a `Expression` node, with the following structure: 
+                /// Represents a node with kind `Expression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Expression = (* variant: *) AdditionExpression
@@ -23,13 +23,13 @@ interface cst {
                 ///            | (* variant: *) IDENTIFIER;
                 /// ```
                 %expression,
-                /// This kind represents a `Literal` node, with the following structure: 
+                /// Represents a node with kind `Literal`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Literal = (* variant: *) STRING_LITERAL;
                 /// ```
                 %literal,
-                /// This kind represents a `MemberAccessExpression` node, with the following structure: 
+                /// Represents a node with kind `MemberAccessExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Postfix unary operator *)
@@ -38,7 +38,7 @@ interface cst {
                 ///                          (* member: *) IDENTIFIER;
                 /// ```
                 %member-access-expression,
-                /// This kind represents a `NegationExpression` node, with the following structure: 
+                /// Represents a node with kind `NegationExpression`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Prefix unary operator *)
@@ -46,20 +46,20 @@ interface cst {
                 ///                      (* operand: *) Expression;
                 /// ```
                 %negation-expression,
-                /// This kind represents a `SeparatedIdentifiers` node, with the following structure: 
+                /// Represents a node with kind `SeparatedIdentifiers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// (* Introduced in 1.0.0 *)
                 /// SeparatedIdentifiers = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
                 /// ```
                 %separated-identifiers,
-                /// This kind represents a `SourceUnit` node, with the following structure: 
+                /// Represents a node with kind `SourceUnit`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnit = (* members: *) SourceUnitMembers;
                 /// ```
                 %source-unit,
-                /// This kind represents a `SourceUnitMember` node, with the following structure: 
+                /// Represents a node with kind `SourceUnitMember`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnitMember = (* variant: *) Tree
@@ -68,13 +68,13 @@ interface cst {
                 ///                  | (* variant: *) Literal;
                 /// ```
                 %source-unit-member,
-                /// This kind represents a `SourceUnitMembers` node, with the following structure: 
+                /// Represents a node with kind `SourceUnitMembers`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SourceUnitMembers = (* item: *) SourceUnitMember+;
                 /// ```
                 %source-unit-members,
-                /// This kind represents a `Tree` node, with the following structure: 
+                /// Represents a node with kind `Tree`, having the following structure:
                 ///
                 /// ```ebnf
                 /// Tree = (* keyword: *) TREE_KEYWORD
@@ -83,7 +83,7 @@ interface cst {
                 ///        (* semicolon: *) SEMICOLON;
                 /// ```
                 %tree,
-                /// This kind represents a `TreeNode` node, with the following structure: 
+                /// Represents a node with kind `TreeNode`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TreeNode = (* open_bracket: *) OPEN_BRACKET
@@ -91,14 +91,14 @@ interface cst {
                 ///            (* close_bracket: *) CLOSE_BRACKET;
                 /// ```
                 %tree-node,
-                /// This kind represents a `TreeNodeChild` node, with the following structure: 
+                /// Represents a node with kind `TreeNodeChild`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TreeNodeChild = (* variant: *) TreeNode
                 ///               | (* variant: *) DELIMITED_IDENTIFIER;
                 /// ```
                 %tree-node-child,
-                /// This kind represents a `TreeNodeChildren` node, with the following structure: 
+                /// Represents a node with kind `TreeNodeChildren`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TreeNodeChildren = (* item: *) TreeNodeChild+;
@@ -115,85 +115,85 @@ interface cst {
         /// This terminal is created when the parser is expecting a certain terminal, but it cannot find it.
         /// Adding the missing input in this position may allow the parser to produce a valid tree there.
         missing,
-                /// This kind represents a `Bang` node, with the following structure: 
+                /// Represents a node with kind `Bang`, having the following structure:
                 ///
                 /// ```ebnf
                 /// BANG = "!";
                 /// ```
                 %bang,
-                /// This kind represents a `CloseBracket` node, with the following structure: 
+                /// Represents a node with kind `CloseBracket`, having the following structure:
                 ///
                 /// ```ebnf
                 /// CLOSE_BRACKET = "]";
                 /// ```
                 %close-bracket,
-                /// This kind represents a `DelimitedIdentifier` node, with the following structure: 
+                /// Represents a node with kind `DelimitedIdentifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// DELIMITED_IDENTIFIER = «DELIMITED_IDENTIFIER_START» «DELIMITED_IDENTIFIER_PART»*;
                 /// ```
                 %delimited-identifier,
-                /// This kind represents a `EndOfLine` node, with the following structure: 
+                /// Represents a node with kind `EndOfLine`, having the following structure:
                 ///
                 /// ```ebnf
                 /// END_OF_LINE = "\r"? "\n";
                 /// ```
                 %end-of-line,
-                /// This kind represents a `Identifier` node, with the following structure: 
+                /// Represents a node with kind `Identifier`, having the following structure:
                 ///
                 /// ```ebnf
                 /// IDENTIFIER = «RAW_IDENTIFIER»;
                 /// ```
                 %identifier,
-                /// This kind represents a `MultiLineComment` node, with the following structure: 
+                /// Represents a node with kind `MultiLineComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*/";
                 /// ```
                 %multi-line-comment,
-                /// This kind represents a `OpenBracket` node, with the following structure: 
+                /// Represents a node with kind `OpenBracket`, having the following structure:
                 ///
                 /// ```ebnf
                 /// OPEN_BRACKET = "[";
                 /// ```
                 %open-bracket,
-                /// This kind represents a `Period` node, with the following structure: 
+                /// Represents a node with kind `Period`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PERIOD = ".";
                 /// ```
                 %period,
-                /// This kind represents a `Plus` node, with the following structure: 
+                /// Represents a node with kind `Plus`, having the following structure:
                 ///
                 /// ```ebnf
                 /// PLUS = "+";
                 /// ```
                 %plus,
-                /// This kind represents a `Semicolon` node, with the following structure: 
+                /// Represents a node with kind `Semicolon`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SEMICOLON = ";";
                 /// ```
                 %semicolon,
-                /// This kind represents a `SingleLineComment` node, with the following structure: 
+                /// Represents a node with kind `SingleLineComment`, having the following structure:
                 ///
                 /// ```ebnf
                 /// SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
                 /// ```
                 %single-line-comment,
-                /// This kind represents a `StringLiteral` node, with the following structure: 
+                /// Represents a node with kind `StringLiteral`, having the following structure:
                 ///
                 /// ```ebnf
                 /// STRING_LITERAL = '"' («ESCAPE_SEQUENCE» | !('"' "\\" "\r" "\n"))* '"';
                 /// ```
                 %string-literal,
-                /// This kind represents a `TreeKeyword` node, with the following structure: 
+                /// Represents a node with kind `TreeKeyword`, having the following structure:
                 ///
                 /// ```ebnf
                 /// TREE_KEYWORD = "tree";
                 /// ```
                 %tree-keyword,
-                /// This kind represents a `Whitespace` node, with the following structure: 
+                /// Represents a node with kind `Whitespace`, having the following structure:
                 ///
                 /// ```ebnf
                 /// WHITESPACE = (" " | "\t")+;
@@ -211,23 +211,41 @@ interface cst {
 
     /// Represents the different types of relationships between nodes in the syntax tree.
     enum edge-label {
+            /// Represents a child node with the label `item`.
             %item,
+            /// Represents a child node with the label `variant`.
             %variant,
+            /// Represents a child node with the label `separator`.
             %separator,
+            /// Represents a child node with the label `operand`.
             %operand,
+            /// Represents a child node with the label `left_operand`.
             %left-operand,
+            /// Represents a child node with the label `right_operand`.
             %right-operand,
+            /// Represents a child node with the label `leading_trivia`.
             %leading-trivia,
+            /// Represents a child node with the label `trailing_trivia`.
             %trailing-trivia,
+                /// Represents a child node with the label `close_bracket`.
                 %close-bracket,
+                /// Represents a child node with the label `keyword`.
                 %keyword,
+                /// Represents a child node with the label `member`.
                 %member,
+                /// Represents a child node with the label `members`.
                 %members,
+                /// Represents a child node with the label `name`.
                 %name,
+                /// Represents a child node with the label `node`.
                 %node,
+                /// Represents a child node with the label `open_bracket`.
                 %open-bracket,
+                /// Represents a child node with the label `operator`.
                 %operator,
+                /// Represents a child node with the label `period`.
                 %period,
+                /// Represents a child node with the label `semicolon`.
                 %semicolon,
     }
 

--- a/crates/testlang/outputs/npm/package/src/generated/ast/generated/nodes.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/ast/generated/nodes.mts
@@ -1,33 +1,61 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../../wasm/index.mjs";
+import * as wasm from "../../../../wasm/index.mjs";
 import { NonterminalKind, NonterminalNode, TerminalNode } from "../../cst/index.mjs";
 
-/*
- * Sequences:
- */
+//
+// Sequences:
+//
 
+/**
+ * This node represents a `SourceUnit` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnit = (* members: *) SourceUnitMembers;
+ * ```
+ */
 export class SourceUnit {
   private readonly fetch = once(() => {
-    const [$members] = generated.ast.Selectors.sequence(this.cst);
+    const [$members] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       members: new SourceUnitMembers($members as NonterminalNode),
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnit`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnit`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnit);
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): SourceUnitMembers {
     return this.fetch().members;
   }
 }
 
+/**
+ * This node represents a `Tree` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Tree = (* keyword: *) TREE_KEYWORD
+ *        (* name: *) IDENTIFIER?
+ *        (* node: *) TreeNode
+ *        (* semicolon: *) SEMICOLON;
+ * ```
+ */
 export class Tree {
   private readonly fetch = once(() => {
-    const [$keyword, $name, $node, $semicolon] = generated.ast.Selectors.sequence(this.cst);
+    const [$keyword, $name, $node, $semicolon] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       keyword: $keyword as TerminalNode,
@@ -37,30 +65,59 @@ export class Tree {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Tree`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Tree`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Tree);
   }
 
+  /**
+   * Returns the child node that has the label `keyword`.
+   */
   public get keyword(): TerminalNode {
     return this.fetch().keyword;
   }
 
+  /**
+   * Returns the child node that has the label `name`.
+   */
   public get name(): TerminalNode | undefined {
     return this.fetch().name;
   }
 
+  /**
+   * Returns the child node that has the label `node`.
+   */
   public get node(): TreeNode {
     return this.fetch().node;
   }
 
+  /**
+   * Returns the child node that has the label `semicolon`.
+   */
   public get semicolon(): TerminalNode {
     return this.fetch().semicolon;
   }
 }
 
+/**
+ * This node represents a `TreeNode` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TreeNode = (* open_bracket: *) OPEN_BRACKET
+ *            (* members: *) TreeNodeChildren
+ *            (* close_bracket: *) CLOSE_BRACKET;
+ * ```
+ */
 export class TreeNode {
   private readonly fetch = once(() => {
-    const [$openBracket, $members, $closeBracket] = generated.ast.Selectors.sequence(this.cst);
+    const [$openBracket, $members, $closeBracket] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       openBracket: $openBracket as TerminalNode,
@@ -69,26 +126,53 @@ export class TreeNode {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TreeNode`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TreeNode`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TreeNode);
   }
 
+  /**
+   * Returns the child node that has the label `open_bracket`.
+   */
   public get openBracket(): TerminalNode {
     return this.fetch().openBracket;
   }
 
+  /**
+   * Returns the child node that has the label `members`.
+   */
   public get members(): TreeNodeChildren {
     return this.fetch().members;
   }
 
+  /**
+   * Returns the child node that has the label `close_bracket`.
+   */
   public get closeBracket(): TerminalNode {
     return this.fetch().closeBracket;
   }
 }
 
+/**
+ * This node represents a `AdditionExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Left-associative binary operator *)
+ * AdditionExpression = (* left_operand: *) Expression
+ *                      (* operator: *) PLUS
+ *                      (* right_operand: *) Expression;
+ * ```
+ */
 export class AdditionExpression {
   private readonly fetch = once(() => {
-    const [$leftOperand, $operator, $rightOperand] = generated.ast.Selectors.sequence(this.cst);
+    const [$leftOperand, $operator, $rightOperand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       leftOperand: new Expression($leftOperand as NonterminalNode),
@@ -97,26 +181,52 @@ export class AdditionExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `AdditionExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `AdditionExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.AdditionExpression);
   }
 
+  /**
+   * Returns the child node that has the label `left_operand`.
+   */
   public get leftOperand(): Expression {
     return this.fetch().leftOperand;
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `right_operand`.
+   */
   public get rightOperand(): Expression {
     return this.fetch().rightOperand;
   }
 }
 
+/**
+ * This node represents a `NegationExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Prefix unary operator *)
+ * NegationExpression = (* operator: *) BANG
+ *                      (* operand: *) Expression;
+ * ```
+ */
 export class NegationExpression {
   private readonly fetch = once(() => {
-    const [$operator, $operand] = generated.ast.Selectors.sequence(this.cst);
+    const [$operator, $operand] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operator: $operator as TerminalNode,
@@ -124,22 +234,46 @@ export class NegationExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `NegationExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `NegationExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.NegationExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operator`.
+   */
   public get operator(): TerminalNode {
     return this.fetch().operator;
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 }
 
+/**
+ * This node represents a `MemberAccessExpression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Postfix unary operator *)
+ * MemberAccessExpression = (* operand: *) Expression
+ *                          (* period: *) PERIOD
+ *                          (* member: *) IDENTIFIER;
+ * ```
+ */
 export class MemberAccessExpression {
   private readonly fetch = once(() => {
-    const [$operand, $period, $member] = generated.ast.Selectors.sequence(this.cst);
+    const [$operand, $period, $member] = wasm.ast.Selectors.sequence(this.cst);
 
     return {
       operand: new Expression($operand as NonterminalNode),
@@ -148,30 +282,57 @@ export class MemberAccessExpression {
     };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `MemberAccessExpression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `MemberAccessExpression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.MemberAccessExpression);
   }
 
+  /**
+   * Returns the child node that has the label `operand`.
+   */
   public get operand(): Expression {
     return this.fetch().operand;
   }
 
+  /**
+   * Returns the child node that has the label `period`.
+   */
   public get period(): TerminalNode {
     return this.fetch().period;
   }
 
+  /**
+   * Returns the child node that has the label `member`.
+   */
   public get member(): TerminalNode {
     return this.fetch().member;
   }
 }
 
-/*
- * Choices:
- */
+//
+// Choices:
+//
 
+/**
+ * This node represents a `SourceUnitMember` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnitMember = (* variant: *) Tree
+ *                  | (* variant: *) Expression
+ *                  | (* variant: *) SeparatedIdentifiers
+ *                  | (* variant: *) Literal;
+ * ```
+ */
 export class SourceUnitMember {
   private readonly fetch: () => Tree | Expression | SeparatedIdentifiers | Literal = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     switch (variant.kind) {
       case NonterminalKind.Tree:
@@ -188,18 +349,37 @@ export class SourceUnitMember {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnitMember`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnitMember`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnitMember);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): Tree | Expression | SeparatedIdentifiers | Literal {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `TreeNodeChild` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TreeNodeChild = (* variant: *) TreeNode
+ *               | (* variant: *) DELIMITED_IDENTIFIER;
+ * ```
+ */
 export class TreeNodeChild {
   private readonly fetch: () => TreeNode | TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     if (variant.isTerminalNode()) {
       return variant;
@@ -214,19 +394,41 @@ export class TreeNodeChild {
     }
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TreeNodeChild`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TreeNodeChild`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TreeNodeChild);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TreeNode | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `Expression` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Expression = (* variant: *) AdditionExpression
+ *            | (* variant: *) NegationExpression
+ *            | (* variant: *) MemberAccessExpression
+ *            | (* variant: *) STRING_LITERAL
+ *            | (* variant: *) IDENTIFIER;
+ * ```
+ */
 export class Expression {
   private readonly fetch: () => AdditionExpression | NegationExpression | MemberAccessExpression | TerminalNode = once(
     () => {
-      const variant = generated.ast.Selectors.choice(this.cst);
+      const variant = wasm.ast.Selectors.choice(this.cst);
 
       if (variant.isTerminalNode()) {
         return variant;
@@ -246,92 +448,175 @@ export class Expression {
     },
   );
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Expression`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Expression`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Expression);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): AdditionExpression | NegationExpression | MemberAccessExpression | TerminalNode {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `Literal` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * Literal = (* variant: *) STRING_LITERAL;
+ * ```
+ */
 export class Literal {
   private readonly fetch: () => TerminalNode = once(() => {
-    const variant = generated.ast.Selectors.choice(this.cst);
+    const variant = wasm.ast.Selectors.choice(this.cst);
 
     return variant as TerminalNode;
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `Literal`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `Literal`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.Literal);
   }
 
+  /**
+   * Returns the child node that has the label `variant`.
+   */
   public get variant(): TerminalNode {
     return this.fetch();
   }
 }
 
-/*
- * Repeated:
- */
+//
+// Repeated:
+//
 
+/**
+ * This node represents a `SourceUnitMembers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * SourceUnitMembers = (* item: *) SourceUnitMember+;
+ * ```
+ */
 export class SourceUnitMembers {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new SourceUnitMember(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SourceUnitMembers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SourceUnitMembers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SourceUnitMembers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly SourceUnitMember[] {
     return this.fetch();
   }
 }
 
+/**
+ * This node represents a `TreeNodeChildren` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * TreeNodeChildren = (* item: *) TreeNodeChild+;
+ * ```
+ */
 export class TreeNodeChildren {
   private readonly fetch = once(() => {
-    const items = generated.ast.Selectors.repeated(this.cst);
+    const items = wasm.ast.Selectors.repeated(this.cst);
     return items.map((item) => new TreeNodeChild(item as NonterminalNode));
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `TreeNodeChildren`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `TreeNodeChildren`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.TreeNodeChildren);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TreeNodeChild[] {
     return this.fetch();
   }
 }
 
-/*
- * Separated:
- */
+//
+// Separated:
+//
 
+/**
+ * This node represents a `SeparatedIdentifiers` nonterminal, with the following structure:
+ *
+ * ```ebnf
+ * (* Introduced in 1.0.0 *)
+ * SeparatedIdentifiers = (* item: *) IDENTIFIER ((* separator: *) PERIOD (* item: *) IDENTIFIER)*;
+ * ```
+ */
 export class SeparatedIdentifiers {
   private readonly fetch = once(() => {
-    const [items, separators] = generated.ast.Selectors.separated(this.cst);
+    const [items, separators] = wasm.ast.Selectors.separated(this.cst);
 
     return { items: items as TerminalNode[], separators: separators as TerminalNode[] };
   });
 
-  public constructor(public readonly cst: NonterminalNode) {
+  /**
+   * Constructs a new AST node of type `SeparatedIdentifiers`, given a nonterminal CST node of the same kind.
+   */
+  public constructor(
+    /**
+     * The underlying nonterminal CST node of kind `SeparatedIdentifiers`.
+     */
+    public readonly cst: NonterminalNode,
+  ) {
     assertKind(this.cst.kind, NonterminalKind.SeparatedIdentifiers);
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `item`.
+   */
   public get items(): readonly TerminalNode[] {
     return this.fetch().items;
   }
 
+  /**
+   * Returns an array of the child nodes that have the label `separator`.
+   */
   public get separators(): readonly TerminalNode[] {
     return this.fetch().separators;
   }
 }
-
-/*
- * Helpers:
- */
 
 function once<T>(factory: () => T): () => T {
   let value: T | undefined;

--- a/crates/testlang/outputs/npm/package/src/generated/bindings/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/bindings/index.mts
@@ -1,23 +1,36 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const BindingGraph = generated.bindings.BindingGraph;
-export type BindingGraph = generated.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export const BindingGraph = wasm.bindings.BindingGraph;
+/** {@inheritDoc wasm.bindings.BindingGraph} */
+export type BindingGraph = wasm.bindings.BindingGraph;
 
-export const Definition = generated.bindings.Definition;
-export type Definition = generated.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export const Definition = wasm.bindings.Definition;
+/** {@inheritDoc wasm.bindings.Definition} */
+export type Definition = wasm.bindings.Definition;
 
-export const Reference = generated.bindings.Reference;
-export type Reference = generated.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export const Reference = wasm.bindings.Reference;
+/** {@inheritDoc wasm.bindings.Reference} */
+export type Reference = wasm.bindings.Reference;
 
-export type BindingLocation = generated.bindings.BindingLocation;
+/** {@inheritDoc wasm.bindings.BindingLocation} */
+export type BindingLocation = wasm.bindings.BindingLocation;
 
-export const BindingLocationType = generated.bindings.BindingLocationType;
-export type BindingLocationType = generated.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export const BindingLocationType = wasm.bindings.BindingLocationType;
+/** {@inheritDoc wasm.bindings.BindingLocationType} */
+export type BindingLocationType = wasm.bindings.BindingLocationType;
 
-export const UserFileLocation = generated.bindings.UserFileLocation;
-export type UserFileLocation = generated.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export const UserFileLocation = wasm.bindings.UserFileLocation;
+/** {@inheritDoc wasm.bindings.UserFileLocation} */
+export type UserFileLocation = wasm.bindings.UserFileLocation;
 
-export const BuiltInLocation = generated.bindings.BuiltInLocation;
-export type BuiltInLocation = generated.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export const BuiltInLocation = wasm.bindings.BuiltInLocation;
+/** {@inheritDoc wasm.bindings.BuiltInLocation} */
+export type BuiltInLocation = wasm.bindings.BuiltInLocation;

--- a/crates/testlang/outputs/npm/package/src/generated/compilation/builder.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/compilation/builder.mts
@@ -3,10 +3,7 @@
 import { Cursor } from "../cst/index.mjs";
 import { CompilationUnit } from "./index.mjs";
 
-import * as generated from "../../../wasm/index.mjs";
-
-const InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
-type InternalCompilationBuilder = generated.compilation.InternalCompilationBuilder;
+import * as wasm from "../../../wasm/index.mjs";
 
 /**
  * User-provided options and callbacks necessary for the `CompilationBuilder` class to perform its job.
@@ -51,7 +48,7 @@ export class CompilationBuilder {
   private readonly seenFiles: Set<string> = new Set();
 
   private constructor(
-    private readonly internalBuilder: InternalCompilationBuilder,
+    private readonly internalBuilder: wasm.compilation.InternalCompilationBuilder,
 
     /**
      * The user-supplied configuration.
@@ -63,7 +60,7 @@ export class CompilationBuilder {
    * Creates a new compilation builder for the specified language version.
    */
   public static create(config: CompilationBuilderConfig): CompilationBuilder {
-    const internalBuilder = InternalCompilationBuilder.create(config.languageVersion);
+    const internalBuilder = wasm.compilation.InternalCompilationBuilder.create(config.languageVersion);
     return new CompilationBuilder(internalBuilder, config);
   }
 

--- a/crates/testlang/outputs/npm/package/src/generated/compilation/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/compilation/index.mts
@@ -1,16 +1,15 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
-import * as builder from "./builder.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-// This is a wrapper around 'generated.compilation.InternalCompilationBuilder':
-export const CompilationBuilder = builder.CompilationBuilder;
-export type CompilationBuilder = builder.CompilationBuilder;
+export { CompilationBuilder, CompilationBuilderConfig } from "./builder.mjs";
 
-export type CompilationBuilderConfig = builder.CompilationBuilderConfig;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export const CompilationUnit = wasm.compilation.CompilationUnit;
+/** {@inheritDoc wasm.compilation.CompilationUnit} */
+export type CompilationUnit = wasm.compilation.CompilationUnit;
 
-export const CompilationUnit = generated.compilation.CompilationUnit;
-export type CompilationUnit = generated.compilation.CompilationUnit;
-
-export const File = generated.compilation.File;
-export type File = generated.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export const File = wasm.compilation.File;
+/** {@inheritDoc wasm.compilation.File} */
+export type File = wasm.compilation.File;

--- a/crates/testlang/outputs/npm/package/src/generated/cst/assertions.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/cst/assertions.mts
@@ -1,0 +1,41 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+import { NonterminalKind, NonterminalNode, TerminalKind, TerminalNode } from "./index.mjs";
+
+/**
+ * Asserts that this node is a `NonterminalNode` with the provided kind and text.
+ */
+export function assertIsNonterminalNode(
+  node: unknown,
+  kind?: NonterminalKind,
+  text?: string,
+): asserts node is NonterminalNode {
+  if (!(node instanceof NonterminalNode)) {
+    throw new Error("Node provided is not a NonterminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}
+
+/**
+ * Asserts that this node is a `TerminalKind` with the provided kind and text.
+ */
+export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
+  if (!(node instanceof TerminalNode)) {
+    throw new Error("Node provided is not a TerminalNode.");
+  }
+
+  if (kind !== undefined && kind !== node.kind) {
+    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
+  }
+
+  if (text !== undefined && text !== node.unparse()) {
+    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
+  }
+}

--- a/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
@@ -1,89 +1,83 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const NonterminalKind = generated.cst.NonterminalKind;
-export type NonterminalKind = generated.cst.NonterminalKind;
+export * from "./assertions.mjs";
 
-export const TerminalKind = generated.cst.TerminalKind;
-export type TerminalKind = generated.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export const NonterminalKind = wasm.cst.NonterminalKind;
+/** {@inheritDoc wasm.cst.NonterminalKind} */
+export type NonterminalKind = wasm.cst.NonterminalKind;
 
-export const TerminalKindExtensions = generated.cst.TerminalKindExtensions;
-export type TerminalKindExtensions = generated.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export const TerminalKind = wasm.cst.TerminalKind;
+/** {@inheritDoc wasm.cst.TerminalKind} */
+export type TerminalKind = wasm.cst.TerminalKind;
 
-export const EdgeLabel = generated.cst.EdgeLabel;
-export type EdgeLabel = generated.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export const TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
+/** {@inheritDoc wasm.cst.TerminalKindExtensions} */
+export type TerminalKindExtensions = wasm.cst.TerminalKindExtensions;
 
-export type Node = generated.cst.Node;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export const EdgeLabel = wasm.cst.EdgeLabel;
+/** {@inheritDoc wasm.cst.EdgeLabel} */
+export type EdgeLabel = wasm.cst.EdgeLabel;
 
-export const NodeType = generated.cst.NodeType;
-export type NodeType = generated.cst.NodeType;
+/** {@inheritDoc wasm.cst.Node} */
+export type Node = wasm.cst.Node;
 
-export const NonterminalNode = generated.cst.NonterminalNode;
-export type NonterminalNode = generated.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NodeType} */
+export const NodeType = wasm.cst.NodeType;
+/** {@inheritDoc wasm.cst.NodeType} */
+export type NodeType = wasm.cst.NodeType;
 
-export const TerminalNode = generated.cst.TerminalNode;
-export type TerminalNode = generated.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export const NonterminalNode = wasm.cst.NonterminalNode;
+/** {@inheritDoc wasm.cst.NonterminalNode} */
+export type NonterminalNode = wasm.cst.NonterminalNode;
 
-export type Edge = generated.cst.Edge;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export const TerminalNode = wasm.cst.TerminalNode;
+/** {@inheritDoc wasm.cst.TerminalNode} */
+export type TerminalNode = wasm.cst.TerminalNode;
 
-export const Cursor = generated.cst.Cursor;
-export type Cursor = generated.cst.Cursor;
+/** {@inheritDoc wasm.cst.Edge} */
+export type Edge = wasm.cst.Edge;
 
-export const CursorIterator = generated.cst.CursorIterator;
-export type CursorIterator = generated.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.Cursor} */
+export const Cursor = wasm.cst.Cursor;
+/** {@inheritDoc wasm.cst.Cursor} */
+export type Cursor = wasm.cst.Cursor;
 
-export const AncestorsIterator = generated.cst.AncestorsIterator;
-export type AncestorsIterator = generated.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export const CursorIterator = wasm.cst.CursorIterator;
+/** {@inheritDoc wasm.cst.CursorIterator} */
+export type CursorIterator = wasm.cst.CursorIterator;
 
-export const Query = generated.cst.Query;
-export type Query = generated.cst.Query;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export const AncestorsIterator = wasm.cst.AncestorsIterator;
+/** {@inheritDoc wasm.cst.AncestorsIterator} */
+export type AncestorsIterator = wasm.cst.AncestorsIterator;
 
-export type QueryError = generated.cst.QueryError;
+/** {@inheritDoc wasm.cst.Query} */
+export const Query = wasm.cst.Query;
+/** {@inheritDoc wasm.cst.Query} */
+export type Query = wasm.cst.Query;
 
-export type QueryMatch = generated.cst.QueryMatch;
+/** {@inheritDoc wasm.cst.QueryError} */
+export type QueryError = wasm.cst.QueryError;
 
-export const QueryMatchIterator = generated.cst.QueryMatchIterator;
-export type QueryMatchIterator = generated.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatch} */
+export type QueryMatch = wasm.cst.QueryMatch;
 
-export type TextIndex = generated.cst.TextIndex;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export const QueryMatchIterator = wasm.cst.QueryMatchIterator;
+/** {@inheritDoc wasm.cst.QueryMatchIterator} */
+export type QueryMatchIterator = wasm.cst.QueryMatchIterator;
 
-export type TextRange = generated.cst.TextRange;
+/** {@inheritDoc wasm.cst.TextIndex} */
+export type TextIndex = wasm.cst.TextIndex;
 
-/**
- * Asserts that this node is a `NonterminalNode` with the provided kind and text.
- */
-export function assertIsNonterminalNode(
-  node: unknown,
-  kind?: NonterminalKind,
-  text?: string,
-): asserts node is NonterminalNode {
-  if (!(node instanceof NonterminalNode)) {
-    throw new Error("Node provided is not a NonterminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's NonterminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
-
-/**
- * Asserts that this node is a `TerminalKind` with the provided kind and text.
- */
-export function assertIsTerminalNode(node: unknown, kind?: TerminalKind, text?: string): asserts node is TerminalNode {
-  if (!(node instanceof TerminalNode)) {
-    throw new Error("Node provided is not a TerminalNode.");
-  }
-
-  if (kind !== undefined && kind !== node.kind) {
-    throw new Error(`Node's TerminalKind is expected to be '${kind}', but got '${node.kind}'.`);
-  }
-
-  if (text !== undefined && text !== node.unparse()) {
-    throw new Error(`Node's text content is expected to be '${text}', but got '${node.unparse()}'.`);
-  }
-}
+/** {@inheritDoc wasm.cst.TextRange} */
+export type TextRange = wasm.cst.TextRange;

--- a/crates/testlang/outputs/npm/package/src/generated/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/index.mts
@@ -1,5 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+/*
+ * __SLANG_NPM_PACKAGE_EXPORTS__ (keep in sync)
+ */
 export * as ast from "./ast/index.mjs";
 export * as bindings from "./bindings/index.mjs";
 export * as compilation from "./compilation/index.mjs";

--- a/crates/testlang/outputs/npm/package/src/generated/parser/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/parser/index.mts
@@ -1,12 +1,18 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const Parser = generated.parser.Parser;
-export type Parser = generated.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export const Parser = wasm.parser.Parser;
+/** {@inheritDoc wasm.parser.Parser} */
+export type Parser = wasm.parser.Parser;
 
-export const ParseError = generated.parser.ParseError;
-export type ParseError = generated.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export const ParseError = wasm.parser.ParseError;
+/** {@inheritDoc wasm.parser.ParseError} */
+export type ParseError = wasm.parser.ParseError;
 
-export const ParseOutput = generated.parser.ParseOutput;
-export type ParseOutput = generated.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export const ParseOutput = wasm.parser.ParseOutput;
+/** {@inheritDoc wasm.parser.ParseOutput} */
+export type ParseOutput = wasm.parser.ParseOutput;

--- a/crates/testlang/outputs/npm/package/src/generated/utils/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/utils/index.mts
@@ -1,6 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-import * as generated from "../../../wasm/index.mjs";
+import * as wasm from "../../../wasm/index.mjs";
 
-export const LanguageFacts = generated.utils.LanguageFacts;
-export type LanguageFacts = generated.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export const LanguageFacts = wasm.utils.LanguageFacts;
+/** {@inheritDoc wasm.utils.LanguageFacts} */
+export type LanguageFacts = wasm.utils.LanguageFacts;

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-ast.d.ts
@@ -7,6 +7,10 @@ import type { Node } from "./nomic-foundation-slang-cst.js";
 export { Node };
 import type { NonterminalNode } from "./nomic-foundation-slang-cst.js";
 export { NonterminalNode };
+
+/**
+ * @internal
+ */
 export class Selectors {
   static sequence(node: NonterminalNode): (Node | undefined)[];
   static choice(node: NonterminalNode): Node;

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-bindings.d.ts
@@ -16,8 +16,19 @@ export { Cursor };
  * It can either be in a user file, or a built-in in the language.
  */
 export type BindingLocation = UserFileLocation | BuiltInLocation;
+
+/**
+ * Enumerates different variants of the `BindingLocation` type.
+ */
 export enum BindingLocationType {
+  /**
+   * Represents a variant of type `UserFileLocation`.
+   */
   UserFileLocation = "UserFileLocation",
+
+  /**
+   * Represents a variant of type `BuiltInLocation`.
+   */
   BuiltInLocation = "BuiltInLocation",
 }
 

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-compilation.d.ts
@@ -77,6 +77,8 @@ export class File {
  *
  * This is an internal API, and exposed via a public `CompilationBuilder` wrapper class written in TypeScript.
  * This allows storing/invoking user supplied callbacks in TypeScript, rather than Rust, which has its limitations.
+ *
+ * @internal
  */
 export class InternalCompilationBuilder {
   /**

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -21,7 +21,7 @@ export namespace NomicFoundationSlangCst {
  */
 export declare enum NonterminalKind {
   /**
-   * This kind represents a `AdditionExpression` node, with the following structure:
+   * Represents a node with kind `AdditionExpression`, having the following structure:
    *
    * ```ebnf
    * (* Left-associative binary operator *)
@@ -32,7 +32,7 @@ export declare enum NonterminalKind {
    */
   AdditionExpression = "AdditionExpression",
   /**
-   * This kind represents a `Expression` node, with the following structure:
+   * Represents a node with kind `Expression`, having the following structure:
    *
    * ```ebnf
    * Expression = (* variant: *) AdditionExpression
@@ -44,7 +44,7 @@ export declare enum NonterminalKind {
    */
   Expression = "Expression",
   /**
-   * This kind represents a `Literal` node, with the following structure:
+   * Represents a node with kind `Literal`, having the following structure:
    *
    * ```ebnf
    * Literal = (* variant: *) STRING_LITERAL;
@@ -52,7 +52,7 @@ export declare enum NonterminalKind {
    */
   Literal = "Literal",
   /**
-   * This kind represents a `MemberAccessExpression` node, with the following structure:
+   * Represents a node with kind `MemberAccessExpression`, having the following structure:
    *
    * ```ebnf
    * (* Postfix unary operator *)
@@ -63,7 +63,7 @@ export declare enum NonterminalKind {
    */
   MemberAccessExpression = "MemberAccessExpression",
   /**
-   * This kind represents a `NegationExpression` node, with the following structure:
+   * Represents a node with kind `NegationExpression`, having the following structure:
    *
    * ```ebnf
    * (* Prefix unary operator *)
@@ -73,7 +73,7 @@ export declare enum NonterminalKind {
    */
   NegationExpression = "NegationExpression",
   /**
-   * This kind represents a `SeparatedIdentifiers` node, with the following structure:
+   * Represents a node with kind `SeparatedIdentifiers`, having the following structure:
    *
    * ```ebnf
    * (* Introduced in 1.0.0 *)
@@ -82,7 +82,7 @@ export declare enum NonterminalKind {
    */
   SeparatedIdentifiers = "SeparatedIdentifiers",
   /**
-   * This kind represents a `SourceUnit` node, with the following structure:
+   * Represents a node with kind `SourceUnit`, having the following structure:
    *
    * ```ebnf
    * SourceUnit = (* members: *) SourceUnitMembers;
@@ -90,7 +90,7 @@ export declare enum NonterminalKind {
    */
   SourceUnit = "SourceUnit",
   /**
-   * This kind represents a `SourceUnitMember` node, with the following structure:
+   * Represents a node with kind `SourceUnitMember`, having the following structure:
    *
    * ```ebnf
    * SourceUnitMember = (* variant: *) Tree
@@ -101,7 +101,7 @@ export declare enum NonterminalKind {
    */
   SourceUnitMember = "SourceUnitMember",
   /**
-   * This kind represents a `SourceUnitMembers` node, with the following structure:
+   * Represents a node with kind `SourceUnitMembers`, having the following structure:
    *
    * ```ebnf
    * SourceUnitMembers = (* item: *) SourceUnitMember+;
@@ -109,7 +109,7 @@ export declare enum NonterminalKind {
    */
   SourceUnitMembers = "SourceUnitMembers",
   /**
-   * This kind represents a `Tree` node, with the following structure:
+   * Represents a node with kind `Tree`, having the following structure:
    *
    * ```ebnf
    * Tree = (* keyword: *) TREE_KEYWORD
@@ -120,7 +120,7 @@ export declare enum NonterminalKind {
    */
   Tree = "Tree",
   /**
-   * This kind represents a `TreeNode` node, with the following structure:
+   * Represents a node with kind `TreeNode`, having the following structure:
    *
    * ```ebnf
    * TreeNode = (* open_bracket: *) OPEN_BRACKET
@@ -130,7 +130,7 @@ export declare enum NonterminalKind {
    */
   TreeNode = "TreeNode",
   /**
-   * This kind represents a `TreeNodeChild` node, with the following structure:
+   * Represents a node with kind `TreeNodeChild`, having the following structure:
    *
    * ```ebnf
    * TreeNodeChild = (* variant: *) TreeNode
@@ -139,7 +139,7 @@ export declare enum NonterminalKind {
    */
   TreeNodeChild = "TreeNodeChild",
   /**
-   * This kind represents a `TreeNodeChildren` node, with the following structure:
+   * Represents a node with kind `TreeNodeChildren`, having the following structure:
    *
    * ```ebnf
    * TreeNodeChildren = (* item: *) TreeNodeChild+;
@@ -163,7 +163,7 @@ export declare enum TerminalKind {
    */
   Missing = "Missing",
   /**
-   * This kind represents a `Bang` node, with the following structure:
+   * Represents a node with kind `Bang`, having the following structure:
    *
    * ```ebnf
    * BANG = "!";
@@ -171,7 +171,7 @@ export declare enum TerminalKind {
    */
   Bang = "Bang",
   /**
-   * This kind represents a `CloseBracket` node, with the following structure:
+   * Represents a node with kind `CloseBracket`, having the following structure:
    *
    * ```ebnf
    * CLOSE_BRACKET = "]";
@@ -179,7 +179,7 @@ export declare enum TerminalKind {
    */
   CloseBracket = "CloseBracket",
   /**
-   * This kind represents a `DelimitedIdentifier` node, with the following structure:
+   * Represents a node with kind `DelimitedIdentifier`, having the following structure:
    *
    * ```ebnf
    * DELIMITED_IDENTIFIER = «DELIMITED_IDENTIFIER_START» «DELIMITED_IDENTIFIER_PART»*;
@@ -187,7 +187,7 @@ export declare enum TerminalKind {
    */
   DelimitedIdentifier = "DelimitedIdentifier",
   /**
-   * This kind represents a `EndOfLine` node, with the following structure:
+   * Represents a node with kind `EndOfLine`, having the following structure:
    *
    * ```ebnf
    * END_OF_LINE = "\r"? "\n";
@@ -195,7 +195,7 @@ export declare enum TerminalKind {
    */
   EndOfLine = "EndOfLine",
   /**
-   * This kind represents a `Identifier` node, with the following structure:
+   * Represents a node with kind `Identifier`, having the following structure:
    *
    * ```ebnf
    * IDENTIFIER = «RAW_IDENTIFIER»;
@@ -203,7 +203,7 @@ export declare enum TerminalKind {
    */
   Identifier = "Identifier",
   /**
-   * This kind represents a `MultiLineComment` node, with the following structure:
+   * Represents a node with kind `MultiLineComment`, having the following structure:
    *
    * ```ebnf
    * MULTI_LINE_COMMENT = "/*" (!"*" | "*")* "*\/";
@@ -211,7 +211,7 @@ export declare enum TerminalKind {
    */
   MultiLineComment = "MultiLineComment",
   /**
-   * This kind represents a `OpenBracket` node, with the following structure:
+   * Represents a node with kind `OpenBracket`, having the following structure:
    *
    * ```ebnf
    * OPEN_BRACKET = "[";
@@ -219,7 +219,7 @@ export declare enum TerminalKind {
    */
   OpenBracket = "OpenBracket",
   /**
-   * This kind represents a `Period` node, with the following structure:
+   * Represents a node with kind `Period`, having the following structure:
    *
    * ```ebnf
    * PERIOD = ".";
@@ -227,7 +227,7 @@ export declare enum TerminalKind {
    */
   Period = "Period",
   /**
-   * This kind represents a `Plus` node, with the following structure:
+   * Represents a node with kind `Plus`, having the following structure:
    *
    * ```ebnf
    * PLUS = "+";
@@ -235,7 +235,7 @@ export declare enum TerminalKind {
    */
   Plus = "Plus",
   /**
-   * This kind represents a `Semicolon` node, with the following structure:
+   * Represents a node with kind `Semicolon`, having the following structure:
    *
    * ```ebnf
    * SEMICOLON = ";";
@@ -243,7 +243,7 @@ export declare enum TerminalKind {
    */
   Semicolon = "Semicolon",
   /**
-   * This kind represents a `SingleLineComment` node, with the following structure:
+   * Represents a node with kind `SingleLineComment`, having the following structure:
    *
    * ```ebnf
    * SINGLE_LINE_COMMENT = "//" (!("\r" "\n"))*;
@@ -251,7 +251,7 @@ export declare enum TerminalKind {
    */
   SingleLineComment = "SingleLineComment",
   /**
-   * This kind represents a `StringLiteral` node, with the following structure:
+   * Represents a node with kind `StringLiteral`, having the following structure:
    *
    * ```ebnf
    * STRING_LITERAL = '"' («ESCAPE_SEQUENCE» | !('"' "\\" "\r" "\n"))* '"';
@@ -259,7 +259,7 @@ export declare enum TerminalKind {
    */
   StringLiteral = "StringLiteral",
   /**
-   * This kind represents a `TreeKeyword` node, with the following structure:
+   * Represents a node with kind `TreeKeyword`, having the following structure:
    *
    * ```ebnf
    * TREE_KEYWORD = "tree";
@@ -267,7 +267,7 @@ export declare enum TerminalKind {
    */
   TreeKeyword = "TreeKeyword",
   /**
-   * This kind represents a `Whitespace` node, with the following structure:
+   * Represents a node with kind `Whitespace`, having the following structure:
    *
    * ```ebnf
    * WHITESPACE = (" " | "\t")+;
@@ -279,31 +279,96 @@ export declare enum TerminalKind {
  * Represents the different types of relationships between nodes in the syntax tree.
  */
 export declare enum EdgeLabel {
+  /**
+   * Represents a child node with the label `item`.
+   */
   Item = "Item",
+  /**
+   * Represents a child node with the label `variant`.
+   */
   Variant = "Variant",
+  /**
+   * Represents a child node with the label `separator`.
+   */
   Separator = "Separator",
+  /**
+   * Represents a child node with the label `operand`.
+   */
   Operand = "Operand",
+  /**
+   * Represents a child node with the label `left_operand`.
+   */
   LeftOperand = "LeftOperand",
+  /**
+   * Represents a child node with the label `right_operand`.
+   */
   RightOperand = "RightOperand",
+  /**
+   * Represents a child node with the label `leading_trivia`.
+   */
   LeadingTrivia = "LeadingTrivia",
+  /**
+   * Represents a child node with the label `trailing_trivia`.
+   */
   TrailingTrivia = "TrailingTrivia",
+  /**
+   * Represents a child node with the label `close_bracket`.
+   */
   CloseBracket = "CloseBracket",
+  /**
+   * Represents a child node with the label `keyword`.
+   */
   Keyword = "Keyword",
+  /**
+   * Represents a child node with the label `member`.
+   */
   Member = "Member",
+  /**
+   * Represents a child node with the label `members`.
+   */
   Members = "Members",
+  /**
+   * Represents a child node with the label `name`.
+   */
   Name = "Name",
+  /**
+   * Represents a child node with the label `node`.
+   */
   Node = "Node",
+  /**
+   * Represents a child node with the label `open_bracket`.
+   */
   OpenBracket = "OpenBracket",
+  /**
+   * Represents a child node with the label `operator`.
+   */
   Operator = "Operator",
+  /**
+   * Represents a child node with the label `period`.
+   */
   Period = "Period",
+  /**
+   * Represents a child node with the label `semicolon`.
+   */
   Semicolon = "Semicolon",
 }
 /**
  * The super type of all nodes in a tree.
  */
 export type Node = NonterminalNode | TerminalNode;
+
+/**
+ * Enumerates different variants of the `Node` type.
+ */
 export enum NodeType {
+  /**
+   * Represents a variant of type `NonterminalNode`.
+   */
   NonterminalNode = "NonterminalNode",
+
+  /**
+   * Represents a variant of type `TerminalNode`.
+   */
   TerminalNode = "TerminalNode",
 }
 /**
@@ -397,6 +462,9 @@ export interface TextRange {
  * Iterator over all ancestors of the current node, starting with the immediate parent, and moving upwards, ending with the root node.
  */
 export class AncestorsIterator {
+  /**
+   * Returns an iterator over `NonterminalNode` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<NonterminalNode>;
   /**
    * Returns the next nonterminal node in the iteration, or `undefined` if there are no more nodes.
@@ -538,6 +606,9 @@ export class Cursor {
  * Iterator over all the remaining nodes in the current tree, moving in pre-order traversal, until the tree is completed.
  */
 export class CursorIterator {
+  /**
+   * Returns an iterator over `Edge` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<Edge>;
   /**
    * Returns the next edge in the iteration, or `undefined` if there are no more edges.
@@ -626,6 +697,9 @@ export class Query {
  * Iterator over query matches in the syntax tree.
  */
 export class QueryMatchIterator {
+  /**
+   * Returns an iterator over `QueryMatch` objects. Called by the semantics of the for-of statement.
+   */
   [Symbol.iterator](): Iterator<QueryMatch>;
   /**
    * Returns the next match or `undefined` if there are no more matches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "prettier-plugin-sh": "0.14.0",
         "remark-parse": "11.0.0",
         "remark-stringify": "11.0.0",
+        "typedoc": "0.27.6",
         "typescript": "5.7.2",
         "unified": "11.0.5"
       }
@@ -1454,6 +1455,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.24.4.tgz",
+      "integrity": "sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^1.24.2",
+        "@shikijs/types": "^1.24.2",
+        "@shikijs/vscode-textmate": "^9.3.1"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2504,6 +2517,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.2.tgz",
+      "integrity": "sha512-ZN6k//aDNWRJs1uKB12pturKHh7GejKugowOFGAuG7TxDRLod1Bd5JhpOikOiFqPmKjKEPtEA6mRCf7q3ulDyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.24.2",
+        "@shikijs/vscode-textmate": "^9.3.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.2.tgz",
+      "integrity": "sha512-bdeWZiDtajGLG9BudI0AHet0b6e7FbR0EsE4jpGaI0YwHm/XJunI9+3uZnzFtX65gsyJ6ngCIWUfA4NWRPnBkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2639,6 +2681,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -7029,6 +7081,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -9214,6 +9273,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.27.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
+      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^1.24.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.6.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
 
     /* Emit */
     "noEmit": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
 
     /* JavaScript Support */
     "allowJs": true,


### PR DESCRIPTION
Adds `typedoc` linter, and fixes all violations in the public API.

See the config in `crates/solidity/outputs/npm/package/typedoc.mjs` for more info.