### PR TITLE
Make try/catch parameters and init vars in for loops available in Yul

### DIFF
--- a/.changeset/five-things-accept.md
+++ b/.changeset/five-things-accept.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": patch
+---
+
+Make try/catch parameters and vars in for loop initialization available in Yul

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1955,6 +1955,12 @@ inherit .star_extension
     edge @stmt.defs -> @body.defs
     edge @stmt.defs -> @stmt.init_defs
   }
+
+  ;; For initialization defs are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @stmt.init_defs
 }
 
 ;; While loops
@@ -1994,6 +2000,12 @@ inherit .star_extension
   edge @body.lexical_scope -> @return_params.defs
   ;; Similar to functions, return params shadow other declarations
   attr (@body.lexical_scope -> @return_params.defs) precedence = 1
+
+  ;; Return params are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @return_params.defs
 }
 
 @stmt [Statement [TryStatement [CatchClauses [CatchClause
@@ -2010,6 +2022,12 @@ inherit .star_extension
   edge @body.lexical_scope -> @catch_params.defs
   ;; Similar to functions, catch params shadow other declarations
   attr (@body.lexical_scope -> @catch_params.defs) precedence = 1
+
+  ;; Catch params are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @catch_params.defs
 }
 
 @stmt [Statement [TryStatement [CatchClauses [CatchClause

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -1959,6 +1959,12 @@ inherit .star_extension
     edge @stmt.defs -> @body.defs
     edge @stmt.defs -> @stmt.init_defs
   }
+
+  ;; For initialization defs are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @stmt.init_defs
 }
 
 ;; While loops
@@ -1998,6 +2004,12 @@ inherit .star_extension
   edge @body.lexical_scope -> @return_params.defs
   ;; Similar to functions, return params shadow other declarations
   attr (@body.lexical_scope -> @return_params.defs) precedence = 1
+
+  ;; Return params are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @return_params.defs
 }
 
 @stmt [Statement [TryStatement [CatchClauses [CatchClause
@@ -2014,6 +2026,12 @@ inherit .star_extension
   edge @body.lexical_scope -> @catch_params.defs
   ;; Similar to functions, catch params shadow other declarations
   attr (@body.lexical_scope -> @catch_params.defs) precedence = 1
+
+  ;; Catch params are also available to Yul assembly blocks
+  node yul_locals
+  attr (yul_locals) pop_symbol = "@yul_locals"
+  edge @body.lexical_scope -> yul_locals
+  edge yul_locals -> @catch_params.defs
 }
 
 @stmt [Statement [TryStatement [CatchClauses [CatchClause

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/yul.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/generated/yul.rs
@@ -37,6 +37,11 @@ fn external_variables() -> Result<()> {
 }
 
 #[test]
+fn for_init_variables() -> Result<()> {
+    run(T, "for_init_variables")
+}
+
+#[test]
 fn functions() -> Result<()> {
     run(T, "functions")
 }
@@ -79,6 +84,11 @@ fn solidity_built_in_doesn_t_bind() -> Result<()> {
 #[test]
 fn stack_assign() -> Result<()> {
     run(T, "stack_assign")
+}
+
+#[test]
+fn try_catch_params() -> Result<()> {
+    run(T, "try_catch_params")
 }
 
 #[test]

--- a/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/generated/0.4.11-failure.txt
@@ -1,0 +1,39 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected OpenBrace or ReturnsKeyword or Semicolon.
+    ╭─[input.sol:5:45]
+    │
+  5 │ ╭─▶     function copy(bytes memory data) public pure returns (bytes memory result) {
+    ┆ ┆   
+ 21 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+   ╭─[input.sol:1:1]
+   │
+ 4 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 5 │     function copy(bytes memory data) public pure returns (bytes memory result) {
+   │              ──┬─              ──┬─  
+   │                ╰───────────────────── name: 2
+   │                                  │   
+   │                                  ╰─── name: 3
+───╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─▶ 
+    ┆ ┆   
+  5 │ │       function copy(bytes memory data) public pure returns (bytes memory result) {
+    │ │   ─────────────────────┬────┬────────────────  
+    │ │                        ╰─────────────────────── definiens: 2
+    │ │                             │                  
+    │ │                             ╰────────────────── definiens: 3
+    ┆ ┆   
+ 22 │ ├─▶ }
+    │ │       
+    │ ╰─────── definiens: 1
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/generated/0.4.16-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/generated/0.4.16-success.txt
@@ -1,0 +1,115 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function copy(bytes memory data) public pure returns (bytes memory result) {
+    │              ──┬─              ──┬─                                    ───┬──  
+    │                ╰─────────────────────────────────────────────────────────────── name: 2
+    │                                  │                                        │    
+    │                                  ╰───────────────────────────────────────────── name: 3
+    │                                                                           │    
+    │                                                                           ╰──── name: 4
+  6 │         uint256 length = data.length;
+    │                 ───┬──   ──┬─ ───┬──  
+    │                    ╰────────────────── name: 5
+    │                            │     │    
+    │                            ╰────────── ref: 3
+    │                                  │    
+    │                                  ╰──── ref: built-in
+    │ 
+  9 │             result := mload(0x40)
+    │             ───┬──    ──┬──  
+    │                ╰───────────── ref: 4
+    │                         │    
+    │                         ╰──── ref: built-in
+ 10 │             mstore(0x40, add(add(result, length), 32))
+    │             ───┬──       ─┬─ ─┬─ ───┬──  ───┬──  
+    │                ╰───────────────────────────────── ref: built-in
+    │                           │   │     │       │    
+    │                           ╰────────────────────── ref: built-in
+    │                               │     │       │    
+    │                               ╰────────────────── ref: built-in
+    │                                     │       │    
+    │                                     ╰──────────── ref: 4
+    │                                             │    
+    │                                             ╰──── ref: 5
+ 11 │             mstore(result, length)
+    │             ───┬── ───┬──  ───┬──  
+    │                ╰─────────────────── ref: built-in
+    │                       │       │    
+    │                       ╰──────────── ref: 4
+    │                               │    
+    │                               ╰──── ref: 5
+    │ 
+ 14 │         for (uint256 i = 0; i < length; i += 32) {
+    │                      ┬      ┬   ───┬──  ┬  
+    │                      ╰───────────────────── name: 6
+    │                             │      │    │  
+    │                             ╰────────────── ref: 6
+    │                                    │    │  
+    │                                    ╰─────── ref: 5
+    │                                         │  
+    │                                         ╰── ref: 6
+ 15 │             bytes32 chunk;
+    │                     ──┬──  
+    │                       ╰──── name: 7
+    │ 
+ 17 │                 chunk := mload(add(data, add(i, 32)))
+    │                 ──┬──    ──┬── ─┬─ ──┬─  ─┬─ ┬  
+    │                   ╰───────────────────────────── ref: 7
+    │                            │    │    │    │  │  
+    │                            ╰──────────────────── ref: built-in
+    │                                 │    │    │  │  
+    │                                 ╰─────────────── ref: built-in
+    │                                      │    │  │  
+    │                                      ╰────────── ref: 3
+    │                                           │  │  
+    │                                           ╰───── ref: built-in
+    │                                              │  
+    │                                              ╰── ref: 6
+ 18 │                 mstore(add(result, add(i, 32)), chunk)
+    │                 ───┬── ─┬─ ───┬──  ─┬─ ┬        ──┬──  
+    │                    ╰─────────────────────────────────── ref: built-in
+    │                         │     │     │  │          │    
+    │                         ╰────────────────────────────── ref: built-in
+    │                               │     │  │          │    
+    │                               ╰──────────────────────── ref: 4
+    │                                     │  │          │    
+    │                                     ╰────────────────── ref: built-in
+    │                                        │          │    
+    │                                        ╰─────────────── ref: 6
+    │                                                   │    
+    │                                                   ╰──── ref: 7
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭───▶ 
+    ┆ ┆ ┆   
+  5 │ │ ╭─▶     function copy(bytes memory data) public pure returns (bytes memory result) {
+    │ │ │                     ────────┬────────                       ─────────┬─────────  
+    │ │ │                             ╰──────────────────────────────────────────────────── definiens: 3
+    │ │ │                                                                      │           
+    │ │ │                                                                      ╰─────────── definiens: 4
+  6 │ │ │           uint256 length = data.length;
+    │ │ │   ───────────────────┬──────────────────  
+    │ │ │                      ╰──────────────────── definiens: 5
+    ┆ ┆ ┆   
+ 14 │ │ │           for (uint256 i = 0; i < length; i += 32) {
+    │ │ │                ───────┬──────  
+    │ │ │                       ╰──────── definiens: 6
+ 15 │ │ │               bytes32 chunk;
+    │ │ │   ─────────────┬─────────────  
+    │ │ │                ╰─────────────── definiens: 7
+    ┆ ┆ ┆   
+ 21 │ │ ├─▶     }
+    │ │ │           
+    │ │ ╰─────────── definiens: 2
+ 22 │ ├───▶ }
+    │ │         
+    │ ╰───────── definiens: 1
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/for_init_variables/input.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.29;
+
+contract Test {
+    function copy(bytes memory data) public pure returns (bytes memory result) {
+        uint256 length = data.length;
+
+        assembly {
+            result := mload(0x40)
+            mstore(0x40, add(add(result, length), 32))
+            mstore(result, length)
+        }
+
+        for (uint256 i = 0; i < length; i += 32) {
+            bytes32 chunk;
+            assembly {
+                chunk := mload(add(data, add(i, 32)))
+                mstore(add(result, add(i, 32)), chunk)
+            }
+        }
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.4.11-failure.txt
@@ -1,0 +1,61 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or SuperKeyword or ThisKeyword or ThrowKeyword or TrueKeyword or UfixedKeyword or UintKeyword or VarKeyword or WhileKeyword.
+    ╭─[input.sol:6:9]
+    │
+  6 │ ╭─▶         try service.test() returns (uint v) {
+    ┆ ┆   
+ 19 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 5
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 5
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 6
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 6
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 5
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.4.21-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.4.21-failure.txt
@@ -1,0 +1,61 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or SuperKeyword or ThisKeyword or ThrowKeyword or TrueKeyword or UfixedKeyword or UintKeyword or VarKeyword or WhileKeyword.
+    ╭─[input.sol:6:9]
+    │
+  6 │ ╭─▶         try service.test() returns (uint v) {
+    ┆ ┆   
+ 19 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 5
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 5
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 6
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 6
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 5
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.5.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.5.0-failure.txt
@@ -1,0 +1,61 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or SuperKeyword or ThisKeyword or TrueKeyword or UfixedKeyword or UintKeyword or WhileKeyword.
+    ╭─[input.sol:6:9]
+    │
+  6 │ ╭─▶         try service.test() returns (uint v) {
+    ┆ ┆   
+ 19 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 5
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 5
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 6
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 6
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 5
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.5.3-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.5.3-failure.txt
@@ -1,0 +1,61 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected AddressKeyword or AssemblyKeyword or BoolKeyword or BreakKeyword or ByteKeyword or BytesKeyword or CloseBrace or ContinueKeyword or DecimalLiteral or DoKeyword or DoubleQuotedHexStringLiteral or DoubleQuotedStringLiteral or EmitKeyword or FalseKeyword or FixedKeyword or ForKeyword or FunctionKeyword or HexLiteral or Identifier or IfKeyword or IntKeyword or MappingKeyword or NewKeyword or OpenBrace or OpenBracket or OpenParen or ReturnKeyword or SingleQuotedHexStringLiteral or SingleQuotedStringLiteral or StringKeyword or SuperKeyword or ThisKeyword or TrueKeyword or TypeKeyword or UfixedKeyword or UintKeyword or WhileKeyword.
+    ╭─[input.sol:6:9]
+    │
+  6 │ ╭─▶         try service.test() returns (uint v) {
+    ┆ ┆   
+ 19 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 5
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 5
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 6
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 6
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 5
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.6.0-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.6.0-success.txt
@@ -1,0 +1,95 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 7
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+  6 │         try service.test() returns (uint v) {
+    │             ───┬─── ──┬─                 ┬  
+    │                ╰──────────────────────────── ref: 3
+    │                       │                  │  
+    │                       ╰───────────────────── ref: 8
+    │                                          │  
+    │                                          ╰── name: 5
+    │ 
+  8 │                 r := v
+    │                 ┬    ┬  
+    │                 ╰─────── ref: 4
+    │                      │  
+    │                      ╰── ref: 5
+    │ 
+ 10 │         } catch (bytes memory reason) {
+    │                               ───┬──  
+    │                                  ╰──── name: 6
+ 11 │             if (reason.length == 0) {
+    │                 ───┬── ───┬──  
+    │                    ╰─────────── ref: 6
+    │                           │    
+    │                           ╰──── ref: built-in
+ 12 │                 revert("error");
+    │                 ───┬──  
+    │                    ╰──── refs: built-in, built-in
+    │ 
+ 15 │                     revert(add(32, reason), mload(reason))
+    │                     ───┬── ─┬─     ───┬──   ──┬── ───┬──  
+    │                        ╰────────────────────────────────── ref: built-in
+    │                             │         │       │      │    
+    │                             ╰───────────────────────────── ref: built-in
+    │                                       │       │      │    
+    │                                       ╰─────────────────── ref: 6
+    │                                               │      │    
+    │                                               ╰─────────── ref: built-in
+    │                                                      │    
+    │                                                      ╰──── ref: 6
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 7
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 8
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+  6 │ │ │             try service.test() returns (uint v) {
+    │ │ │                                         ───┬──  
+    │ │ │                                            ╰──── definiens: 5
+    ┆ ┆ ┆     
+ 10 │ │ │             } catch (bytes memory reason) {
+    │ │ │                      ─────────┬─────────  
+    │ │ │                               ╰─────────── definiens: 6
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 8
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 7
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.8.4-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/generated/0.8.4-success.txt
@@ -1,0 +1,92 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  4 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  5 │     function test(Service service) public returns (uint r) {
+    │              ──┬─ ───┬─── ───┬───                       ┬  
+    │                ╰─────────────────────────────────────────── name: 2
+    │                      │       │                          │  
+    │                      ╰───────────────────────────────────── ref: 7
+    │                              │                          │  
+    │                              ╰───────────────────────────── name: 3
+    │                                                         │  
+    │                                                         ╰── name: 4
+  6 │         try service.test() returns (uint v) {
+    │             ───┬─── ──┬─                 ┬  
+    │                ╰──────────────────────────── ref: 3
+    │                       │                  │  
+    │                       ╰───────────────────── ref: 8
+    │                                          │  
+    │                                          ╰── name: 5
+    │ 
+  8 │                 r := v
+    │                 ┬    ┬  
+    │                 ╰─────── ref: 4
+    │                      │  
+    │                      ╰── ref: 5
+    │ 
+ 10 │         } catch (bytes memory reason) {
+    │                               ───┬──  
+    │                                  ╰──── name: 6
+ 11 │             if (reason.length == 0) {
+    │                 ───┬── ───┬──  
+    │                    ╰─────────── ref: 6
+    │                           │    
+    │                           ╰──── ref: built-in
+    │ 
+ 15 │                     revert(add(32, reason), mload(reason))
+    │                     ───┬── ─┬─     ───┬──   ──┬── ───┬──  
+    │                        ╰────────────────────────────────── ref: built-in
+    │                             │         │       │      │    
+    │                             ╰───────────────────────────── ref: built-in
+    │                                       │       │      │    
+    │                                       ╰─────────────────── ref: 6
+    │                                               │      │    
+    │                                               ╰─────────── ref: built-in
+    │                                                      │    
+    │                                                      ╰──── ref: 6
+    │ 
+ 22 │ interface Service {
+    │           ───┬───  
+    │              ╰───── name: 7
+ 23 │     function test() external returns (uint);
+    │              ──┬─  
+    │                ╰─── name: 8
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  3 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  5 │ │ ╭───▶     function test(Service service) public returns (uint r) {
+    │ │ │                       ───────┬───────                  ───┬──  
+    │ │ │                              ╰───────────────────────────────── definiens: 3
+    │ │ │                                                           │    
+    │ │ │                                                           ╰──── definiens: 4
+  6 │ │ │             try service.test() returns (uint v) {
+    │ │ │                                         ───┬──  
+    │ │ │                                            ╰──── definiens: 5
+    ┆ ┆ ┆     
+ 10 │ │ │             } catch (bytes memory reason) {
+    │ │ │                      ─────────┬─────────  
+    │ │ │                               ╰─────────── definiens: 6
+    ┆ ┆ ┆     
+ 19 │ │ ├───▶     }
+    │ │ │             
+    │ │ ╰───────────── definiens: 2
+ 20 │ ├───│ ▶ }
+    │ │   │       
+    │ ╰─────────── definiens: 1
+ 21 │     ╭─▶ 
+    ┆     ┆   
+ 23 │     │       function test() external returns (uint);
+    │     │   ──────────────────────┬──────────────────────  
+    │     │                         ╰──────────────────────── definiens: 8
+ 24 │     ├─▶ }
+    │     │       
+    │     ╰─────── definiens: 7
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/try_catch_params/input.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.29;
+
+contract Test {
+    function test(Service service) public returns (uint r) {
+        try service.test() returns (uint v) {
+            assembly {
+                r := v
+            }
+        } catch (bytes memory reason) {
+            if (reason.length == 0) {
+                revert("error");
+            } else {
+                assembly {
+                    revert(add(32, reason), mload(reason))
+                }
+            }
+        }
+    }
+}
+
+interface Service {
+    function test() external returns (uint);
+}


### PR DESCRIPTION
`try` return parameters and `catch` clause parameters are not made available inside `assembly` blocks. And similarly with local variables defined in the initialization clause of a `for` loop. Provide access to them in the bindings graph.
