### PR TITLE
Reduce size of CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     # Skip 'pull_request' events from the main repository, as the workflow is already triggered by the 'push' event:
     if: "${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'NomicFoundation/slang' }}"
 
+    env:
+      SLANG_INFRA_RELEASE: "true"
+
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"

--- a/crates/infra/cli/src/commands/check/mod.rs
+++ b/crates/infra/cli/src/commands/check/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::cargo::CargoWorkspaceCommands;
 use infra_utils::commands::Command;
 use infra_utils::terminal::Terminal;
 use rayon::iter::{ParallelBridge, ParallelIterator};
@@ -43,12 +42,10 @@ impl OrderedCommand for CheckCommand {
 }
 
 fn check_cargo() {
-    Command::new("cargo")
-        .arg("check")
+    Command::cargo("check")
         .flag("--workspace")
         .flag("--all-features")
         .flag("--all-targets")
-        .add_build_rustflags()
         .run();
 }
 

--- a/crates/infra/cli/src/commands/lint/mod.rs
+++ b/crates/infra/cli/src/commands/lint/mod.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use infra_utils::cargo::CargoWorkspaceCommands;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 use infra_utils::paths::{FileWalker, PathExtensions};
@@ -76,25 +75,26 @@ impl OrderedCommand for LintCommand {
 }
 
 fn run_clippy() {
-    Command::new("cargo")
-        .arg("clippy")
+    Command::cargo("clippy")
         .flag("--workspace")
         .flag("--all-features")
         .flag("--all-targets")
         .flag("--no-deps")
-        .add_build_rustflags()
         .run();
 }
 
 fn run_rustdoc() {
-    Command::new("cargo")
-        .arg("doc")
+    Command::cargo("doc")
         .flag("--workspace")
         .flag("--all-features")
         .flag("--no-deps")
         .flag("--document-private-items")
-        .add_build_rustflags()
         .run();
+
+    
+    Command::cargo("rustdoc")
+        .flag("--all-features")
+        .flag("--no-deps");
 }
 
 fn run_mkdocs() {

--- a/crates/infra/cli/src/commands/lint/mod.rs
+++ b/crates/infra/cli/src/commands/lint/mod.rs
@@ -29,6 +29,8 @@ enum LintCommand {
     Clippy,
     /// Run `cargo doc` to generate Rustdoc documentation and check for any broken links.
     Rustdoc,
+    /// Use rustdoc to generate public api documentation.
+    PublicApi,
     /// Check mkdocs documentation for any build issues or broken links.
     Mkdocs,
     /// Check for spelling issues in Markdown files.
@@ -58,6 +60,7 @@ impl OrderedCommand for LintCommand {
         match self {
             LintCommand::Clippy => run_clippy(),
             LintCommand::Rustdoc => run_rustdoc(),
+            LintCommand::PublicApi => run_public_api(),
             LintCommand::Mkdocs => run_mkdocs(),
             LintCommand::Cspell => run_cspell(),
             LintCommand::Prettier => run_prettier(),
@@ -90,11 +93,10 @@ fn run_rustdoc() {
         .flag("--no-deps")
         .flag("--document-private-items")
         .run();
+}
 
-    
-    Command::cargo("rustdoc")
-        .flag("--all-features")
-        .flag("--no-deps");
+fn run_public_api() {
+    infra_utils::cargo::public_api_snapshots();
 }
 
 fn run_mkdocs() {

--- a/crates/infra/cli/src/commands/run/mod.rs
+++ b/crates/infra/cli/src/commands/run/mod.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
 use infra_utils::commands::Command;
+use infra_utils::github::GitHub;
 use infra_utils::terminal::Terminal;
 
 use crate::utils::ClapExtensions;
@@ -39,7 +40,7 @@ impl RunController {
 
         let mut command = Command::new("cargo").arg("run");
 
-        if self.release {
+        if self.release || GitHub::is_running_in_ci() {
             command = command.flag("--release");
         }
 

--- a/crates/infra/cli/src/commands/setup/npm/mod.rs
+++ b/crates/infra/cli/src/commands/setup/npm/mod.rs
@@ -16,10 +16,12 @@ pub fn setup_npm() {
         .args(["install"])
         .run();
 
-    Command::new("npm")
-        .current_dir(Path::repo_path("submodules/jco"))
-        .args(["run", "build"])
-        .run();
+    if !GitHub::is_running_in_ci() {
+        Command::new("npm")
+            .current_dir(Path::repo_path("submodules/jco"))
+            .args(["run", "build"])
+            .run();
+    }
 
     Command::new("npm")
         .current_dir(Path::repo_path("submodules/jco"))

--- a/crates/infra/utils/Cargo.toml
+++ b/crates/infra/utils/Cargo.toml
@@ -14,8 +14,10 @@ ignore = { workspace = true }
 Inflector = { workspace = true }
 itertools = { workspace = true }
 num-format = { workspace = true }
+public-api = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+rustdoc-json = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -25,12 +27,6 @@ strum_macros = { workspace = true }
 tera = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
-
-[dev-dependencies]
-anyhow = { workspace = true }
-public-api = { workspace = true }
-rayon = { workspace = true }
-rustdoc-json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/infra/utils/src/cargo/mod.rs
+++ b/crates/infra/utils/src/cargo/mod.rs
@@ -2,5 +2,5 @@ mod manifest;
 mod public_api;
 mod workspace;
 
-pub use public_api::UserFacingCrate;
+pub use public_api::{public_api_snapshots, UserFacingCrate};
 pub use workspace::{CargoWorkspace, CargoWorkspaceCommands};

--- a/crates/infra/utils/src/commands/mod.rs
+++ b/crates/infra/utils/src/commands/mod.rs
@@ -10,6 +10,7 @@ use anyhow::{bail, Context, Result};
 use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
+use crate::cargo::CargoWorkspaceCommands;
 use crate::github::GitHub;
 use crate::paths::{PathExtensions, PrivatePathExtensions};
 
@@ -36,6 +37,17 @@ impl Command {
 
             current_dir: None,
         }
+    }
+
+    #[must_use]
+    pub fn cargo(arg: impl Into<String>) -> Self {
+        let mut command = Command::new("cargo").arg(arg).add_build_rustflags();
+
+        if GitHub::is_running_in_ci() {
+            command = command.flag("--release");
+        }
+
+        command
     }
 
     #[must_use]

--- a/scripts/bin/infra
+++ b/scripts/bin/infra
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Check for the flag SLANG_INFRA_RELEASE before calling `set -u`
+# Otherwise the script will fail if a value for the flag is not provided,
+# but we want to default to a debug build in that case
+is_release="${SLANG_INFRA_RELEASE:-}"
+
 set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
@@ -13,14 +19,27 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 # spawned by 'infra_cli'. We have to build and run the binary directly to ensure it has a clean env.
 # Otherwise, they leak into cross-platform or multi-target builds, and cause build failures.
 #
+crate_dir="${REPO_ROOT:?}/crates/infra/cli"
 
-(
-  crate_dir="${REPO_ROOT:?}/crates/infra/cli"
+if [[ -n ${is_release} ]]; then
+  (
 
-  cargo build \
-    --bin "infra_cli" \
-    --manifest-path "${crate_dir}/Cargo.toml" \
-    --target-dir "${crate_dir}/target"
+    cargo build \
+      --bin "infra_cli" \
+      --release \
+      --manifest-path "${crate_dir}/Cargo.toml" \
+      --target-dir "${crate_dir}/target"
 
-  "${crate_dir}/target/debug/infra_cli" "$@"
-)
+    "${crate_dir}/target/release/infra_cli" "$@"
+  )
+else
+  (
+    cargo build \
+      --bin "infra_cli" \
+      --manifest-path "${crate_dir}/Cargo.toml" \
+      --target-dir "${crate_dir}/target"
+
+    "${crate_dir}/target/debug/infra_cli" "$@"
+  )
+fi
+


### PR DESCRIPTION
The goal of this PR is to reduce the size of our build artifacts in CI to avoid failures due to lack of disk space. This has been a sporadic issue for a while, but it's become unavoidable starting with #1225, which is constantly running out of space. That's because the new version of JCO that it's bringing in is too large. We can build the project in release mode in CI to compensate for this.

I've added some extra logic in `infra_cli` when running cargo commands to append a `--release` flag when running in CI (indicated with the environment variable `CI`). I also added a new flag to use in the `infra` script (`scripts/bin/infra`), `SLANG_INFRA_RELEASE`, which will cause the infra crates to be built in release mode too when set. With both of these changes we can get the project size down to ~13 Gb with either version of JCO. This keeps us under the [14 Gb threshold](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

---

Built with JCO rev. `d1b3344` (what `main` points to currently)

| Command | Total project size |
| --- | --- |
|  `infra ci` | 16 Gb |
| `CI=true infra ci` | 14 Gb |
| `CI=true SLANG_INFRA_RELEASE=true infra ci` | 13 Gb |

Built with JCO rev `b7818f3` (new rev that will come in once #1225 is complete)

| Command | Total project size |
| --- | --- |
| `infra ci` | 17 Gb |
| `CI=true infra ci` | 14 Gb |
| `CI=true SLANG_INFRA_RELEASE=true infra ci` | 13 Gb |

---

I've also moved the generation of `public_api.txt` out of the unit tests and in to a new step, `infra lint public-api`. I chose `infra lint` because this is where the rustdocs are currently generated. This makes the api docs generation a bit more visible and therefore easier to debug, and also helps with unit test execution times.

Generating these docs causes debug artifacts to be generated - 1.2 Gb worth, by my measurements. We might be able to reduce the overall project size further by building this in release mode too, however the crate we call which runs `cargo` to generate these does not provide an API to do so. I believe that we could remove this crate entirely and generate the rustdoc json file ourselves, but it didn't seem necessary here and is outside the pure scope of this change so I left it as-is for now.



