### PR TITLE
Add standalone examples to the user guides

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
     "instanceof",
     "ipfs",
     "jumpi",
+    "linenums",
     "metaslang",
     "mkdocs",
     "napi",

--- a/documentation/public/user-guide/.navigation.md
+++ b/documentation/public/user-guide/.navigation.md
@@ -6,3 +6,4 @@
 - [5. Syntax Trees](./05-syntax-trees/)
 - [6. Query Language](./06-query-language/)
 - [7. Semantic Analysis](./07-semantic-analysis/)
+- [8. Examples](./08-examples/)

--- a/documentation/public/user-guide/07-semantic-analysis/03-solidity-builtins/examples/01-solidity-builtins.test.mts
+++ b/documentation/public/user-guide/07-semantic-analysis/03-solidity-builtins/examples/01-solidity-builtins.test.mts
@@ -6,7 +6,10 @@ test("solidity builtins", async () => {
   const unit = await buildCompilationUnit();
 
   const query = Query.create(`
-    [MemberAccessExpression [Expression @start ["tx"]] ["origin"]]
+    [MemberAccessExpression
+      [Expression @start ["tx"]]
+      ["origin"]
+    ]
   `);
 
   const cursor = unit.file("contract.sol")!.createTreeCursor();

--- a/documentation/public/user-guide/08-examples/.navigation.md
+++ b/documentation/public/user-guide/08-examples/.navigation.md
@@ -1,1 +1,3 @@
-- [Examples](./index.md)
+- [8. Examples](./index.md)
+- [8.1. List functions in a contract](./01-list-functions-in-contract/index.md)
+- [8.2. Find usages](./02-find-usages/index.md)

--- a/documentation/public/user-guide/08-examples/.navigation.md
+++ b/documentation/public/user-guide/08-examples/.navigation.md
@@ -1,3 +1,4 @@
 - [8. Examples](./index.md)
 - [8.1. List functions in a contract](./01-list-functions-in-contract/index.md)
 - [8.2. Find usages](./02-find-usages/index.md)
+- [8.3. Jump to definition](./03-jump-to-definition/index.md)

--- a/documentation/public/user-guide/08-examples/.navigation.md
+++ b/documentation/public/user-guide/08-examples/.navigation.md
@@ -1,0 +1,1 @@
+- [Examples](./index.md)

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
@@ -1,17 +1,20 @@
-import assert from "node:assert";
-import { Query } from "@nomicfoundation/slang/cst";
+import { assertNonterminalNode, Query } from "@nomicfoundation/slang/cst";
 import { ContractDefinition, FunctionDefinition } from "@nomicfoundation/slang/ast";
 import { CompilationUnit } from "@nomicfoundation/slang/compilation";
 
-export function listFunctionsInContract(unit: CompilationUnit, contractName: string): FunctionDefinition[] | undefined {
+export function listFunctionsInContract(unit: CompilationUnit, contractName: string): FunctionDefinition[] {
   for (const file of unit.files()) {
     const cursor = file.createTreeCursor();
-    const query = Query.create(`[ContractDefinition @name name: [Identifier]]`);
+    const query = Query.create(`
+      [ContractDefinition
+        @name name: [Identifier]
+      ]
+    `);
     const matches = cursor.query([query]);
 
     for (const match of matches) {
       const contractNode = match.root.node;
-      assert(contractNode.isNonterminalNode());
+      assertNonterminalNode(contractNode);
       const name = match.captures["name"][0].node.unparse();
       if (name == contractName) {
         // found the contract
@@ -24,6 +27,5 @@ export function listFunctionsInContract(unit: CompilationUnit, contractName: str
     }
   }
 
-  // no contracts found
-  return undefined;
+  throw new Error(`Could not find contract named ${contractName}`);
 }

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
@@ -1,0 +1,32 @@
+import assert from "node:assert";
+import { Query } from "@nomicfoundation/slang/cst";
+import { ContractDefinition, FunctionDefinition } from "@nomicfoundation/slang/ast";
+import { CompilationUnit } from "@nomicfoundation/slang/compilation";
+
+export function listFunctionsInContract(
+  unit: CompilationUnit,
+  contractName: string,
+): FunctionDefinition[] | undefined {
+  for (const file of unit.files()) {
+    const cursor = file.createTreeCursor();
+    const query = Query.create(`[ContractDefinition @name name: [Identifier]]`);
+    const matches = cursor.query([query]);
+
+    for (const match of matches) {
+      const contractNode = match.root.node;
+      assert(contractNode.isNonterminalNode());
+      const name = match.captures["name"][0].node.unparse();
+      if (name == contractName) {
+        // found the contract
+        const contract = new ContractDefinition(contractNode);
+        const functions = contract.members.items
+          .map((member) => member.variant)
+          .filter((member) => member instanceof FunctionDefinition);
+        return functions;
+      }
+    }
+  }
+
+  // no contracts found
+  return undefined;
+}

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts
@@ -3,10 +3,7 @@ import { Query } from "@nomicfoundation/slang/cst";
 import { ContractDefinition, FunctionDefinition } from "@nomicfoundation/slang/ast";
 import { CompilationUnit } from "@nomicfoundation/slang/compilation";
 
-export function listFunctionsInContract(
-  unit: CompilationUnit,
-  contractName: string,
-): FunctionDefinition[] | undefined {
+export function listFunctionsInContract(unit: CompilationUnit, contractName: string): FunctionDefinition[] | undefined {
   for (const file of unit.files()) {
     const cursor = file.createTreeCursor();
     const query = Query.create(`[ContractDefinition @name name: [Identifier]]`);

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
@@ -6,9 +6,6 @@ test("list functions by contract name", async () => {
   const unit = await buildSampleCompilationUnit();
 
   const functions = listFunctionsInContract(unit, "Counter");
-  assert(functions);
-  assert.strictEqual(functions.length, 2);
-
   const functionNames = functions.map((fun) => fun.name.cst.unparse().trim());
   assert.deepEqual(functionNames, ["count", "increment"]);
 });

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
@@ -1,0 +1,36 @@
+import assert from "node:assert";
+import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
+import { listFunctionsInContract } from "./list-functions-in-contract.mjs";
+
+test("list functions by contract name", async () => {
+  const CONTRACT_VFS = new Map<string, string>([
+    [
+      "contract.sol",
+      `
+contract Counter {
+  uint _count;
+  constructor(uint initialCount) {
+    _count = initialCount;
+  }
+  function count() public view returns (uint) {
+    return _count;
+  }
+  function increment(uint delta) public returns (uint) {
+    require(delta > 0, "Delta must be positive");
+    _count += delta;
+    return _count;
+  }
+}
+      `,
+    ],
+  ]);
+
+  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+
+  const functions = listFunctionsInContract(unit, "Counter");
+  assert(functions);
+  assert.strictEqual(functions.length, 2);
+
+  const functionNames = functions.map((fun) => fun.name.cst.unparse().trim());
+  assert.deepEqual(functionNames, ["count", "increment"]);
+});

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts
@@ -1,31 +1,9 @@
 import assert from "node:assert";
-import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
 import { listFunctionsInContract } from "./list-functions-in-contract.mjs";
+import buildSampleCompilationUnit from "../../common/sample-contract.mjs";
 
 test("list functions by contract name", async () => {
-  const CONTRACT_VFS = new Map<string, string>([
-    [
-      "contract.sol",
-      `
-contract Counter {
-  uint _count;
-  constructor(uint initialCount) {
-    _count = initialCount;
-  }
-  function count() public view returns (uint) {
-    return _count;
-  }
-  function increment(uint delta) public returns (uint) {
-    require(delta > 0, "Delta must be positive");
-    _count += delta;
-    return _count;
-  }
-}
-      `,
-    ],
-  ]);
-
-  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+  const unit = await buildSampleCompilationUnit();
 
   const functions = listFunctionsInContract(unit, "Counter");
   assert(functions);

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
@@ -1,0 +1,9 @@
+# 8.1. List functions in a contract
+
+```ts title="list-functions-in-contract.mts"
+--8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts"
+```
+
+```ts title="test-list-functions.test.mts"
+--8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts"
+```

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
@@ -1,8 +1,12 @@
 # 8.1. List functions in a contract
 
+This function finds a contract in the compilation unit with the given name and returns a list of `FunctionDefinition` within it. We use a combination of the [Query API](../../06-query-language/02-executing-queries/index.md) and the [AST types](../../05-syntax-trees/04-using-ast-types/index.md):
+
 ```ts title="list-functions-in-contract.mts"
 --8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts"
 ```
+
+From the list of `FunctionDefinition`s it's easy to obtain the names of the functions:
 
 ```ts title="test-list-functions.test.mts"
 --8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts"

--- a/documentation/public/user-guide/08-examples/02-find-usages/examples/find-usages.mts
+++ b/documentation/public/user-guide/08-examples/02-find-usages/examples/find-usages.mts
@@ -1,0 +1,46 @@
+import assert from "node:assert";
+import { TerminalKindExtensions } from "@nomicfoundation/slang/cst";
+import { CompilationUnit } from "@nomicfoundation/slang/compilation";
+import { assertUserFileLocation } from "@nomicfoundation/slang/bindings";
+import { findTerminalNodeAt } from "../../common/find-terminal-node-at.mjs";
+
+type Usage = {
+  file: string;
+  line: number;
+  column: number;
+};
+
+export function findUsages(unit: CompilationUnit, fileId: string, line: number, column: number): Usage[] | string {
+  const file = unit.file(fileId);
+  if (!file) {
+    return `${fileId} not found in compilation unit`;
+  }
+
+  const cursor = findTerminalNodeAt(file.createTreeCursor(), line, column);
+  if (!cursor) {
+    return `${fileId}:${line}:${column} is not a valid text location`;
+  }
+
+  assert(cursor.node.isTerminalNode());
+  if (!TerminalKindExtensions.isIdentifier(cursor.node.kind)) {
+    // location is not a valid identifier
+    return `Could not find a valid identifier at ${fileId}:${line}:${column}`;
+  }
+
+  const definition = unit.bindingGraph.definitionAt(cursor);
+  if (!definition) {
+    return `Identifier ${cursor.node.unparse()} is not a definition at ${fileId}:${line}:${column}`;
+  }
+
+  const references = definition.references();
+  const usages = [];
+  for (const reference of references) {
+    assertUserFileLocation(reference.location);
+    usages.push({
+      file: reference.location.fileId,
+      line: reference.location.cursor.textOffset.line,
+      column: reference.location.cursor.textOffset.column,
+    });
+  }
+  return usages;
+}

--- a/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
+++ b/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
@@ -5,8 +5,8 @@ import buildSampleCompilationUnit from "../../common/sample-contract.mjs";
 test("find usages", async () => {
   const unit = await buildSampleCompilationUnit();
 
-  const usages = findUsages(unit, "contract.sol", 2, 10); // the _count state variable definition
-  assert(typeof usages !== "string");
+  // the _count state variable definition
+  const usages = findUsages(unit, "contract.sol", 2, 10);
 
   assert.deepEqual(usages, [
     { file: "contract.sol", line: 4, column: 4 },

--- a/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
+++ b/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
@@ -1,31 +1,9 @@
 import assert from "node:assert";
-import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
 import { findUsages } from "./find-usages.mjs";
+import buildSampleCompilationUnit from "../../common/sample-contract.mjs";
 
 test("find usages", async () => {
-  const CONTRACT_VFS = new Map<string, string>([
-    [
-      "contract.sol",
-      `
-contract Counter {
-  uint _count;
-  constructor(uint initialCount) {
-    _count = initialCount;
-  }
-  function count() public view returns (uint) {
-    return _count;
-  }
-  function increment(uint delta) public returns (uint) {
-    require(delta > 0, "Delta must be positive");
-    _count += delta;
-    return _count;
-  }
-}
-      `,
-    ],
-  ]);
-
-  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+  const unit = await buildSampleCompilationUnit();
 
   const usages = findUsages(unit, "contract.sol", 2, 10); // the _count state variable definition
   assert(typeof usages !== "string");

--- a/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
+++ b/documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
+import { findUsages } from "./find-usages.mjs";
+
+test("find usages", async () => {
+  const CONTRACT_VFS = new Map<string, string>([
+    [
+      "contract.sol",
+      `
+contract Counter {
+  uint _count;
+  constructor(uint initialCount) {
+    _count = initialCount;
+  }
+  function count() public view returns (uint) {
+    return _count;
+  }
+  function increment(uint delta) public returns (uint) {
+    require(delta > 0, "Delta must be positive");
+    _count += delta;
+    return _count;
+  }
+}
+      `,
+    ],
+  ]);
+
+  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+
+  const usages = findUsages(unit, "contract.sol", 2, 10); // the _count state variable definition
+  assert(typeof usages !== "string");
+
+  assert.deepEqual(usages, [
+    { file: "contract.sol", line: 4, column: 4 },
+    { file: "contract.sol", line: 7, column: 11 },
+    { file: "contract.sol", line: 11, column: 4 },
+    { file: "contract.sol", line: 12, column: 11 },
+  ]);
+});

--- a/documentation/public/user-guide/08-examples/02-find-usages/index.md
+++ b/documentation/public/user-guide/08-examples/02-find-usages/index.md
@@ -1,7 +1,33 @@
 # 8.2. Find usages
 
+A typical use case for an IDE is finding where some variable, function, or type is used in the code base. In Slang this can be easily accomplished by using the [Binding Graph API](../../07-semantic-analysis/02-binding-graph/index.md):
+
 ```ts title="find-usages.mts"
 --8<-- "documentation/public/user-guide/08-examples/02-find-usages/examples/find-usages.mts"
+```
+
+For example, we can look for usages of the `_count` state variable defined in the sample contract:
+
+```solidity
+ 1: contract Counter {
+ 2:   uint _count;
+           ^^^^^^
+ 3:   constructor(uint initialCount) {
+ 4:     _count = initialCount;
+        ^^^^^^
+ 5:   }
+ 6:   function count() public view returns (uint) {
+ 7:     return _count;
+               ^^^^^^
+ 8:   }
+ 9:   function increment(uint delta) public returns (uint) {
+10:     require(delta > 0, "Delta must be positive");
+11:     _count += delta;
+        ^^^^^^
+12:     return _count;
+               ^^^^^^
+13:   }
+14: }
 ```
 
 ```ts title="test-find-usages.test.mts"

--- a/documentation/public/user-guide/08-examples/02-find-usages/index.md
+++ b/documentation/public/user-guide/08-examples/02-find-usages/index.md
@@ -1,0 +1,9 @@
+# 8.2. Find usages
+
+```ts title="find-usages.mts"
+--8<-- "documentation/public/user-guide/08-examples/02-find-usages/examples/find-usages.mts"
+```
+
+```ts title="test-find-usages.test.mts"
+--8<-- "documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts"
+```

--- a/documentation/public/user-guide/08-examples/02-find-usages/index.md
+++ b/documentation/public/user-guide/08-examples/02-find-usages/index.md
@@ -6,28 +6,10 @@ A typical use case for an IDE is finding where some variable, function, or type 
 --8<-- "documentation/public/user-guide/08-examples/02-find-usages/examples/find-usages.mts"
 ```
 
-For example, we can look for usages of the `_count` state variable defined in the sample contract:
+For example, we can look for usages of the `_count` state variable defined in line 2 of the sample contract:
 
-```solidity
- 1: contract Counter {
- 2:   uint _count;
-           ^^^^^^
- 3:   constructor(uint initialCount) {
- 4:     _count = initialCount;
-        ^^^^^^
- 5:   }
- 6:   function count() public view returns (uint) {
- 7:     return _count;
-               ^^^^^^
- 8:   }
- 9:   function increment(uint delta) public returns (uint) {
-10:     require(delta > 0, "Delta must be positive");
-11:     _count += delta;
-        ^^^^^^
-12:     return _count;
-               ^^^^^^
-13:   }
-14: }
+```solidity linenums="1" hl_lines="2 4 7 11 12"
+--8<-- "documentation/public/user-guide/08-examples/common/sample-contract.sol"
 ```
 
 ```ts title="test-find-usages.test.mts"

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts
@@ -1,0 +1,50 @@
+import assert from "node:assert";
+import { TerminalKindExtensions } from "@nomicfoundation/slang/cst";
+import { CompilationUnit } from "@nomicfoundation/slang/compilation";
+import { findTerminalNodeAt } from "../../common/find-terminal-node-at.mjs";
+
+type Target = {
+  file: string;
+  line: number;
+  column: number;
+};
+
+export function jumpToDefinition(unit: CompilationUnit, fileId: string, line: number, column: number): Target | string {
+  const file = unit.file(fileId);
+  if (!file) {
+    return `${fileId} not found in compilation unit`;
+  }
+
+  const cursor = findTerminalNodeAt(file.createTreeCursor(), line, column);
+  if (!cursor) {
+    return `${fileId}:${line}:${column} is not a valid text location`;
+  }
+
+  assert(cursor.node.isTerminalNode());
+  if (!TerminalKindExtensions.isIdentifier(cursor.node.kind)) {
+    // location is not a valid identifier
+    return `Could not find a valid identifier at ${fileId}:${line}:${column}`;
+  }
+
+  const reference = unit.bindingGraph.referenceAt(cursor);
+  if (!reference) {
+    return `Identifier ${cursor.node.unparse()} is not a reference at ${fileId}:${line}:${column}`;
+  }
+
+  const definitions = reference.definitions();
+  if (definitions.length == 0) {
+    return `${cursor.node.unparse()} is not defined`;
+  } else {
+    // we take the first definition arbitrarily
+    const location = definitions[0].nameLocation;
+    if (location.isUserFileLocation()) {
+      return {
+        file: location.fileId,
+        line: location.cursor.textOffset.line,
+        column: location.cursor.textOffset.column,
+      };
+    } else {
+      return `${cursor.node.unparse()} is a built-in`;
+    }
+  }
+}

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts
@@ -1,5 +1,4 @@
-import assert from "node:assert";
-import { TerminalKindExtensions } from "@nomicfoundation/slang/cst";
+import { assertTerminalNode, TerminalKindExtensions } from "@nomicfoundation/slang/cst";
 import { CompilationUnit } from "@nomicfoundation/slang/compilation";
 import { findTerminalNodeAt } from "../../common/find-terminal-node-at.mjs";
 
@@ -9,42 +8,42 @@ type Target = {
   column: number;
 };
 
-export function jumpToDefinition(unit: CompilationUnit, fileId: string, line: number, column: number): Target | string {
+export function jumpToDefinition(unit: CompilationUnit, fileId: string, line: number, column: number): Target {
   const file = unit.file(fileId);
   if (!file) {
-    return `${fileId} not found in compilation unit`;
+    throw new Error(`${fileId} not found in compilation unit`);
   }
 
   const cursor = findTerminalNodeAt(file.createTreeCursor(), line, column);
   if (!cursor) {
-    return `${fileId}:${line}:${column} is not a valid text location`;
+    throw new Error(`${fileId}:${line}:${column} is not a valid text location`);
   }
 
-  assert(cursor.node.isTerminalNode());
+  assertTerminalNode(cursor.node);
   if (!TerminalKindExtensions.isIdentifier(cursor.node.kind)) {
     // location is not a valid identifier
-    return `Could not find a valid identifier at ${fileId}:${line}:${column}`;
+    throw new Error(`Could not find a valid identifier at ${fileId}:${line}:${column}`);
   }
 
   const reference = unit.bindingGraph.referenceAt(cursor);
   if (!reference) {
-    return `Identifier ${cursor.node.unparse()} is not a reference at ${fileId}:${line}:${column}`;
+    throw new Error(`Identifier ${cursor.node.unparse()} is not a reference at ${fileId}:${line}:${column}`);
   }
 
   const definitions = reference.definitions();
   if (definitions.length == 0) {
-    return `${cursor.node.unparse()} is not defined`;
-  } else {
-    // we take the first definition arbitrarily
-    const location = definitions[0].nameLocation;
-    if (location.isUserFileLocation()) {
-      return {
-        file: location.fileId,
-        line: location.cursor.textOffset.line,
-        column: location.cursor.textOffset.column,
-      };
-    } else {
-      return `${cursor.node.unparse()} is a built-in`;
-    }
+    throw new Error(`${cursor.node.unparse()} is not defined`);
   }
+
+  // we take the first definition arbitrarily
+  const location = definitions[0].nameLocation;
+  if (!location.isUserFileLocation()) {
+    throw new Error(`${cursor.node.unparse()} is a built-in`);
+  }
+
+  return {
+    file: location.fileId,
+    line: location.cursor.textOffset.line,
+    column: location.cursor.textOffset.column,
+  };
 }

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
@@ -1,0 +1,35 @@
+import assert from "node:assert";
+import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
+import { jumpToDefinition } from "./jump-to-definition.mjs";
+
+test("jump to definition", async () => {
+  const CONTRACT_VFS = new Map<string, string>([
+    [
+      "contract.sol",
+      `
+contract Counter {
+  uint _count;
+  constructor(uint initialCount) {
+    _count = initialCount;
+  }
+  function count() public view returns (uint) {
+    return _count;
+  }
+  function increment(uint delta) public returns (uint) {
+    require(delta > 0, "Delta must be positive");
+    _count += delta;
+    return _count;
+  }
+}
+      `,
+    ],
+  ]);
+
+  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+
+  // the reference to `delta` in the assignment addition
+  const definition = jumpToDefinition(unit, "contract.sol", 11, 16);
+  assert(typeof definition !== "string");
+
+  assert.deepEqual(definition, { file: "contract.sol", line: 9, column: 26 });
+});

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
@@ -7,7 +7,6 @@ test("jump to definition", async () => {
 
   // the reference to `delta` in the assignment addition
   const definition = jumpToDefinition(unit, "contract.sol", 11, 16);
-  assert(typeof definition !== "string");
 
   assert.deepEqual(definition, { file: "contract.sol", line: 9, column: 26 });
 });

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts
@@ -1,31 +1,9 @@
 import assert from "node:assert";
-import { buildCompilationUnit } from "../../common/compilation-builder.mjs";
 import { jumpToDefinition } from "./jump-to-definition.mjs";
+import buildSampleCompilationUnit from "../../common/sample-contract.mjs";
 
 test("jump to definition", async () => {
-  const CONTRACT_VFS = new Map<string, string>([
-    [
-      "contract.sol",
-      `
-contract Counter {
-  uint _count;
-  constructor(uint initialCount) {
-    _count = initialCount;
-  }
-  function count() public view returns (uint) {
-    return _count;
-  }
-  function increment(uint delta) public returns (uint) {
-    require(delta > 0, "Delta must be positive");
-    _count += delta;
-    return _count;
-  }
-}
-      `,
-    ],
-  ]);
-
-  const unit = await buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+  const unit = await buildSampleCompilationUnit();
 
   // the reference to `delta` in the assignment addition
   const definition = jumpToDefinition(unit, "contract.sol", 11, 16);

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
@@ -8,23 +8,8 @@ Another often used feature of an IDE is the ability to jump to the definition of
 
 The following example shows jumping to the definition of the parameter `delta` in line 11:
 
-```solidity
- 1: contract Counter {
- 2:   uint _count;
- 3:   constructor(uint initialCount) {
- 4:     _count = initialCount;
- 5:   }
- 6:   function count() public view returns (uint) {
- 7:     return _count;
- 8:   }
- 9:   function increment(uint delta) public returns (uint) {
-                              ^^^^^
-10:     require(delta > 0, "Delta must be positive");
-11:     _count += delta;
-                  ^^^^^
-12:     return _count;
-13:   }
-14: }
+```solidity linenums="1" hl_lines="9 11"
+--8<-- "documentation/public/user-guide/08-examples/common/sample-contract.sol"
 ```
 
 ```ts title="test-jump-to-definition.test.mts"

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
@@ -1,0 +1,9 @@
+# 8.3. Jump to definition
+
+```ts title="jump-to-definition.mts"
+--8<-- "documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts"
+```
+
+```ts title="test-jump-to-definition.test.mts"
+--8<-- "documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts"
+```

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
@@ -1,7 +1,30 @@
 # 8.3. Jump to definition
 
+Another often used feature of an IDE is the ability to jump to the definition of a given identifier. Again, we can use the [Binding Graph API](../../07-semantic-analysis/02-binding-graph/index.md) to do it:
+
 ```ts title="jump-to-definition.mts"
 --8<-- "documentation/public/user-guide/08-examples/03-jump-to-definition/examples/jump-to-definition.mts"
+```
+
+The following example shows jumping to the definition of the parameter `delta` in line 11:
+
+```solidity
+ 1: contract Counter {
+ 2:   uint _count;
+ 3:   constructor(uint initialCount) {
+ 4:     _count = initialCount;
+ 5:   }
+ 6:   function count() public view returns (uint) {
+ 7:     return _count;
+ 8:   }
+ 9:   function increment(uint delta) public returns (uint) {
+                              ^^^^^
+10:     require(delta > 0, "Delta must be positive");
+11:     _count += delta;
+                  ^^^^^
+12:     return _count;
+13:   }
+14: }
 ```
 
 ```ts title="test-jump-to-definition.test.mts"

--- a/documentation/public/user-guide/08-examples/common/compilation-builder.mts
+++ b/documentation/public/user-guide/08-examples/common/compilation-builder.mts
@@ -1,0 +1,34 @@
+import { Cursor } from "@nomicfoundation/slang/cst";
+import { CompilationBuilder, CompilationUnit } from "@nomicfoundation/slang/compilation";
+
+function buildReadFile(virtualFs: Map<string, string>): (fileId: string) => Promise<string> {
+  return async (fileId: string) => {
+    const contents = virtualFs.get(fileId);
+    if (!contents) {
+      throw new Error(`${fileId} not found`);
+    }
+    return contents;
+  };
+}
+
+async function resolveImport(_sourceFileId: string, importPath: Cursor) {
+  const importLiteral = importPath.node.unparse();
+  const importString = importLiteral.replace(/^["']/, "").replace(/["']$/, "");
+  return importString;
+}
+
+export async function buildCompilationUnit(
+  virtualFs: Map<string, string>,
+  version: string,
+  mainFileId: string,
+): Promise<CompilationUnit> {
+  const builder = CompilationBuilder.create({
+    languageVersion: version,
+    readFile: buildReadFile(virtualFs),
+    resolveImport,
+  });
+
+  await builder.addFile(mainFileId);
+
+  return builder.build();
+}

--- a/documentation/public/user-guide/08-examples/common/find-terminal-node-at.mts
+++ b/documentation/public/user-guide/08-examples/common/find-terminal-node-at.mts
@@ -1,0 +1,30 @@
+import assert from "node:assert";
+import { Cursor } from "@nomicfoundation/slang/cst";
+
+export function findTerminalNodeAt(cursor: Cursor, line: number, column: number): Cursor | undefined {
+  const range = cursor.textRange;
+  if (
+    line < range.start.line ||
+    (line == range.start.line && column < range.start.column) ||
+    line > range.end.line ||
+    (line == range.end.line && column > range.end.column)
+  ) {
+    // initial cursor is outside of the range of the CST tree
+    return undefined;
+  }
+
+  outer: while (cursor.node.isNonterminalNode()) {
+    assert(cursor.goToFirstChild());
+    do {
+      const childRange = cursor.textRange;
+      if (line < childRange.end.line || (line == childRange.end.line && column <= childRange.end.column)) {
+        continue outer;
+      }
+    } while (cursor.goToNextSibling());
+
+    // we should have found a child to recurse into (or the target terminal node)
+    throw new Error("should not be reached");
+  }
+  assert(cursor.node.isTerminalNode());
+  return cursor;
+}

--- a/documentation/public/user-guide/08-examples/common/sample-contract.mts
+++ b/documentation/public/user-guide/08-examples/common/sample-contract.mts
@@ -1,0 +1,28 @@
+import { CompilationUnit } from "@nomicfoundation/slang/compilation";
+import { buildCompilationUnit } from "./compilation-builder.mjs";
+
+const CONTRACT_VFS = new Map<string, string>([
+  [
+    "contract.sol",
+    `
+contract Counter {
+  uint _count;
+  constructor(uint initialCount) {
+    _count = initialCount;
+  }
+  function count() public view returns (uint) {
+    return _count;
+  }
+  function increment(uint delta) public returns (uint) {
+    require(delta > 0, "Delta must be positive");
+    _count += delta;
+    return _count;
+  }
+}
+    `,
+  ],
+]);
+
+export default function (): Promise<CompilationUnit> {
+  return buildCompilationUnit(CONTRACT_VFS, "0.8.0", "contract.sol");
+}

--- a/documentation/public/user-guide/08-examples/common/sample-contract.sol
+++ b/documentation/public/user-guide/08-examples/common/sample-contract.sol
@@ -1,0 +1,14 @@
+contract Counter {
+  uint _count;
+  constructor(uint initialCount) {
+    _count = initialCount;
+  }
+  function count() public view returns (uint) {
+    return _count;
+  }
+  function increment(uint delta) public returns (uint) {
+    require(delta > 0, "Delta must be positive");
+    _count += delta;
+    return _count;
+  }
+}

--- a/documentation/public/user-guide/08-examples/index.md
+++ b/documentation/public/user-guide/08-examples/index.md
@@ -2,7 +2,7 @@
 
 - [8.1. List functions in a contract](./01-list-functions-in-contract/index.md)
 - [8.2. Find usages](./02-find-usages/index.md)
-- 8.3. Find definitions of an identifier
+- [8.3. Jump to definition](./03-jump-to-definition/index.md)
 
 ```ts title="compilation-builder.mts"
 --8<-- "documentation/public/user-guide/08-examples/common/compilation-builder.mts"

--- a/documentation/public/user-guide/08-examples/index.md
+++ b/documentation/public/user-guide/08-examples/index.md
@@ -1,0 +1,9 @@
+# 8. Examples
+
+- [8.1. List functions in a contract](./01-list-functions-in-contract/index.md)
+- 8.2. Find all calls to a function
+- 8.3. Find definitions of an identifier
+
+```ts title="compilation-builder.mts"
+--8<-- "documentation/public/user-guide/08-examples/common/compilation-builder.mts"
+```

--- a/documentation/public/user-guide/08-examples/index.md
+++ b/documentation/public/user-guide/08-examples/index.md
@@ -1,9 +1,13 @@
 # 8. Examples
 
 - [8.1. List functions in a contract](./01-list-functions-in-contract/index.md)
-- 8.2. Find all calls to a function
+- [8.2. Find usages](./02-find-usages/index.md)
 - 8.3. Find definitions of an identifier
 
 ```ts title="compilation-builder.mts"
 --8<-- "documentation/public/user-guide/08-examples/common/compilation-builder.mts"
+```
+
+```ts title="find-terminal-node-at.mts"
+--8<-- "documentation/public/user-guide/08-examples/common/find-terminal-node-at.mts"
 ```

--- a/documentation/public/user-guide/08-examples/index.md
+++ b/documentation/public/user-guide/08-examples/index.md
@@ -4,9 +4,17 @@
 - [8.2. Find usages](./02-find-usages/index.md)
 - [8.3. Jump to definition](./03-jump-to-definition/index.md)
 
+Throughout the examples in this section we will use a sample contract. We need some setup code to [create a `CompilationUnit`](../07-semantic-analysis/01-compilation-units/index.md) with the contents of the contract:
+
+```ts title="sample-contract.mts"
+--8<-- "documentation/public/user-guide/08-examples/common/sample-contract.mts"
+```
+
 ```ts title="compilation-builder.mts"
 --8<-- "documentation/public/user-guide/08-examples/common/compilation-builder.mts"
 ```
+
+For the last two examples we also need an easy way to obtain a `Cursor` pointing to a specific line and column in a file. This can be achieved using the [Cursor Navigation API](../05-syntax-trees/03-navigating-with-cursors/index.md):
 
 ```ts title="find-terminal-node-at.mts"
 --8<-- "documentation/public/user-guide/08-examples/common/find-terminal-node-at.mts"

--- a/documentation/public/user-guide/index.md
+++ b/documentation/public/user-guide/index.md
@@ -7,3 +7,4 @@
 - [5. Syntax Trees](./05-syntax-trees/index.md)
 - [6. Query Language](./06-query-language/index.md)
 - [7. Semantic Analysis](./07-semantic-analysis/index.md)
+- [8. Examples](./08-examples/index.md)


### PR DESCRIPTION
Resubmitting this since #1267 was closed when #1257 was merged.

Adds a section with standalone examples to the user guide. These examples demonstrate almost all the Slang APIs.