### PR TITLE
Add `codesize` and `codecopy` yul builtins

### DIFF
--- a/.changeset/wicked-dingos-drop.md
+++ b/.changeset/wicked-dingos-drop.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/slang": minor
+"@nomicfoundation/slang": patch
 ---
 
 Adding missing YUL built in functions:

--- a/.changeset/wicked-dingos-drop.md
+++ b/.changeset/wicked-dingos-drop.md
@@ -1,0 +1,8 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+Adding missing YUL built in functions:
+
+- `codesize()`
+- `codecopy(f, t, s)`

--- a/.cspell.json
+++ b/.cspell.json
@@ -6,7 +6,9 @@
   "ignoreWords": [
     // Alphabetically sorted list of "allowed" words to ignore:
     "abicoder",
+    "codecopy",
     "codegen",
+    "codesize",
     "contentful",
     "devcontainer",
     "doxygen",

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -6638,12 +6638,8 @@ codegen_language_macros::compile!(Language(
                 ),
                 BuiltInFunction(name = "callvalue", parameters = [], return_type = "uint256"),
                 BuiltInFunction(
-                    name = "codecopy", 
-                    parameters = [
-                        "uint256 t",
-                        "uint256 f",
-                        "uint256 s"
-                    ]
+                    name = "codecopy",
+                    parameters = ["uint256 t", "uint256 f", "uint256 s"]
                 ),
                 BuiltInFunction(name = "codesize", parameters = [], return_type = "uint256"),
                 BuiltInFunction(name = "coinbase", parameters = [], return_type = "uint256"),

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -6642,8 +6642,8 @@ codegen_language_macros::compile!(Language(
                     parameters = [
                         "uint256 t",
                         "uint256 f",
-                        "uint256 s",
-                    ],
+                        "uint256 s"
+                    ]
                 ),
                 BuiltInFunction(name = "codesize", parameters = [], return_type = "uint256"),
                 BuiltInFunction(name = "coinbase", parameters = [], return_type = "uint256"),

--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -6637,6 +6637,15 @@ codegen_language_macros::compile!(Language(
                     return_type = "uint256"
                 ),
                 BuiltInFunction(name = "callvalue", parameters = [], return_type = "uint256"),
+                BuiltInFunction(
+                    name = "codecopy", 
+                    parameters = [
+                        "uint256 t",
+                        "uint256 f",
+                        "uint256 s",
+                    ],
+                ),
+                BuiltInFunction(name = "codesize", parameters = [], return_type = "uint256"),
                 BuiltInFunction(name = "coinbase", parameters = [], return_type = "uint256"),
                 BuiltInFunction(
                     name = "create",

--- a/crates/solidity/outputs/cargo/crate/src/generated/extensions/built_ins.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/extensions/built_ins.rs
@@ -108,6 +108,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -265,6 +267,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -426,6 +430,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -595,6 +601,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -767,6 +775,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -938,6 +948,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -1114,6 +1126,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -1294,6 +1308,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -1476,6 +1492,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -1660,6 +1678,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -1839,6 +1859,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2018,6 +2040,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2198,6 +2222,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2380,6 +2406,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2563,6 +2591,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2750,6 +2780,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -2938,6 +2970,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -3127,6 +3161,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -3318,6 +3354,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));
@@ -3515,6 +3553,8 @@ pub fn define_built_ins<KT: KindTypes + 'static>(
             scope.define_function(builder, "caller", Some("uint256"));
             scope.define_function(builder, "call", Some("uint256"));
             scope.define_function(builder, "callvalue", Some("uint256"));
+            scope.define_function(builder, "codecopy", None);
+            scope.define_function(builder, "codesize", Some("uint256"));
             scope.define_function(builder, "coinbase", Some("uint256"));
             scope.define_function(builder, "create", Some("uint256"));
             scope.define_function(builder, "delegatecall", Some("uint256"));

--- a/crates/solidity/outputs/spec/generated/language-definition.json
+++ b/crates/solidity/outputs/spec/generated/language-definition.json
@@ -9128,6 +9128,10 @@
           }
         },
         { "BuiltInFunction": { "item": { "name": "callvalue", "return_type": "uint256" } } },
+        {
+          "BuiltInFunction": { "item": { "name": "codecopy", "parameters": ["uint256 t", "uint256 f", "uint256 s"] } }
+        },
+        { "BuiltInFunction": { "item": { "name": "codesize", "return_type": "uint256" } } },
         { "BuiltInFunction": { "item": { "name": "coinbase", "return_type": "uint256" } } },
         {
           "BuiltInFunction": {

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.4.11-failure.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── unresolved
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── unresolved
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── unresolved
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── unresolved
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── unresolved
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── unresolved
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── unresolved
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── unresolved
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.4.14-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.4.14-failure.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── ref: built-in
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── unresolved
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── unresolved
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── unresolved
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── unresolved
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── unresolved
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.5.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.5.0-failure.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── ref: built-in
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── unresolved
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── unresolved
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── unresolved
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── unresolved
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.18-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.18-failure.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── ref: built-in
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── unresolved
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── unresolved
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── unresolved
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.27-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.27-success.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── ref: built-in
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── ref: built-in
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.8-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/generated/0.8.8-failure.txt
@@ -64,184 +64,190 @@ References and definitions:
  21 │             chainid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 22 │             coinbase()
+ 22 │             codecopy()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 23 │             create()
+ 23 │             codesize()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 24 │             coinbase()
+    │             ────┬───  
+    │                 ╰───── ref: built-in
+ 25 │             create()
     │             ───┬──  
     │                ╰──── ref: built-in
- 24 │             create2()
+ 26 │             create2()
     │             ───┬───  
     │                ╰───── ref: built-in
- 25 │             delegatecall()
+ 27 │             delegatecall()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 26 │             div()
+ 28 │             div()
     │             ─┬─  
     │              ╰─── ref: built-in
- 27 │             eq()
+ 29 │             eq()
     │             ─┬  
     │              ╰── ref: built-in
- 28 │             exp()
+ 30 │             exp()
     │             ─┬─  
     │              ╰─── ref: built-in
- 29 │             extcodecopy()
+ 31 │             extcodecopy()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 30 │             extcodehash()
+ 32 │             extcodehash()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 31 │             extcodesize()
+ 33 │             extcodesize()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 32 │             gas()
+ 34 │             gas()
     │             ─┬─  
     │              ╰─── ref: built-in
- 33 │             gaslimit()
+ 35 │             gaslimit()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 34 │             gasprice()
+ 36 │             gasprice()
     │             ────┬───  
     │                 ╰───── ref: built-in
- 35 │             gt()
+ 37 │             gt()
     │             ─┬  
     │              ╰── ref: built-in
- 36 │             invalid()
+ 38 │             invalid()
     │             ───┬───  
     │                ╰───── ref: built-in
- 37 │             iszero()
+ 39 │             iszero()
     │             ───┬──  
     │                ╰──── ref: built-in
- 38 │             keccak256()
+ 40 │             keccak256()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 39 │             log0()
+ 41 │             log0()
     │             ──┬─  
     │               ╰─── ref: built-in
- 40 │             log1()
+ 42 │             log1()
     │             ──┬─  
     │               ╰─── ref: built-in
- 41 │             log2()
+ 43 │             log2()
     │             ──┬─  
     │               ╰─── ref: built-in
- 42 │             log3()
+ 44 │             log3()
     │             ──┬─  
     │               ╰─── ref: built-in
- 43 │             log4()
+ 45 │             log4()
     │             ──┬─  
     │               ╰─── ref: built-in
- 44 │             lt()
+ 46 │             lt()
     │             ─┬  
     │              ╰── ref: built-in
- 45 │             mcopy()
+ 47 │             mcopy()
     │             ──┬──  
     │               ╰──── unresolved
- 46 │             mload()
+ 48 │             mload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 47 │             mod()
+ 49 │             mod()
     │             ─┬─  
     │              ╰─── ref: built-in
- 48 │             msize()
+ 50 │             msize()
     │             ──┬──  
     │               ╰──── ref: built-in
- 49 │             mstore()
+ 51 │             mstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 50 │             mstore8()
+ 52 │             mstore8()
     │             ───┬───  
     │                ╰───── ref: built-in
- 51 │             mul()
+ 53 │             mul()
     │             ─┬─  
     │              ╰─── ref: built-in
- 52 │             mulmod()
+ 54 │             mulmod()
     │             ───┬──  
     │                ╰──── ref: built-in
- 53 │             not()
+ 55 │             not()
     │             ─┬─  
     │              ╰─── ref: built-in
- 54 │             number()
+ 56 │             number()
     │             ───┬──  
     │                ╰──── ref: built-in
- 55 │             or()
+ 57 │             or()
     │             ─┬  
     │              ╰── ref: built-in
- 56 │             origin()
+ 58 │             origin()
     │             ───┬──  
     │                ╰──── ref: built-in
- 57 │             pop()
+ 59 │             pop()
     │             ─┬─  
     │              ╰─── ref: built-in
- 58 │             prevrandao()
+ 60 │             prevrandao()
     │             ─────┬────  
     │                  ╰────── unresolved
- 59 │             return()
+ 61 │             return()
     │             ───┬──  
     │                ╰──── ref: built-in
- 60 │             returndatacopy()
+ 62 │             returndatacopy()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 61 │             returndatasize()
+ 63 │             returndatasize()
     │             ───────┬──────  
     │                    ╰──────── ref: built-in
- 62 │             revert()
+ 64 │             revert()
     │             ───┬──  
     │                ╰──── ref: built-in
- 63 │             sar()
+ 65 │             sar()
     │             ─┬─  
     │              ╰─── ref: built-in
- 64 │             sdiv()
+ 66 │             sdiv()
     │             ──┬─  
     │               ╰─── ref: built-in
- 65 │             selfbalance()
+ 67 │             selfbalance()
     │             ─────┬─────  
     │                  ╰─────── ref: built-in
- 66 │             selfdestruct()
+ 68 │             selfdestruct()
     │             ──────┬─────  
     │                   ╰─────── ref: built-in
- 67 │             sgt()
+ 69 │             sgt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 68 │             shl()
+ 70 │             shl()
     │             ─┬─  
     │              ╰─── ref: built-in
- 69 │             shr()
+ 71 │             shr()
     │             ─┬─  
     │              ╰─── ref: built-in
- 70 │             signextend()
+ 72 │             signextend()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 71 │             sload()
+ 73 │             sload()
     │             ──┬──  
     │               ╰──── ref: built-in
- 72 │             slt()
+ 74 │             slt()
     │             ─┬─  
     │              ╰─── ref: built-in
- 73 │             smod()
+ 75 │             smod()
     │             ──┬─  
     │               ╰─── ref: built-in
- 74 │             sstore()
+ 76 │             sstore()
     │             ───┬──  
     │                ╰──── ref: built-in
- 75 │             staticcall()
+ 77 │             staticcall()
     │             ─────┬────  
     │                  ╰────── ref: built-in
- 76 │             stop()
+ 78 │             stop()
     │             ──┬─  
     │               ╰─── ref: built-in
- 77 │             sub()
+ 79 │             sub()
     │             ─┬─  
     │              ╰─── ref: built-in
- 78 │             timestamp()
+ 80 │             timestamp()
     │             ────┬────  
     │                 ╰────── ref: built-in
- 79 │             tload()
+ 81 │             tload()
     │             ──┬──  
     │               ╰──── unresolved
- 80 │             tstore()
+ 82 │             tstore()
     │             ───┬──  
     │                ╰──── unresolved
- 81 │             xor()
+ 83 │             xor()
     │             ─┬─  
     │              ╰─── ref: built-in
 ────╯
@@ -251,10 +257,10 @@ Definiens:
   1 │ ╭─│ ▶ contract Test {
   2 │ │ ╭─▶     function test() public {
     ┆ ┆ ┆   
- 83 │ │ ├─▶     }
+ 85 │ │ ├─▶     }
     │ │ │           
     │ │ ╰─────────── definiens: 2
- 84 │ ├───▶ }
+ 86 │ ├───▶ }
     │ │         
     │ ╰───────── definiens: 1
 ────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/all_built_ins/input.sol
@@ -19,6 +19,8 @@ contract Test {
             caller()
             callvalue()
             chainid()
+            codecopy()
+            codesize()
             coinbase()
             create()
             create2()


### PR DESCRIPTION
These two yul builtins are missing from the language definition:

1. `codesize()`
2. `codecopy(t, f, s)`

