### PR TITLE
documentation fixes

### DIFF
--- a/documentation/public/user-guide/03-concepts/index.md
+++ b/documentation/public/user-guide/03-concepts/index.md
@@ -7,7 +7,7 @@ which are handed the input and only their output can be observed.
 
 ## Language Grammar
 
-The entire Solidity grammar (Across all supported versions) is defined in the [Solidity Grammar](../../solidity-grammar/index.md) section.
+The entire Solidity grammar (across all supported versions) is defined in the [Solidity Grammar](../../solidity-grammar/index.md) section.
 You can use this as a guide when developing your own tools using Slang. The grammar is also included as documentation on top of the corresponding APIs
 (like `TerminalKind`, `NonterminalKind`, and `EdgeLabel` variants). It explains the structure of each node, and the relationships between each parent
 and its children.

--- a/documentation/public/user-guide/05-syntax-trees/01-parsing-source-code/index.md
+++ b/documentation/public/user-guide/05-syntax-trees/01-parsing-source-code/index.md
@@ -6,7 +6,7 @@ It allows us to parse not just the input as a top-level source unit, but also in
 ## Parsing Source Files
 
 Let's start with this simple source file, that contains a single contract, and parse it into a concrete syntax tree.
-The parser will produce a `ParseOutput` object, which contains a `SourceUnit` root node:
+The parser will produce a `ParseOutput` object, which contains a [`SourceUnit`](../../../solidity-grammar/01-file-structure/02-source-unit.md) root node:
 
 ```ts title="parsing-source-files.mts"
 --8<-- "documentation/public/user-guide/05-syntax-trees/01-parsing-source-code/examples/01-parsing-source-files.test.mts"
@@ -15,7 +15,7 @@ The parser will produce a `ParseOutput` object, which contains a `SourceUnit` ro
 ## Parsing Nonterminals
 
 The parser API also allows you to parse specific nonterminal nodes, like statements or expressions.
-This is useful when you want to parse a snippet, and not an entire source file, like the `AdditiveExpression` node below:
+This is useful when you want to parse a snippet, and not an entire source file, like the [`AdditiveExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) node below:
 
 ```ts title="parsing-nonterminals.mts"
 --8<-- "documentation/public/user-guide/05-syntax-trees/01-parsing-source-code/examples/02-parsing-nonterminals.test.mts"

--- a/documentation/public/user-guide/05-syntax-trees/03-navigating-with-cursors/index.md
+++ b/documentation/public/user-guide/05-syntax-trees/03-navigating-with-cursors/index.md
@@ -18,9 +18,9 @@ The below example uses a cursor to list the names of all contracts in a source f
 ## Visiting Only a Sub-tree
 
 Next, we will try to get the names of all contract functions, grouped by the contract name.
-In this case, it is not enough to just visit all instances of `FunctionDefinition` nodes, since we want to exclude the ones that are not part of a contract.
+In this case, it is not enough to just visit all instances of [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md) nodes, since we want to exclude the ones that are not part of a contract.
 
-We need first to find all `ContractDefinition` nodes, and then for each contract, look for all `FunctionDefinition` nodes,
+We need first to find all [`ContractDefinition`](../../../solidity-grammar/02-definitions/01-contracts.md) nodes, and then for each contract, look for all [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md) nodes,
 limiting the search to just the contract's subtree.
 To do that, we need to use the `cursor.spawn()` API, which cheaply creates a new cursor that starts at the given node,
 without copying the ancestry information, so it will only be able to see the sub-tree of the current node.

--- a/documentation/public/user-guide/05-syntax-trees/04-using-ast-types/index.md
+++ b/documentation/public/user-guide/05-syntax-trees/04-using-ast-types/index.md
@@ -5,10 +5,10 @@ convenient to use for extracting information of the program. In the following ex
 obtain the parameters and attributes of a function using the AST, an abstract representation of the program tree.
 
 We start as usual by parsing the input, and then we can use the `ParseOutput` root
-to create the CST type. Since it is a node of kind `FunctionDefinition`, we are using
+to create the CST type. Since it is a node of kind [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md), we are using
 the AST type of the same name to analyze it.
 
-The `FunctionDefinition` type has named fields to access all its children.
+The [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md) type has named fields to access all its children.
 For example, we can check the name of the function, list its parameters, or attributes:
 
 ```ts title="using-ast-types.mts"

--- a/documentation/public/user-guide/06-query-language/01-query-syntax/index.md
+++ b/documentation/public/user-guide/06-query-language/01-query-syntax/index.md
@@ -12,41 +12,41 @@ A _query_ is a pattern that matches a
 certain set of nodes in a tree. The expression to match a given node
 consists of a pair of brackets (`[]`) containing two things: the node's kind, and
 optionally, a series of other patterns that match the node's children. For
-example, this pattern would match any `MultiplicativeExpression` node that has
-two children `Expression` nodes, with an `Asterisk` node in between:
+example, this pattern would match any [`MultiplicativeExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) node that has
+two children [`Expression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) nodes, with an [`Asterisk`](../../../solidity-grammar/01-file-structure/09-punctuation.md) node in between:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:query-syntax-1"
 ```
 
 The children of a node can optionally be labeled. The label is a property of the edge from
 the node to the child, and is not a property of the child. For example, this pattern will match
-a `MultiplicativeExpression` node with the two `Expression` children labeled `left_operand` and `right_operand`:
+a [`MultiplicativeExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) node with the two [`Expression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) children labeled `left_operand` and `right_operand`:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:query-syntax-2"
 ```
 
 You can also match a node's textual content using a string literal. For example, this pattern would match a
-`MultiplicativeExpression` with a `*` operator (for clarity):
+[`MultiplicativeExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) with a `*` operator (for clarity):
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:query-syntax-3"
 ```
 
 If you don't care about the kind of a node, you can use an underscore `_`, which matches any kind.
-For example, this pattern will match a `MultiplicativeExpression`
+For example, this pattern will match a [`MultiplicativeExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md)
 node with any two children with any kind, as long as one of them is labeled `left_operand`:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:query-syntax-4"
 ```
 
 Children can be elided. For example, this would produce multiple matches for a
-`MultiplicativeExpression` where at least _one_ of the children is an expression of a `StringExpression` variant, where each match
-is associated with each of the `StringExpression` children:
+[`MultiplicativeExpression`](../../../solidity-grammar/05-expressions/01-base-expressions.md) where at least _one_ of the children is an expression of a [`StringExpression`](../../../solidity-grammar/05-expressions/05-strings.md) variant, where each match
+is associated with each of the [`StringExpression`](../../../solidity-grammar/05-expressions/05-strings.md) children:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:query-syntax-5"
 ```
 
@@ -64,14 +64,14 @@ written _before_ the nodes that they refer to, and start with an `@` character.
 For example, this pattern would match any struct definition and it would associate
 the name `struct_name` with the identifier:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:capturing-nodes-1"
 ```
 
 And this pattern would match all event definitions for a contract, associating the name
 `event_name` with the event name, `contract_name` with the containing contract name:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:capturing-nodes-2"
 ```
 
@@ -84,20 +84,20 @@ matches _one or more_.
 
 For example, this pattern would match a sequence of one or more import directives at the top of the file:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:quantification-1"
 ```
 
 This pattern would match a structure definition with one or more members, capturing their names:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:quantification-2"
 ```
 
 This pattern would match all function calls, capturing a string argument if one was
 present:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:quantification-3"
 ```
 
@@ -108,13 +108,13 @@ An alternation is written as a sequence of patterns separated by `|` and surroun
 For example, this pattern would match a call to either a variable or an object property.
 In the case of a variable, capture it as `@function`, and in the case of a property, capture it as `@method`:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:alternations-1"
 ```
 
 This pattern would match a set of possible keyword terminals, capturing them as `@keyword`:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:alternations-2"
 ```
 
@@ -126,13 +126,13 @@ the first or the last child nodes.
 For example, the following pattern would match only the first parameter
 declaration in a function definition:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:adjacency-1"
 ```
 
 And conversely the following will match only the last parameter:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:adjacency-2"
 ```
 
@@ -140,6 +140,6 @@ If the adjacency operator is used in between two patterns it constrains matches
 on both patterns to occur consecutively, ie. without any other sibling node in
 between. For example, this pattern matches pairs of consecutive statements:
 
-```.scheme
+```.smalltalk
 --8<-- "documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts:adjacency-3"
 ```

--- a/documentation/public/user-guide/06-query-language/02-executing-queries/index.md
+++ b/documentation/public/user-guide/06-query-language/02-executing-queries/index.md
@@ -9,8 +9,8 @@ created with `cursor.spawn()` to restrict the search to a given sub-tree.
 You can create a `Query` object using `Query.create()`, which accepts a string value.
 These can be then used by `cursor.query()` to execute it.
 
-You can pass multiple queries to a cursor to and efficiently traverse the tree looking for matches.
-They will be executed simultaneously, returning matches in the order they appear in input.
+You can pass multiple queries to a cursor to efficiently traverse the tree looking for matches.
+They will be executed simultaneously, returning matches in the order they appear in the input.
 
 ```ts title="common.mts"
 --8<-- "documentation/public/user-guide/06-query-language/02-executing-queries/examples/common.mts"
@@ -49,7 +49,7 @@ The error will contain a message to indicate what went wrong, and the text range
 
 ## Multiple queries simultaneously
 
-We can also execute multiple queries simultaneously, which will return all the matches for as they are found in the tree.
+We can also execute multiple queries simultaneously, which will return all the matches as they are found in the tree.
 This can be useful when you want to match multiple types of nodes in a single pass.
 Results will be reported in order, and each will have an index that can be used to identify which query is matched.
 

--- a/documentation/public/user-guide/07-semantic-analysis/02-binding-graph/index.md
+++ b/documentation/public/user-guide/07-semantic-analysis/02-binding-graph/index.md
@@ -7,7 +7,8 @@ Building this graph can be an expensive operation. So, it is constructed lazily 
 You can use cursors to query the graph for definitions or references.
 
 Any identifier in the tree can be resolved to a definition or a reference. Note that there are multiple kinds of identifiers.
-For example, Solidity has `Identifier`, and Yul has `YulIdentifier`. To find/filter terminals that are identifiers,
+For example, Solidity has [`Identifier`](../../../solidity-grammar/05-expressions/06-identifiers.md), and Yul has
+[`YulIdentifier`](../../../solidity-grammar/06-yul/02-yul-expressions.md). To find/filter terminals that are identifiers,
 you can use the `TerminalKindExtensions.isIdentifier()` API to test for that.
 
 ## Resolving Definitions
@@ -36,9 +37,9 @@ User file binding locations will also contain a `cursor` to the underlying ident
 
 We find 3 definitions:
 
-- the `Log` imported symbol
-- the `MyContract` contract
-- the `test` method
+- The `Log` imported symbol.
+- The `MyContract` contract.
+- The `test` method.
 
 The `Log` import symbol is a special case and also acts as a reference to the actual event type defined in `events.sol`. Let's find all references in the file next.
 

--- a/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
+++ b/documentation/public/user-guide/08-examples/01-list-functions-in-contract/index.md
@@ -1,13 +1,13 @@
 # 8.1. List functions in a contract
 
-This function finds a contract in the compilation unit with the given name and returns a list of `FunctionDefinition` within it. We use a combination of the [Query API](../../06-query-language/02-executing-queries/index.md) and the [AST types](../../05-syntax-trees/04-using-ast-types/index.md):
+This function finds a contract in the compilation unit with the given name and returns a list of [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md) within it. We use a combination of the [Query API](../../06-query-language/02-executing-queries/index.md) and the [AST types](../../05-syntax-trees/04-using-ast-types/index.md):
 
 ```ts title="list-functions-in-contract.mts"
 --8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/list-functions-in-contract.mts"
 ```
 
-From the list of `FunctionDefinition`s it's easy to obtain the names of the functions:
+From the list of [`FunctionDefinition`](../../../solidity-grammar/02-definitions/08-functions.md) nodes, it's easy to obtain the names of the functions:
 
-```ts title="test-list-functions.test.mts"
+```ts title="test-list-functions.mts"
 --8<-- "documentation/public/user-guide/08-examples/01-list-functions-in-contract/examples/test-list-functions.test.mts"
 ```

--- a/documentation/public/user-guide/08-examples/02-find-usages/index.md
+++ b/documentation/public/user-guide/08-examples/02-find-usages/index.md
@@ -12,6 +12,6 @@ For example, we can look for usages of the `_count` state variable defined in li
 --8<-- "documentation/public/user-guide/08-examples/common/sample-contract.sol"
 ```
 
-```ts title="test-find-usages.test.mts"
+```ts title="test-find-usages.mts"
 --8<-- "documentation/public/user-guide/08-examples/02-find-usages/examples/test-find-usages.test.mts"
 ```

--- a/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
+++ b/documentation/public/user-guide/08-examples/03-jump-to-definition/index.md
@@ -12,6 +12,6 @@ The following example shows jumping to the definition of the parameter `delta` i
 --8<-- "documentation/public/user-guide/08-examples/common/sample-contract.sol"
 ```
 
-```ts title="test-jump-to-definition.test.mts"
+```ts title="test-jump-to-definition.mts"
 --8<-- "documentation/public/user-guide/08-examples/03-jump-to-definition/examples/test-jump-to-definition.test.mts"
 ```


### PR DESCRIPTION
- apply remaining suggestions from #1257
- add grammar links to any remaining node names in user guides
- change query hilighting language to `smalltalk` as it is more readable