### PR TITLE
Bind top-level `ConstantDefinition`s to their type

### DIFF
--- a/.changeset/easy-eggs-cover.md
+++ b/.changeset/easy-eggs-cover.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": patch
+---
+
+Top-level `ConstantDefinition`s now bind to their type and resolve extension functions called on them

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -2367,6 +2367,11 @@ inherit .star_extension
 
   edge @constant.def -> def
 
+  node typeof
+  attr (typeof) push_symbol = "@typeof"
+
+  edge def -> typeof
+  edge typeof -> @type_name.output
   edge @type_name.type_ref -> @constant.lexical_scope
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -2371,6 +2371,11 @@ inherit .star_extension
 
   edge @constant.def -> def
 
+  node typeof
+  attr (typeof) push_symbol = "@typeof"
+
+  edge def -> typeof
+  edge typeof -> @type_name.output
   edge @type_name.type_ref -> @constant.lexical_scope
 }
 

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/constants.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/constants.rs
@@ -7,6 +7,11 @@ use crate::bindings_output::runner::run;
 const T: &str = "constants";
 
 #[test]
+fn bind_to_type() -> Result<()> {
+    run(T, "bind_to_type")
+}
+
+#[test]
 fn in_contract() -> Result<()> {
     run(T, "in_contract")
 }

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.4.11-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.6.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.6.0-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or EnumKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword or StructKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.7.1-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.7.1-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected ContractKeyword or EnumKeyword or FunctionKeyword or ImportKeyword or InterfaceKeyword or LibraryKeyword or PragmaKeyword or StructKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.7.4-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.7.4-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or ByteKeyword or BytesKeyword or ContractKeyword or EnumKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.0-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.13-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.13-success.txt
@@ -1,0 +1,90 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ type MemoryPointer is uint256;
+    │      ──────┬──────  
+    │            ╰──────── name: 1
+    │ 
+  6 │ using MemoryReaders for MemoryPointer;
+    │       ──────┬──────     ──────┬──────  
+    │             ╰────────────────────────── ref: 5
+    │                               │        
+    │                               ╰──────── ref: 1
+    │ 
+  8 │ MemoryPointer constant FreeMemoryPPtr = MemoryPointer.wrap(0x40);
+    │ ──────┬──────          ───────┬──────   ──────┬────── ──┬─  
+    │       ╰───────────────────────────────────────────────────── ref: 1
+    │                               │               │         │   
+    │                               ╰───────────────────────────── name: 2
+    │                                               │         │   
+    │                                               ╰───────────── ref: 1
+    │                                                         │   
+    │                                                         ╰─── ref: built-in
+    │ 
+ 10 │ function getFreeMemoryPointer() pure returns (MemoryPointer mPtr) {
+    │          ──────────┬─────────                 ──────┬────── ──┬─  
+    │                    ╰────────────────────────────────────────────── name: 3
+    │                                                     │         │   
+    │                                                     ╰───────────── ref: 1
+    │                                                               │   
+    │                                                               ╰─── name: 4
+    │ 
+ 12 │     mPtr = FreeMemoryPPtr.readMemoryPointer();
+    │     ──┬─   ───────┬────── ────────┬────────  
+    │       ╰────────────────────────────────────── ref: 4
+    │                   │               │          
+    │                   ╰────────────────────────── ref: 2
+    │                                   │          
+    │                                   ╰────────── ref: 6
+    │ 
+ 15 │ library MemoryReaders {
+    │         ──────┬──────  
+    │               ╰──────── name: 5
+ 16 │     function readMemoryPointer(MemoryPointer mPtr) internal pure returns (MemoryPointer value) {
+    │              ────────┬──────── ──────┬────── ──┬─                         ──────┬────── ──┬──  
+    │                      ╰───────────────────────────────────────────────────────────────────────── name: 6
+    │                                      │         │                                │         │    
+    │                                      ╰───────────────────────────────────────────────────────── ref: 1
+    │                                                │                                │         │    
+    │                                                ╰─────────────────────────────────────────────── name: 7
+    │                                                                                 │         │    
+    │                                                                                 ╰────────────── ref: 1
+    │                                                                                           │    
+    │                                                                                           ╰──── name: 8
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │         ╭─▶ 
+  4 │         ├─▶ type MemoryPointer is uint256;
+    │         │                                    
+    │         ╰──────────────────────────────────── definiens: 1
+    │ 
+  7 │       ╭───▶ 
+  8 │ │     ├───▶ MemoryPointer constant FreeMemoryPPtr = MemoryPointer.wrap(0x40);
+    │ │     │                                                                         
+    │ │     ╰───────────────────────────────────────────────────────────────────────── definiens: 2
+  9 │ ╭─────────▶ 
+ 10 │ │           function getFreeMemoryPointer() pure returns (MemoryPointer mPtr) {
+    │ │                                                         ─────────┬────────  
+    │ │                                                                  ╰────────── definiens: 4
+    ┆ ┆           
+ 13 │ ├─│ ──────▶ }
+    │ │ │             
+    │ ╰─────────────── definiens: 3
+ 14 │   ╭───────▶ 
+    ┆   ┆ ┆       
+ 16 │   │ ╭─────▶     function readMemoryPointer(MemoryPointer mPtr) internal pure returns (MemoryPointer value) {
+    │   │ │                                      ─────────┬────────                         ─────────┬─────────  
+    │   │ │                                               ╰────────────────────────────────────────────────────── definiens: 7
+    │   │ │                                                                                          │           
+    │   │ │                                                                                          ╰─────────── definiens: 8
+ 17 │   │ ├─────▶     }
+    │   │ │               
+    │   │ ╰─────────────── definiens: 6
+ 18 │   ├───────▶ }
+    │   │             
+    │   ╰───────────── definiens: 5
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.4-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.4-failure.txt
@@ -1,0 +1,14 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or ErrorKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or UfixedKeyword or UintKeyword.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ type MemoryPointer is uint256;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+Definiens: 

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.8-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/generated/0.8.8-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or BoolKeyword or BytesKeyword or ContractKeyword or EnumKeyword or ErrorKeyword or FixedKeyword or FunctionKeyword or Identifier or ImportKeyword or IntKeyword or InterfaceKeyword or LibraryKeyword or MappingKeyword or PragmaKeyword or StringKeyword or StructKeyword or TypeKeyword or UfixedKeyword or UintKeyword.
+    ╭─[input.sol:6:1]
+    │
+  6 │ ╭─▶ using MemoryReaders for MemoryPointer;
+    ┆ ┆   
+ 18 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 4 │ type MemoryPointer is uint256;
+   │      ──────┬──────  
+   │            ╰──────── name: 1
+───╯
+Definiens: 
+   ╭─[input.sol:1:1]
+   │
+ 3 │ ╭─▶ 
+ 4 │ ├─▶ type MemoryPointer is uint256;
+   │ │                                    
+   │ ╰──────────────────────────────────── definiens: 1
+───╯

--- a/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/constants/bind_to_type/input.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+type MemoryPointer is uint256;
+
+using MemoryReaders for MemoryPointer;
+
+MemoryPointer constant FreeMemoryPPtr = MemoryPointer.wrap(0x40);
+
+function getFreeMemoryPointer() pure returns (MemoryPointer mPtr) {
+    // `readMemoryPointer` should bind to the library function (issue #1333)
+    mPtr = FreeMemoryPPtr.readMemoryPointer();
+}
+
+library MemoryReaders {
+    function readMemoryPointer(MemoryPointer mPtr) internal pure returns (MemoryPointer value) {
+    }
+}


### PR DESCRIPTION
Fixes #1333 

Binding the definition from a top-level `ConstantDefinition` to its type allows resolving methods and extension functions called on them.

