### PR TITLE
Register resolved imports when building the `CompilationUnit` on Sourcify tests

### DIFF
--- a/crates/solidity/testing/sourcify/src/compilation_builder.rs
+++ b/crates/solidity/testing/sourcify/src/compilation_builder.rs
@@ -40,8 +40,8 @@ impl<'c> CompilationBuilder<'c> {
 
         let AddFileResponse { import_paths } = self.internal.add_file(filename.into(), &source);
 
-        for import_path in import_paths {
-            let import_path = import_path.node().unparse();
+        for import_path_cursor in import_paths {
+            let import_path = import_path_cursor.node().unparse();
             let import_path = import_path
                 .strip_prefix(|c| matches!(c, '"' | '\''))
                 .unwrap()
@@ -56,6 +56,12 @@ impl<'c> CompilationBuilder<'c> {
                 .ok_or(Error::msg(format!(
                     "Could not resolve import path {import_path} in source file {filename}"
                 )))?;
+
+            self.internal.resolve_import(
+                filename,
+                &import_path_cursor,
+                import_real_name.clone(),
+            )?;
             self.add_file(&import_real_name)?;
         }
 

--- a/crates/solidity/testing/sourcify/src/run.rs
+++ b/crates/solidity/testing/sourcify/src/run.rs
@@ -30,13 +30,13 @@ pub fn test_single_contract(
 pub fn run_with_trace(archive: &ContractArchive, events: &Events, opts: &TestOptions) {
     for contract in archive.contracts() {
         events.trace(format!(
-            "[{version}] Starting contract {name}",
+            "[{name} {version}] Starting contract {name}",
             version = contract.version,
             name = contract.name
         ));
         run_test(&contract, events, opts);
         events.trace(format!(
-            "[{version}] Finished contract {name}",
+            "[{name} {version}] Finished contract {name}",
             version = contract.version,
             name = contract.name
         ));
@@ -102,7 +102,7 @@ fn run_parser_check(contract: &Contract, unit: &CompilationUnit, events: &Events
                     let msg =
                         slang_solidity::diagnostic::render(error, &source_name, &source, true);
                     events.parse_error(format!(
-                        "[{version}] Parse error in contract {contract_name}\n{msg}",
+                        "[{contract_name} {version}] Parse error\n{msg}",
                         contract_name = contract.name,
                         version = contract.version
                     ));
@@ -130,7 +130,7 @@ fn run_version_inference_check(
                     .get_source_id(file.id())
                     .unwrap_or(file.id().into());
                 events.version_error(format!(
-                    "[{version}] Could not infer correct version for {contract_name}:{source_name}",
+                    "[{contract_name} {version}] Could not infer correct version in file {source_name}",
                     version = contract.version,
                     contract_name = contract.name,
                 ));
@@ -178,7 +178,8 @@ fn run_bindings_check(
                 true,
             );
             events.bindings_error(format!(
-                "[{version}] Binding Error: Reference has no definitions\n{msg}",
+                "[{contract_name} {version}] Binding Error: Reference has no definitions\n{msg}",
+                contract_name = contract.name,
                 version = contract.version,
             ));
 
@@ -218,7 +219,8 @@ fn run_bindings_check(
                         true,
                     );
                     events.bindings_error(format!(
-                        "[{version}] Binding Error: No definition or reference\n{msg}",
+                        "[{contract_name} {version}] Binding Error: No definition or reference\n{msg}",
+                        contract_name = contract.name,
                         version = contract.version,
                     ));
                 }

--- a/crates/solidity/testing/sourcify/src/run.rs
+++ b/crates/solidity/testing/sourcify/src/run.rs
@@ -30,13 +30,13 @@ pub fn test_single_contract(
 pub fn run_with_trace(archive: &ContractArchive, events: &Events, opts: &TestOptions) {
     for contract in archive.contracts() {
         events.trace(format!(
-            "[{name} {version}] Starting contract {name}",
+            "[{name} {version}] Starting contract",
             version = contract.version,
             name = contract.name
         ));
         run_test(&contract, events, opts);
         events.trace(format!(
-            "[{name} {version}] Finished contract {name}",
+            "[{name} {version}] Finished contract",
             version = contract.version,
             name = contract.name
         ));


### PR DESCRIPTION
When building the `CompilationUnit` for Sourcify tests we were missing the registration of the resolved imports. This information is later used by the binding graph to link the partial graphs from each file. Without this, resolving symbols in imported files didn't work properly.

This PR also includes two additional improvements:

- the argument to `--shard-count` is validated and can now accept the value 256 (it wouldn't previously because it was stored in a `u8`)
- when reporting failures, always print the contract name alongside the version (this makes it easier to iterate on failing contracts using the `--contract` option)
