### PR TITLE
remove deduplication condition from `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
   ci:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
 
-    # Skip 'pull_request' events from the main repository, as the workflow is already triggered by the 'push' event:
-    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'NomicFoundation/slang' }}"
-
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -56,9 +53,6 @@ jobs:
   # Instead, we just validate the devcontainer is built correctly by running a minimal check below.
   validate-devcontainer:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
-
-    # Skip 'pull_request' events from the main repository, as the workflow is already triggered by the 'push' event:
-    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'NomicFoundation/slang' }}"
 
     steps:
       - name: "Checkout Repository"


### PR DESCRIPTION
Observed that CI is no longer running on changeset PRs (example #1270). Not sure why yet. But let's remove the deduplication condition for now to unblock the release, and I will follow up with a fix sometime later.