### PR TITLE
Fix typos in comments

### DIFF
--- a/crates/metaslang/cst/src/nodes.rs
+++ b/crates/metaslang/cst/src/nodes.rs
@@ -67,7 +67,7 @@ impl<T: KindTypes> Node<T> {
         Self::Terminal(TerminalNode::create(kind, text))
     }
 
-    /// Returns a unique identifier of the node. It is not reproducable over parses
+    /// Returns a unique identifier of the node. It is not reproducible over parses
     /// and cannot be used in a persistent/serialised sense.
     pub fn id(&self) -> usize {
         match self {
@@ -226,7 +226,7 @@ impl<T: KindTypes> NonterminalNode<T> {
         })
     }
 
-    /// Returns a unique identifier of the node. It is not reproducable over parses
+    /// Returns a unique identifier of the node. It is not reproducible over parses
     /// and cannot be used in a persistent/serialised sense.
     pub fn id(self: &Rc<Self>) -> usize {
         Rc::as_ptr(self) as usize
@@ -269,7 +269,7 @@ impl<T: KindTypes> TerminalNode<T> {
         Rc::new(Self { kind, text })
     }
 
-    /// Returns a unique identifier of the node. It is not reproducable over parses
+    /// Returns a unique identifier of the node. It is not reproducible over parses
     /// and cannot be used in a persistent/serialised sense.
     pub fn id(self: &Rc<Self>) -> usize {
         Rc::as_ptr(self) as usize

--- a/crates/metaslang/graph_builder/src/variables.rs
+++ b/crates/metaslang/graph_builder/src/variables.rs
@@ -67,7 +67,7 @@ impl<'a, V> VariableMap<'a, V> {
         }
     }
 
-    /// Clears this enviroment.
+    /// Clears this environment.
     pub(crate) fn clear(&mut self) {
         self.values.clear();
     }
@@ -161,7 +161,7 @@ impl<'a> Globals<'a> {
             .or_else(|| self.context.as_ref().map(|p| p.get(name)).flatten())
     }
 
-    /// Remove a variable from this enviroment, if it exists.
+    /// Remove a variable from this environment, if it exists.
     pub fn remove(&mut self, name: &Identifier) {
         self.values.remove(name);
     }
@@ -174,7 +174,7 @@ impl<'a> Globals<'a> {
         Iter(self.values.iter())
     }
 
-    /// Clears this enviroment.
+    /// Clears this environment.
     pub fn clear(&mut self) {
         self.values.clear();
     }

--- a/crates/metaslang/graph_builder/src/variables.rs
+++ b/crates/metaslang/graph_builder/src/variables.rs
@@ -67,7 +67,7 @@ impl<'a, V> VariableMap<'a, V> {
         }
     }
 
-    /// Clears this environment.
+    /// Clears this enviroment.
     pub(crate) fn clear(&mut self) {
         self.values.clear();
     }
@@ -161,7 +161,7 @@ impl<'a> Globals<'a> {
             .or_else(|| self.context.as_ref().map(|p| p.get(name)).flatten())
     }
 
-    /// Remove a variable from this environment, if it exists.
+    /// Remove a variable from this enviroment, if it exists.
     pub fn remove(&mut self, name: &Identifier) {
         self.values.remove(name);
     }
@@ -174,7 +174,7 @@ impl<'a> Globals<'a> {
         Iter(self.values.iter())
     }
 
-    /// Clears this environment.
+    /// Clears this enviroment.
     pub fn clear(&mut self) {
         self.values.clear();
     }


### PR DESCRIPTION
This PR fixes spelling mistakes in code comments:

- Corrects "reproducable" to "reproducible" in node identifier comments
- Corrects "enviroment" to "environment" in variable-related comments

These changes only affect comments and do not modify any functional code.