### PR TITLE
Adding definitions for mapping parameters

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1090,7 +1090,7 @@ inherit .star_extension
   edge @mapping.pop_begin -> @value_type.pop_begin
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
-  edge @mapping.pop_end -> pop_mapping
+  edge pop_mapping -> @mapping.pop_end
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1034,9 +1034,10 @@ inherit .star_extension
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 @mapping [MappingType
-    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])]]
-    [MappingValue @value_type [TypeName]]
+    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
+    [MappingValue @value_type [TypeName] [Identifier]?]
 ] {
+  print "MAPPING FULL"
   node @mapping.lexical_scope
   node @mapping.output
 
@@ -1087,6 +1088,15 @@ inherit .star_extension
   let @mapping.pop_end = pop_mapping
 }
 
+;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
+;;; we still need the basics to get bindings working
+@mapping [MappingType [MappingKey] [UNRECOGNIZED]] {
+  print "MAPPING UNRECOGNIZED"
+  node @mapping.lexical_scope
+  node @mapping.output
+  node @mapping.pop_begin
+  node @mapping.pop_end
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Arrays types

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1033,14 +1033,19 @@ inherit .star_extension
 ;;; Mappings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
+;;; we still need the basics to get bindings working
+@mapping [MappingType] {
+  node @mapping.lexical_scope
+  node @mapping.output
+  node @mapping.pop_begin
+  node @mapping.pop_end
+}
+
 @mapping [MappingType
     [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
     [MappingValue @value_type [TypeName] [Identifier]?]
 ] {
-  print "MAPPING FULL"
-  node @mapping.lexical_scope
-  node @mapping.output
-
   ; Define the pushing path of the mapping type
   ;   ValueType <- top of the symbol stack
   ;   KeyType
@@ -1082,20 +1087,10 @@ inherit .star_extension
   node pop_mapping
   attr (pop_mapping) pop_symbol = "%Mapping"
 
-  let @mapping.pop_begin = @value_type.pop_begin
+  edge @mapping.pop_begin -> @value_type.pop_begin
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
-  let @mapping.pop_end = pop_mapping
-}
-
-;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
-;;; we still need the basics to get bindings working
-@mapping [MappingType [MappingKey] [UNRECOGNIZED]] {
-  print "MAPPING UNRECOGNIZED"
-  node @mapping.lexical_scope
-  node @mapping.output
-  node @mapping.pop_begin
-  node @mapping.pop_end
+  edge @mapping.pop_end -> pop_mapping
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1043,8 +1043,8 @@ inherit .star_extension
 }
 
 @mapping [MappingType
-    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
-    [MappingValue @value_type [TypeName] [Identifier]?]
+    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])]]
+    [MappingValue @value_type [TypeName]]
 ] {
   ; Define the pushing path of the mapping type
   ;   ValueType <- top of the symbol stack
@@ -1091,6 +1091,28 @@ inherit .star_extension
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
   edge pop_mapping -> @mapping.pop_end
+
+  node @mapping.defs
+}
+
+@mapping [MappingType
+    @key [MappingKey [MappingKeyType] @key_name [Identifier]]
+    [MappingValue]
+] {
+  node @key.def
+  attr (@key.def) node_definition = @key_name
+  attr (@key.def) definiens_node = @key
+  edge @key.def -> @mapping.defs
+}
+
+@mapping [MappingType
+    [MappingKey]
+    @value [MappingValue [TypeName] @value_name [Identifier]]
+] {
+  node @value.def
+  attr (@value.def) node_definition = @value_name
+  attr (@value.def) definiens_node = @value
+  edge @value.def -> @mapping.defs
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -1048,8 +1048,8 @@ inherit .star_extension
 }
 
 @mapping [MappingType
-    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
-    [MappingValue @value_type [TypeName] [Identifier]?]
+    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])]]
+    [MappingValue @value_type [TypeName]]
 ] {
   ; Define the pushing path of the mapping type
   ;   ValueType <- top of the symbol stack
@@ -1096,6 +1096,28 @@ inherit .star_extension
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
   edge pop_mapping -> @mapping.pop_end
+
+  node @mapping.defs
+}
+
+@mapping [MappingType
+    @key [MappingKey [MappingKeyType] @key_name [Identifier]]
+    [MappingValue]
+] {
+  node @key.def
+  attr (@key.def) node_definition = @key_name
+  attr (@key.def) definiens_node = @key
+  edge @key.def -> @mapping.defs
+}
+
+@mapping [MappingType
+    [MappingKey]
+    @value [MappingValue [TypeName] @value_name [Identifier]]
+] {
+  node @value.def
+  attr (@value.def) node_definition = @value_name
+  attr (@value.def) definiens_node = @value
+  edge @value.def -> @mapping.defs
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -1039,11 +1039,12 @@ inherit .star_extension
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 @mapping [MappingType
-    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])]]
-    [MappingValue @value_type [TypeName]]
+    [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
+    [MappingValue @value_type [TypeName] [Identifier]?]
 ] {
-  node @mapping.lexical_scope
-  node @mapping.output
+  print "MAPPING FULL"
+  ;node @mapping.lexical_scope
+  ;node @mapping.output
 
   ; Define the pushing path of the mapping type
   ;   ValueType <- top of the symbol stack
@@ -1092,6 +1093,15 @@ inherit .star_extension
   let @mapping.pop_end = pop_mapping
 }
 
+;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
+;;; we still need the basics to get bindings working
+@mapping [MappingType [MappingKey] [UNRECOGNIZED]] {
+  print "MAPPING UNRECOGNIZED"
+  node @mapping.lexical_scope
+  node @mapping.output
+  node @mapping.pop_begin
+  node @mapping.pop_end
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Arrays types

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -1095,7 +1095,7 @@ inherit .star_extension
   edge @mapping.pop_begin -> @value_type.pop_begin
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
-  edge @mapping.pop_end -> pop_mapping
+  edge pop_mapping -> @mapping.pop_end
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -1038,14 +1038,19 @@ inherit .star_extension
 ;;; Mappings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
+;;; we still need the basics to get bindings working
+@mapping [MappingType] {
+  node @mapping.lexical_scope
+  node @mapping.output
+  node @mapping.pop_begin
+  node @mapping.pop_end
+}
+
 @mapping [MappingType
     [MappingKey [MappingKeyType @key_type ([IdentifierPath] | [ElementaryType])] [Identifier]?]
     [MappingValue @value_type [TypeName] [Identifier]?]
 ] {
-  print "MAPPING FULL"
-  ;node @mapping.lexical_scope
-  ;node @mapping.output
-
   ; Define the pushing path of the mapping type
   ;   ValueType <- top of the symbol stack
   ;   KeyType
@@ -1087,20 +1092,10 @@ inherit .star_extension
   node pop_mapping
   attr (pop_mapping) pop_symbol = "%Mapping"
 
-  let @mapping.pop_begin = @value_type.pop_begin
+  edge @mapping.pop_begin -> @value_type.pop_begin
   edge @value_type.pop_end -> @key_type.pop_begin
   edge @key_type.pop_end -> pop_mapping
-  let @mapping.pop_end = pop_mapping
-}
-
-;;; When there's a parsing error (like a name in parameters for versions below 0.8.18)
-;;; we still need the basics to get bindings working
-@mapping [MappingType [MappingKey] [UNRECOGNIZED]] {
-  print "MAPPING UNRECOGNIZED"
-  node @mapping.lexical_scope
-  node @mapping.output
-  node @mapping.pop_begin
-  node @mapping.pop_end
+  edge @mapping.pop_end -> pop_mapping
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/mappings.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/mappings.rs
@@ -20,6 +20,11 @@ fn indexing() -> Result<()> {
 }
 
 #[test]
+fn named_parameters() -> Result<()> {
+    run("mappings", "named_parameters")
+}
+
+#[test]
 fn nested() -> Result<()> {
     run("mappings", "nested")
 }

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.4.11-failure.txt
@@ -4,9 +4,23 @@ Parse errors:
 Error: Expected EqualGreaterThan or PayableKeyword.
    ╭─[input.sol:2:19]
    │
- 2 │   mapping(address name => uint256) public myMap;
+ 2 │   mapping(address name => uint256) public justNameInKey;
    │                   ───────┬───────  
    │                          ╰───────── Error occurred here.
+───╯
+Error: Expected CloseParen or OpenBracket.
+   ╭─[input.sol:4:30]
+   │
+ 4 │   mapping(address => uint256 amount) public justNameInValue;
+   │                              ───┬──  
+   │                                 ╰──── Error occurred here.
+───╯
+Error: Expected EqualGreaterThan or PayableKeyword.
+   ╭─[input.sol:6:19]
+   │
+ 6 │   mapping(address name => uint256 amount) public nameInBoth;
+   │                   ───────────┬──────────  
+   │                              ╰──────────── Error occurred here.
 ───╯
 References and definitions: 
    ╭─[input.sol:1:1]
@@ -14,19 +28,34 @@ References and definitions:
  1 │ contract NamedMapping {
    │          ──────┬─────  
    │                ╰─────── name: 1
- 2 │   mapping(address name => uint256) public myMap;
-   │                                           ──┬──  
-   │                                             ╰──── name: 2
+ 2 │   mapping(address name => uint256) public justNameInKey;
+   │                                           ──────┬──────  
+   │                                                 ╰──────── name: 2
+   │ 
+ 4 │   mapping(address => uint256 amount) public justNameInValue;
+   │                                             ───────┬───────  
+   │                                                    ╰───────── name: 3
+   │ 
+ 6 │   mapping(address name => uint256 amount) public nameInBoth;
+   │                                                  ─────┬────  
+   │                                                       ╰────── name: 4
 ───╯
 Definiens: 
    ╭─[input.sol:1:1]
    │
- 1 │ ╭─▶ contract NamedMapping {
- 2 │ │     mapping(address name => uint256) public myMap;
-   │ │   ────────────────────────┬────────────────────────  
-   │ │                           ╰────────────────────────── definiens: 2
-   ┆ ┆   
- 7 │ ├─▶ }
-   │ │       
-   │ ╰─────── definiens: 1
+ 1 │ ╭─────▶ contract NamedMapping {
+ 2 │ │ │       mapping(address name => uint256) public justNameInKey;
+   │ │ │     ────────────────────────────┬────────────────────────────  
+   │ │ │                                 ╰────────────────────────────── definiens: 2
+ 3 │ │ ╭───▶ 
+ 4 │ │ ├─│ ▶   mapping(address => uint256 amount) public justNameInValue;
+   │ │ │ │                                                                  
+   │ │ ╰──────────────────────────────────────────────────────────────────── definiens: 3
+ 5 │ │   ╭─▶ 
+ 6 │ │   ├─▶   mapping(address name => uint256 amount) public nameInBoth;
+   │ │   │                                                                  
+   │ │   ╰────────────────────────────────────────────────────────────────── definiens: 4
+ 7 │ ├─────▶ }
+   │ │           
+   │ ╰─────────── definiens: 1
 ───╯

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.4.11-failure.txt
@@ -1,0 +1,32 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected EqualGreaterThan or PayableKeyword.
+   ╭─[input.sol:2:19]
+   │
+ 2 │   mapping(address name => uint256) public myMap;
+   │                   ───────┬───────  
+   │                          ╰───────── Error occurred here.
+───╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract NamedMapping {
+   │          ──────┬─────  
+   │                ╰─────── name: 1
+ 2 │   mapping(address name => uint256) public myMap;
+   │                                           ──┬──  
+   │                                             ╰──── name: 2
+───╯
+Definiens: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ ╭─▶ contract NamedMapping {
+ 2 │ │     mapping(address name => uint256) public myMap;
+   │ │   ────────────────────────┬────────────────────────  
+   │ │                           ╰────────────────────────── definiens: 2
+   ┆ ┆   
+ 7 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 1
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.8.18-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.8.18-success.txt
@@ -6,19 +6,50 @@ References and definitions:
  1 │ contract NamedMapping {
    │          ──────┬─────  
    │                ╰─────── name: 1
- 2 │   mapping(address name => uint256) public myMap;
-   │                                           ──┬──  
-   │                                             ╰──── name: 2
+ 2 │   mapping(address name => uint256) public justNameInKey;
+   │                   ──┬─                    ──────┬──────  
+   │                     ╰──────────────────────────────────── name: 3
+   │                                                 │        
+   │                                                 ╰──────── name: 2
+   │ 
+ 4 │   mapping(address => uint256 amount) public justNameInValue;
+   │                              ───┬──         ───────┬───────  
+   │                                 ╰──────────────────────────── name: 5
+   │                                                    │         
+   │                                                    ╰───────── name: 4
+   │ 
+ 6 │   mapping(address name => uint256 amount) public nameInBoth;
+   │                   ──┬─            ───┬──         ─────┬────  
+   │                     ╰──────────────────────────────────────── name: 7
+   │                                      │                │      
+   │                                      ╰─────────────────────── name: 8
+   │                                                       │      
+   │                                                       ╰────── name: 6
 ───╯
 Definiens: 
    ╭─[input.sol:1:1]
    │
- 1 │ ╭─▶ contract NamedMapping {
- 2 │ │     mapping(address name => uint256) public myMap;
-   │ │   ────────────────────────┬────────────────────────  
-   │ │                           ╰────────────────────────── definiens: 2
-   ┆ ┆   
- 7 │ ├─▶ }
-   │ │       
-   │ ╰─────── definiens: 1
+ 1 │ ╭─────▶ contract NamedMapping {
+ 2 │ │ │       mapping(address name => uint256) public justNameInKey;
+   │ │ │     ────────────────┬───────────┬────────────────────────────  
+   │ │ │                     ╰────────────────────────────────────────── definiens: 3
+   │ │ │                                 │                              
+   │ │ │                                 ╰────────────────────────────── definiens: 2
+ 3 │ │ ╭───▶ 
+ 4 │ │ ├─│ ▶   mapping(address => uint256 amount) public justNameInValue;
+   │ │ │ │                       ───────┬───────                            
+   │ │ │ │                              ╰─────────────────────────────────── definiens: 5
+   │ │ │ │                                                                  
+   │ │ ╰──────────────────────────────────────────────────────────────────── definiens: 4
+ 5 │ │   ╭─▶ 
+ 6 │ │   ├─▶   mapping(address name => uint256 amount) public nameInBoth;
+   │ │   │             ──────┬─────   ───────┬───────                       
+   │ │   │                   ╰────────────────────────────────────────────── definiens: 7
+   │ │   │                                   │                              
+   │ │   │                                   ╰────────────────────────────── definiens: 8
+   │ │   │                                                                  
+   │ │   ╰────────────────────────────────────────────────────────────────── definiens: 6
+ 7 │ ├─────▶ }
+   │ │           
+   │ ╰─────────── definiens: 1
 ───╯

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.8.18-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/generated/0.8.18-success.txt
@@ -1,0 +1,24 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract NamedMapping {
+   │          ──────┬─────  
+   │                ╰─────── name: 1
+ 2 │   mapping(address name => uint256) public myMap;
+   │                                           ──┬──  
+   │                                             ╰──── name: 2
+───╯
+Definiens: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ ╭─▶ contract NamedMapping {
+ 2 │ │     mapping(address name => uint256) public myMap;
+   │ │   ────────────────────────┬────────────────────────  
+   │ │                           ╰────────────────────────── definiens: 2
+   ┆ ┆   
+ 7 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 1
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/input.sol
@@ -1,7 +1,7 @@
 contract NamedMapping {
-  mapping(address name => uint256) public myMap;
+  mapping(address name => uint256) public justNameInKey;
 
-  // function test(address _addr) public view returns (uint256) {
-  //   return this.myMap(_addr);
-  // }
+  mapping(address => uint256 amount) public justNameInValue;
+
+  mapping(address name => uint256 amount) public nameInBoth;
 }

--- a/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/mappings/named_parameters/input.sol
@@ -1,0 +1,7 @@
+contract NamedMapping {
+  mapping(address name => uint256) public myMap;
+
+  // function test(address _addr) public view returns (uint256) {
+  //   return this.myMap(_addr);
+  // }
+}


### PR DESCRIPTION
Fixes #1213

I had to make the rule for `[MappingType]` fault-tolerant in order to accommodate for older versions of Solidity, by splitting it in two.

Questions:
 - Is it possible to avoid having to make a query for each key or value parameter, and instead have `[Identifier]?` and query for its existence?
 - The nodes for the parameters are "hanging in the air", as they don't participate in anything useful. Should we attach them to the mapping somehow?