### PR TITLE
Remove error variant when creating a `BindingGraphBuilder`

### DIFF
--- a/crates/codegen/runtime/cargo/crate/src/extensions/bindings/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/extensions/bindings/mod.rs
@@ -1,12 +1,8 @@
 use semver::Version;
 
 use crate::bindings::BindingGraphBuilder;
-use crate::parser::ParserInitializationError;
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn add_built_ins(
-    _binding_graph_builder: &mut BindingGraphBuilder,
-    _version: Version,
-) -> Result<(), ParserInitializationError> {
+pub fn add_built_ins(_binding_graph_builder: &mut BindingGraphBuilder, _version: Version) {
     unreachable!("Built-ins are Solidity-specific")
 }

--- a/crates/codegen/runtime/cargo/crate/src/runtime/bindings/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/bindings/mod.rs
@@ -16,27 +16,19 @@ pub type UserFileLocation = metaslang_bindings::UserFileLocation<KindTypes>;
 
 pub use metaslang_bindings::{BuiltInLocation, PathResolver};
 
-use crate::parser::ParserInitializationError;
-
-#[derive(thiserror::Error, Debug)]
-pub enum BindingGraphInitializationError {
-    #[error(transparent)]
-    ParserInitialization(#[from] ParserInitializationError),
-}
-
 pub fn create_with_resolver(
     version: Version,
     resolver: Rc<dyn PathResolver<KindTypes>>,
-) -> Result<BindingGraphBuilder, BindingGraphInitializationError> {
+) -> BindingGraphBuilder {
     let mut binding_graph = BindingGraphBuilder::create(
         version.clone(),
         binding_rules::BINDING_RULES_SOURCE,
         resolver,
     );
 
-    crate::extensions::bindings::add_built_ins(&mut binding_graph, version)?;
+    crate::extensions::bindings::add_built_ins(&mut binding_graph, version);
 
-    Ok(binding_graph)
+    binding_graph
 }
 
 #[cfg(feature = "__private_testing_utils")]

--- a/crates/codegen/runtime/cargo/crate/src/runtime/compilation/unit.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/compilation/unit.rs
@@ -42,8 +42,7 @@ impl CompilationUnit {
             };
 
             let mut builder =
-                create_with_resolver(self.language_version.clone(), Rc::new(resolver))
-                    .expect("Language version is already validated by the builder");
+                create_with_resolver(self.language_version.clone(), Rc::new(resolver));
 
             for (id, file) in &self.files {
                 builder.add_user_file(id, file.create_tree_cursor());

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -6965,17 +6965,7 @@ pub type slang_solidity::backend::l2_flat_contracts::YulVariableNames = alloc::v
 pub mod slang_solidity::bindings
 pub use slang_solidity::bindings::BuiltInLocation
 pub use slang_solidity::bindings::PathResolver
-pub enum slang_solidity::bindings::BindingGraphInitializationError
-pub slang_solidity::bindings::BindingGraphInitializationError::ParserInitialization(slang_solidity::parser::ParserInitializationError)
-impl core::convert::From<slang_solidity::parser::ParserInitializationError> for slang_solidity::bindings::BindingGraphInitializationError
-pub fn slang_solidity::bindings::BindingGraphInitializationError::from(source: slang_solidity::parser::ParserInitializationError) -> Self
-impl core::error::Error for slang_solidity::bindings::BindingGraphInitializationError
-pub fn slang_solidity::bindings::BindingGraphInitializationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-impl core::fmt::Debug for slang_solidity::bindings::BindingGraphInitializationError
-pub fn slang_solidity::bindings::BindingGraphInitializationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for slang_solidity::bindings::BindingGraphInitializationError
-pub fn slang_solidity::bindings::BindingGraphInitializationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn slang_solidity::bindings::create_with_resolver(version: semver::Version, resolver: alloc::rc::Rc<dyn metaslang_bindings::builder::PathResolver<slang_solidity::cst::KindTypes>>) -> core::result::Result<slang_solidity::bindings::BindingGraphBuilder, slang_solidity::bindings::BindingGraphInitializationError>
+pub fn slang_solidity::bindings::create_with_resolver(version: semver::Version, resolver: alloc::rc::Rc<dyn metaslang_bindings::builder::PathResolver<slang_solidity::cst::KindTypes>>) -> slang_solidity::bindings::BindingGraphBuilder
 pub fn slang_solidity::bindings::get_binding_rules() -> &'static str
 pub type slang_solidity::bindings::BindingGraph = metaslang_bindings::graph::BindingGraph<slang_solidity::cst::KindTypes>
 pub type slang_solidity::bindings::BindingGraphBuilder = metaslang_bindings::builder::BindingGraphBuilder<slang_solidity::cst::KindTypes>
@@ -7815,8 +7805,6 @@ pub fn slang_solidity::diagnostic::render<D: slang_solidity::diagnostic::Diagnos
 pub mod slang_solidity::parser
 pub enum slang_solidity::parser::ParserInitializationError
 pub slang_solidity::parser::ParserInitializationError::UnsupportedLanguageVersion(semver::Version)
-impl core::convert::From<slang_solidity::parser::ParserInitializationError> for slang_solidity::bindings::BindingGraphInitializationError
-pub fn slang_solidity::bindings::BindingGraphInitializationError::from(source: slang_solidity::parser::ParserInitializationError) -> Self
 impl core::error::Error for slang_solidity::parser::ParserInitializationError
 impl core::fmt::Debug for slang_solidity::parser::ParserInitializationError
 pub fn slang_solidity::parser::ParserInitializationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/crates/solidity/outputs/cargo/crate/src/extensions/bindings/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/extensions/bindings/mod.rs
@@ -8,15 +8,11 @@ use metaslang_bindings::ScopeGraphBuilder;
 use metaslang_cst::text_index::TextIndex;
 use semver::Version;
 
-use crate::bindings::{BindingGraphBuilder, BindingGraphInitializationError};
+use crate::bindings::BindingGraphBuilder;
 use crate::cst::{Node, NonterminalKind};
 
 #[allow(clippy::needless_pass_by_value)]
-#[allow(clippy::unnecessary_wraps)]
-pub fn add_built_ins(
-    builder: &mut BindingGraphBuilder,
-    version: Version,
-) -> Result<(), BindingGraphInitializationError> {
+pub fn add_built_ins(builder: &mut BindingGraphBuilder, version: Version) {
     let empty_node = Node::nonterminal(NonterminalKind::SourceUnit, Vec::new())
         .into_nonterminal()
         .unwrap();
@@ -29,6 +25,4 @@ pub fn add_built_ins(
     let mut globals = ScopeGraphBuilder::new(&mut file_builder, "@@built-ins@@", root_node, None);
 
     define_built_ins(&mut file_builder, &mut globals, &version);
-
-    Ok(())
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/mod.rs
@@ -18,27 +18,19 @@ pub type UserFileLocation = metaslang_bindings::UserFileLocation<KindTypes>;
 
 pub use metaslang_bindings::{BuiltInLocation, PathResolver};
 
-use crate::parser::ParserInitializationError;
-
-#[derive(thiserror::Error, Debug)]
-pub enum BindingGraphInitializationError {
-    #[error(transparent)]
-    ParserInitialization(#[from] ParserInitializationError),
-}
-
 pub fn create_with_resolver(
     version: Version,
     resolver: Rc<dyn PathResolver<KindTypes>>,
-) -> Result<BindingGraphBuilder, BindingGraphInitializationError> {
+) -> BindingGraphBuilder {
     let mut binding_graph = BindingGraphBuilder::create(
         version.clone(),
         binding_rules::BINDING_RULES_SOURCE,
         resolver,
     );
 
-    crate::extensions::bindings::add_built_ins(&mut binding_graph, version)?;
+    crate::extensions::bindings::add_built_ins(&mut binding_graph, version);
 
-    Ok(binding_graph)
+    binding_graph
 }
 
 #[cfg(feature = "__private_testing_utils")]

--- a/crates/solidity/outputs/cargo/crate/src/generated/compilation/unit.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/compilation/unit.rs
@@ -44,8 +44,7 @@ impl CompilationUnit {
             };
 
             let mut builder =
-                create_with_resolver(self.language_version.clone(), Rc::new(resolver))
-                    .expect("Language version is already validated by the builder");
+                create_with_resolver(self.language_version.clone(), Rc::new(resolver));
 
             for (id, file) in &self.files {
                 builder.add_user_file(id, file.create_tree_cursor());

--- a/crates/solidity/outputs/cargo/tests/src/binding_resolver.rs
+++ b/crates/solidity/outputs/cargo/tests/src/binding_resolver.rs
@@ -46,7 +46,7 @@ fn setup() -> Result<(Cursor, Rc<BindingGraph>)> {
     let version = TEST_VERSION;
     let parser = Parser::create(version.clone())?;
     let mut builder =
-        bindings::create_with_resolver(version.clone(), Rc::new(TestsPathResolver {}))?;
+        bindings::create_with_resolver(version.clone(), Rc::new(TestsPathResolver {}));
 
     let parse_output = parser.parse_file_contents(INPUT_FILE);
     builder.add_user_file("input.sol", parse_output.create_tree_cursor());

--- a/crates/solidity/outputs/cargo/tests/src/bindings_output/runner.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings_output/runner.rs
@@ -45,7 +45,7 @@ pub fn run(group_name: &str, test_name: &str) -> Result<()> {
     for version in &VERSION_BREAKS {
         let parser = Parser::create(version.clone())?;
         let mut builder =
-            bindings::create_with_resolver(version.clone(), Rc::new(TestsPathResolver {}))?;
+            bindings::create_with_resolver(version.clone(), Rc::new(TestsPathResolver {}));
 
         let mut parsed_parts: Vec<ParsedPart<'_>> = Vec::new();
         let multi_part = split_multi_file(&contents);

--- a/crates/solidity/testing/perf/src/tests/bindings_build.rs
+++ b/crates/solidity/testing/perf/src/tests/bindings_build.rs
@@ -13,8 +13,7 @@ pub fn setup() -> Vec<ParsedFile> {
 }
 
 pub fn run(files: Vec<ParsedFile>) -> Rc<BindingGraph> {
-    let mut bindings_graph_builder =
-        create_with_resolver(SOLC_VERSION, Rc::new(Resolver {})).unwrap();
+    let mut bindings_graph_builder = create_with_resolver(SOLC_VERSION, Rc::new(Resolver {}));
 
     for file in files {
         bindings_graph_builder.add_user_file(

--- a/crates/solidity/testing/sanctuary/src/tests.rs
+++ b/crates/solidity/testing/sanctuary/src/tests.rs
@@ -141,7 +141,7 @@ pub fn run_test(
     }
 
     if check_bindings {
-        let binding_errors = run_bindings_check(&version, source_id, &output)?;
+        let binding_errors = run_bindings_check(&version, source_id, &output);
         if !binding_errors.is_empty() {
             for error in &binding_errors {
                 let report =
@@ -217,9 +217,9 @@ fn run_bindings_check(
     version: &Version,
     source_id: &str,
     output: &ParseOutput,
-) -> Result<Vec<BindingError>> {
+) -> Vec<BindingError> {
     let mut errors = Vec::new();
-    let binding_graph = create_bindings(version, source_id, output)?;
+    let binding_graph = create_bindings(version, source_id, output);
 
     for reference in binding_graph.all_references() {
         if reference.get_file().is_built_ins() {
@@ -259,24 +259,20 @@ fn run_bindings_check(
         }
     }
 
-    Ok(errors)
+    errors
 }
 
-fn create_bindings(
-    version: &Version,
-    source_id: &str,
-    output: &ParseOutput,
-) -> Result<Rc<BindingGraph>> {
+fn create_bindings(version: &Version, source_id: &str, output: &ParseOutput) -> Rc<BindingGraph> {
     let mut builder = bindings::create_with_resolver(
         version.clone(),
         Rc::new(SingleFileResolver {
             source_id: source_id.into(),
         }),
-    )?;
+    );
 
     builder.add_user_file(source_id, output.create_tree_cursor());
 
-    Ok(builder.build())
+    builder.build()
 }
 
 /// The `PathResolver` that always resolves to the given `source_id`.

--- a/crates/testlang/outputs/cargo/crate/src/extensions/bindings/mod.rs
+++ b/crates/testlang/outputs/cargo/crate/src/extensions/bindings/mod.rs
@@ -1,12 +1,8 @@
 use semver::Version;
 
 use crate::bindings::BindingGraphBuilder;
-use crate::parser::ParserInitializationError;
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn add_built_ins(
-    _binding_graph_builder: &mut BindingGraphBuilder,
-    _version: Version,
-) -> Result<(), ParserInitializationError> {
+pub fn add_built_ins(_binding_graph_builder: &mut BindingGraphBuilder, _version: Version) {
     unreachable!("Built-ins are Solidity-specific")
 }

--- a/crates/testlang/outputs/cargo/crate/src/generated/bindings/mod.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/bindings/mod.rs
@@ -18,27 +18,19 @@ pub type UserFileLocation = metaslang_bindings::UserFileLocation<KindTypes>;
 
 pub use metaslang_bindings::{BuiltInLocation, PathResolver};
 
-use crate::parser::ParserInitializationError;
-
-#[derive(thiserror::Error, Debug)]
-pub enum BindingGraphInitializationError {
-    #[error(transparent)]
-    ParserInitialization(#[from] ParserInitializationError),
-}
-
 pub fn create_with_resolver(
     version: Version,
     resolver: Rc<dyn PathResolver<KindTypes>>,
-) -> Result<BindingGraphBuilder, BindingGraphInitializationError> {
+) -> BindingGraphBuilder {
     let mut binding_graph = BindingGraphBuilder::create(
         version.clone(),
         binding_rules::BINDING_RULES_SOURCE,
         resolver,
     );
 
-    crate::extensions::bindings::add_built_ins(&mut binding_graph, version)?;
+    crate::extensions::bindings::add_built_ins(&mut binding_graph, version);
 
-    Ok(binding_graph)
+    binding_graph
 }
 
 #[cfg(feature = "__private_testing_utils")]

--- a/crates/testlang/outputs/cargo/crate/src/generated/compilation/unit.rs
+++ b/crates/testlang/outputs/cargo/crate/src/generated/compilation/unit.rs
@@ -44,8 +44,7 @@ impl CompilationUnit {
             };
 
             let mut builder =
-                create_with_resolver(self.language_version.clone(), Rc::new(resolver))
-                    .expect("Language version is already validated by the builder");
+                create_with_resolver(self.language_version.clone(), Rc::new(resolver));
 
             for (id, file) in &self.files {
                 builder.add_user_file(id, file.create_tree_cursor());


### PR DESCRIPTION
Returning a `Result` was previously required because adding built-ins to the initial empty binding graph was done by parsing a generated Solidity source file and processing it normally. But now the partial graph to support built-ins is being generated directly.