### PR TITLE
Resolve references lazily

### DIFF
--- a/crates/metaslang/bindings/src/builder/mod.rs
+++ b/crates/metaslang/bindings/src/builder/mod.rs
@@ -19,30 +19,30 @@ pub(crate) type CursorID = usize;
 pub use crate::graph::BindingGraph;
 
 pub(crate) struct DefinitionBindingInfo<KT: KindTypes + 'static> {
-    pub(crate) cursor: Cursor<KT>,
-    pub(crate) definiens: Cursor<KT>,
+    cursor: Cursor<KT>,
+    definiens: Cursor<KT>,
     parents: Vec<GraphHandle>,
     extension_scope: Option<GraphHandle>,
     inherit_extensions: bool,
 }
 
 pub(crate) struct ReferenceBindingInfo<KT: KindTypes + 'static> {
-    pub(crate) cursor: Cursor<KT>,
+    cursor: Cursor<KT>,
     parents: Vec<GraphHandle>,
 }
 
 pub struct BindingGraphBuilder<KT: KindTypes + 'static> {
     graph_builder_file: File<KT>,
     functions: Functions<KT>,
-    pub(crate) info: BindingInfo<KT>,
+    graph: ExtendedStackGraph<KT>,
 }
 
-pub(crate) struct BindingInfo<KT: KindTypes + 'static> {
+pub(crate) struct ExtendedStackGraph<KT: KindTypes + 'static> {
     pub(crate) stack_graph: StackGraph,
-    pub(crate) definitions_info: HashMap<GraphHandle, DefinitionBindingInfo<KT>>,
-    pub(crate) references_info: HashMap<GraphHandle, ReferenceBindingInfo<KT>>,
-    pub(crate) cursor_to_definitions: HashMap<CursorID, GraphHandle>,
-    pub(crate) cursor_to_references: HashMap<CursorID, GraphHandle>,
+    definitions_info: HashMap<GraphHandle, DefinitionBindingInfo<KT>>,
+    references_info: HashMap<GraphHandle, ReferenceBindingInfo<KT>>,
+    cursor_to_definitions: HashMap<CursorID, GraphHandle>,
+    cursor_to_references: HashMap<CursorID, GraphHandle>,
     extension_hooks: HashSet<GraphHandle>,
 }
 
@@ -121,7 +121,7 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         Self {
             graph_builder_file,
             functions,
-            info: BindingInfo {
+            graph: ExtendedStackGraph {
                 stack_graph,
                 definitions_info: HashMap::new(),
                 references_info: HashMap::new(),
@@ -134,19 +134,13 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
 
     pub fn add_system_file(&mut self, file_path: &str, tree_cursor: Cursor<KT>) {
         let file_kind = FileDescriptor::System(file_path.into());
-        let file = self
-            .info
-            .stack_graph
-            .get_or_create_file(&file_kind.as_string());
+        let file = self.graph.get_or_create_file(&file_kind);
         _ = self.add_file_internal(file, tree_cursor);
     }
 
     pub fn add_user_file(&mut self, file_path: &str, tree_cursor: Cursor<KT>) {
         let file_kind = FileDescriptor::User(file_path.into());
-        let file = self
-            .info
-            .stack_graph
-            .get_or_create_file(&file_kind.as_string());
+        let file = self.graph.get_or_create_file(&file_kind);
         _ = self.add_file_internal(file, tree_cursor);
     }
 
@@ -157,10 +151,7 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         tree_cursor: Cursor<KT>,
     ) -> metaslang_graph_builder::graph::Graph<KT> {
         let file_kind = FileDescriptor::User(file_path.into());
-        let file = self
-            .info
-            .stack_graph
-            .get_or_create_file(&file_kind.as_string());
+        let file = self.graph.get_or_create_file(&file_kind);
         let result = self.add_file_internal(file, tree_cursor);
         result.graph
     }
@@ -169,7 +160,7 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         let loader = Loader::new(
             &self.graph_builder_file,
             &self.functions,
-            &mut self.info.stack_graph,
+            &mut self.graph.stack_graph,
             file,
             tree_cursor,
         );
@@ -182,23 +173,23 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
             .iter()
             .for_each(|(handle, definition_info)| {
                 let cursor_id = definition_info.cursor.node().id();
-                self.info.cursor_to_definitions.insert(cursor_id, *handle);
+                self.graph.cursor_to_definitions.insert(cursor_id, *handle);
             });
         result
             .references_info
             .iter()
             .for_each(|(handle, reference_info)| {
                 let cursor_id = reference_info.cursor.node().id();
-                self.info.cursor_to_references.insert(cursor_id, *handle);
+                self.graph.cursor_to_references.insert(cursor_id, *handle);
             });
 
-        self.info
+        self.graph
             .definitions_info
             .extend(result.definitions_info.drain());
-        self.info
+        self.graph
             .references_info
             .extend(result.references_info.drain());
-        self.info
+        self.graph
             .extension_hooks
             .extend(result.extension_hooks.drain());
 
@@ -206,11 +197,41 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
     }
 
     pub fn build(self) -> Rc<BindingGraph<KT>> {
-        BindingGraph::build(self.info)
+        BindingGraph::build(self.graph)
     }
 }
 
-impl<KT: KindTypes + 'static> BindingInfo<KT> {
+impl<KT: KindTypes + 'static> ExtendedStackGraph<KT> {
+    fn get_or_create_file(&mut self, file_kind: &FileDescriptor) -> FileHandle {
+        self.stack_graph.get_or_create_file(&file_kind.as_string())
+    }
+
+    pub(crate) fn iter_definitions(&self) -> impl Iterator<Item = GraphHandle> + '_ {
+        self.stack_graph
+            .iter_nodes()
+            .filter(|handle| self.is_definition(*handle))
+    }
+
+    pub(crate) fn iter_references(&self) -> impl Iterator<Item = GraphHandle> + '_ {
+        self.stack_graph
+            .iter_nodes()
+            .filter(|handle| self.is_reference(*handle))
+    }
+
+    pub(crate) fn iter_files(&self) -> impl Iterator<Item = FileHandle> + '_ {
+        self.stack_graph.iter_files()
+    }
+
+    pub(crate) fn definition_at(&self, cursor: &Cursor<KT>) -> Option<GraphHandle> {
+        let cursor_id = cursor.node().id();
+        self.cursor_to_definitions.get(&cursor_id).copied()
+    }
+
+    pub(crate) fn reference_at(&self, cursor: &Cursor<KT>) -> Option<GraphHandle> {
+        let cursor_id = cursor.node().id();
+        self.cursor_to_references.get(&cursor_id).copied()
+    }
+
     pub(crate) fn get_parents(&self, handle: GraphHandle) -> Vec<GraphHandle> {
         if self.is_definition(handle) {
             self.definitions_info
@@ -245,7 +266,7 @@ impl<KT: KindTypes + 'static> BindingInfo<KT> {
             .is_some_and(|info| info.inherit_extensions)
     }
 
-    pub(crate) fn get_file(&self, handle: GraphHandle) -> Option<FileDescriptor> {
+    pub(crate) fn get_file_descriptor(&self, handle: GraphHandle) -> Option<FileDescriptor> {
         self.stack_graph[handle]
             .file()
             .map(|file| FileDescriptor::from(self.stack_graph[file].name()))
@@ -253,5 +274,25 @@ impl<KT: KindTypes + 'static> BindingInfo<KT> {
 
     pub(crate) fn is_extension_hook(&self, node_handle: GraphHandle) -> bool {
         self.extension_hooks.contains(&node_handle)
+    }
+
+    pub(crate) fn get_cursor(&self, handle: GraphHandle) -> Option<&Cursor<KT>> {
+        if self.is_definition(handle) {
+            self.definitions_info.get(&handle).map(|info| &info.cursor)
+        } else if self.is_reference(handle) {
+            self.references_info.get(&handle).map(|info| &info.cursor)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn get_definiens_cursor(&self, handle: GraphHandle) -> Option<&Cursor<KT>> {
+        if self.is_definition(handle) {
+            self.definitions_info
+                .get(&handle)
+                .map(|info| &info.definiens)
+        } else {
+            None
+        }
     }
 }

--- a/crates/metaslang/bindings/src/builder/mod.rs
+++ b/crates/metaslang/bindings/src/builder/mod.rs
@@ -1,5 +1,4 @@
 mod loader;
-mod resolver;
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
@@ -10,7 +9,6 @@ use metaslang_cst::cursor::Cursor;
 use metaslang_cst::kinds::KindTypes;
 use metaslang_graph_builder::ast::File;
 use metaslang_graph_builder::functions::Functions;
-use resolver::Resolver;
 use semver::Version;
 use stack_graphs::graph::StackGraph;
 
@@ -182,9 +180,7 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
     }
 
     pub fn build(self) -> Rc<BindingGraph<KT>> {
-        let resolver = Resolver::new(&self);
-        let resolved_references = resolver.resolve();
-        BindingGraph::build(self, resolved_references)
+        BindingGraph::build(self)
     }
 
     pub(crate) fn get_parents(&self, handle: GraphHandle) -> Vec<GraphHandle> {
@@ -201,27 +197,27 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         }
     }
 
-    fn is_definition(&self, handle: GraphHandle) -> bool {
+    pub(crate) fn is_definition(&self, handle: GraphHandle) -> bool {
         self.stack_graph[handle].is_definition()
     }
 
-    fn is_reference(&self, handle: GraphHandle) -> bool {
+    pub(crate) fn is_reference(&self, handle: GraphHandle) -> bool {
         self.stack_graph[handle].is_reference()
     }
 
-    fn get_extension_scope(&self, handle: GraphHandle) -> Option<GraphHandle> {
+    pub(crate) fn get_extension_scope(&self, handle: GraphHandle) -> Option<GraphHandle> {
         self.definitions_info
             .get(&handle)
             .and_then(|info| info.extension_scope)
     }
 
-    fn inherits_extensions(&self, handle: GraphHandle) -> bool {
+    pub(crate) fn inherits_extensions(&self, handle: GraphHandle) -> bool {
         self.definitions_info
             .get(&handle)
             .is_some_and(|info| info.inherit_extensions)
     }
 
-    fn get_file(&self, handle: GraphHandle) -> Option<FileDescriptor> {
+    pub(crate) fn get_file(&self, handle: GraphHandle) -> Option<FileDescriptor> {
         self.stack_graph[handle]
             .file()
             .map(|file| FileDescriptor::from(self.stack_graph[file].name()))

--- a/crates/metaslang/bindings/src/builder/mod.rs
+++ b/crates/metaslang/bindings/src/builder/mod.rs
@@ -174,7 +174,7 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         });
         result.references_info.iter().for_each(|(handle, reference_info)| {
             let cursor_id = reference_info.cursor.node().id();
-            self.info.cursor_to_definitions.insert(cursor_id, *handle);
+            self.info.cursor_to_references.insert(cursor_id, *handle);
         });
 
         self.info.definitions_info

--- a/crates/metaslang/bindings/src/builder/mod.rs
+++ b/crates/metaslang/bindings/src/builder/mod.rs
@@ -128,19 +128,25 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
                 cursor_to_definitions: HashMap::new(),
                 cursor_to_references: HashMap::new(),
                 extension_hooks: HashSet::new(),
-            }
+            },
         }
     }
 
     pub fn add_system_file(&mut self, file_path: &str, tree_cursor: Cursor<KT>) {
         let file_kind = FileDescriptor::System(file_path.into());
-        let file = self.info.stack_graph.get_or_create_file(&file_kind.as_string());
+        let file = self
+            .info
+            .stack_graph
+            .get_or_create_file(&file_kind.as_string());
         _ = self.add_file_internal(file, tree_cursor);
     }
 
     pub fn add_user_file(&mut self, file_path: &str, tree_cursor: Cursor<KT>) {
         let file_kind = FileDescriptor::User(file_path.into());
-        let file = self.info.stack_graph.get_or_create_file(&file_kind.as_string());
+        let file = self
+            .info
+            .stack_graph
+            .get_or_create_file(&file_kind.as_string());
         _ = self.add_file_internal(file, tree_cursor);
     }
 
@@ -151,7 +157,10 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
         tree_cursor: Cursor<KT>,
     ) -> metaslang_graph_builder::graph::Graph<KT> {
         let file_kind = FileDescriptor::User(file_path.into());
-        let file = self.info.stack_graph.get_or_create_file(&file_kind.as_string());
+        let file = self
+            .info
+            .stack_graph
+            .get_or_create_file(&file_kind.as_string());
         let result = self.add_file_internal(file, tree_cursor);
         result.graph
     }
@@ -168,19 +177,30 @@ impl<KT: KindTypes + 'static> BindingGraphBuilder<KT> {
             .execute(&loader::NoCancellation)
             .expect("Internal error while building bindings");
 
-        result.definitions_info.iter().for_each(|(handle, definition_info)| {
-            let cursor_id = definition_info.cursor.node().id();
-            self.info.cursor_to_definitions.insert(cursor_id, *handle);
-        });
-        result.references_info.iter().for_each(|(handle, reference_info)| {
-            let cursor_id = reference_info.cursor.node().id();
-            self.info.cursor_to_references.insert(cursor_id, *handle);
-        });
+        result
+            .definitions_info
+            .iter()
+            .for_each(|(handle, definition_info)| {
+                let cursor_id = definition_info.cursor.node().id();
+                self.info.cursor_to_definitions.insert(cursor_id, *handle);
+            });
+        result
+            .references_info
+            .iter()
+            .for_each(|(handle, reference_info)| {
+                let cursor_id = reference_info.cursor.node().id();
+                self.info.cursor_to_references.insert(cursor_id, *handle);
+            });
 
-        self.info.definitions_info
+        self.info
+            .definitions_info
             .extend(result.definitions_info.drain());
-        self.info.references_info.extend(result.references_info.drain());
-        self.info.extension_hooks.extend(result.extension_hooks.drain());
+        self.info
+            .references_info
+            .extend(result.references_info.drain());
+        self.info
+            .extension_hooks
+            .extend(result.extension_hooks.drain());
 
         result
     }

--- a/crates/metaslang/bindings/src/graph/definition.rs
+++ b/crates/metaslang/bindings/src/graph/definition.rs
@@ -38,29 +38,23 @@ impl<KT: KindTypes + 'static> Definition<KT> {
     }
 
     pub fn get_cursor(&self) -> &Cursor<KT> {
-        &self
-            .owner
-            .info
-            .definitions_info
-            .get(&self.handle)
+        self.owner
+            .graph
+            .get_cursor(self.handle)
             .expect("Definition handle is valid")
-            .cursor
     }
 
     pub fn get_definiens_cursor(&self) -> &Cursor<KT> {
-        &self
-            .owner
-            .info
-            .definitions_info
-            .get(&self.handle)
+        self.owner
+            .graph
+            .get_definiens_cursor(self.handle)
             .expect("Definition handle is valid")
-            .definiens
     }
 
     pub fn get_file(&self) -> FileDescriptor {
-        self.owner.info.stack_graph[self.handle]
-            .file()
-            .map(|file_handle| self.owner.get_file(file_handle))
+        self.owner
+            .graph
+            .get_file_descriptor(self.handle)
             .expect("Definition to have a valid file descriptor")
     }
 }

--- a/crates/metaslang/bindings/src/graph/definition.rs
+++ b/crates/metaslang/bindings/src/graph/definition.rs
@@ -40,7 +40,8 @@ impl<KT: KindTypes + 'static> Definition<KT> {
     pub fn get_cursor(&self) -> &Cursor<KT> {
         &self
             .owner
-            .definitions
+            .info
+            .definitions_info
             .get(&self.handle)
             .expect("Definition handle is valid")
             .cursor
@@ -49,22 +50,18 @@ impl<KT: KindTypes + 'static> Definition<KT> {
     pub fn get_definiens_cursor(&self) -> &Cursor<KT> {
         &self
             .owner
-            .definitions
+            .info
+            .definitions_info
             .get(&self.handle)
             .expect("Definition handle is valid")
             .definiens
     }
 
     pub fn get_file(&self) -> FileDescriptor {
-        self.owner
-            .get_file(
-                self.owner
-                    .definitions
-                    .get(&self.handle)
-                    .expect("Definition handle is valid")
-                    .file,
-            )
-            .expect("Definition does not have a valid file descriptor")
+        self.owner.info.stack_graph[self.handle]
+            .file()
+            .map(|file_handle| self.owner.get_file(file_handle))
+            .expect("Definition to have a valid file descriptor")
     }
 }
 

--- a/crates/metaslang/bindings/src/graph/mod.rs
+++ b/crates/metaslang/bindings/src/graph/mod.rs
@@ -12,9 +12,9 @@ pub use location::{BindingLocation, BuiltInLocation, UserFileLocation};
 use metaslang_cst::cursor::Cursor;
 use metaslang_cst::kinds::KindTypes;
 pub use reference::Reference;
+use resolver::Resolver;
 
 use crate::builder::{BindingInfo, FileDescriptor, FileHandle, GraphHandle};
-use resolver::Resolver;
 
 pub struct BindingGraph<KT: KindTypes + 'static> {
     info: BindingInfo<KT>,

--- a/crates/metaslang/bindings/src/graph/mod.rs
+++ b/crates/metaslang/bindings/src/graph/mod.rs
@@ -4,7 +4,6 @@ mod reference;
 mod resolver;
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::rc::Rc;
 
@@ -17,21 +16,7 @@ pub use reference::Reference;
 use crate::builder::{BindingInfo, FileDescriptor, FileHandle, GraphHandle};
 use resolver::Resolver;
 
-struct DefinitionInfo<KT: KindTypes + 'static> {
-    file: FileHandle,
-    cursor: Cursor<KT>,
-    definiens: Cursor<KT>,
-}
-
-struct ReferenceInfo<KT: KindTypes + 'static> {
-    file: FileHandle,
-    cursor: Cursor<KT>,
-}
-
 pub struct BindingGraph<KT: KindTypes + 'static> {
-    files: HashMap<FileHandle, FileDescriptor>,
-    definitions: BTreeMap<GraphHandle, DefinitionInfo<KT>>,
-    references: BTreeMap<GraphHandle, ReferenceInfo<KT>>,
     info: BindingInfo<KT>,
     resolver: Rc<RefCell<Resolver>>,
 }
@@ -41,57 +26,25 @@ impl<KT: KindTypes + 'static> BindingGraph<KT> {
         let mut resolver = Resolver::new(&builder);
         resolver.resolve(&builder);
 
-        let mut files = HashMap::new();
-        for handle in builder.stack_graph.iter_files() {
-            files.insert(
-                handle,
-                FileDescriptor::from(builder.stack_graph[handle].name()),
-            );
-        }
-        let mut definitions = BTreeMap::new();
-        let mut references = BTreeMap::new();
-        for handle in builder.stack_graph.iter_nodes() {
-            let graph_node = &builder.stack_graph[handle];
-            let Some(file) = graph_node.file() else {
-                continue;
-            };
-            if graph_node.is_definition() {
-                let definition_info = &builder.definitions_info[&handle];
-                let cursor = definition_info.cursor.clone();
-                let definiens = definition_info.definiens.clone();
-                definitions.insert(
-                    handle,
-                    DefinitionInfo {
-                        file,
-                        cursor,
-                        definiens,
-                    },
-                );
-            } else if graph_node.is_reference() {
-                let reference_info = &builder.references_info[&handle];
-                let cursor = reference_info.cursor.clone();
-                references.insert(handle, ReferenceInfo { file, cursor });
-            }
-        }
-
         Rc::new(Self {
-            files,
-            definitions,
-            references,
             info: builder,
             resolver: Rc::new(RefCell::new(resolver)),
         })
     }
 
     pub fn all_definitions(self: &Rc<Self>) -> impl Iterator<Item = Definition<KT>> + '_ {
-        self.definitions.keys().map(|handle| Definition {
-            owner: Rc::clone(self),
-            handle: *handle,
-        })
+        self.info
+            .stack_graph
+            .iter_nodes()
+            .filter(|handle| self.info.stack_graph[*handle].is_definition())
+            .map(|handle| Definition {
+                owner: Rc::clone(self),
+                handle,
+            })
     }
 
     fn to_definition(self: &Rc<Self>, handle: GraphHandle) -> Option<Definition<KT>> {
-        if self.definitions.contains_key(&handle) {
+        if self.info.stack_graph[handle].is_definition() {
             Some(Definition {
                 owner: Rc::clone(self),
                 handle,
@@ -102,10 +55,14 @@ impl<KT: KindTypes + 'static> BindingGraph<KT> {
     }
 
     pub fn all_references(self: &Rc<Self>) -> impl Iterator<Item = Reference<KT>> + '_ {
-        self.references.keys().map(|handle| Reference {
-            owner: Rc::clone(self),
-            handle: *handle,
-        })
+        self.info
+            .stack_graph
+            .iter_nodes()
+            .filter(|handle| self.info.stack_graph[*handle].is_reference())
+            .map(|handle| Reference {
+                owner: Rc::clone(self),
+                handle,
+            })
     }
 
     pub fn definition_at(self: &Rc<Self>, cursor: &Cursor<KT>) -> Option<Definition<KT>> {
@@ -130,8 +87,8 @@ impl<KT: KindTypes + 'static> BindingGraph<KT> {
             })
     }
 
-    fn get_file(&self, handle: FileHandle) -> Option<FileDescriptor> {
-        self.files.get(&handle).cloned()
+    fn get_file(&self, handle: FileHandle) -> FileDescriptor {
+        FileDescriptor::from(self.info.stack_graph[handle].name())
     }
 }
 

--- a/crates/metaslang/bindings/src/graph/mod.rs
+++ b/crates/metaslang/bindings/src/graph/mod.rs
@@ -23,8 +23,7 @@ pub struct BindingGraph<KT: KindTypes + 'static> {
 
 impl<KT: KindTypes + 'static> BindingGraph<KT> {
     pub(crate) fn build(builder: BindingInfo<KT>) -> Rc<Self> {
-        let mut resolver = Resolver::new(&builder);
-        resolver.resolve(&builder);
+        let resolver = Resolver::new(&builder);
 
         Rc::new(Self {
             info: builder,

--- a/crates/metaslang/bindings/src/graph/mod.rs
+++ b/crates/metaslang/bindings/src/graph/mod.rs
@@ -1,6 +1,7 @@
 mod definition;
 mod location;
 mod reference;
+mod resolver;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -12,6 +13,7 @@ use metaslang_cst::cursor::Cursor;
 use metaslang_cst::kinds::KindTypes;
 pub use reference::Reference;
 
+use resolver::Resolver;
 use crate::builder::{CursorID, FileDescriptor, FileHandle, GraphHandle};
 use crate::BindingGraphBuilder;
 
@@ -38,8 +40,10 @@ pub struct BindingGraph<KT: KindTypes + 'static> {
 impl<KT: KindTypes + 'static> BindingGraph<KT> {
     pub(crate) fn build(
         builder: BindingGraphBuilder<KT>,
-        resolved_references: HashMap<GraphHandle, Vec<GraphHandle>>,
     ) -> Rc<Self> {
+        let resolver = Resolver::new(&builder);
+        let resolved_references = resolver.resolve(&builder);
+
         let mut files = HashMap::new();
         for handle in builder.stack_graph.iter_files() {
             files.insert(

--- a/crates/metaslang/bindings/src/graph/mod.rs
+++ b/crates/metaslang/bindings/src/graph/mod.rs
@@ -55,12 +55,9 @@ impl<KT: KindTypes + 'static> BindingGraph<KT> {
                 continue;
             };
             if graph_node.is_definition() {
-                let cursor = builder
-                    .cursors
-                    .get(&handle)
-                    .expect("Definition to have a valid cursor")
-                    .clone();
-                let definiens = builder.definitions_info[&handle].definiens.clone();
+                let definition_info = &builder.definitions_info[&handle];
+                let cursor = definition_info.cursor.clone();
+                let definiens = definition_info.definiens.clone();
                 definitions.insert(
                     handle,
                     DefinitionInfo {
@@ -70,11 +67,8 @@ impl<KT: KindTypes + 'static> BindingGraph<KT> {
                     },
                 );
             } else if graph_node.is_reference() {
-                let cursor = builder
-                    .cursors
-                    .get(&handle)
-                    .expect("Reference to have a valid cursor")
-                    .clone();
+                let reference_info = &builder.references_info[&handle];
+                let cursor = reference_info.cursor.clone();
                 references.insert(handle, ReferenceInfo { file, cursor });
             }
         }

--- a/crates/metaslang/bindings/src/graph/reference.rs
+++ b/crates/metaslang/bindings/src/graph/reference.rs
@@ -31,22 +31,18 @@ impl<KT: KindTypes + 'static> Reference<KT> {
     pub fn get_cursor(&self) -> &Cursor<KT> {
         &self
             .owner
-            .references
+            .info
+            .references_info
             .get(&self.handle)
             .expect("Reference handle is valid")
             .cursor
     }
 
     pub fn get_file(&self) -> FileDescriptor {
-        self.owner
-            .get_file(
-                self.owner
-                    .references
-                    .get(&self.handle)
-                    .expect("Reference handle is valid")
-                    .file,
-            )
-            .expect("Reference does not have a valid file descriptor")
+        self.owner.info.stack_graph[self.handle]
+            .file()
+            .map(|file_handle| self.owner.get_file(file_handle))
+            .expect("Reference to have a valid file descriptor")
     }
 
     pub fn definitions(&self) -> Vec<Definition<KT>> {

--- a/crates/metaslang/bindings/src/graph/reference.rs
+++ b/crates/metaslang/bindings/src/graph/reference.rs
@@ -29,33 +29,21 @@ impl<KT: KindTypes + 'static> Reference<KT> {
     }
 
     pub fn get_cursor(&self) -> &Cursor<KT> {
-        &self
-            .owner
-            .info
-            .references_info
-            .get(&self.handle)
+        self.owner
+            .graph
+            .get_cursor(self.handle)
             .expect("Reference handle is valid")
-            .cursor
     }
 
     pub fn get_file(&self) -> FileDescriptor {
-        self.owner.info.stack_graph[self.handle]
-            .file()
-            .map(|file_handle| self.owner.get_file(file_handle))
+        self.owner
+            .graph
+            .get_file_descriptor(self.handle)
             .expect("Reference to have a valid file descriptor")
     }
 
     pub fn definitions(&self) -> Vec<Definition<KT>> {
-        let mut resolver = self.owner.resolver.borrow_mut();
-        let definitions = resolver.resolve_single(&self.owner.info, self.handle);
-        definitions
-            .iter()
-            .map(|handle| {
-                self.owner
-                    .to_definition(*handle)
-                    .expect("Resolved reference handle to be a definition")
-            })
-            .collect()
+        self.owner.resolve_reference(self.handle)
     }
 }
 

--- a/crates/metaslang/bindings/src/graph/reference.rs
+++ b/crates/metaslang/bindings/src/graph/reference.rs
@@ -50,7 +50,8 @@ impl<KT: KindTypes + 'static> Reference<KT> {
     }
 
     pub fn definitions(&self) -> Vec<Definition<KT>> {
-        self.owner.resolved_references[&self.handle]
+        let resolver = self.owner.resolver.borrow();
+        resolver.references[&self.handle]
             .iter()
             .map(|handle| {
                 self.owner

--- a/crates/metaslang/bindings/src/graph/reference.rs
+++ b/crates/metaslang/bindings/src/graph/reference.rs
@@ -46,8 +46,9 @@ impl<KT: KindTypes + 'static> Reference<KT> {
     }
 
     pub fn definitions(&self) -> Vec<Definition<KT>> {
-        let resolver = self.owner.resolver.borrow();
-        resolver.references[&self.handle]
+        let mut resolver = self.owner.resolver.borrow_mut();
+        let definitions = resolver.resolve_single(&self.owner.info, self.handle);
+        definitions
             .iter()
             .map(|handle| {
                 self.owner

--- a/crates/metaslang/bindings/src/graph/resolver.rs
+++ b/crates/metaslang/bindings/src/graph/resolver.rs
@@ -176,15 +176,10 @@ impl Resolver {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn resolve_all<KT: KindTypes + 'static>(
-        &mut self,
-        owner: &BindingInfo<KT>,
-    ) {
+    pub(crate) fn resolve_all<KT: KindTypes + 'static>(&mut self, owner: &BindingInfo<KT>) {
         for handle in owner.stack_graph.iter_nodes() {
             if owner.is_reference(handle)
-                && owner
-                    .get_file(handle)
-                    .is_some_and(|file| file.is_user())
+                && owner.get_file(handle).is_some_and(|file| file.is_user())
             {
                 let definition_handles = self.resolve_internal(owner, handle, true);
                 self.references.insert(handle, definition_handles);
@@ -197,11 +192,7 @@ impl Resolver {
         owner: &BindingInfo<KT>,
         handle: GraphHandle,
     ) -> Vec<GraphHandle> {
-        if owner.is_reference(handle)
-            && owner
-            .get_file(handle)
-            .is_some_and(|file| file.is_user())
-        {
+        if owner.is_reference(handle) && owner.get_file(handle).is_some_and(|file| file.is_user()) {
             if let Some(definitions) = self.references.get(&handle) {
                 definitions.clone()
             } else {

--- a/crates/metaslang/bindings/src/graph/resolver.rs
+++ b/crates/metaslang/bindings/src/graph/resolver.rs
@@ -175,7 +175,8 @@ impl Resolver {
         results
     }
 
-    pub(crate) fn resolve<KT: KindTypes + 'static>(
+    #[allow(dead_code)]
+    pub(crate) fn resolve_all<KT: KindTypes + 'static>(
         &mut self,
         owner: &BindingInfo<KT>,
     ) {
@@ -188,6 +189,28 @@ impl Resolver {
                 let definition_handles = self.resolve_internal(owner, handle, true);
                 self.references.insert(handle, definition_handles);
             }
+        }
+    }
+
+    pub(crate) fn resolve_single<KT: KindTypes + 'static>(
+        &mut self,
+        owner: &BindingInfo<KT>,
+        handle: GraphHandle,
+    ) -> Vec<GraphHandle> {
+        if owner.is_reference(handle)
+            && owner
+            .get_file(handle)
+            .is_some_and(|file| file.is_user())
+        {
+            if let Some(definitions) = self.references.get(&handle) {
+                definitions.clone()
+            } else {
+                let definition_handles = self.resolve_internal(owner, handle, true);
+                self.references.insert(handle, definition_handles.clone());
+                definition_handles
+            }
+        } else {
+            Vec::new()
         }
     }
 }

--- a/crates/metaslang/bindings/src/graph/resolver.rs
+++ b/crates/metaslang/bindings/src/graph/resolver.rs
@@ -161,19 +161,6 @@ impl Resolver {
         results
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn resolve_all<KT: KindTypes + 'static>(&mut self, graph: &ExtendedStackGraph<KT>) {
-        for handle in graph.iter_references() {
-            if graph
-                .get_file_descriptor(handle)
-                .is_some_and(|file| file.is_user())
-            {
-                let definition_handles = self.resolve_internal(graph, handle, true);
-                self.references.insert(handle, definition_handles);
-            }
-        }
-    }
-
     pub(crate) fn resolve_single<KT: KindTypes + 'static>(
         &mut self,
         graph: &ExtendedStackGraph<KT>,


### PR DESCRIPTION
This hopefully reduces resolution time when not all references (eg. those in dependencies) need to be resolved, but requires the `BindingGraph` to retain both the `StackGraph` and the `Resolver` (with the database of partial path candidates and the partial paths arena).

This PR also includes an optimization to the resolution algorithm. When selecting candidates to extend an already complete partial path, discard those that would immediately push a `@typeof` symbol (eg. through the path that replaces a variable by its type) since we know those will never resolve. This can halve the number of evaluated partial paths (ie. references that resolve to a variable/field definition) and provide a very significant performance gain in some cases.