### PR TITLE
upgrade `actions/cache` to v4.2.0

### DIFF
--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: "Restore Cache"
-      uses: "actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9"
+      uses: "actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57"
       with:
         # __SLANG_CI_CACHE_PATHS__ (keep in sync)
         key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -8,7 +8,7 @@ runs:
       run: "sudo chown -R $USER:$USER $GITHUB_WORKSPACE"
 
     - name: "Save Cache"
-      uses: "actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9"
+      uses: "actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57"
       with:
         # __SLANG_CI_CACHE_PATHS__ (keep in sync)
         key: "cache-${{ github.ref_name }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('package-lock.json') }}"


### PR DESCRIPTION
Per this warning in CI:

> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9.
> Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions.
> Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

cc @beta-ziliani 