### PR TITLE
move lints outside `infra check`

### DIFF
--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -6,7 +6,6 @@ use infra_utils::terminal::Terminal;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use strum::IntoEnumIterator;
 
-use crate::toolchains::mkdocs::Mkdocs;
 use crate::toolchains::wasm::WasmPackage;
 use crate::utils::{ClapExtensions, OrderedCommand};
 
@@ -26,12 +25,8 @@ impl CheckController {
 enum CheckCommand {
     /// Run 'cargo check' for all crates, features, and targets.
     Cargo,
-    /// Run `cargo doc` to generate Rustdoc documentation and check for any broken links.
-    Rustdoc,
     /// Check NPM packages for any outdated codegen steps.
     Npm,
-    /// Check mkdocs documentation for any build issues or broken links.
-    Mkdocs,
 }
 
 impl OrderedCommand for CheckCommand {
@@ -40,9 +35,7 @@ impl OrderedCommand for CheckCommand {
 
         match self {
             CheckCommand::Cargo => check_cargo(),
-            CheckCommand::Rustdoc => check_rustdoc(),
             CheckCommand::Npm => check_npm(),
-            CheckCommand::Mkdocs => check_mkdocs(),
         };
 
         Ok(())
@@ -50,24 +43,11 @@ impl OrderedCommand for CheckCommand {
 }
 
 fn check_cargo() {
-    // 'cargo clippy' will run both 'cargo check', and 'clippy' lints:
     Command::new("cargo")
-        .arg("clippy")
+        .arg("check")
         .flag("--workspace")
         .flag("--all-features")
         .flag("--all-targets")
-        .flag("--no-deps")
-        .add_build_rustflags()
-        .run();
-}
-
-fn check_rustdoc() {
-    Command::new("cargo")
-        .arg("doc")
-        .flag("--workspace")
-        .flag("--all-features")
-        .flag("--no-deps")
-        .flag("--document-private-items")
         .add_build_rustflags()
         .run();
 }
@@ -76,8 +56,4 @@ fn check_npm() {
     WasmPackage::iter()
         .par_bridge()
         .for_each(|package| package.build().unwrap());
-}
-
-fn check_mkdocs() {
-    Mkdocs::check();
 }


### PR DESCRIPTION
`infra check` was doing so much that isn't directly related to updating generated files. Moved to linting instead. Local REPL is much faster now.