### PR TITLE
reduce scanner string allocations

### DIFF
--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/lexer/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/lexer/mod.rs
@@ -99,7 +99,10 @@ pub(crate) trait Lexer {
         let end = input.position();
 
         ParserResult::r#match(
-            vec![Edge::root(Node::terminal(kind, input.content(start..end)))],
+            vec![Edge::root(Node::terminal(
+                kind,
+                input.content(start..end).to_owned(),
+            ))],
             vec![],
         )
     }
@@ -129,7 +132,10 @@ pub(crate) trait Lexer {
             return ParserResult::no_match(vec![kind]);
         }
         let end = input.position();
-        children.push(Edge::root(Node::terminal(kind, input.content(start..end))));
+        children.push(Edge::root(Node::terminal(
+            kind,
+            input.content(start..end).to_owned(),
+        )));
 
         let restore = input.position();
         if let ParserResult::Match(r#match) = self.trailing_trivia(input) {

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser.rs.jinja2
@@ -113,7 +113,7 @@ impl Parser {
 
         {%- for keyword_name, keyword_code in model.parser.keyword_compound_scanners %}
             #[inline]
-            fn {{ keyword_name | snake_case }}(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan { {{ keyword_code }} }
+            fn {{ keyword_name | snake_case }}(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan { {{ keyword_code }} }
         {% endfor %}
 
     {% endif %}
@@ -218,15 +218,14 @@ impl Lexer for Parser {
                             if kw_scan == KeywordScan::Absent {
                                 input.set_position(save);
 
-                                // TODO(#1001): Don't allocate a string here
-                                let ident_value = input.content(save..furthest_position);
+                                let ident_len = furthest_position - save;
 
                                 for keyword_compound_scanner in [
                                 {%- for keyword_name, _ in context.keyword_compound_scanners %}
                                     Self::{{ keyword_name | snake_case }},
                                 {%- endfor %}
                                 ] {
-                                    match keyword_compound_scanner(self, input, &ident_value) {
+                                    match keyword_compound_scanner(self, input, ident_len) {
                                         _ if input.position() < furthest_position => {/* Strict prefix */},
                                         KeywordScan::Absent => {},
                                         value => kw_scan = value,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/context.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/context.rs
@@ -147,8 +147,8 @@ impl<'s> ParserContext<'s> {
         self.position = position;
     }
 
-    pub fn content(&self, range: Range<usize>) -> String {
-        self.source[range].to_owned()
+    pub fn content(&self, range: Range<usize>) -> &str {
+        &self.source[range]
     }
 
     pub fn cached_leading_trivia_or(

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/parser_function.rs
@@ -88,14 +88,14 @@ where
                     (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                 };
 
-                let node = Node::terminal(kind, input.to_string());
+                let node = Node::terminal(kind, input.to_owned());
 
                 children.push(Edge { label, node });
 
                 ParseOutput {
                     tree: NonterminalNode::create(topmost_kind, children),
                     errors: vec![ParseError::create(
-                        start..start + input.into(),
+                        start..(start + input.into()),
                         no_match.expected_terminals,
                     )],
                 }
@@ -146,7 +146,7 @@ where
                         (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                     };
 
-                    let skipped_node = Node::terminal(kind, input[start..].to_string());
+                    let skipped_node = Node::terminal(kind, input[start..].to_owned());
                     let mut new_children = topmost_node.children.clone();
                     new_children.push(Edge {
                         label,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/recovery.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/recovery.rs
@@ -86,7 +86,7 @@ impl ParserResult {
                 expected_terminals.push(expected);
             }
 
-            let skipped = input.content(skipped_range.utf8());
+            let skipped = input.content(skipped_range.utf8()).to_owned();
 
             input.emit(ParseError::create(
                 skipped_range,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/separated_helper.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/parser_support/separated_helper.rs
@@ -56,9 +56,10 @@ impl SeparatedHelper {
                             } else {
                                 (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                             };
+                            let skipped = input.content(skipped_range.utf8()).to_owned();
                             accum.push(Edge {
                                 label,
-                                node: Node::terminal(kind, input.content(skipped_range.utf8())),
+                                node: Node::terminal(kind, skipped),
                             });
                             input.emit(ParseError::create(
                                 skipped_range,

--- a/crates/codegen/runtime/cargo/crate/src/runtime/parser/scanner_macros/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/parser/scanner_macros/mod.rs
@@ -74,13 +74,13 @@ macro_rules! scan_choice {
 pub(crate) use scan_choice;
 
 macro_rules! scan_keyword_choice {
-    ($stream:ident, $ident:ident, $($scanner:expr),*) => {
+    ($stream:ident, $ident_len:expr, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
                 {
                     if let result @ (KeywordScan::Present(..) | KeywordScan::Reserved(..)) = ($scanner) {
-                        if $ident.len() == $stream.position() - save {
+                        if $ident_len == $stream.position() - save {
                             break result;
                         }
                     }

--- a/crates/codegen/runtime/generator/src/parser/codegen/keyword_scanner_definition.rs
+++ b/crates/codegen/runtime/generator/src/parser/codegen/keyword_scanner_definition.rs
@@ -75,7 +75,7 @@ impl KeywordScannerDefinitionCodegen for model::KeywordItem {
 
         match &kw_scanners[..] {
             [] => quote! { KeywordScan::Absent },
-            multiple => quote! { scan_keyword_choice!(input, ident, #(#multiple),*) },
+            multiple => quote! { scan_keyword_choice!(input, ident_len, #(#multiple),*) },
         }
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/generated/parser.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/generated/parser.rs
@@ -7947,10 +7947,10 @@ impl Parser {
     }
 
     #[inline]
-    fn bytes_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn bytes_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if scan_sequence!(
                 scan_chars!(input, 'b', 'y', 't', 'e', 's'),
                 scan_optional!(
@@ -8000,10 +8000,10 @@ impl Parser {
     }
 
     #[inline]
-    fn fixed_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn fixed_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if scan_chars!(input, 'f', 'i', 'x', 'e', 'd') {
                 KeywordScan::Reserved(TerminalKind::FixedKeyword)
             } else {
@@ -8304,10 +8304,10 @@ impl Parser {
     }
 
     #[inline]
-    fn int_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn int_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if scan_sequence!(
                 scan_chars!(input, 'i', 'n', 't'),
                 scan_optional!(
@@ -8357,10 +8357,10 @@ impl Parser {
     }
 
     #[inline]
-    fn ufixed_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn ufixed_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if scan_chars!(input, 'u', 'f', 'i', 'x', 'e', 'd') {
                 KeywordScan::Reserved(TerminalKind::UfixedKeyword)
             } else {
@@ -8661,10 +8661,10 @@ impl Parser {
     }
 
     #[inline]
-    fn uint_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn uint_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if scan_sequence!(
                 scan_chars!(input, 'u', 'i', 'n', 't'),
                 scan_optional!(
@@ -8714,10 +8714,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_bytes_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_bytes_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if !self.version_is_at_least_0_7_1
                 && scan_sequence!(
                     scan_chars!(input, 'b', 'y', 't', 'e', 's'),
@@ -8769,10 +8769,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_fixed_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_fixed_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if !self.version_is_at_least_0_7_1 && scan_chars!(input, 'f', 'i', 'x', 'e', 'd') {
                 KeywordScan::Reserved(TerminalKind::YulFixedKeyword)
             } else {
@@ -9075,10 +9075,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_int_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_int_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if !self.version_is_at_least_0_7_1
                 && scan_sequence!(
                     scan_chars!(input, 'i', 'n', 't'),
@@ -9130,10 +9130,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_jump_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_jump_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if (!self.version_is_at_least_0_6_0 || !self.version_is_at_least_0_5_0)
                 && scan_chars!(input, 'j', 'u', 'm', 'p')
             {
@@ -9154,10 +9154,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_jumpi_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_jumpi_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if (!self.version_is_at_least_0_6_0 || !self.version_is_at_least_0_5_0)
                 && scan_chars!(input, 'j', 'u', 'm', 'p', 'i')
             {
@@ -9178,10 +9178,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_ufixed_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_ufixed_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if !self.version_is_at_least_0_7_1 && scan_chars!(input, 'u', 'f', 'i', 'x', 'e', 'd') {
                 KeywordScan::Reserved(TerminalKind::YulUfixedKeyword)
             } else {
@@ -9484,10 +9484,10 @@ impl Parser {
     }
 
     #[inline]
-    fn yul_uint_keyword(&self, input: &mut ParserContext<'_>, ident: &str) -> KeywordScan {
+    fn yul_uint_keyword(&self, input: &mut ParserContext<'_>, ident_len: usize) -> KeywordScan {
         scan_keyword_choice!(
             input,
-            ident,
+            ident_len,
             if !self.version_is_at_least_0_7_1
                 && scan_sequence!(
                     scan_chars!(input, 'u', 'i', 'n', 't'),
@@ -11022,8 +11022,7 @@ impl Lexer for Parser {
                     if kw_scan == KeywordScan::Absent {
                         input.set_position(save);
 
-                        // TODO(#1001): Don't allocate a string here
-                        let ident_value = input.content(save..furthest_position);
+                        let ident_len = furthest_position - save;
 
                         for keyword_compound_scanner in [
                             Self::bytes_keyword,
@@ -11032,7 +11031,7 @@ impl Lexer for Parser {
                             Self::ufixed_keyword,
                             Self::uint_keyword,
                         ] {
-                            match keyword_compound_scanner(self, input, &ident_value) {
+                            match keyword_compound_scanner(self, input, ident_len) {
                                 _ if input.position() < furthest_position => { /* Strict prefix */ }
                                 KeywordScan::Absent => {}
                                 value => kw_scan = value,
@@ -13609,8 +13608,7 @@ impl Lexer for Parser {
                     if kw_scan == KeywordScan::Absent {
                         input.set_position(save);
 
-                        // TODO(#1001): Don't allocate a string here
-                        let ident_value = input.content(save..furthest_position);
+                        let ident_len = furthest_position - save;
 
                         for keyword_compound_scanner in [
                             Self::yul_bytes_keyword,
@@ -13621,7 +13619,7 @@ impl Lexer for Parser {
                             Self::yul_ufixed_keyword,
                             Self::yul_uint_keyword,
                         ] {
-                            match keyword_compound_scanner(self, input, &ident_value) {
+                            match keyword_compound_scanner(self, input, ident_len) {
                                 _ if input.position() < furthest_position => { /* Strict prefix */ }
                                 KeywordScan::Absent => {}
                                 value => kw_scan = value,

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/lexer/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/lexer/mod.rs
@@ -101,7 +101,10 @@ pub(crate) trait Lexer {
         let end = input.position();
 
         ParserResult::r#match(
-            vec![Edge::root(Node::terminal(kind, input.content(start..end)))],
+            vec![Edge::root(Node::terminal(
+                kind,
+                input.content(start..end).to_owned(),
+            ))],
             vec![],
         )
     }
@@ -131,7 +134,10 @@ pub(crate) trait Lexer {
             return ParserResult::no_match(vec![kind]);
         }
         let end = input.position();
-        children.push(Edge::root(Node::terminal(kind, input.content(start..end))));
+        children.push(Edge::root(Node::terminal(
+            kind,
+            input.content(start..end).to_owned(),
+        )));
 
         let restore = input.position();
         if let ParserResult::Match(r#match) = self.trailing_trivia(input) {

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/context.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/context.rs
@@ -149,8 +149,8 @@ impl<'s> ParserContext<'s> {
         self.position = position;
     }
 
-    pub fn content(&self, range: Range<usize>) -> String {
-        self.source[range].to_owned()
+    pub fn content(&self, range: Range<usize>) -> &str {
+        &self.source[range]
     }
 
     pub fn cached_leading_trivia_or(

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -90,14 +90,14 @@ where
                     (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                 };
 
-                let node = Node::terminal(kind, input.to_string());
+                let node = Node::terminal(kind, input.to_owned());
 
                 children.push(Edge { label, node });
 
                 ParseOutput {
                     tree: NonterminalNode::create(topmost_kind, children),
                     errors: vec![ParseError::create(
-                        start..start + input.into(),
+                        start..(start + input.into()),
                         no_match.expected_terminals,
                     )],
                 }
@@ -148,7 +148,7 @@ where
                         (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                     };
 
-                    let skipped_node = Node::terminal(kind, input[start..].to_string());
+                    let skipped_node = Node::terminal(kind, input[start..].to_owned());
                     let mut new_children = topmost_node.children.clone();
                     new_children.push(Edge {
                         label,

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/recovery.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/recovery.rs
@@ -88,7 +88,7 @@ impl ParserResult {
                 expected_terminals.push(expected);
             }
 
-            let skipped = input.content(skipped_range.utf8());
+            let skipped = input.content(skipped_range.utf8()).to_owned();
 
             input.emit(ParseError::create(
                 skipped_range,

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/separated_helper.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/parser_support/separated_helper.rs
@@ -58,9 +58,10 @@ impl SeparatedHelper {
                             } else {
                                 (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                             };
+                            let skipped = input.content(skipped_range.utf8()).to_owned();
                             accum.push(Edge {
                                 label,
-                                node: Node::terminal(kind, input.content(skipped_range.utf8())),
+                                node: Node::terminal(kind, skipped),
                             });
                             input.emit(ParseError::create(
                                 skipped_range,

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/scanner_macros/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/scanner_macros/mod.rs
@@ -76,13 +76,13 @@ macro_rules! scan_choice {
 pub(crate) use scan_choice;
 
 macro_rules! scan_keyword_choice {
-    ($stream:ident, $ident:ident, $($scanner:expr),*) => {
+    ($stream:ident, $ident_len:expr, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
                 {
                     if let result @ (KeywordScan::Present(..) | KeywordScan::Reserved(..)) = ($scanner) {
-                        if $ident.len() == $stream.position() - save {
+                        if $ident_len == $stream.position() - save {
                             break result;
                         }
                     }

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/lexer/mod.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/lexer/mod.rs
@@ -101,7 +101,10 @@ pub(crate) trait Lexer {
         let end = input.position();
 
         ParserResult::r#match(
-            vec![Edge::root(Node::terminal(kind, input.content(start..end)))],
+            vec![Edge::root(Node::terminal(
+                kind,
+                input.content(start..end).to_owned(),
+            ))],
             vec![],
         )
     }
@@ -131,7 +134,10 @@ pub(crate) trait Lexer {
             return ParserResult::no_match(vec![kind]);
         }
         let end = input.position();
-        children.push(Edge::root(Node::terminal(kind, input.content(start..end))));
+        children.push(Edge::root(Node::terminal(
+            kind,
+            input.content(start..end).to_owned(),
+        )));
 
         let restore = input.position();
         if let ParserResult::Match(r#match) = self.trailing_trivia(input) {

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/context.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/context.rs
@@ -149,8 +149,8 @@ impl<'s> ParserContext<'s> {
         self.position = position;
     }
 
-    pub fn content(&self, range: Range<usize>) -> String {
-        self.source[range].to_owned()
+    pub fn content(&self, range: Range<usize>) -> &str {
+        &self.source[range]
     }
 
     pub fn cached_leading_trivia_or(

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/parser_function.rs
@@ -90,14 +90,14 @@ where
                     (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                 };
 
-                let node = Node::terminal(kind, input.to_string());
+                let node = Node::terminal(kind, input.to_owned());
 
                 children.push(Edge { label, node });
 
                 ParseOutput {
                     tree: NonterminalNode::create(topmost_kind, children),
                     errors: vec![ParseError::create(
-                        start..start + input.into(),
+                        start..(start + input.into()),
                         no_match.expected_terminals,
                     )],
                 }
@@ -148,7 +148,7 @@ where
                         (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                     };
 
-                    let skipped_node = Node::terminal(kind, input[start..].to_string());
+                    let skipped_node = Node::terminal(kind, input[start..].to_owned());
                     let mut new_children = topmost_node.children.clone();
                     new_children.push(Edge {
                         label,

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/recovery.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/recovery.rs
@@ -88,7 +88,7 @@ impl ParserResult {
                 expected_terminals.push(expected);
             }
 
-            let skipped = input.content(skipped_range.utf8());
+            let skipped = input.content(skipped_range.utf8()).to_owned();
 
             input.emit(ParseError::create(
                 skipped_range,

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/separated_helper.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/parser_support/separated_helper.rs
@@ -58,9 +58,10 @@ impl SeparatedHelper {
                             } else {
                                 (TerminalKind::UNRECOGNIZED, EdgeLabel::Unrecognized)
                             };
+                            let skipped = input.content(skipped_range.utf8()).to_owned();
                             accum.push(Edge {
                                 label,
-                                node: Node::terminal(kind, input.content(skipped_range.utf8())),
+                                node: Node::terminal(kind, skipped),
                             });
                             input.emit(ParseError::create(
                                 skipped_range,

--- a/crates/testlang/outputs/cargo/crate/src/generated/parser/scanner_macros/mod.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/parser/scanner_macros/mod.rs
@@ -76,13 +76,13 @@ macro_rules! scan_choice {
 pub(crate) use scan_choice;
 
 macro_rules! scan_keyword_choice {
-    ($stream:ident, $ident:ident, $($scanner:expr),*) => {
+    ($stream:ident, $ident_len:expr, $($scanner:expr),*) => {
         loop {
             let save = $stream.position();
             $(
                 {
                     if let result @ (KeywordScan::Present(..) | KeywordScan::Reserved(..)) = ($scanner) {
-                        if $ident.len() == $stream.position() - save {
+                        if $ident_len == $stream.position() - save {
                             break result;
                         }
                     }


### PR DESCRIPTION
Found while cleaning up the remaining `TODO` comments before the release (see #1251).
Fixed This one since it was a minor change to stop allocating strings on every scanner invocation.

Closes #1001