### PR TITLE
Fix global `using` extensions propagation across multiple files

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -15,8 +15,8 @@ attribute scoped_node_reference  = node => type = "push_scoped_symbol", node_sym
 attribute pop_scoped_symbol = symbol    => type = "pop_scoped_symbol", symbol = symbol
 attribute push_scoped_symbol = symbol   => type = "push_scoped_symbol", symbol = symbol
 
-;; Keeps a link to the enclosing contract definition to provide a parent for
-;; method calls (to correctly resolve virtual methods)
+;; Keeps a link to the enclosing definition (eg. contract, library or global
+;; function) to provide extension scopes.
 inherit .enclosing_def
 
 inherit .parent_scope
@@ -76,6 +76,11 @@ inherit .star_extension
   ; Provide a default star extension sink node that gets inherited. This is
   ; connected to from expressions, and those can potentially happen anywhere.
   node @source_unit.star_extension
+
+  ; We'll collect global using extensions in this scope, which we can hook from
+  ; contracts and global functions
+  node @source_unit.extensions
+  attr (@source_unit.extensions) is_exported
 }
 
 ;; Top-level definitions...
@@ -118,10 +123,27 @@ inherit .star_extension
 }
 
 @source_unit [SourceUnit [SourceUnitMembers [SourceUnitMember @using [UsingDirective]]]] {
-  ; TODO: this is the hook for top-level extensions, but this should connect to
-  ; an extensions scope that gets pushed to the scope stack, as in the case of
-  ; contracts/libraries (defined further down below).
-  edge @source_unit.lexical_scope -> @using.def
+  ; Link the using directive to the source unit extensions scope, which will
+  ; then be hooked to the lexical_scope via the enclosing def (contract,
+  ; library, etc.) extension_scope
+  edge @source_unit.extensions -> @using.def
+}
+
+@source_unit [SourceUnit [SourceUnitMembers
+    [SourceUnitMember @unit_member (
+          [ContractDefinition]
+        | [LibraryDefinition]
+    )]
+]] {
+  ;; Global using extensions also apply to contracts and libraries
+  edge @unit_member.extensions -> @source_unit.extensions
+}
+
+@source_unit [SourceUnit [SourceUnitMembers [SourceUnitMember @function [FunctionDefinition]]]] {
+  ;; Global functions act as enclosing definitions for expressions within and
+  ;; use the source unit's extension scope
+  attr (@function.def) extension_scope = @source_unit.extensions
+  let @function.enclosing_def = @function.def
 }
 
 @source_unit [SourceUnit [SourceUnitMembers [SourceUnitMember
@@ -659,7 +681,6 @@ inherit .star_extension
   attr (hook) extension_hook
   attr (hook) is_endpoint
   edge push_name -> hook
-  ; edge push_name -> JUMP_TO_SCOPE_NODE
 
   ;; "namespace" like access path
   node ns_member

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/using.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/using.rs
@@ -55,6 +55,11 @@ fn global() -> Result<()> {
 }
 
 #[test]
+fn global_multi_file() -> Result<()> {
+    run("using", "global_multi_file")
+}
+
+#[test]
 fn in_contract() -> Result<()> {
     run("using", "in_contract")
 }

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.4.11-failure.txt
@@ -1,0 +1,59 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── unresolved
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+Parse errors:
+Error: Expected ContractKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword.
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── Error occurred here.
+───╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.6.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.6.0-failure.txt
@@ -1,0 +1,59 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or EnumKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword or StructKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── unresolved
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+Parse errors:
+Error: Expected ContractKeyword or EnumKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword or StructKeyword.
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── Error occurred here.
+───╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.7.1-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.7.1-failure.txt
@@ -1,0 +1,70 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or EnumKeyword or FunctionKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword or StructKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── ref: 5
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 5
+   │                   │  
+   │                   ╰── name: 6
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 6
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 6
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.7.4-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.7.4-failure.txt
@@ -1,0 +1,70 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or ByteKeyword or BytesKeyword or ContractKeyword or EnumKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── ref: 5
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 5
+   │                   │  
+   │                   ╰── name: 6
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 6
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 6
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.0-failure.txt
@@ -1,0 +1,70 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── ref: 5
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 5
+   │                   │  
+   │                   ╰── name: 6
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 6
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 6
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.13-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.13-success.txt
@@ -1,0 +1,124 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[main.sol:1:1]
+    │
+  1 │ import {foo} from "other.sol";
+    │         ─┬─  
+    │          ╰─── name: 1
+    │          │   
+    │          ╰─── ref: 10
+    │ 
+  3 │ library Lib {
+    │         ─┬─  
+    │          ╰─── name: 2
+  4 │     function nop(uint x) public {}
+    │              ─┬─      ┬  
+    │               ╰────────── name: 3
+    │                       │  
+    │                       ╰── name: 4
+    │ 
+  7 │ using Lib for uint;
+    │       ─┬─  
+    │        ╰─── ref: 2
+    │ 
+  9 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 5
+ 10 │     function test(uint a) public {
+    │              ──┬─      ┬  
+    │                ╰────────── name: 6
+    │                        │  
+    │                        ╰── name: 7
+ 11 │         a.nop();
+    │         ┬ ─┬─  
+    │         ╰────── ref: 7
+    │            │   
+    │            ╰─── ref: 3
+ 12 │         foo(a).nop();
+    │         ─┬─ ┬  ─┬─  
+    │          ╰────────── refs: 1, 10
+    │             │   │   
+    │             ╰─────── ref: 7
+    │                 │   
+    │                 ╰─── ref: 3
+    │ 
+ 16 │ function bar(uint a) {
+    │          ─┬─      ┬  
+    │           ╰────────── name: 8
+    │                   │  
+    │                   ╰── name: 9
+ 17 │     a.nop();
+    │     ┬ ─┬─  
+    │     ╰────── ref: 9
+    │        │   
+    │        ╰─── ref: 3
+ 18 │     foo(a).nop();
+    │     ─┬─ ┬  ─┬─  
+    │      ╰────────── refs: 1, 10
+    │         │   │   
+    │         ╰─────── ref: 9
+    │             │   
+    │             ╰─── ref: 3
+────╯
+Definiens: 
+    ╭─[main.sol:1:1]
+    │
+  1 │       │   import {foo} from "other.sol";
+    │       │           ─┬─  
+    │       │            ╰─── definiens: 1
+  2 │       ╭─▶ 
+    ┆       ┆   
+  4 │       │       function nop(uint x) public {}
+    │       │   ─────────────────┬──┬──────────────  
+    │       │                    ╰─────────────────── definiens: 3
+    │       │                       │                
+    │       │                       ╰──────────────── definiens: 4
+  5 │       ├─▶ }
+    │       │       
+    │       ╰─────── definiens: 2
+    │ 
+  8 │ ╭───────▶ 
+    ┆ ┆ ┆       
+ 10 │ │ ╭─────▶     function test(uint a) public {
+    │ │ │                         ───┬──  
+    │ │ │                            ╰──── definiens: 7
+    ┆ ┆ ┆       
+ 13 │ │ ├─────▶     }
+    │ │ │               
+    │ │ ╰─────────────── definiens: 6
+ 14 │ ├───│ ──▶ }
+    │ │   │         
+    │ ╰───────────── definiens: 5
+ 15 │     ╭───▶ 
+ 16 │     │     function bar(uint a) {
+    │     │                  ───┬──  
+    │     │                     ╰──── definiens: 9
+    ┆     ┆     
+ 19 │     ├───▶ }
+    │     │         
+    │     ╰───────── definiens: 8
+────╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 10
+   │                   │  
+   │                   ╰── name: 11
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 11
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 11
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 10
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.4-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.4-failure.txt
@@ -1,0 +1,70 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or ErrorKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── ref: 5
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 5
+   │                   │  
+   │                   ╰── name: 6
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 6
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 6
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.8-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/generated/0.8.8-failure.txt
@@ -1,0 +1,70 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or ErrorKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or TypeKeyword or UfixedKeyword or UintKeyword.
+    ╭─[main.sol:7:1]
+    │
+  7 │ ╭─▶ using Lib for uint;
+    ┆ ┆   
+ 20 │ ├─▶ 
+    │ │      
+    │ ╰────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {foo} from "other.sol";
+   │         ─┬─  
+   │          ╰─── name: 1
+   │          │   
+   │          ╰─── ref: 5
+   │ 
+ 3 │ library Lib {
+   │         ─┬─  
+   │          ╰─── name: 2
+ 4 │     function nop(uint x) public {}
+   │              ─┬─      ┬  
+   │               ╰────────── name: 3
+   │                       │  
+   │                       ╰── name: 4
+───╯
+Definiens: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ │   import {foo} from "other.sol";
+   │ │           ─┬─  
+   │ │            ╰─── definiens: 1
+ 2 │ ╭─▶ 
+   ┆ ┆   
+ 4 │ │       function nop(uint x) public {}
+   │ │   ─────────────────┬──┬──────────────  
+   │ │                    ╰─────────────────── definiens: 3
+   │ │                       │                
+   │ │                       ╰──────────────── definiens: 4
+ 5 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 2
+───╯
+References and definitions: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function foo(uint a) pure returns (uint) {
+   │          ─┬─      ┬  
+   │           ╰────────── name: 5
+   │                   │  
+   │                   ╰── name: 6
+ 2 │     return a;
+   │            ┬  
+   │            ╰── ref: 6
+───╯
+Definiens: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ ╭─▶ function foo(uint a) pure returns (uint) {
+   │ │                ───┬──  
+   │ │                   ╰──── definiens: 6
+   ┆ ┆   
+ 3 │ ├─▶ }
+   │ │       
+   │ ╰─────── definiens: 5
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/using/global_multi_file/input.sol
@@ -1,0 +1,25 @@
+// ---- path: main.sol
+import {foo} from "other.sol";
+
+library Lib {
+    function nop(uint x) public {}
+}
+
+using Lib for uint;
+
+contract Test {
+    function test(uint a) public {
+        a.nop();
+        foo(a).nop();
+    }
+}
+
+function bar(uint a) {
+    a.nop();
+    foo(a).nop();
+}
+
+// ---- path: other.sol
+function foo(uint a) pure returns (uint) {
+    return a;
+}


### PR DESCRIPTION
Closes #1249

Global extensions were being hooked directly to the source unit's lexical scope instead of using a proper extensions scope. That meant it would only apply if the type reference was located in the same file as the `using` directive and would break eg. for functions in imported files returning the extended type.