### PR TITLE
Remove the minimum version check for nodes to include in the generated IRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,6 @@ dependencies = [
  "codegen_testing",
  "infra_utils",
  "rayon",
- "semver",
  "solidity_language",
  "testlang_language",
 ]

--- a/crates/codegen/runner/Cargo.toml
+++ b/crates/codegen/runner/Cargo.toml
@@ -14,7 +14,6 @@ codegen_spec = { workspace = true }
 codegen_testing = { workspace = true }
 infra_utils = { workspace = true }
 rayon = { workspace = true }
-semver = { workspace = true }
 solidity_language = { workspace = true }
 testlang_language = { workspace = true }
 

--- a/crates/codegen/runner/src/passes.rs
+++ b/crates/codegen/runner/src/passes.rs
@@ -3,7 +3,6 @@ use codegen_language_definition::model::Language;
 use codegen_runtime_generator::ir::{IrModel, ModelWithBuilder, ModelWithTransformer};
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::{CodegenFileSystem, CodegenRuntime};
-use semver::Version;
 
 pub fn generate_passes(
     fs: &mut CodegenFileSystem,
@@ -15,8 +14,7 @@ pub fn generate_passes(
     let ir_output_dir = CargoWorkspace::locate_source_crate(output_crate)?.join("src/backend");
 
     // L0: CST:
-    let minimum_version = Version::parse("0.8.0").unwrap();
-    let cst_model = IrModel::from_language("cst", language, minimum_version);
+    let cst_model = IrModel::from_language("cst", language);
 
     // L1: typed CST:
     let l1_typed_cst_model = build_l1_typed_cst_model(&cst_model);

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -150,6 +150,7 @@ pub fn slang_solidity::backend::l1_typed_cst::builder::build_string_literals(nod
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_struct_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_struct_member(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructMember, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_struct_members(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructMembers, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_throw_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::ThrowStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_try_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TryStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_tuple_deconstruction_element(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_tuple_deconstruction_elements(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements, alloc::string::String>
@@ -164,6 +165,9 @@ pub fn slang_solidity::backend::l1_typed_cst::builder::build_typed_tuple_member(
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_unchecked_block(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UncheckedBlock, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_unicode_string_literal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_unicode_string_literals(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_unnamed_function_attribute(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_unnamed_function_attributes(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_unnamed_function_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_untyped_tuple_member(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UntypedTupleMember, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_user_defined_value_type_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_using_alias(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UsingAlias, alloc::string::String>
@@ -190,13 +194,16 @@ pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_arguments(node:
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_assignment_operator(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_block(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulBlock, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_break_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulBreakStatement, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_colon_and_equal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulColonAndEqual, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_continue_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulContinueStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_default_case(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulDefaultCase, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_equal_and_colon(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulEqualAndColon, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_expression(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulExpression, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_for_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulForStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_function_call_expression(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_function_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulFunctionDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_if_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulIfStatement, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_label(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLabel, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_leave_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLeaveStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_literal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLiteral, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_parameters(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulParameters, alloc::string::String>
@@ -204,6 +211,8 @@ pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_parameters_decl
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_path(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulPath, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_paths(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulPaths, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_returns_declaration(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_stack_assignment_operator(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator, alloc::string::String>
+pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_stack_assignment_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStatement, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_statements(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStatements, alloc::string::String>
 pub fn slang_solidity::backend::l1_typed_cst::builder::build_yul_switch_case(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulSwitchCase, alloc::string::String>
@@ -246,6 +255,7 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrit
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleMember) -> slang_solidity::backend::l1_typed_cst::TupleMember
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_type_name(&mut self, source: &slang_solidity::backend::l1_typed_cst::TypeName) -> slang_solidity::backend::l1_typed_cst::TypeName
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_using_clause(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingClause) -> slang_solidity::backend::l1_typed_cst::UsingClause
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_using_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingOperator) -> slang_solidity::backend::l1_typed_cst::UsingOperator
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_using_target(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingTarget) -> slang_solidity::backend::l1_typed_cst::UsingTarget
@@ -256,6 +266,7 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrit
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l1_typed_cst::YulExpression
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l1_typed_cst::YulLiteral
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l1_typed_cst::YulStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::default_rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l1_typed_cst::YulSwitchCase
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_abicoder_pragma(&mut self, source: &slang_solidity::backend::l1_typed_cst::AbicoderPragma) -> slang_solidity::backend::l1_typed_cst::AbicoderPragma
@@ -404,6 +415,7 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_string
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_struct_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructDefinition) -> slang_solidity::backend::l1_typed_cst::StructDefinition
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_struct_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMember) -> slang_solidity::backend::l1_typed_cst::StructMember
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_struct_members(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMembers) -> slang_solidity::backend::l1_typed_cst::StructMembers
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_throw_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::ThrowStatement) -> slang_solidity::backend::l1_typed_cst::ThrowStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_try_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::TryStatement) -> slang_solidity::backend::l1_typed_cst::TryStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_tuple_deconstruction_element(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement) -> slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_tuple_deconstruction_elements(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements) -> slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements
@@ -418,6 +430,9 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_typed_
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unchecked_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::UncheckedBlock) -> slang_solidity::backend::l1_typed_cst::UncheckedBlock
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unicode_string_literals(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unnamed_function_attributes(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_unnamed_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_untyped_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember) -> slang_solidity::backend::l1_typed_cst::UntypedTupleMember
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_user_defined_value_type_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition) -> slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_using_alias(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingAlias) -> slang_solidity::backend::l1_typed_cst::UsingAlias
@@ -444,13 +459,16 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_ar
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBlock) -> slang_solidity::backend::l1_typed_cst::YulBlock
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_break_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBreakStatement) -> slang_solidity::backend::l1_typed_cst::YulBreakStatement
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_colon_and_equal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual) -> slang_solidity::backend::l1_typed_cst::YulColonAndEqual
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_continue_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulContinueStatement) -> slang_solidity::backend::l1_typed_cst::YulContinueStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_default_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulDefaultCase) -> slang_solidity::backend::l1_typed_cst::YulDefaultCase
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_equal_and_colon(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon) -> slang_solidity::backend::l1_typed_cst::YulEqualAndColon
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l1_typed_cst::YulExpression
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_for_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulForStatement) -> slang_solidity::backend::l1_typed_cst::YulForStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_function_call_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression) -> slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition) -> slang_solidity::backend::l1_typed_cst::YulFunctionDefinition
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_if_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulIfStatement) -> slang_solidity::backend::l1_typed_cst::YulIfStatement
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_label(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLabel) -> slang_solidity::backend::l1_typed_cst::YulLabel
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_leave_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement) -> slang_solidity::backend::l1_typed_cst::YulLeaveStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l1_typed_cst::YulLiteral
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_parameters(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulParameters) -> slang_solidity::backend::l1_typed_cst::YulParameters
@@ -458,6 +476,8 @@ pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_pa
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_path(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPath) -> slang_solidity::backend::l1_typed_cst::YulPath
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_paths(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPaths) -> slang_solidity::backend::l1_typed_cst::YulPaths
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_returns_declaration(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration) -> slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_stack_assignment_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l1_typed_cst::YulStatement
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_statements(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatements) -> slang_solidity::backend::l1_typed_cst::YulStatements
 pub fn slang_solidity::backend::l1_typed_cst::rewriter::Rewriter::rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l1_typed_cst::YulSwitchCase
@@ -617,6 +637,7 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_string_lit
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_struct_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructDefinition) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_struct_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructMember) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_struct_members(&mut self, _items: &slang_solidity::backend::l1_typed_cst::StructMembers) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_throw_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::ThrowStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_try_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TryStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements) -> bool
@@ -631,6 +652,9 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_typed_tupl
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unchecked_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_using_alias(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UsingAlias) -> bool
@@ -657,13 +681,16 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_argume
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBlock) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_break_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_default_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulExpression) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_for_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulForStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_if_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulIfStatement) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_label(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLabel) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_parameters(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulParameters) -> bool
@@ -671,6 +698,8 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_parame
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_path(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPath) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_paths(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPaths) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> bool
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStatement) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_statements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulStatements) -> bool
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::enter_yul_switch_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> bool
@@ -827,6 +856,7 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_string_lit
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_struct_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructDefinition)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_struct_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructMember)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_struct_members(&mut self, _items: &slang_solidity::backend::l1_typed_cst::StructMembers)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_throw_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::ThrowStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_try_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TryStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements)
@@ -841,6 +871,9 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_typed_tupl
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unchecked_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_using_alias(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UsingAlias)
@@ -867,13 +900,16 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_argume
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBlock)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_break_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_default_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulExpression)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_for_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulForStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_if_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulIfStatement)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_label(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLabel)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLiteral)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_parameters(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulParameters)
@@ -881,6 +917,8 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_parame
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_path(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPath)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_paths(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPaths)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStatement)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_statements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulStatements)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::Visitor::leave_yul_switch_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase)
@@ -1006,6 +1044,7 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_string_expression(
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_string_literal(_node: &slang_solidity::backend::l1_typed_cst::StringLiteral, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_struct_definition(node: &slang_solidity::backend::l1_typed_cst::StructDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_struct_member(node: &slang_solidity::backend::l1_typed_cst::StructMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_throw_statement(node: &slang_solidity::backend::l1_typed_cst::ThrowStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_try_statement(node: &slang_solidity::backend::l1_typed_cst::TryStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_tuple_deconstruction_element(node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_tuple_deconstruction_statement(node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -1017,6 +1056,8 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_type_name(node: &s
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_typed_tuple_member(node: &slang_solidity::backend::l1_typed_cst::TypedTupleMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_unchecked_block(node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_unicode_string_literal(_node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_unnamed_function_attribute(node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_unnamed_function_definition(node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_untyped_tuple_member(node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_user_defined_value_type_definition(node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_using_alias(node: &slang_solidity::backend::l1_typed_cst::UsingAlias, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -1036,20 +1077,25 @@ pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_version_pragma(nod
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_version_range(node: &slang_solidity::backend::l1_typed_cst::VersionRange, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_version_term(node: &slang_solidity::backend::l1_typed_cst::VersionTerm, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_while_statement(node: &slang_solidity::backend::l1_typed_cst::WhileStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
-pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_assignment_operator(_node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_assignment_operator(node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_block(node: &slang_solidity::backend::l1_typed_cst::YulBlock, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_break_statement(node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_colon_and_equal(node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_continue_statement(node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_default_case(node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_equal_and_colon(node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_expression(node: &slang_solidity::backend::l1_typed_cst::YulExpression, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_for_statement(node: &slang_solidity::backend::l1_typed_cst::YulForStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_function_call_expression(node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_function_definition(node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_if_statement(node: &slang_solidity::backend::l1_typed_cst::YulIfStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_label(node: &slang_solidity::backend::l1_typed_cst::YulLabel, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_leave_statement(node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_literal(node: &slang_solidity::backend::l1_typed_cst::YulLiteral, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_parameters_declaration(node: &slang_solidity::backend::l1_typed_cst::YulParametersDeclaration, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_returns_declaration(node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_stack_assignment_operator(node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_stack_assignment_statement(node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_statement(node: &slang_solidity::backend::l1_typed_cst::YulStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_switch_case(node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l1_typed_cst::visitor::accept_yul_switch_statement(node: &slang_solidity::backend::l1_typed_cst::YulSwitchStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -1065,8 +1111,10 @@ pub fn slang_solidity::backend::l1_typed_cst::ArgumentsDeclaration::fmt(&self, f
 pub enum slang_solidity::backend::l1_typed_cst::ConstructorAttribute
 pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::InternalKeyword
 pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
+pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::OverrideKeyword
 pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::PayableKeyword
 pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::PublicKeyword
+pub slang_solidity::backend::l1_typed_cst::ConstructorAttribute::VirtualKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ConstructorAttribute
 pub fn slang_solidity::backend::l1_typed_cst::ConstructorAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::ContractMember
@@ -1080,6 +1128,7 @@ pub slang_solidity::backend::l1_typed_cst::ContractMember::ModifierDefinition(sl
 pub slang_solidity::backend::l1_typed_cst::ContractMember::ReceiveFunctionDefinition(slang_solidity::backend::l1_typed_cst::ReceiveFunctionDefinition)
 pub slang_solidity::backend::l1_typed_cst::ContractMember::StateVariableDefinition(slang_solidity::backend::l1_typed_cst::StateVariableDefinition)
 pub slang_solidity::backend::l1_typed_cst::ContractMember::StructDefinition(slang_solidity::backend::l1_typed_cst::StructDefinition)
+pub slang_solidity::backend::l1_typed_cst::ContractMember::UnnamedFunctionDefinition(slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition)
 pub slang_solidity::backend::l1_typed_cst::ContractMember::UserDefinedValueTypeDefinition(slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition)
 pub slang_solidity::backend::l1_typed_cst::ContractMember::UsingDirective(slang_solidity::backend::l1_typed_cst::UsingDirective)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ContractMember
@@ -1092,6 +1141,7 @@ pub fn slang_solidity::backend::l1_typed_cst::ContractSpecifier::fmt(&self, f: &
 pub enum slang_solidity::backend::l1_typed_cst::ElementaryType
 pub slang_solidity::backend::l1_typed_cst::ElementaryType::AddressType(slang_solidity::backend::l1_typed_cst::AddressType)
 pub slang_solidity::backend::l1_typed_cst::ElementaryType::BoolKeyword
+pub slang_solidity::backend::l1_typed_cst::ElementaryType::ByteKeyword
 pub slang_solidity::backend::l1_typed_cst::ElementaryType::BytesKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l1_typed_cst::ElementaryType::FixedKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l1_typed_cst::ElementaryType::IntKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
@@ -1164,6 +1214,7 @@ pub slang_solidity::backend::l1_typed_cst::ForStatementInitialization::VariableD
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ForStatementInitialization
 pub fn slang_solidity::backend::l1_typed_cst::ForStatementInitialization::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::FunctionAttribute
+pub slang_solidity::backend::l1_typed_cst::FunctionAttribute::ConstantKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionAttribute::ExternalKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionAttribute::InternalKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
@@ -1188,6 +1239,7 @@ pub slang_solidity::backend::l1_typed_cst::FunctionName::ReceiveKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::FunctionName
 pub fn slang_solidity::backend::l1_typed_cst::FunctionName::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::FunctionTypeAttribute
+pub slang_solidity::backend::l1_typed_cst::FunctionTypeAttribute::ConstantKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionTypeAttribute::ExternalKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionTypeAttribute::InternalKeyword
 pub slang_solidity::backend::l1_typed_cst::FunctionTypeAttribute::PayableKeyword
@@ -1221,12 +1273,15 @@ pub fn slang_solidity::backend::l1_typed_cst::ModifierAttribute::fmt(&self, f: &
 pub enum slang_solidity::backend::l1_typed_cst::NumberUnit
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::DaysKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::EtherKeyword
+pub slang_solidity::backend::l1_typed_cst::NumberUnit::FinneyKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::GweiKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::HoursKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::MinutesKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::SecondsKeyword
+pub slang_solidity::backend::l1_typed_cst::NumberUnit::SzaboKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::WeeksKeyword
 pub slang_solidity::backend::l1_typed_cst::NumberUnit::WeiKeyword
+pub slang_solidity::backend::l1_typed_cst::NumberUnit::YearsKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::NumberUnit
 pub fn slang_solidity::backend::l1_typed_cst::NumberUnit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::Pragma
@@ -1281,6 +1336,7 @@ pub slang_solidity::backend::l1_typed_cst::Statement::ForStatement(slang_solidit
 pub slang_solidity::backend::l1_typed_cst::Statement::IfStatement(slang_solidity::backend::l1_typed_cst::IfStatement)
 pub slang_solidity::backend::l1_typed_cst::Statement::ReturnStatement(slang_solidity::backend::l1_typed_cst::ReturnStatement)
 pub slang_solidity::backend::l1_typed_cst::Statement::RevertStatement(slang_solidity::backend::l1_typed_cst::RevertStatement)
+pub slang_solidity::backend::l1_typed_cst::Statement::ThrowStatement(slang_solidity::backend::l1_typed_cst::ThrowStatement)
 pub slang_solidity::backend::l1_typed_cst::Statement::TryStatement(slang_solidity::backend::l1_typed_cst::TryStatement)
 pub slang_solidity::backend::l1_typed_cst::Statement::TupleDeconstructionStatement(slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatement)
 pub slang_solidity::backend::l1_typed_cst::Statement::UncheckedBlock(slang_solidity::backend::l1_typed_cst::UncheckedBlock)
@@ -1295,7 +1351,9 @@ pub slang_solidity::backend::l1_typed_cst::StorageLocation::StorageKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StorageLocation
 pub fn slang_solidity::backend::l1_typed_cst::StorageLocation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::StringExpression
+pub slang_solidity::backend::l1_typed_cst::StringExpression::HexStringLiteral(slang_solidity::backend::l1_typed_cst::HexStringLiteral)
 pub slang_solidity::backend::l1_typed_cst::StringExpression::HexStringLiterals(slang_solidity::backend::l1_typed_cst::HexStringLiterals)
+pub slang_solidity::backend::l1_typed_cst::StringExpression::StringLiteral(slang_solidity::backend::l1_typed_cst::StringLiteral)
 pub slang_solidity::backend::l1_typed_cst::StringExpression::StringLiterals(slang_solidity::backend::l1_typed_cst::StringLiterals)
 pub slang_solidity::backend::l1_typed_cst::StringExpression::UnicodeStringLiterals(slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StringExpression
@@ -1323,6 +1381,18 @@ pub slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral::DoubleQuotedUni
 pub slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral::SingleQuotedUnicodeStringLiteral(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
 pub fn slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::ConstantKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::ExternalKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::InternalKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::PayableKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::PrivateKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::PublicKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::PureKeyword
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::ViewKeyword
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::UsingClause
 pub slang_solidity::backend::l1_typed_cst::UsingClause::IdentifierPath(slang_solidity::backend::l1_typed_cst::IdentifierPath)
 pub slang_solidity::backend::l1_typed_cst::UsingClause::UsingDeconstruction(slang_solidity::backend::l1_typed_cst::UsingDeconstruction)
@@ -1353,6 +1423,7 @@ impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UsingTarget
 pub fn slang_solidity::backend::l1_typed_cst::UsingTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::VariableDeclarationType
 pub slang_solidity::backend::l1_typed_cst::VariableDeclarationType::TypeName(slang_solidity::backend::l1_typed_cst::TypeName)
+pub slang_solidity::backend::l1_typed_cst::VariableDeclarationType::VarKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::VariableDeclarationType
 pub fn slang_solidity::backend::l1_typed_cst::VariableDeclarationType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::VersionExpression
@@ -1378,6 +1449,7 @@ impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::VersionOperator
 pub fn slang_solidity::backend::l1_typed_cst::VersionOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub slang_solidity::backend::l1_typed_cst::YulAssignmentOperator::ColonEqual
+pub slang_solidity::backend::l1_typed_cst::YulAssignmentOperator::YulColonAndEqual(slang_solidity::backend::l1_typed_cst::YulColonAndEqual)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l1_typed_cst::YulAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::YulExpression
@@ -1395,6 +1467,11 @@ pub slang_solidity::backend::l1_typed_cst::YulLiteral::YulHexLiteral(alloc::rc::
 pub slang_solidity::backend::l1_typed_cst::YulLiteral::YulTrueKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLiteral
 pub fn slang_solidity::backend::l1_typed_cst::YulLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator::EqualColon
+pub slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator::YulEqualAndColon(slang_solidity::backend::l1_typed_cst::YulEqualAndColon)
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l1_typed_cst::YulStatement
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulBlock(slang_solidity::backend::l1_typed_cst::YulBlock)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulBreakStatement(slang_solidity::backend::l1_typed_cst::YulBreakStatement)
@@ -1403,7 +1480,9 @@ pub slang_solidity::backend::l1_typed_cst::YulStatement::YulExpression(slang_sol
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulForStatement(slang_solidity::backend::l1_typed_cst::YulForStatement)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulFunctionDefinition(slang_solidity::backend::l1_typed_cst::YulFunctionDefinition)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulIfStatement(slang_solidity::backend::l1_typed_cst::YulIfStatement)
+pub slang_solidity::backend::l1_typed_cst::YulStatement::YulLabel(slang_solidity::backend::l1_typed_cst::YulLabel)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulLeaveStatement(slang_solidity::backend::l1_typed_cst::YulLeaveStatement)
+pub slang_solidity::backend::l1_typed_cst::YulStatement::YulStackAssignmentStatement(slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulSwitchStatement(slang_solidity::backend::l1_typed_cst::YulSwitchStatement)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulVariableAssignmentStatement(slang_solidity::backend::l1_typed_cst::YulVariableAssignmentStatement)
 pub slang_solidity::backend::l1_typed_cst::YulStatement::YulVariableDeclarationStatement(slang_solidity::backend::l1_typed_cst::YulVariableDeclarationStatement)
@@ -1671,6 +1750,7 @@ pub fn slang_solidity::backend::l1_typed_cst::FunctionTypeStruct::fmt(&self, f: 
 pub struct slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct
 pub slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct::literal: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct::unit: core::option::Option<slang_solidity::backend::l1_typed_cst::NumberUnit>
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct
 pub fn slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::IfStatementStruct
@@ -1933,6 +2013,10 @@ pub slang_solidity::backend::l1_typed_cst::StructMemberStruct::node_id: metaslan
 pub slang_solidity::backend::l1_typed_cst::StructMemberStruct::type_name: slang_solidity::backend::l1_typed_cst::TypeName
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StructMemberStruct
 pub fn slang_solidity::backend::l1_typed_cst::StructMemberStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::ThrowStatementStruct
+pub slang_solidity::backend::l1_typed_cst::ThrowStatementStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ThrowStatementStruct
+pub fn slang_solidity::backend::l1_typed_cst::ThrowStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::TryStatementStruct
 pub slang_solidity::backend::l1_typed_cst::TryStatementStruct::body: slang_solidity::backend::l1_typed_cst::Block
 pub slang_solidity::backend::l1_typed_cst::TryStatementStruct::catch_clauses: slang_solidity::backend::l1_typed_cst::CatchClauses
@@ -1950,6 +2034,7 @@ pub struct slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementSt
 pub slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::elements: slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements
 pub slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::expression: slang_solidity::backend::l1_typed_cst::Expression
 pub slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::var_keyword: core::option::Option<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::TupleExpressionStruct
@@ -1979,6 +2064,13 @@ pub slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct::block: slang_so
 pub slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct
 pub fn slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::attributes: slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::body: slang_solidity::backend::l1_typed_cst::FunctionBody
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::parameters: slang_solidity::backend::l1_typed_cst::ParametersDeclaration
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct
+pub fn slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::UntypedTupleMemberStruct
 pub slang_solidity::backend::l1_typed_cst::UntypedTupleMemberStruct::name: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l1_typed_cst::UntypedTupleMemberStruct::node_id: metaslang_cst::nodes::NodeId
@@ -2059,6 +2151,10 @@ pub struct slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct
 pub slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct
+pub slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct
 pub slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct
@@ -2068,6 +2164,10 @@ pub slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct::body: slang_sol
 pub slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct
+pub slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::YulForStatementStruct
 pub slang_solidity::backend::l1_typed_cst::YulForStatementStruct::body: slang_solidity::backend::l1_typed_cst::YulBlock
 pub slang_solidity::backend::l1_typed_cst::YulForStatementStruct::condition: slang_solidity::backend::l1_typed_cst::YulExpression
@@ -2096,6 +2196,11 @@ pub slang_solidity::backend::l1_typed_cst::YulIfStatementStruct::condition: slan
 pub slang_solidity::backend::l1_typed_cst::YulIfStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulIfStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulIfStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::YulLabelStruct
+pub slang_solidity::backend::l1_typed_cst::YulLabelStruct::label: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+pub slang_solidity::backend::l1_typed_cst::YulLabelStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLabelStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulLabelStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct
 pub slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct
@@ -2110,6 +2215,12 @@ pub slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct::node_id:
 pub slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct::variables: slang_solidity::backend::l1_typed_cst::YulVariableNames
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct
+pub slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct::assignment: slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct::variable: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l1_typed_cst::YulSwitchStatementStruct
 pub slang_solidity::backend::l1_typed_cst::YulSwitchStatementStruct::cases: slang_solidity::backend::l1_typed_cst::YulSwitchCases
 pub slang_solidity::backend::l1_typed_cst::YulSwitchStatementStruct::expression: slang_solidity::backend::l1_typed_cst::YulExpression
@@ -2260,6 +2371,7 @@ pub type slang_solidity::backend::l1_typed_cst::StringLiterals = alloc::vec::Vec
 pub type slang_solidity::backend::l1_typed_cst::StructDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::StructDefinitionStruct>
 pub type slang_solidity::backend::l1_typed_cst::StructMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::StructMemberStruct>
 pub type slang_solidity::backend::l1_typed_cst::StructMembers = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::StructMember>
+pub type slang_solidity::backend::l1_typed_cst::ThrowStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::ThrowStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::TryStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TryStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElementStruct>
 pub type slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement>
@@ -2271,6 +2383,8 @@ pub type slang_solidity::backend::l1_typed_cst::TypeExpression = alloc::rc::Rc<s
 pub type slang_solidity::backend::l1_typed_cst::TypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TypedTupleMemberStruct>
 pub type slang_solidity::backend::l1_typed_cst::UncheckedBlock = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct>
 pub type slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral>
+pub type slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute>
+pub type slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct>
 pub type slang_solidity::backend::l1_typed_cst::UntypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UntypedTupleMemberStruct>
 pub type slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinitionStruct>
 pub type slang_solidity::backend::l1_typed_cst::UsingAlias = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UsingAliasStruct>
@@ -2289,18 +2403,22 @@ pub type slang_solidity::backend::l1_typed_cst::WhileStatement = alloc::rc::Rc<s
 pub type slang_solidity::backend::l1_typed_cst::YulArguments = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulExpression>
 pub type slang_solidity::backend::l1_typed_cst::YulBlock = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulBlockStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulBreakStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct>
+pub type slang_solidity::backend::l1_typed_cst::YulColonAndEqual = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulContinueStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulDefaultCase = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct>
+pub type slang_solidity::backend::l1_typed_cst::YulEqualAndColon = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulForStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulForStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulFunctionCallExpressionStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulFunctionDefinitionStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulIfStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulIfStatementStruct>
+pub type slang_solidity::backend::l1_typed_cst::YulLabel = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulLabelStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulLeaveStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulParameters = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l1_typed_cst::YulParametersDeclaration = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulParametersDeclarationStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulPath = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l1_typed_cst::YulPaths = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulPath>
 pub type slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct>
+pub type slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct>
 pub type slang_solidity::backend::l1_typed_cst::YulStatements = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulStatement>
 pub type slang_solidity::backend::l1_typed_cst::YulSwitchCases = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulSwitchCase>
 pub type slang_solidity::backend::l1_typed_cst::YulSwitchStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulSwitchStatementStruct>
@@ -2459,6 +2577,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_string_
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_struct_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_struct_member(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructMember, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_struct_members(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::StructMembers, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_throw_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::ThrowStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_try_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TryStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_tuple_deconstruction_element(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_tuple_deconstruction_elements(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements, alloc::string::String>
@@ -2473,6 +2592,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_typed_t
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unchecked_block(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UncheckedBlock, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unicode_string_literal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unicode_string_literals(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unnamed_function_attribute(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unnamed_function_attributes(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_unnamed_function_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_untyped_tuple_member(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UntypedTupleMember, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_user_defined_value_type_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_using_alias(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::UsingAlias, alloc::string::String>
@@ -2499,13 +2621,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_arg
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_assignment_operator(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_block(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulBlock, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_break_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulBreakStatement, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_colon_and_equal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulColonAndEqual, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_continue_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulContinueStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_default_case(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulDefaultCase, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_equal_and_colon(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulEqualAndColon, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_expression(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulExpression, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_for_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulForStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_function_call_expression(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_function_definition(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulFunctionDefinition, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_if_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulIfStatement, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_label(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLabel, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_leave_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLeaveStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_literal(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulLiteral, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_parameters(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulParameters, alloc::string::String>
@@ -2513,6 +2638,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_par
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_path(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulPath, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_paths(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulPaths, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_returns_declaration(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_stack_assignment_operator(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator, alloc::string::String>
+pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_stack_assignment_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_statement(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStatement, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_statements(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulStatements, alloc::string::String>
 pub fn slang_solidity::backend::l2_flat_contracts::input::builder::build_yul_switch_case(node: &alloc::rc::Rc<slang_solidity::cst::NonterminalNode>) -> core::result::Result<slang_solidity::backend::l1_typed_cst::YulSwitchCase, alloc::string::String>
@@ -2555,6 +2682,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::de
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleMember) -> slang_solidity::backend::l1_typed_cst::TupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_type_name(&mut self, source: &slang_solidity::backend::l1_typed_cst::TypeName) -> slang_solidity::backend::l1_typed_cst::TypeName
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_using_clause(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingClause) -> slang_solidity::backend::l1_typed_cst::UsingClause
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_using_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingOperator) -> slang_solidity::backend::l1_typed_cst::UsingOperator
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_using_target(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingTarget) -> slang_solidity::backend::l1_typed_cst::UsingTarget
@@ -2565,6 +2693,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::de
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l1_typed_cst::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l1_typed_cst::YulLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l1_typed_cst::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::default_rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l1_typed_cst::YulSwitchCase
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_abicoder_pragma(&mut self, source: &slang_solidity::backend::l1_typed_cst::AbicoderPragma) -> slang_solidity::backend::l1_typed_cst::AbicoderPragma
@@ -2713,6 +2842,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::re
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_struct_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructDefinition) -> slang_solidity::backend::l1_typed_cst::StructDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_struct_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMember) -> slang_solidity::backend::l1_typed_cst::StructMember
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_struct_members(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMembers) -> slang_solidity::backend::l1_typed_cst::StructMembers
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_throw_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::ThrowStatement) -> slang_solidity::backend::l1_typed_cst::ThrowStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_try_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::TryStatement) -> slang_solidity::backend::l1_typed_cst::TryStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_tuple_deconstruction_element(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement) -> slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_tuple_deconstruction_elements(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements) -> slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements
@@ -2727,6 +2857,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::re
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unchecked_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::UncheckedBlock) -> slang_solidity::backend::l1_typed_cst::UncheckedBlock
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unicode_string_literals(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals) -> slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unnamed_function_attributes(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_unnamed_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition) -> slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_untyped_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember) -> slang_solidity::backend::l1_typed_cst::UntypedTupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_user_defined_value_type_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition) -> slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_using_alias(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingAlias) -> slang_solidity::backend::l1_typed_cst::UsingAlias
@@ -2753,13 +2886,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::re
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBlock) -> slang_solidity::backend::l1_typed_cst::YulBlock
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_break_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBreakStatement) -> slang_solidity::backend::l1_typed_cst::YulBreakStatement
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_colon_and_equal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual) -> slang_solidity::backend::l1_typed_cst::YulColonAndEqual
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_continue_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulContinueStatement) -> slang_solidity::backend::l1_typed_cst::YulContinueStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_default_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulDefaultCase) -> slang_solidity::backend::l1_typed_cst::YulDefaultCase
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_equal_and_colon(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon) -> slang_solidity::backend::l1_typed_cst::YulEqualAndColon
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l1_typed_cst::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_for_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulForStatement) -> slang_solidity::backend::l1_typed_cst::YulForStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_function_call_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression) -> slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition) -> slang_solidity::backend::l1_typed_cst::YulFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_if_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulIfStatement) -> slang_solidity::backend::l1_typed_cst::YulIfStatement
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_label(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLabel) -> slang_solidity::backend::l1_typed_cst::YulLabel
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_leave_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement) -> slang_solidity::backend::l1_typed_cst::YulLeaveStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l1_typed_cst::YulLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_parameters(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulParameters) -> slang_solidity::backend::l1_typed_cst::YulParameters
@@ -2767,6 +2903,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::re
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_path(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPath) -> slang_solidity::backend::l1_typed_cst::YulPath
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_paths(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPaths) -> slang_solidity::backend::l1_typed_cst::YulPaths
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_returns_declaration(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration) -> slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_stack_assignment_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement) -> slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l1_typed_cst::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_statements(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatements) -> slang_solidity::backend::l1_typed_cst::YulStatements
 pub fn slang_solidity::backend::l2_flat_contracts::input::rewriter::Rewriter::rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l1_typed_cst::YulSwitchCase
@@ -2926,6 +3064,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::ente
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_struct_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_struct_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructMember) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_struct_members(&mut self, _items: &slang_solidity::backend::l1_typed_cst::StructMembers) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_throw_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::ThrowStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_try_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TryStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements) -> bool
@@ -2940,6 +3079,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::ente
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unchecked_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_using_alias(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UsingAlias) -> bool
@@ -2966,13 +3108,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::ente
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBlock) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_break_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_default_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulExpression) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_for_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulForStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_if_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulIfStatement) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_label(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLabel) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_parameters(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulParameters) -> bool
@@ -2980,6 +3125,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::ente
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_path(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPath) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_paths(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPaths) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_statements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulStatements) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::enter_yul_switch_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> bool
@@ -3136,6 +3283,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leav
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_struct_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_struct_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::StructMember)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_struct_members(&mut self, _items: &slang_solidity::backend::l1_typed_cst::StructMembers)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_throw_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::ThrowStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_try_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TryStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements)
@@ -3150,6 +3298,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leav
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unchecked_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_using_alias(&mut self, _node: &slang_solidity::backend::l1_typed_cst::UsingAlias)
@@ -3176,13 +3327,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leav
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_block(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBlock)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_break_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_default_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulExpression)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_for_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulForStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_function_definition(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_if_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulIfStatement)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_label(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLabel)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_literal(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulLiteral)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_parameters(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulParameters)
@@ -3190,6 +3344,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leav
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_path(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPath)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_paths(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulPaths)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_statement(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_statements(&mut self, _items: &slang_solidity::backend::l1_typed_cst::YulStatements)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::Visitor::leave_yul_switch_case(&mut self, _node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase)
@@ -3315,6 +3471,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_string
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_string_literal(_node: &slang_solidity::backend::l1_typed_cst::StringLiteral, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_struct_definition(node: &slang_solidity::backend::l1_typed_cst::StructDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_struct_member(node: &slang_solidity::backend::l1_typed_cst::StructMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_throw_statement(node: &slang_solidity::backend::l1_typed_cst::ThrowStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_try_statement(node: &slang_solidity::backend::l1_typed_cst::TryStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_tuple_deconstruction_element(node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_tuple_deconstruction_statement(node: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -3326,6 +3483,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_type_n
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_typed_tuple_member(node: &slang_solidity::backend::l1_typed_cst::TypedTupleMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_unchecked_block(node: &slang_solidity::backend::l1_typed_cst::UncheckedBlock, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_unicode_string_literal(_node: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_unnamed_function_attribute(node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_unnamed_function_definition(node: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_untyped_tuple_member(node: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_user_defined_value_type_definition(node: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_using_alias(node: &slang_solidity::backend::l1_typed_cst::UsingAlias, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -3345,20 +3504,25 @@ pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_versio
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_version_range(node: &slang_solidity::backend::l1_typed_cst::VersionRange, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_version_term(node: &slang_solidity::backend::l1_typed_cst::VersionTerm, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_while_statement(node: &slang_solidity::backend::l1_typed_cst::WhileStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
-pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_assignment_operator(_node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, _visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_assignment_operator(node: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_block(node: &slang_solidity::backend::l1_typed_cst::YulBlock, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_break_statement(node: &slang_solidity::backend::l1_typed_cst::YulBreakStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_colon_and_equal(node: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_continue_statement(node: &slang_solidity::backend::l1_typed_cst::YulContinueStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_default_case(node: &slang_solidity::backend::l1_typed_cst::YulDefaultCase, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_equal_and_colon(node: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_expression(node: &slang_solidity::backend::l1_typed_cst::YulExpression, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_for_statement(node: &slang_solidity::backend::l1_typed_cst::YulForStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_function_call_expression(node: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_function_definition(node: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_if_statement(node: &slang_solidity::backend::l1_typed_cst::YulIfStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_label(node: &slang_solidity::backend::l1_typed_cst::YulLabel, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_leave_statement(node: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_literal(node: &slang_solidity::backend::l1_typed_cst::YulLiteral, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_parameters_declaration(node: &slang_solidity::backend::l1_typed_cst::YulParametersDeclaration, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_returns_declaration(node: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_stack_assignment_operator(node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_stack_assignment_statement(node: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_statement(node: &slang_solidity::backend::l1_typed_cst::YulStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_switch_case(node: &slang_solidity::backend::l1_typed_cst::YulSwitchCase, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::input::visitor::accept_yul_switch_statement(node: &slang_solidity::backend::l1_typed_cst::YulSwitchStatement, visitor: &mut impl slang_solidity::backend::l1_typed_cst::visitor::Visitor)
@@ -3374,8 +3538,10 @@ pub fn slang_solidity::backend::l1_typed_cst::ArgumentsDeclaration::fmt(&self, f
 pub enum slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute
 pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
+pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::OverrideKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::PayableKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::PublicKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::ConstructorAttribute::VirtualKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ConstructorAttribute
 pub fn slang_solidity::backend::l1_typed_cst::ConstructorAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::ContractMember
@@ -3389,6 +3555,7 @@ pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::ModifierD
 pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::ReceiveFunctionDefinition(slang_solidity::backend::l1_typed_cst::ReceiveFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::StateVariableDefinition(slang_solidity::backend::l1_typed_cst::StateVariableDefinition)
 pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::StructDefinition(slang_solidity::backend::l1_typed_cst::StructDefinition)
+pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::UnnamedFunctionDefinition(slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::UserDefinedValueTypeDefinition(slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition)
 pub slang_solidity::backend::l2_flat_contracts::input::ContractMember::UsingDirective(slang_solidity::backend::l1_typed_cst::UsingDirective)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ContractMember
@@ -3401,6 +3568,7 @@ pub fn slang_solidity::backend::l1_typed_cst::ContractSpecifier::fmt(&self, f: &
 pub enum slang_solidity::backend::l2_flat_contracts::input::ElementaryType
 pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::AddressType(slang_solidity::backend::l1_typed_cst::AddressType)
 pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::BoolKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::ByteKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::BytesKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::FixedKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l2_flat_contracts::input::ElementaryType::IntKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
@@ -3473,6 +3641,7 @@ pub slang_solidity::backend::l2_flat_contracts::input::ForStatementInitializatio
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ForStatementInitialization
 pub fn slang_solidity::backend::l1_typed_cst::ForStatementInitialization::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::FunctionAttribute
+pub slang_solidity::backend::l2_flat_contracts::input::FunctionAttribute::ConstantKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionAttribute::ExternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
@@ -3497,6 +3666,7 @@ pub slang_solidity::backend::l2_flat_contracts::input::FunctionName::ReceiveKeyw
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::FunctionName
 pub fn slang_solidity::backend::l1_typed_cst::FunctionName::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::FunctionTypeAttribute
+pub slang_solidity::backend::l2_flat_contracts::input::FunctionTypeAttribute::ConstantKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionTypeAttribute::ExternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionTypeAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::FunctionTypeAttribute::PayableKeyword
@@ -3530,12 +3700,15 @@ pub fn slang_solidity::backend::l1_typed_cst::ModifierAttribute::fmt(&self, f: &
 pub enum slang_solidity::backend::l2_flat_contracts::input::NumberUnit
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::DaysKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::EtherKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::FinneyKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::GweiKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::HoursKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::MinutesKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::SecondsKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::SzaboKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::WeeksKeyword
 pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::WeiKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::NumberUnit::YearsKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::NumberUnit
 pub fn slang_solidity::backend::l1_typed_cst::NumberUnit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::Pragma
@@ -3590,6 +3763,7 @@ pub slang_solidity::backend::l2_flat_contracts::input::Statement::ForStatement(s
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::IfStatement(slang_solidity::backend::l1_typed_cst::IfStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::ReturnStatement(slang_solidity::backend::l1_typed_cst::ReturnStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::RevertStatement(slang_solidity::backend::l1_typed_cst::RevertStatement)
+pub slang_solidity::backend::l2_flat_contracts::input::Statement::ThrowStatement(slang_solidity::backend::l1_typed_cst::ThrowStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::TryStatement(slang_solidity::backend::l1_typed_cst::TryStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::TupleDeconstructionStatement(slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::Statement::UncheckedBlock(slang_solidity::backend::l1_typed_cst::UncheckedBlock)
@@ -3604,7 +3778,9 @@ pub slang_solidity::backend::l2_flat_contracts::input::StorageLocation::StorageK
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StorageLocation
 pub fn slang_solidity::backend::l1_typed_cst::StorageLocation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::StringExpression
+pub slang_solidity::backend::l2_flat_contracts::input::StringExpression::HexStringLiteral(slang_solidity::backend::l1_typed_cst::HexStringLiteral)
 pub slang_solidity::backend::l2_flat_contracts::input::StringExpression::HexStringLiterals(slang_solidity::backend::l1_typed_cst::HexStringLiterals)
+pub slang_solidity::backend::l2_flat_contracts::input::StringExpression::StringLiteral(slang_solidity::backend::l1_typed_cst::StringLiteral)
 pub slang_solidity::backend::l2_flat_contracts::input::StringExpression::StringLiterals(slang_solidity::backend::l1_typed_cst::StringLiterals)
 pub slang_solidity::backend::l2_flat_contracts::input::StringExpression::UnicodeStringLiterals(slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StringExpression
@@ -3632,6 +3808,18 @@ pub slang_solidity::backend::l2_flat_contracts::input::UnicodeStringLiteral::Dou
 pub slang_solidity::backend::l2_flat_contracts::input::UnicodeStringLiteral::SingleQuotedUnicodeStringLiteral(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral
 pub fn slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::ConstantKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::ExternalKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::InternalKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::ModifierInvocation(slang_solidity::backend::l1_typed_cst::ModifierInvocation)
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::PayableKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::PrivateKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::PublicKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::PureKeyword
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttribute::ViewKeyword
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::UsingClause
 pub slang_solidity::backend::l2_flat_contracts::input::UsingClause::IdentifierPath(slang_solidity::backend::l1_typed_cst::IdentifierPath)
 pub slang_solidity::backend::l2_flat_contracts::input::UsingClause::UsingDeconstruction(slang_solidity::backend::l1_typed_cst::UsingDeconstruction)
@@ -3662,6 +3850,7 @@ impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UsingTarget
 pub fn slang_solidity::backend::l1_typed_cst::UsingTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::VariableDeclarationType
 pub slang_solidity::backend::l2_flat_contracts::input::VariableDeclarationType::TypeName(slang_solidity::backend::l1_typed_cst::TypeName)
+pub slang_solidity::backend::l2_flat_contracts::input::VariableDeclarationType::VarKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::VariableDeclarationType
 pub fn slang_solidity::backend::l1_typed_cst::VariableDeclarationType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::VersionExpression
@@ -3687,6 +3876,7 @@ impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::VersionOperator
 pub fn slang_solidity::backend::l1_typed_cst::VersionOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::YulAssignmentOperator
 pub slang_solidity::backend::l2_flat_contracts::input::YulAssignmentOperator::ColonEqual
+pub slang_solidity::backend::l2_flat_contracts::input::YulAssignmentOperator::YulColonAndEqual(slang_solidity::backend::l1_typed_cst::YulColonAndEqual)
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulAssignmentOperator
 pub fn slang_solidity::backend::l1_typed_cst::YulAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::YulExpression
@@ -3704,6 +3894,11 @@ pub slang_solidity::backend::l2_flat_contracts::input::YulLiteral::YulHexLiteral
 pub slang_solidity::backend::l2_flat_contracts::input::YulLiteral::YulTrueKeyword
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLiteral
 pub fn slang_solidity::backend::l1_typed_cst::YulLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentOperator
+pub slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentOperator::EqualColon
+pub slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentOperator::YulEqualAndColon(slang_solidity::backend::l1_typed_cst::YulEqualAndColon)
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::input::YulStatement
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulBlock(slang_solidity::backend::l1_typed_cst::YulBlock)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulBreakStatement(slang_solidity::backend::l1_typed_cst::YulBreakStatement)
@@ -3712,7 +3907,9 @@ pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulExpressi
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulForStatement(slang_solidity::backend::l1_typed_cst::YulForStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulFunctionDefinition(slang_solidity::backend::l1_typed_cst::YulFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulIfStatement(slang_solidity::backend::l1_typed_cst::YulIfStatement)
+pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulLabel(slang_solidity::backend::l1_typed_cst::YulLabel)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulLeaveStatement(slang_solidity::backend::l1_typed_cst::YulLeaveStatement)
+pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulStackAssignmentStatement(slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulSwitchStatement(slang_solidity::backend::l1_typed_cst::YulSwitchStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulVariableAssignmentStatement(slang_solidity::backend::l1_typed_cst::YulVariableAssignmentStatement)
 pub slang_solidity::backend::l2_flat_contracts::input::YulStatement::YulVariableDeclarationStatement(slang_solidity::backend::l1_typed_cst::YulVariableDeclarationStatement)
@@ -3980,6 +4177,7 @@ pub fn slang_solidity::backend::l1_typed_cst::FunctionTypeStruct::fmt(&self, f: 
 pub struct slang_solidity::backend::l2_flat_contracts::input::HexNumberExpressionStruct
 pub slang_solidity::backend::l2_flat_contracts::input::HexNumberExpressionStruct::literal: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l2_flat_contracts::input::HexNumberExpressionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::input::HexNumberExpressionStruct::unit: core::option::Option<slang_solidity::backend::l1_typed_cst::NumberUnit>
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct
 pub fn slang_solidity::backend::l1_typed_cst::HexNumberExpressionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::IfStatementStruct
@@ -4242,6 +4440,10 @@ pub slang_solidity::backend::l2_flat_contracts::input::StructMemberStruct::node_
 pub slang_solidity::backend::l2_flat_contracts::input::StructMemberStruct::type_name: slang_solidity::backend::l1_typed_cst::TypeName
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::StructMemberStruct
 pub fn slang_solidity::backend::l1_typed_cst::StructMemberStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::ThrowStatementStruct
+pub slang_solidity::backend::l2_flat_contracts::input::ThrowStatementStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::ThrowStatementStruct
+pub fn slang_solidity::backend::l1_typed_cst::ThrowStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::TryStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::input::TryStatementStruct::body: slang_solidity::backend::l1_typed_cst::Block
 pub slang_solidity::backend::l2_flat_contracts::input::TryStatementStruct::catch_clauses: slang_solidity::backend::l1_typed_cst::CatchClauses
@@ -4259,6 +4461,7 @@ pub struct slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructio
 pub slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionStatementStruct::elements: slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements
 pub slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionStatementStruct::expression: slang_solidity::backend::l1_typed_cst::Expression
 pub slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionStatementStruct::var_keyword: core::option::Option<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::TupleDeconstructionStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::TupleExpressionStruct
@@ -4288,6 +4491,13 @@ pub slang_solidity::backend::l2_flat_contracts::input::UncheckedBlockStruct::blo
 pub slang_solidity::backend::l2_flat_contracts::input::UncheckedBlockStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct
 pub fn slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinitionStruct
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinitionStruct::attributes: slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinitionStruct::body: slang_solidity::backend::l1_typed_cst::FunctionBody
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinitionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinitionStruct::parameters: slang_solidity::backend::l1_typed_cst::ParametersDeclaration
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct
+pub fn slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::UntypedTupleMemberStruct
 pub slang_solidity::backend::l2_flat_contracts::input::UntypedTupleMemberStruct::name: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l2_flat_contracts::input::UntypedTupleMemberStruct::node_id: metaslang_cst::nodes::NodeId
@@ -4368,6 +4578,10 @@ pub struct slang_solidity::backend::l2_flat_contracts::input::YulBreakStatementS
 pub slang_solidity::backend::l2_flat_contracts::input::YulBreakStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::YulColonAndEqualStruct
+pub slang_solidity::backend::l2_flat_contracts::input::YulColonAndEqualStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::YulContinueStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::input::YulContinueStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct
@@ -4377,6 +4591,10 @@ pub slang_solidity::backend::l2_flat_contracts::input::YulDefaultCaseStruct::bod
 pub slang_solidity::backend::l2_flat_contracts::input::YulDefaultCaseStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::YulEqualAndColonStruct
+pub slang_solidity::backend::l2_flat_contracts::input::YulEqualAndColonStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::YulForStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::input::YulForStatementStruct::body: slang_solidity::backend::l1_typed_cst::YulBlock
 pub slang_solidity::backend::l2_flat_contracts::input::YulForStatementStruct::condition: slang_solidity::backend::l1_typed_cst::YulExpression
@@ -4405,6 +4623,11 @@ pub slang_solidity::backend::l2_flat_contracts::input::YulIfStatementStruct::con
 pub slang_solidity::backend::l2_flat_contracts::input::YulIfStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulIfStatementStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulIfStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::YulLabelStruct
+pub slang_solidity::backend::l2_flat_contracts::input::YulLabelStruct::label: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+pub slang_solidity::backend::l2_flat_contracts::input::YulLabelStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLabelStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulLabelStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::YulLeaveStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::input::YulLeaveStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct
@@ -4419,6 +4642,12 @@ pub slang_solidity::backend::l2_flat_contracts::input::YulReturnsDeclarationStru
 pub slang_solidity::backend::l2_flat_contracts::input::YulReturnsDeclarationStruct::variables: slang_solidity::backend::l1_typed_cst::YulVariableNames
 impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct
 pub fn slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentStatementStruct
+pub slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentStatementStruct::assignment: slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator
+pub slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentStatementStruct::variable: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+impl core::fmt::Debug for slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct
+pub fn slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::input::YulSwitchStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::input::YulSwitchStatementStruct::cases: slang_solidity::backend::l1_typed_cst::YulSwitchCases
 pub slang_solidity::backend::l2_flat_contracts::input::YulSwitchStatementStruct::expression: slang_solidity::backend::l1_typed_cst::YulExpression
@@ -4569,6 +4798,7 @@ pub type slang_solidity::backend::l2_flat_contracts::input::StringLiterals = all
 pub type slang_solidity::backend::l2_flat_contracts::input::StructDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::StructDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::StructMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::StructMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::StructMembers = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::StructMember>
+pub type slang_solidity::backend::l2_flat_contracts::input::ThrowStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::ThrowStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::TryStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TryStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionElement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::TupleDeconstructionElements = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement>
@@ -4580,6 +4810,8 @@ pub type slang_solidity::backend::l2_flat_contracts::input::TypeExpression = all
 pub type slang_solidity::backend::l2_flat_contracts::input::TypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::TypedTupleMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::UncheckedBlock = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UncheckedBlockStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::UnicodeStringLiterals = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral>
+pub type slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionAttributes = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute>
+pub type slang_solidity::backend::l2_flat_contracts::input::UnnamedFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::UntypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UntypedTupleMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::UserDefinedValueTypeDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::UsingAlias = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::UsingAliasStruct>
@@ -4598,18 +4830,22 @@ pub type slang_solidity::backend::l2_flat_contracts::input::WhileStatement = all
 pub type slang_solidity::backend::l2_flat_contracts::input::YulArguments = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulExpression>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulBlock = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulBlockStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulBreakStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulBreakStatementStruct>
+pub type slang_solidity::backend::l2_flat_contracts::input::YulColonAndEqual = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulColonAndEqualStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulContinueStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulContinueStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulDefaultCase = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulDefaultCaseStruct>
+pub type slang_solidity::backend::l2_flat_contracts::input::YulEqualAndColon = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulEqualAndColonStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulForStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulForStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulFunctionCallExpression = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulFunctionCallExpressionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulFunctionDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulIfStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulIfStatementStruct>
+pub type slang_solidity::backend::l2_flat_contracts::input::YulLabel = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulLabelStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulLeaveStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulLeaveStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulParameters = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulParametersDeclaration = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulParametersDeclarationStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulPath = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulPaths = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulPath>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulReturnsDeclaration = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulReturnsDeclarationStruct>
+pub type slang_solidity::backend::l2_flat_contracts::input::YulStackAssignmentStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulStatements = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulStatement>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulSwitchCases = alloc::vec::Vec<slang_solidity::backend::l1_typed_cst::YulSwitchCase>
 pub type slang_solidity::backend::l2_flat_contracts::input::YulSwitchStatement = alloc::rc::Rc<slang_solidity::backend::l1_typed_cst::YulSwitchStatementStruct>
@@ -4650,6 +4886,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_r
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_tuple_member(&mut self, source: &slang_solidity::backend::l2_flat_contracts::TupleMember) -> slang_solidity::backend::l2_flat_contracts::TupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_type_name(&mut self, source: &slang_solidity::backend::l2_flat_contracts::TypeName) -> slang_solidity::backend::l2_flat_contracts::TypeName
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_using_clause(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UsingClause) -> slang_solidity::backend::l2_flat_contracts::UsingClause
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_using_operator(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UsingOperator) -> slang_solidity::backend::l2_flat_contracts::UsingOperator
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_using_target(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UsingTarget) -> slang_solidity::backend::l2_flat_contracts::UsingTarget
@@ -4660,6 +4897,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_r
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulExpression) -> slang_solidity::backend::l2_flat_contracts::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulLiteral) -> slang_solidity::backend::l2_flat_contracts::YulLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStatement) -> slang_solidity::backend::l2_flat_contracts::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::default_rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulSwitchCase) -> slang_solidity::backend::l2_flat_contracts::YulSwitchCase
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_abicoder_pragma(&mut self, source: &slang_solidity::backend::l2_flat_contracts::AbicoderPragma) -> slang_solidity::backend::l2_flat_contracts::AbicoderPragma
@@ -4807,6 +5045,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_s
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_struct_definition(&mut self, source: &slang_solidity::backend::l2_flat_contracts::StructDefinition) -> slang_solidity::backend::l2_flat_contracts::StructDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_struct_member(&mut self, source: &slang_solidity::backend::l2_flat_contracts::StructMember) -> slang_solidity::backend::l2_flat_contracts::StructMember
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_struct_members(&mut self, source: &slang_solidity::backend::l2_flat_contracts::StructMembers) -> slang_solidity::backend::l2_flat_contracts::StructMembers
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_throw_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::ThrowStatement) -> slang_solidity::backend::l2_flat_contracts::ThrowStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_try_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::TryStatement) -> slang_solidity::backend::l2_flat_contracts::TryStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_tuple_deconstruction_element(&mut self, source: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement) -> slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_tuple_deconstruction_elements(&mut self, source: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements) -> slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements
@@ -4821,6 +5060,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_t
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unchecked_block(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UncheckedBlock) -> slang_solidity::backend::l2_flat_contracts::UncheckedBlock
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unicode_string_literal(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unicode_string_literals(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unnamed_function_attributes(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_unnamed_function_definition(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_untyped_tuple_member(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UntypedTupleMember) -> slang_solidity::backend::l2_flat_contracts::UntypedTupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_user_defined_value_type_definition(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition) -> slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_using_alias(&mut self, source: &slang_solidity::backend::l2_flat_contracts::UsingAlias) -> slang_solidity::backend::l2_flat_contracts::UsingAlias
@@ -4847,13 +5089,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_y
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_block(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulBlock) -> slang_solidity::backend::l2_flat_contracts::YulBlock
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_break_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulBreakStatement) -> slang_solidity::backend::l2_flat_contracts::YulBreakStatement
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_colon_and_equal(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulColonAndEqual) -> slang_solidity::backend::l2_flat_contracts::YulColonAndEqual
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_continue_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulContinueStatement) -> slang_solidity::backend::l2_flat_contracts::YulContinueStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_default_case(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulDefaultCase) -> slang_solidity::backend::l2_flat_contracts::YulDefaultCase
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_equal_and_colon(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulEqualAndColon) -> slang_solidity::backend::l2_flat_contracts::YulEqualAndColon
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_expression(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulExpression) -> slang_solidity::backend::l2_flat_contracts::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_for_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulForStatement) -> slang_solidity::backend::l2_flat_contracts::YulForStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_function_call_expression(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression) -> slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_function_definition(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition) -> slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_if_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulIfStatement) -> slang_solidity::backend::l2_flat_contracts::YulIfStatement
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_label(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulLabel) -> slang_solidity::backend::l2_flat_contracts::YulLabel
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_leave_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulLeaveStatement) -> slang_solidity::backend::l2_flat_contracts::YulLeaveStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_literal(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulLiteral) -> slang_solidity::backend::l2_flat_contracts::YulLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_parameters(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulParameters) -> slang_solidity::backend::l2_flat_contracts::YulParameters
@@ -4861,6 +5106,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_y
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_path(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulPath) -> slang_solidity::backend::l2_flat_contracts::YulPath
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_paths(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulPaths) -> slang_solidity::backend::l2_flat_contracts::YulPaths
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_returns_declaration(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration) -> slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_stack_assignment_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_statement(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStatement) -> slang_solidity::backend::l2_flat_contracts::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_statements(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulStatements) -> slang_solidity::backend::l2_flat_contracts::YulStatements
 pub fn slang_solidity::backend::l2_flat_contracts::rewriter::Rewriter::rewrite_yul_switch_case(&mut self, source: &slang_solidity::backend::l2_flat_contracts::YulSwitchCase) -> slang_solidity::backend::l2_flat_contracts::YulSwitchCase
@@ -4903,6 +5150,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::def
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleMember) -> slang_solidity::backend::l2_flat_contracts::TupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_type_name(&mut self, source: &slang_solidity::backend::l1_typed_cst::TypeName) -> slang_solidity::backend::l2_flat_contracts::TypeName
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_using_clause(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingClause) -> slang_solidity::backend::l2_flat_contracts::UsingClause
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_using_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingOperator) -> slang_solidity::backend::l2_flat_contracts::UsingOperator
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_using_target(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingTarget) -> slang_solidity::backend::l2_flat_contracts::UsingTarget
@@ -4913,6 +5161,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::def
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l2_flat_contracts::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l2_flat_contracts::YulLiteral
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l2_flat_contracts::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::default_transform_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l2_flat_contracts::YulSwitchCase
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_abicoder_pragma(&mut self, source: &slang_solidity::backend::l1_typed_cst::AbicoderPragma) -> slang_solidity::backend::l2_flat_contracts::AbicoderPragma
@@ -5060,6 +5309,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::tra
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_struct_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructDefinition) -> slang_solidity::backend::l2_flat_contracts::StructDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_struct_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMember) -> slang_solidity::backend::l2_flat_contracts::StructMember
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_struct_members(&mut self, source: &slang_solidity::backend::l1_typed_cst::StructMembers) -> slang_solidity::backend::l2_flat_contracts::StructMembers
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_throw_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::ThrowStatement) -> slang_solidity::backend::l2_flat_contracts::ThrowStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_try_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::TryStatement) -> slang_solidity::backend::l2_flat_contracts::TryStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_tuple_deconstruction_element(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElement) -> slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_tuple_deconstruction_elements(&mut self, source: &slang_solidity::backend::l1_typed_cst::TupleDeconstructionElements) -> slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements
@@ -5074,6 +5324,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::tra
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unchecked_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::UncheckedBlock) -> slang_solidity::backend::l2_flat_contracts::UncheckedBlock
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unicode_string_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiteral) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unicode_string_literals(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnicodeStringLiterals) -> slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unnamed_function_attribute(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttribute) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unnamed_function_attributes(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionAttributes) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_unnamed_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UnnamedFunctionDefinition) -> slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_untyped_tuple_member(&mut self, source: &slang_solidity::backend::l1_typed_cst::UntypedTupleMember) -> slang_solidity::backend::l2_flat_contracts::UntypedTupleMember
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_user_defined_value_type_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::UserDefinedValueTypeDefinition) -> slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_using_alias(&mut self, source: &slang_solidity::backend::l1_typed_cst::UsingAlias) -> slang_solidity::backend::l2_flat_contracts::UsingAlias
@@ -5100,13 +5353,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::tra
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_block(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBlock) -> slang_solidity::backend::l2_flat_contracts::YulBlock
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_break_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulBreakStatement) -> slang_solidity::backend::l2_flat_contracts::YulBreakStatement
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_colon_and_equal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulColonAndEqual) -> slang_solidity::backend::l2_flat_contracts::YulColonAndEqual
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_continue_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulContinueStatement) -> slang_solidity::backend::l2_flat_contracts::YulContinueStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_default_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulDefaultCase) -> slang_solidity::backend::l2_flat_contracts::YulDefaultCase
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_equal_and_colon(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulEqualAndColon) -> slang_solidity::backend::l2_flat_contracts::YulEqualAndColon
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulExpression) -> slang_solidity::backend::l2_flat_contracts::YulExpression
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_for_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulForStatement) -> slang_solidity::backend::l2_flat_contracts::YulForStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_function_call_expression(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionCallExpression) -> slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_function_definition(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulFunctionDefinition) -> slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_if_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulIfStatement) -> slang_solidity::backend::l2_flat_contracts::YulIfStatement
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_label(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLabel) -> slang_solidity::backend::l2_flat_contracts::YulLabel
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_leave_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLeaveStatement) -> slang_solidity::backend::l2_flat_contracts::YulLeaveStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_literal(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulLiteral) -> slang_solidity::backend::l2_flat_contracts::YulLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_parameters(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulParameters) -> slang_solidity::backend::l2_flat_contracts::YulParameters
@@ -5114,6 +5370,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::tra
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_path(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPath) -> slang_solidity::backend::l2_flat_contracts::YulPath
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_paths(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulPaths) -> slang_solidity::backend::l2_flat_contracts::YulPaths
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_returns_declaration(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulReturnsDeclaration) -> slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_stack_assignment_operator(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentOperator) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_stack_assignment_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStackAssignmentStatement) -> slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_statement(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatement) -> slang_solidity::backend::l2_flat_contracts::YulStatement
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_statements(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulStatements) -> slang_solidity::backend::l2_flat_contracts::YulStatements
 pub fn slang_solidity::backend::l2_flat_contracts::transformer::Transformer::transform_yul_switch_case(&mut self, source: &slang_solidity::backend::l1_typed_cst::YulSwitchCase) -> slang_solidity::backend::l2_flat_contracts::YulSwitchCase
@@ -5271,6 +5529,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_strin
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_struct_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::StructDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_struct_member(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::StructMember) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_struct_members(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::StructMembers) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_throw_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::ThrowStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_try_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::TryStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements) -> bool
@@ -5285,6 +5544,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_typed
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unchecked_block(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UncheckedBlock) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UntypedTupleMember) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_using_alias(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UsingAlias) -> bool
@@ -5311,13 +5573,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_a
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_block(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulBlock) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_break_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulBreakStatement) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulColonAndEqual) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulContinueStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_default_case(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulDefaultCase) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulEqualAndColon) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_expression(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulExpression) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_for_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulForStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_function_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_if_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulIfStatement) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_label(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLabel) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLeaveStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_literal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLiteral) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_parameters(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulParameters) -> bool
@@ -5325,6 +5590,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_p
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_path(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulPath) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_paths(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulPaths) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator) -> bool
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStatement) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_statements(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulStatements) -> bool
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::enter_yul_switch_case(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulSwitchCase) -> bool
@@ -5480,6 +5747,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_strin
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_struct_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::StructDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_struct_member(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::StructMember)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_struct_members(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::StructMembers)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_throw_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::ThrowStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_try_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::TryStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_tuple_deconstruction_element(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_tuple_deconstruction_elements(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements)
@@ -5494,6 +5762,9 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_typed
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unchecked_block(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UncheckedBlock)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unicode_string_literal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unicode_string_literals(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unnamed_function_attribute(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unnamed_function_attributes(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_unnamed_function_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_untyped_tuple_member(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UntypedTupleMember)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_user_defined_value_type_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_using_alias(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::UsingAlias)
@@ -5520,13 +5791,16 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_a
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_assignment_operator(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_block(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulBlock)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_break_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulBreakStatement)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_colon_and_equal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulColonAndEqual)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_continue_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulContinueStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_default_case(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulDefaultCase)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_equal_and_colon(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulEqualAndColon)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_expression(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulExpression)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_for_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulForStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_function_call_expression(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_function_definition(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_if_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulIfStatement)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_label(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLabel)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_leave_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLeaveStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_literal(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulLiteral)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_parameters(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulParameters)
@@ -5534,6 +5808,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_p
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_path(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulPath)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_paths(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulPaths)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_returns_declaration(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_stack_assignment_operator(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_stack_assignment_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_statement(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulStatement)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_statements(&mut self, _items: &slang_solidity::backend::l2_flat_contracts::YulStatements)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::Visitor::leave_yul_switch_case(&mut self, _node: &slang_solidity::backend::l2_flat_contracts::YulSwitchCase)
@@ -5659,6 +5935,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_string_expres
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_string_literal(_node: &slang_solidity::backend::l2_flat_contracts::StringLiteral, _visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_struct_definition(node: &slang_solidity::backend::l2_flat_contracts::StructDefinition, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_struct_member(node: &slang_solidity::backend::l2_flat_contracts::StructMember, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_throw_statement(node: &slang_solidity::backend::l2_flat_contracts::ThrowStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_try_statement(node: &slang_solidity::backend::l2_flat_contracts::TryStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_tuple_deconstruction_element(node: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_tuple_deconstruction_statement(node: &slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
@@ -5670,6 +5947,8 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_type_name(nod
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_typed_tuple_member(node: &slang_solidity::backend::l2_flat_contracts::TypedTupleMember, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_unchecked_block(node: &slang_solidity::backend::l2_flat_contracts::UncheckedBlock, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_unicode_string_literal(_node: &slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral, _visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_unnamed_function_attribute(node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_unnamed_function_definition(node: &slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_untyped_tuple_member(node: &slang_solidity::backend::l2_flat_contracts::UntypedTupleMember, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_user_defined_value_type_definition(node: &slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_using_alias(node: &slang_solidity::backend::l2_flat_contracts::UsingAlias, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
@@ -5689,20 +5968,25 @@ pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_version_pragm
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_version_range(node: &slang_solidity::backend::l2_flat_contracts::VersionRange, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_version_term(node: &slang_solidity::backend::l2_flat_contracts::VersionTerm, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_while_statement(node: &slang_solidity::backend::l2_flat_contracts::WhileStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
-pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_assignment_operator(_node: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator, _visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_assignment_operator(node: &slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_block(node: &slang_solidity::backend::l2_flat_contracts::YulBlock, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_break_statement(node: &slang_solidity::backend::l2_flat_contracts::YulBreakStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_colon_and_equal(node: &slang_solidity::backend::l2_flat_contracts::YulColonAndEqual, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_continue_statement(node: &slang_solidity::backend::l2_flat_contracts::YulContinueStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_default_case(node: &slang_solidity::backend::l2_flat_contracts::YulDefaultCase, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_equal_and_colon(node: &slang_solidity::backend::l2_flat_contracts::YulEqualAndColon, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_expression(node: &slang_solidity::backend::l2_flat_contracts::YulExpression, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_for_statement(node: &slang_solidity::backend::l2_flat_contracts::YulForStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_function_call_expression(node: &slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_function_definition(node: &slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_if_statement(node: &slang_solidity::backend::l2_flat_contracts::YulIfStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_label(node: &slang_solidity::backend::l2_flat_contracts::YulLabel, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_leave_statement(node: &slang_solidity::backend::l2_flat_contracts::YulLeaveStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_literal(node: &slang_solidity::backend::l2_flat_contracts::YulLiteral, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_parameters_declaration(node: &slang_solidity::backend::l2_flat_contracts::YulParametersDeclaration, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_returns_declaration(node: &slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_stack_assignment_operator(node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
+pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_stack_assignment_statement(node: &slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_statement(node: &slang_solidity::backend::l2_flat_contracts::YulStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_switch_case(node: &slang_solidity::backend::l2_flat_contracts::YulSwitchCase, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
 pub fn slang_solidity::backend::l2_flat_contracts::visitor::accept_yul_switch_statement(node: &slang_solidity::backend::l2_flat_contracts::YulSwitchStatement, visitor: &mut impl slang_solidity::backend::l2_flat_contracts::visitor::Visitor)
@@ -5718,8 +6002,10 @@ pub fn slang_solidity::backend::l2_flat_contracts::ArgumentsDeclaration::fmt(&se
 pub enum slang_solidity::backend::l2_flat_contracts::ConstructorAttribute
 pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::ModifierInvocation(slang_solidity::backend::l2_flat_contracts::ModifierInvocation)
+pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::OverrideKeyword
 pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::PayableKeyword
 pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::PublicKeyword
+pub slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::VirtualKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::ConstructorAttribute
 pub fn slang_solidity::backend::l2_flat_contracts::ConstructorAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::ContractMember
@@ -5733,6 +6019,7 @@ pub slang_solidity::backend::l2_flat_contracts::ContractMember::ModifierDefiniti
 pub slang_solidity::backend::l2_flat_contracts::ContractMember::ReceiveFunctionDefinition(slang_solidity::backend::l2_flat_contracts::ReceiveFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::ContractMember::StateVariableDefinition(slang_solidity::backend::l2_flat_contracts::StateVariableDefinition)
 pub slang_solidity::backend::l2_flat_contracts::ContractMember::StructDefinition(slang_solidity::backend::l2_flat_contracts::StructDefinition)
+pub slang_solidity::backend::l2_flat_contracts::ContractMember::UnnamedFunctionDefinition(slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::ContractMember::UserDefinedValueTypeDefinition(slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition)
 pub slang_solidity::backend::l2_flat_contracts::ContractMember::UsingDirective(slang_solidity::backend::l2_flat_contracts::UsingDirective)
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::ContractMember
@@ -5745,6 +6032,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::ContractSpecifier::fmt(&self,
 pub enum slang_solidity::backend::l2_flat_contracts::ElementaryType
 pub slang_solidity::backend::l2_flat_contracts::ElementaryType::AddressType(slang_solidity::backend::l2_flat_contracts::AddressType)
 pub slang_solidity::backend::l2_flat_contracts::ElementaryType::BoolKeyword
+pub slang_solidity::backend::l2_flat_contracts::ElementaryType::ByteKeyword
 pub slang_solidity::backend::l2_flat_contracts::ElementaryType::BytesKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l2_flat_contracts::ElementaryType::FixedKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 pub slang_solidity::backend::l2_flat_contracts::ElementaryType::IntKeyword(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
@@ -5817,6 +6105,7 @@ pub slang_solidity::backend::l2_flat_contracts::ForStatementInitialization::Vari
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::ForStatementInitialization
 pub fn slang_solidity::backend::l2_flat_contracts::ForStatementInitialization::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::FunctionAttribute
+pub slang_solidity::backend::l2_flat_contracts::FunctionAttribute::ConstantKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionAttribute::ExternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionAttribute::ModifierInvocation(slang_solidity::backend::l2_flat_contracts::ModifierInvocation)
@@ -5841,6 +6130,7 @@ pub slang_solidity::backend::l2_flat_contracts::FunctionName::ReceiveKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::FunctionName
 pub fn slang_solidity::backend::l2_flat_contracts::FunctionName::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::FunctionTypeAttribute
+pub slang_solidity::backend::l2_flat_contracts::FunctionTypeAttribute::ConstantKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionTypeAttribute::ExternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionTypeAttribute::InternalKeyword
 pub slang_solidity::backend::l2_flat_contracts::FunctionTypeAttribute::PayableKeyword
@@ -5874,12 +6164,15 @@ pub fn slang_solidity::backend::l2_flat_contracts::ModifierAttribute::fmt(&self,
 pub enum slang_solidity::backend::l2_flat_contracts::NumberUnit
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::DaysKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::EtherKeyword
+pub slang_solidity::backend::l2_flat_contracts::NumberUnit::FinneyKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::GweiKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::HoursKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::MinutesKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::SecondsKeyword
+pub slang_solidity::backend::l2_flat_contracts::NumberUnit::SzaboKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::WeeksKeyword
 pub slang_solidity::backend::l2_flat_contracts::NumberUnit::WeiKeyword
+pub slang_solidity::backend::l2_flat_contracts::NumberUnit::YearsKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::NumberUnit
 pub fn slang_solidity::backend::l2_flat_contracts::NumberUnit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::Pragma
@@ -5934,6 +6227,7 @@ pub slang_solidity::backend::l2_flat_contracts::Statement::ForStatement(slang_so
 pub slang_solidity::backend::l2_flat_contracts::Statement::IfStatement(slang_solidity::backend::l2_flat_contracts::IfStatement)
 pub slang_solidity::backend::l2_flat_contracts::Statement::ReturnStatement(slang_solidity::backend::l2_flat_contracts::ReturnStatement)
 pub slang_solidity::backend::l2_flat_contracts::Statement::RevertStatement(slang_solidity::backend::l2_flat_contracts::RevertStatement)
+pub slang_solidity::backend::l2_flat_contracts::Statement::ThrowStatement(slang_solidity::backend::l2_flat_contracts::ThrowStatement)
 pub slang_solidity::backend::l2_flat_contracts::Statement::TryStatement(slang_solidity::backend::l2_flat_contracts::TryStatement)
 pub slang_solidity::backend::l2_flat_contracts::Statement::TupleDeconstructionStatement(slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatement)
 pub slang_solidity::backend::l2_flat_contracts::Statement::UncheckedBlock(slang_solidity::backend::l2_flat_contracts::UncheckedBlock)
@@ -5948,7 +6242,9 @@ pub slang_solidity::backend::l2_flat_contracts::StorageLocation::StorageKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::StorageLocation
 pub fn slang_solidity::backend::l2_flat_contracts::StorageLocation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::StringExpression
+pub slang_solidity::backend::l2_flat_contracts::StringExpression::HexStringLiteral(slang_solidity::backend::l2_flat_contracts::HexStringLiteral)
 pub slang_solidity::backend::l2_flat_contracts::StringExpression::HexStringLiterals(slang_solidity::backend::l2_flat_contracts::HexStringLiterals)
+pub slang_solidity::backend::l2_flat_contracts::StringExpression::StringLiteral(slang_solidity::backend::l2_flat_contracts::StringLiteral)
 pub slang_solidity::backend::l2_flat_contracts::StringExpression::StringLiterals(slang_solidity::backend::l2_flat_contracts::StringLiterals)
 pub slang_solidity::backend::l2_flat_contracts::StringExpression::UnicodeStringLiterals(slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals)
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::StringExpression
@@ -5976,6 +6272,18 @@ pub slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral::DoubleQuot
 pub slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral::SingleQuotedUnicodeStringLiteral(alloc::rc::Rc<slang_solidity::cst::TerminalNode>)
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::ConstantKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::ExternalKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::InternalKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::ModifierInvocation(slang_solidity::backend::l2_flat_contracts::ModifierInvocation)
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::PayableKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::PrivateKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::PublicKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::PureKeyword
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::ViewKeyword
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute
+pub fn slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::UsingClause
 pub slang_solidity::backend::l2_flat_contracts::UsingClause::IdentifierPath(slang_solidity::backend::l2_flat_contracts::IdentifierPath)
 pub slang_solidity::backend::l2_flat_contracts::UsingClause::UsingDeconstruction(slang_solidity::backend::l2_flat_contracts::UsingDeconstruction)
@@ -6006,6 +6314,7 @@ impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::UsingTarge
 pub fn slang_solidity::backend::l2_flat_contracts::UsingTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::VariableDeclarationType
 pub slang_solidity::backend::l2_flat_contracts::VariableDeclarationType::TypeName(slang_solidity::backend::l2_flat_contracts::TypeName)
+pub slang_solidity::backend::l2_flat_contracts::VariableDeclarationType::VarKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::VariableDeclarationType
 pub fn slang_solidity::backend::l2_flat_contracts::VariableDeclarationType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::VersionExpression
@@ -6031,6 +6340,7 @@ impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::VersionOpe
 pub fn slang_solidity::backend::l2_flat_contracts::VersionOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator::ColonEqual
+pub slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator::YulColonAndEqual(slang_solidity::backend::l2_flat_contracts::YulColonAndEqual)
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator
 pub fn slang_solidity::backend::l2_flat_contracts::YulAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::YulExpression
@@ -6048,6 +6358,11 @@ pub slang_solidity::backend::l2_flat_contracts::YulLiteral::YulHexLiteral(alloc:
 pub slang_solidity::backend::l2_flat_contracts::YulLiteral::YulTrueKeyword
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulLiteral
 pub fn slang_solidity::backend::l2_flat_contracts::YulLiteral::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
+pub slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator::EqualColon
+pub slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator::YulEqualAndColon(slang_solidity::backend::l2_flat_contracts::YulEqualAndColon)
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
+pub fn slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity::backend::l2_flat_contracts::YulStatement
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulBlock(slang_solidity::backend::l2_flat_contracts::YulBlock)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulBreakStatement(slang_solidity::backend::l2_flat_contracts::YulBreakStatement)
@@ -6056,7 +6371,9 @@ pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulExpression(slan
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulForStatement(slang_solidity::backend::l2_flat_contracts::YulForStatement)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulFunctionDefinition(slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulIfStatement(slang_solidity::backend::l2_flat_contracts::YulIfStatement)
+pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulLabel(slang_solidity::backend::l2_flat_contracts::YulLabel)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulLeaveStatement(slang_solidity::backend::l2_flat_contracts::YulLeaveStatement)
+pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulStackAssignmentStatement(slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulSwitchStatement(slang_solidity::backend::l2_flat_contracts::YulSwitchStatement)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulVariableAssignmentStatement(slang_solidity::backend::l2_flat_contracts::YulVariableAssignmentStatement)
 pub slang_solidity::backend::l2_flat_contracts::YulStatement::YulVariableDeclarationStatement(slang_solidity::backend::l2_flat_contracts::YulVariableDeclarationStatement)
@@ -6325,6 +6642,7 @@ pub fn slang_solidity::backend::l2_flat_contracts::FunctionTypeStruct::fmt(&self
 pub struct slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct
 pub slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct::literal: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct::unit: core::option::Option<slang_solidity::backend::l2_flat_contracts::NumberUnit>
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct
 pub fn slang_solidity::backend::l2_flat_contracts::HexNumberExpressionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::IfStatementStruct
@@ -6587,6 +6905,10 @@ pub slang_solidity::backend::l2_flat_contracts::StructMemberStruct::node_id: met
 pub slang_solidity::backend::l2_flat_contracts::StructMemberStruct::type_name: slang_solidity::backend::l2_flat_contracts::TypeName
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::StructMemberStruct
 pub fn slang_solidity::backend::l2_flat_contracts::StructMemberStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::ThrowStatementStruct
+pub slang_solidity::backend::l2_flat_contracts::ThrowStatementStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::ThrowStatementStruct
+pub fn slang_solidity::backend::l2_flat_contracts::ThrowStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::TryStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::TryStatementStruct::body: slang_solidity::backend::l2_flat_contracts::Block
 pub slang_solidity::backend::l2_flat_contracts::TryStatementStruct::catch_clauses: slang_solidity::backend::l2_flat_contracts::CatchClauses
@@ -6604,6 +6926,7 @@ pub struct slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatem
 pub slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct::elements: slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements
 pub slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct::expression: slang_solidity::backend::l2_flat_contracts::Expression
 pub slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct::var_keyword: core::option::Option<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct
 pub fn slang_solidity::backend::l2_flat_contracts::TupleDeconstructionStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::TupleExpressionStruct
@@ -6633,6 +6956,13 @@ pub slang_solidity::backend::l2_flat_contracts::UncheckedBlockStruct::block: sla
 pub slang_solidity::backend::l2_flat_contracts::UncheckedBlockStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::UncheckedBlockStruct
 pub fn slang_solidity::backend::l2_flat_contracts::UncheckedBlockStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct::attributes: slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct::body: slang_solidity::backend::l2_flat_contracts::FunctionBody
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct::parameters: slang_solidity::backend::l2_flat_contracts::ParametersDeclaration
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct
+pub fn slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::UntypedTupleMemberStruct
 pub slang_solidity::backend::l2_flat_contracts::UntypedTupleMemberStruct::name: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
 pub slang_solidity::backend::l2_flat_contracts::UntypedTupleMemberStruct::node_id: metaslang_cst::nodes::NodeId
@@ -6713,6 +7043,10 @@ pub struct slang_solidity::backend::l2_flat_contracts::YulBreakStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::YulBreakStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulBreakStatementStruct
 pub fn slang_solidity::backend::l2_flat_contracts::YulBreakStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::YulColonAndEqualStruct
+pub slang_solidity::backend::l2_flat_contracts::YulColonAndEqualStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulColonAndEqualStruct
+pub fn slang_solidity::backend::l2_flat_contracts::YulColonAndEqualStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::YulContinueStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::YulContinueStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulContinueStatementStruct
@@ -6722,6 +7056,10 @@ pub slang_solidity::backend::l2_flat_contracts::YulDefaultCaseStruct::body: slan
 pub slang_solidity::backend::l2_flat_contracts::YulDefaultCaseStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulDefaultCaseStruct
 pub fn slang_solidity::backend::l2_flat_contracts::YulDefaultCaseStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::YulEqualAndColonStruct
+pub slang_solidity::backend::l2_flat_contracts::YulEqualAndColonStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulEqualAndColonStruct
+pub fn slang_solidity::backend::l2_flat_contracts::YulEqualAndColonStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::YulForStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::YulForStatementStruct::body: slang_solidity::backend::l2_flat_contracts::YulBlock
 pub slang_solidity::backend::l2_flat_contracts::YulForStatementStruct::condition: slang_solidity::backend::l2_flat_contracts::YulExpression
@@ -6750,6 +7088,11 @@ pub slang_solidity::backend::l2_flat_contracts::YulIfStatementStruct::condition:
 pub slang_solidity::backend::l2_flat_contracts::YulIfStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulIfStatementStruct
 pub fn slang_solidity::backend::l2_flat_contracts::YulIfStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::YulLabelStruct
+pub slang_solidity::backend::l2_flat_contracts::YulLabelStruct::label: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+pub slang_solidity::backend::l2_flat_contracts::YulLabelStruct::node_id: metaslang_cst::nodes::NodeId
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulLabelStruct
+pub fn slang_solidity::backend::l2_flat_contracts::YulLabelStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::YulLeaveStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::YulLeaveStatementStruct::node_id: metaslang_cst::nodes::NodeId
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulLeaveStatementStruct
@@ -6764,6 +7107,12 @@ pub slang_solidity::backend::l2_flat_contracts::YulReturnsDeclarationStruct::nod
 pub slang_solidity::backend::l2_flat_contracts::YulReturnsDeclarationStruct::variables: slang_solidity::backend::l2_flat_contracts::YulVariableNames
 impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulReturnsDeclarationStruct
 pub fn slang_solidity::backend::l2_flat_contracts::YulReturnsDeclarationStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct
+pub slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct::assignment: slang_solidity::backend::l2_flat_contracts::YulStackAssignmentOperator
+pub slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct::node_id: metaslang_cst::nodes::NodeId
+pub slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct::variable: alloc::rc::Rc<slang_solidity::cst::TerminalNode>
+impl core::fmt::Debug for slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct
+pub fn slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity::backend::l2_flat_contracts::YulSwitchStatementStruct
 pub slang_solidity::backend::l2_flat_contracts::YulSwitchStatementStruct::cases: slang_solidity::backend::l2_flat_contracts::YulSwitchCases
 pub slang_solidity::backend::l2_flat_contracts::YulSwitchStatementStruct::expression: slang_solidity::backend::l2_flat_contracts::YulExpression
@@ -6913,6 +7262,7 @@ pub type slang_solidity::backend::l2_flat_contracts::StringLiterals = alloc::vec
 pub type slang_solidity::backend::l2_flat_contracts::StructDefinition = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::StructDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::StructMember = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::StructMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::StructMembers = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::StructMember>
+pub type slang_solidity::backend::l2_flat_contracts::ThrowStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::ThrowStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::TryStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::TryStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElements = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::TupleDeconstructionElement>
@@ -6924,6 +7274,8 @@ pub type slang_solidity::backend::l2_flat_contracts::TypeExpression = alloc::rc:
 pub type slang_solidity::backend::l2_flat_contracts::TypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::TypedTupleMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::UncheckedBlock = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::UncheckedBlockStruct>
 pub type slang_solidity::backend::l2_flat_contracts::UnicodeStringLiterals = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::UnicodeStringLiteral>
+pub type slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttributes = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::UnnamedFunctionAttribute>
+pub type slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::UnnamedFunctionDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::UntypedTupleMember = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::UntypedTupleMemberStruct>
 pub type slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinition = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::UserDefinedValueTypeDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::UsingAlias = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::UsingAliasStruct>
@@ -6942,18 +7294,22 @@ pub type slang_solidity::backend::l2_flat_contracts::WhileStatement = alloc::rc:
 pub type slang_solidity::backend::l2_flat_contracts::YulArguments = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::YulExpression>
 pub type slang_solidity::backend::l2_flat_contracts::YulBlock = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulBlockStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulBreakStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulBreakStatementStruct>
+pub type slang_solidity::backend::l2_flat_contracts::YulColonAndEqual = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulColonAndEqualStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulContinueStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulContinueStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulDefaultCase = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulDefaultCaseStruct>
+pub type slang_solidity::backend::l2_flat_contracts::YulEqualAndColon = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulEqualAndColonStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulForStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulForStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpression = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulFunctionCallExpressionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulFunctionDefinition = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulFunctionDefinitionStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulIfStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulIfStatementStruct>
+pub type slang_solidity::backend::l2_flat_contracts::YulLabel = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulLabelStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulLeaveStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulLeaveStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulParameters = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l2_flat_contracts::YulParametersDeclaration = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulParametersDeclarationStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulPath = alloc::vec::Vec<alloc::rc::Rc<slang_solidity::cst::TerminalNode>>
 pub type slang_solidity::backend::l2_flat_contracts::YulPaths = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::YulPath>
 pub type slang_solidity::backend::l2_flat_contracts::YulReturnsDeclaration = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulReturnsDeclarationStruct>
+pub type slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulStackAssignmentStatementStruct>
 pub type slang_solidity::backend::l2_flat_contracts::YulStatements = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::YulStatement>
 pub type slang_solidity::backend::l2_flat_contracts::YulSwitchCases = alloc::vec::Vec<slang_solidity::backend::l2_flat_contracts::YulSwitchCase>
 pub type slang_solidity::backend::l2_flat_contracts::YulSwitchStatement = alloc::rc::Rc<slang_solidity::backend::l2_flat_contracts::YulSwitchStatementStruct>

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/builder.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/builder.rs
@@ -682,6 +682,29 @@ pub fn build_constructor_definition(node: &Rc<NonterminalNode>) -> Result<Constr
     }))
 }
 
+pub fn build_unnamed_function_definition(
+    node: &Rc<NonterminalNode>,
+) -> Result<UnnamedFunctionDefinition> {
+    expect_nonterminal_kind(node, NonterminalKind::UnnamedFunctionDefinition)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    _ = helper.accept_label(EdgeLabel::FunctionKeyword)?;
+    let parameters = build_parameters_declaration(nonterminal_node(
+        helper.accept_label(EdgeLabel::Parameters)?,
+    )?)?;
+    let attributes = build_unnamed_function_attributes(nonterminal_node(
+        helper.accept_label(EdgeLabel::Attributes)?,
+    )?)?;
+    let body = build_function_body(nonterminal_node(helper.accept_label(EdgeLabel::Body)?)?)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(UnnamedFunctionDefinitionStruct {
+        node_id: node.id(),
+        parameters,
+        attributes,
+        body,
+    }))
+}
+
 pub fn build_fallback_function_definition(
     node: &Rc<NonterminalNode>,
 ) -> Result<FallbackFunctionDefinition> {
@@ -1147,6 +1170,13 @@ pub fn build_tuple_deconstruction_statement(
 ) -> Result<TupleDeconstructionStatement> {
     expect_nonterminal_kind(node, NonterminalKind::TupleDeconstructionStatement)?;
     let mut helper = ChildrenHelper::new(&node.children);
+    let var_keyword = if helper.at_label(EdgeLabel::VarKeyword) {
+        Some(terminal_node_cloned(
+            helper.accept_label(EdgeLabel::VarKeyword)?,
+        )?)
+    } else {
+        None
+    };
     _ = helper.accept_label(EdgeLabel::OpenParen)?;
     let elements = build_tuple_deconstruction_elements(nonterminal_node(
         helper.accept_label(EdgeLabel::Elements)?,
@@ -1161,6 +1191,7 @@ pub fn build_tuple_deconstruction_statement(
 
     Ok(Rc::new(TupleDeconstructionStatementStruct {
         node_id: node.id(),
+        var_keyword,
         elements,
         expression,
     }))
@@ -1541,6 +1572,16 @@ pub fn build_revert_statement(node: &Rc<NonterminalNode>) -> Result<RevertStatem
         error,
         arguments,
     }))
+}
+
+pub fn build_throw_statement(node: &Rc<NonterminalNode>) -> Result<ThrowStatement> {
+    expect_nonterminal_kind(node, NonterminalKind::ThrowStatement)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    _ = helper.accept_label(EdgeLabel::ThrowKeyword)?;
+    _ = helper.accept_label(EdgeLabel::Semicolon)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(ThrowStatementStruct { node_id: node.id() }))
 }
 
 pub fn build_assignment_expression(node: &Rc<NonterminalNode>) -> Result<AssignmentExpression> {
@@ -2072,11 +2113,19 @@ pub fn build_hex_number_expression(node: &Rc<NonterminalNode>) -> Result<HexNumb
     expect_nonterminal_kind(node, NonterminalKind::HexNumberExpression)?;
     let mut helper = ChildrenHelper::new(&node.children);
     let literal = terminal_node_cloned(helper.accept_label(EdgeLabel::Literal)?)?;
+    let unit = if helper.at_label(EdgeLabel::Unit) {
+        Some(build_number_unit(nonterminal_node(
+            helper.accept_label(EdgeLabel::Unit)?,
+        )?)?)
+    } else {
+        None
+    };
     helper.finalize()?;
 
     Ok(Rc::new(HexNumberExpressionStruct {
         node_id: node.id(),
         literal,
+        unit,
     }))
 }
 
@@ -2247,6 +2296,44 @@ pub fn build_yul_variable_assignment_statement(
     }))
 }
 
+pub fn build_yul_colon_and_equal(node: &Rc<NonterminalNode>) -> Result<YulColonAndEqual> {
+    expect_nonterminal_kind(node, NonterminalKind::YulColonAndEqual)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    _ = helper.accept_label(EdgeLabel::Colon)?;
+    _ = helper.accept_label(EdgeLabel::Equal)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(YulColonAndEqualStruct { node_id: node.id() }))
+}
+
+pub fn build_yul_stack_assignment_statement(
+    node: &Rc<NonterminalNode>,
+) -> Result<YulStackAssignmentStatement> {
+    expect_nonterminal_kind(node, NonterminalKind::YulStackAssignmentStatement)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    let assignment = build_yul_stack_assignment_operator(nonterminal_node(
+        helper.accept_label(EdgeLabel::Assignment)?,
+    )?)?;
+    let variable = terminal_node_cloned(helper.accept_label(EdgeLabel::Variable)?)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(YulStackAssignmentStatementStruct {
+        node_id: node.id(),
+        assignment,
+        variable,
+    }))
+}
+
+pub fn build_yul_equal_and_colon(node: &Rc<NonterminalNode>) -> Result<YulEqualAndColon> {
+    expect_nonterminal_kind(node, NonterminalKind::YulEqualAndColon)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    _ = helper.accept_label(EdgeLabel::Equal)?;
+    _ = helper.accept_label(EdgeLabel::Colon)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(YulEqualAndColonStruct { node_id: node.id() }))
+}
+
 pub fn build_yul_if_statement(node: &Rc<NonterminalNode>) -> Result<YulIfStatement> {
     expect_nonterminal_kind(node, NonterminalKind::YulIfStatement)?;
     let mut helper = ChildrenHelper::new(&node.children);
@@ -2357,6 +2444,19 @@ pub fn build_yul_continue_statement(node: &Rc<NonterminalNode>) -> Result<YulCon
     helper.finalize()?;
 
     Ok(Rc::new(YulContinueStatementStruct { node_id: node.id() }))
+}
+
+pub fn build_yul_label(node: &Rc<NonterminalNode>) -> Result<YulLabel> {
+    expect_nonterminal_kind(node, NonterminalKind::YulLabel)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    let label = terminal_node_cloned(helper.accept_label(EdgeLabel::Label)?)?;
+    _ = helper.accept_label(EdgeLabel::Colon)?;
+    helper.finalize()?;
+
+    Ok(Rc::new(YulLabelStruct {
+        node_id: node.id(),
+        label,
+    }))
 }
 
 pub fn build_yul_function_call_expression(
@@ -2726,6 +2826,11 @@ pub fn build_contract_member(node: &Rc<NonterminalNode>) -> Result<ContractMembe
                 nonterminal_node(variant)?,
             )?)
         }
+        NodeKind::Nonterminal(NonterminalKind::UnnamedFunctionDefinition) => {
+            ContractMember::UnnamedFunctionDefinition(build_unnamed_function_definition(
+                nonterminal_node(variant)?,
+            )?)
+        }
         NodeKind::Nonterminal(NonterminalKind::ModifierDefinition) => {
             ContractMember::ModifierDefinition(build_modifier_definition(nonterminal_node(
                 variant,
@@ -2837,6 +2942,7 @@ pub fn build_function_attribute(node: &Rc<NonterminalNode>) -> Result<FunctionAt
                 variant,
             )?)?)
         }
+        NodeKind::Terminal(TerminalKind::ConstantKeyword) => FunctionAttribute::ConstantKeyword,
         NodeKind::Terminal(TerminalKind::ExternalKeyword) => FunctionAttribute::ExternalKeyword,
         NodeKind::Terminal(TerminalKind::InternalKeyword) => FunctionAttribute::InternalKeyword,
         NodeKind::Terminal(TerminalKind::PayableKeyword) => FunctionAttribute::PayableKeyword,
@@ -2887,8 +2993,51 @@ pub fn build_constructor_attribute(node: &Rc<NonterminalNode>) -> Result<Constru
             )?)?)
         }
         NodeKind::Terminal(TerminalKind::InternalKeyword) => ConstructorAttribute::InternalKeyword,
+        NodeKind::Terminal(TerminalKind::OverrideKeyword) => ConstructorAttribute::OverrideKeyword,
         NodeKind::Terminal(TerminalKind::PayableKeyword) => ConstructorAttribute::PayableKeyword,
         NodeKind::Terminal(TerminalKind::PublicKeyword) => ConstructorAttribute::PublicKeyword,
+        NodeKind::Terminal(TerminalKind::VirtualKeyword) => ConstructorAttribute::VirtualKeyword,
+        NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
+            return Err(format!(
+                "Unexpected variant node of kind {:?}",
+                variant.kind()
+            ));
+        }
+    };
+    helper.finalize()?;
+    Ok(item)
+}
+
+pub fn build_unnamed_function_attribute(
+    node: &Rc<NonterminalNode>,
+) -> Result<UnnamedFunctionAttribute> {
+    expect_nonterminal_kind(node, NonterminalKind::UnnamedFunctionAttribute)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    let variant = helper.accept_label(EdgeLabel::Variant)?;
+    let item = match variant.kind() {
+        NodeKind::Nonterminal(NonterminalKind::ModifierInvocation) => {
+            UnnamedFunctionAttribute::ModifierInvocation(build_modifier_invocation(
+                nonterminal_node(variant)?,
+            )?)
+        }
+        NodeKind::Terminal(TerminalKind::ConstantKeyword) => {
+            UnnamedFunctionAttribute::ConstantKeyword
+        }
+        NodeKind::Terminal(TerminalKind::ExternalKeyword) => {
+            UnnamedFunctionAttribute::ExternalKeyword
+        }
+        NodeKind::Terminal(TerminalKind::InternalKeyword) => {
+            UnnamedFunctionAttribute::InternalKeyword
+        }
+        NodeKind::Terminal(TerminalKind::PayableKeyword) => {
+            UnnamedFunctionAttribute::PayableKeyword
+        }
+        NodeKind::Terminal(TerminalKind::PrivateKeyword) => {
+            UnnamedFunctionAttribute::PrivateKeyword
+        }
+        NodeKind::Terminal(TerminalKind::PublicKeyword) => UnnamedFunctionAttribute::PublicKeyword,
+        NodeKind::Terminal(TerminalKind::PureKeyword) => UnnamedFunctionAttribute::PureKeyword,
+        NodeKind::Terminal(TerminalKind::ViewKeyword) => UnnamedFunctionAttribute::ViewKeyword,
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             return Err(format!(
                 "Unexpected variant node of kind {:?}",
@@ -3038,6 +3187,7 @@ pub fn build_function_type_attribute(node: &Rc<NonterminalNode>) -> Result<Funct
         NodeKind::Terminal(TerminalKind::ExternalKeyword) => FunctionTypeAttribute::ExternalKeyword,
         NodeKind::Terminal(TerminalKind::PrivateKeyword) => FunctionTypeAttribute::PrivateKeyword,
         NodeKind::Terminal(TerminalKind::PublicKeyword) => FunctionTypeAttribute::PublicKeyword,
+        NodeKind::Terminal(TerminalKind::ConstantKeyword) => FunctionTypeAttribute::ConstantKeyword,
         NodeKind::Terminal(TerminalKind::PureKeyword) => FunctionTypeAttribute::PureKeyword,
         NodeKind::Terminal(TerminalKind::ViewKeyword) => FunctionTypeAttribute::ViewKeyword,
         NodeKind::Terminal(TerminalKind::PayableKeyword) => FunctionTypeAttribute::PayableKeyword,
@@ -3098,6 +3248,7 @@ pub fn build_elementary_type(node: &Rc<NonterminalNode>) -> Result<ElementaryTyp
             ElementaryType::UfixedKeyword(terminal_node_cloned(variant)?)
         }
         NodeKind::Terminal(TerminalKind::BoolKeyword) => ElementaryType::BoolKeyword,
+        NodeKind::Terminal(TerminalKind::ByteKeyword) => ElementaryType::ByteKeyword,
         NodeKind::Terminal(TerminalKind::StringKeyword) => ElementaryType::StringKeyword,
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             return Err(format!(
@@ -3135,6 +3286,9 @@ pub fn build_statement(node: &Rc<NonterminalNode>) -> Result<Statement> {
         }
         NodeKind::Nonterminal(NonterminalKind::ReturnStatement) => {
             Statement::ReturnStatement(build_return_statement(nonterminal_node(variant)?)?)
+        }
+        NodeKind::Nonterminal(NonterminalKind::ThrowStatement) => {
+            Statement::ThrowStatement(build_throw_statement(nonterminal_node(variant)?)?)
         }
         NodeKind::Nonterminal(NonterminalKind::EmitStatement) => {
             Statement::EmitStatement(build_emit_statement(nonterminal_node(variant)?)?)
@@ -3210,6 +3364,7 @@ pub fn build_variable_declaration_type(
         NodeKind::Nonterminal(NonterminalKind::TypeName) => {
             VariableDeclarationType::TypeName(build_type_name(nonterminal_node(variant)?)?)
         }
+        NodeKind::Terminal(TerminalKind::VarKeyword) => VariableDeclarationType::VarKeyword,
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             return Err(format!(
                 "Unexpected variant node of kind {:?}",
@@ -3462,12 +3617,15 @@ pub fn build_number_unit(node: &Rc<NonterminalNode>) -> Result<NumberUnit> {
     let item = match variant.kind() {
         NodeKind::Terminal(TerminalKind::WeiKeyword) => NumberUnit::WeiKeyword,
         NodeKind::Terminal(TerminalKind::GweiKeyword) => NumberUnit::GweiKeyword,
+        NodeKind::Terminal(TerminalKind::SzaboKeyword) => NumberUnit::SzaboKeyword,
+        NodeKind::Terminal(TerminalKind::FinneyKeyword) => NumberUnit::FinneyKeyword,
         NodeKind::Terminal(TerminalKind::EtherKeyword) => NumberUnit::EtherKeyword,
         NodeKind::Terminal(TerminalKind::SecondsKeyword) => NumberUnit::SecondsKeyword,
         NodeKind::Terminal(TerminalKind::MinutesKeyword) => NumberUnit::MinutesKeyword,
         NodeKind::Terminal(TerminalKind::HoursKeyword) => NumberUnit::HoursKeyword,
         NodeKind::Terminal(TerminalKind::DaysKeyword) => NumberUnit::DaysKeyword,
         NodeKind::Terminal(TerminalKind::WeeksKeyword) => NumberUnit::WeeksKeyword,
+        NodeKind::Terminal(TerminalKind::YearsKeyword) => NumberUnit::YearsKeyword,
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             return Err(format!(
                 "Unexpected variant node of kind {:?}",
@@ -3484,8 +3642,16 @@ pub fn build_string_expression(node: &Rc<NonterminalNode>) -> Result<StringExpre
     let mut helper = ChildrenHelper::new(&node.children);
     let variant = helper.accept_label(EdgeLabel::Variant)?;
     let item = match variant.kind() {
+        NodeKind::Nonterminal(NonterminalKind::StringLiteral) => {
+            StringExpression::StringLiteral(build_string_literal(nonterminal_node(variant)?)?)
+        }
         NodeKind::Nonterminal(NonterminalKind::StringLiterals) => {
             StringExpression::StringLiterals(build_string_literals(nonterminal_node(variant)?)?)
+        }
+        NodeKind::Nonterminal(NonterminalKind::HexStringLiteral) => {
+            StringExpression::HexStringLiteral(build_hex_string_literal(nonterminal_node(
+                variant,
+            )?)?)
         }
         NodeKind::Nonterminal(NonterminalKind::HexStringLiterals) => {
             StringExpression::HexStringLiterals(build_hex_string_literals(nonterminal_node(
@@ -3587,6 +3753,11 @@ pub fn build_yul_statement(node: &Rc<NonterminalNode>) -> Result<YulStatement> {
                 variant,
             )?)?)
         }
+        NodeKind::Nonterminal(NonterminalKind::YulStackAssignmentStatement) => {
+            YulStatement::YulStackAssignmentStatement(build_yul_stack_assignment_statement(
+                nonterminal_node(variant)?,
+            )?)
+        }
         NodeKind::Nonterminal(NonterminalKind::YulIfStatement) => {
             YulStatement::YulIfStatement(build_yul_if_statement(nonterminal_node(variant)?)?)
         }
@@ -3614,6 +3785,9 @@ pub fn build_yul_statement(node: &Rc<NonterminalNode>) -> Result<YulStatement> {
                 nonterminal_node(variant)?,
             )?)
         }
+        NodeKind::Nonterminal(NonterminalKind::YulLabel) => {
+            YulStatement::YulLabel(build_yul_label(nonterminal_node(variant)?)?)
+        }
         NodeKind::Nonterminal(NonterminalKind::YulVariableDeclarationStatement) => {
             YulStatement::YulVariableDeclarationStatement(build_yul_variable_declaration_statement(
                 nonterminal_node(variant)?,
@@ -3638,7 +3812,36 @@ pub fn build_yul_assignment_operator(node: &Rc<NonterminalNode>) -> Result<YulAs
     let mut helper = ChildrenHelper::new(&node.children);
     let variant = helper.accept_label(EdgeLabel::Variant)?;
     let item = match variant.kind() {
+        NodeKind::Nonterminal(NonterminalKind::YulColonAndEqual) => {
+            YulAssignmentOperator::YulColonAndEqual(build_yul_colon_and_equal(nonterminal_node(
+                variant,
+            )?)?)
+        }
         NodeKind::Terminal(TerminalKind::ColonEqual) => YulAssignmentOperator::ColonEqual,
+        NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
+            return Err(format!(
+                "Unexpected variant node of kind {:?}",
+                variant.kind()
+            ));
+        }
+    };
+    helper.finalize()?;
+    Ok(item)
+}
+
+pub fn build_yul_stack_assignment_operator(
+    node: &Rc<NonterminalNode>,
+) -> Result<YulStackAssignmentOperator> {
+    expect_nonterminal_kind(node, NonterminalKind::YulStackAssignmentOperator)?;
+    let mut helper = ChildrenHelper::new(&node.children);
+    let variant = helper.accept_label(EdgeLabel::Variant)?;
+    let item = match variant.kind() {
+        NodeKind::Nonterminal(NonterminalKind::YulEqualAndColon) => {
+            YulStackAssignmentOperator::YulEqualAndColon(build_yul_equal_and_colon(
+                nonterminal_node(variant)?,
+            )?)
+        }
+        NodeKind::Terminal(TerminalKind::EqualColon) => YulStackAssignmentOperator::EqualColon,
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             return Err(format!(
                 "Unexpected variant node of kind {:?}",
@@ -4018,6 +4221,24 @@ pub fn build_constructor_attributes(node: &Rc<NonterminalNode>) -> Result<Constr
     while helper.at_label(EdgeLabel::Item) {
         let child = helper.accept_label(EdgeLabel::Item)?;
         let item = build_constructor_attribute(nonterminal_node(child)?)?;
+        items.push(item);
+        if helper.at_label(EdgeLabel::Separator) {
+            _ = helper.accept_label(EdgeLabel::Separator)?;
+        }
+    }
+    helper.finalize()?;
+    Ok(items)
+}
+
+pub fn build_unnamed_function_attributes(
+    node: &Rc<NonterminalNode>,
+) -> Result<UnnamedFunctionAttributes> {
+    expect_nonterminal_kind(node, NonterminalKind::UnnamedFunctionAttributes)?;
+    let mut items = UnnamedFunctionAttributes::new();
+    let mut helper = ChildrenHelper::new(&node.children);
+    while helper.at_label(EdgeLabel::Item) {
+        let child = helper.accept_label(EdgeLabel::Item)?;
+        let item = build_unnamed_function_attribute(nonterminal_node(child)?)?;
         items.push(item);
         if helper.at_label(EdgeLabel::Separator) {
             _ = helper.accept_label(EdgeLabel::Separator)?;

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/nodes.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/nodes.rs
@@ -331,6 +331,16 @@ pub struct ConstructorDefinitionStruct {
     pub body: Block,
 }
 
+pub type UnnamedFunctionDefinition = Rc<UnnamedFunctionDefinitionStruct>;
+
+#[derive(Debug)]
+pub struct UnnamedFunctionDefinitionStruct {
+    pub node_id: NodeId,
+    pub parameters: ParametersDeclaration,
+    pub attributes: UnnamedFunctionAttributes,
+    pub body: FunctionBody,
+}
+
 pub type FallbackFunctionDefinition = Rc<FallbackFunctionDefinitionStruct>;
 
 #[derive(Debug)]
@@ -536,6 +546,7 @@ pub type TupleDeconstructionStatement = Rc<TupleDeconstructionStatementStruct>;
 #[derive(Debug)]
 pub struct TupleDeconstructionStatementStruct {
     pub node_id: NodeId,
+    pub var_keyword: Option<Rc<TerminalNode>>,
     pub elements: TupleDeconstructionElements,
     pub expression: Expression,
 }
@@ -700,6 +711,13 @@ pub struct RevertStatementStruct {
     pub node_id: NodeId,
     pub error: Option<IdentifierPath>,
     pub arguments: ArgumentsDeclaration,
+}
+
+pub type ThrowStatement = Rc<ThrowStatementStruct>;
+
+#[derive(Debug)]
+pub struct ThrowStatementStruct {
+    pub node_id: NodeId,
 }
 
 pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
@@ -960,6 +978,7 @@ pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 pub struct HexNumberExpressionStruct {
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
+    pub unit: Option<NumberUnit>,
 }
 
 pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
@@ -1034,6 +1053,29 @@ pub struct YulVariableAssignmentStatementStruct {
     pub expression: YulExpression,
 }
 
+pub type YulColonAndEqual = Rc<YulColonAndEqualStruct>;
+
+#[derive(Debug)]
+pub struct YulColonAndEqualStruct {
+    pub node_id: NodeId,
+}
+
+pub type YulStackAssignmentStatement = Rc<YulStackAssignmentStatementStruct>;
+
+#[derive(Debug)]
+pub struct YulStackAssignmentStatementStruct {
+    pub node_id: NodeId,
+    pub assignment: YulStackAssignmentOperator,
+    pub variable: Rc<TerminalNode>,
+}
+
+pub type YulEqualAndColon = Rc<YulEqualAndColonStruct>;
+
+#[derive(Debug)]
+pub struct YulEqualAndColonStruct {
+    pub node_id: NodeId,
+}
+
 pub type YulIfStatement = Rc<YulIfStatementStruct>;
 
 #[derive(Debug)]
@@ -1099,6 +1141,14 @@ pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 #[derive(Debug)]
 pub struct YulContinueStatementStruct {
     pub node_id: NodeId,
+}
+
+pub type YulLabel = Rc<YulLabelStruct>;
+
+#[derive(Debug)]
+pub struct YulLabelStruct {
+    pub node_id: NodeId,
+    pub label: Rc<TerminalNode>,
 }
 
 pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
@@ -1219,6 +1269,7 @@ pub enum ContractMember {
     ConstructorDefinition(ConstructorDefinition),
     ReceiveFunctionDefinition(ReceiveFunctionDefinition),
     FallbackFunctionDefinition(FallbackFunctionDefinition),
+    UnnamedFunctionDefinition(UnnamedFunctionDefinition),
     ModifierDefinition(ModifierDefinition),
     StructDefinition(StructDefinition),
     EnumDefinition(EnumDefinition),
@@ -1250,6 +1301,7 @@ pub enum FunctionName {
 pub enum FunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     OverrideSpecifier(OverrideSpecifier),
+    ConstantKeyword,
     ExternalKeyword,
     InternalKeyword,
     PayableKeyword,
@@ -1270,8 +1322,23 @@ pub enum FunctionBody {
 pub enum ConstructorAttribute {
     ModifierInvocation(ModifierInvocation),
     InternalKeyword,
+    OverrideKeyword,
     PayableKeyword,
     PublicKeyword,
+    VirtualKeyword,
+}
+
+#[derive(Debug)]
+pub enum UnnamedFunctionAttribute {
+    ModifierInvocation(ModifierInvocation),
+    ConstantKeyword,
+    ExternalKeyword,
+    InternalKeyword,
+    PayableKeyword,
+    PrivateKeyword,
+    PublicKeyword,
+    PureKeyword,
+    ViewKeyword,
 }
 
 #[derive(Debug)]
@@ -1315,6 +1382,7 @@ pub enum FunctionTypeAttribute {
     ExternalKeyword,
     PrivateKeyword,
     PublicKeyword,
+    ConstantKeyword,
     PureKeyword,
     ViewKeyword,
     PayableKeyword,
@@ -1335,6 +1403,7 @@ pub enum ElementaryType {
     FixedKeyword(Rc<TerminalNode>),
     UfixedKeyword(Rc<TerminalNode>),
     BoolKeyword,
+    ByteKeyword,
     StringKeyword,
 }
 
@@ -1347,6 +1416,7 @@ pub enum Statement {
     ContinueStatement(ContinueStatement),
     BreakStatement(BreakStatement),
     ReturnStatement(ReturnStatement),
+    ThrowStatement(ThrowStatement),
     EmitStatement(EmitStatement),
     TryStatement(TryStatement),
     RevertStatement(RevertStatement),
@@ -1367,6 +1437,7 @@ pub enum TupleMember {
 #[derive(Debug)]
 pub enum VariableDeclarationType {
     TypeName(TypeName),
+    VarKeyword,
 }
 
 #[derive(Debug)]
@@ -1437,17 +1508,22 @@ pub enum ArgumentsDeclaration {
 pub enum NumberUnit {
     WeiKeyword,
     GweiKeyword,
+    SzaboKeyword,
+    FinneyKeyword,
     EtherKeyword,
     SecondsKeyword,
     MinutesKeyword,
     HoursKeyword,
     DaysKeyword,
     WeeksKeyword,
+    YearsKeyword,
 }
 
 #[derive(Debug)]
 pub enum StringExpression {
+    StringLiteral(StringLiteral),
     StringLiterals(StringLiterals),
+    HexStringLiteral(HexStringLiteral),
     HexStringLiterals(HexStringLiterals),
     UnicodeStringLiterals(UnicodeStringLiterals),
 }
@@ -1474,6 +1550,7 @@ pub enum UnicodeStringLiteral {
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),
+    YulStackAssignmentStatement(YulStackAssignmentStatement),
     YulIfStatement(YulIfStatement),
     YulForStatement(YulForStatement),
     YulSwitchStatement(YulSwitchStatement),
@@ -1481,13 +1558,21 @@ pub enum YulStatement {
     YulBreakStatement(YulBreakStatement),
     YulContinueStatement(YulContinueStatement),
     YulVariableAssignmentStatement(YulVariableAssignmentStatement),
+    YulLabel(YulLabel),
     YulVariableDeclarationStatement(YulVariableDeclarationStatement),
     YulExpression(YulExpression),
 }
 
 #[derive(Debug)]
 pub enum YulAssignmentOperator {
+    YulColonAndEqual(YulColonAndEqual),
     ColonEqual,
+}
+
+#[derive(Debug)]
+pub enum YulStackAssignmentOperator {
+    YulEqualAndColon(YulEqualAndColon),
+    EqualColon,
 }
 
 #[derive(Debug)]
@@ -1552,6 +1637,8 @@ pub type FunctionAttributes = Vec<FunctionAttribute>;
 pub type OverridePaths = Vec<IdentifierPath>;
 
 pub type ConstructorAttributes = Vec<ConstructorAttribute>;
+
+pub type UnnamedFunctionAttributes = Vec<UnnamedFunctionAttribute>;
 
 pub type FallbackFunctionAttributes = Vec<FallbackFunctionAttribute>;
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/rewriter.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/rewriter.rs
@@ -466,6 +466,22 @@ pub trait Rewriter {
         })
     }
 
+    fn rewrite_unnamed_function_definition(
+        &mut self,
+        source: &UnnamedFunctionDefinition,
+    ) -> UnnamedFunctionDefinition {
+        let parameters = self.rewrite_parameters_declaration(&source.parameters);
+        let attributes = self.rewrite_unnamed_function_attributes(&source.attributes);
+        let body = self.rewrite_function_body(&source.body);
+
+        Rc::new(UnnamedFunctionDefinitionStruct {
+            node_id: source.node_id,
+            parameters,
+            attributes,
+            body,
+        })
+    }
+
     fn rewrite_fallback_function_definition(
         &mut self,
         source: &FallbackFunctionDefinition,
@@ -758,11 +774,13 @@ pub trait Rewriter {
         &mut self,
         source: &TupleDeconstructionStatement,
     ) -> TupleDeconstructionStatement {
+        let var_keyword = source.var_keyword.as_ref().map(Rc::clone);
         let elements = self.rewrite_tuple_deconstruction_elements(&source.elements);
         let expression = self.rewrite_expression(&source.expression);
 
         Rc::new(TupleDeconstructionStatementStruct {
             node_id: source.node_id,
+            var_keyword,
             elements,
             expression,
         })
@@ -1003,6 +1021,12 @@ pub trait Rewriter {
             node_id: source.node_id,
             error,
             arguments,
+        })
+    }
+
+    fn rewrite_throw_statement(&mut self, source: &ThrowStatement) -> ThrowStatement {
+        Rc::new(ThrowStatementStruct {
+            node_id: source.node_id,
         })
     }
 
@@ -1369,10 +1393,15 @@ pub trait Rewriter {
         source: &HexNumberExpression,
     ) -> HexNumberExpression {
         let literal = Rc::clone(&source.literal);
+        let unit = source
+            .unit
+            .as_ref()
+            .map(|value| self.rewrite_number_unit(value));
 
         Rc::new(HexNumberExpressionStruct {
             node_id: source.node_id,
             literal,
+            unit,
         })
     }
 
@@ -1494,6 +1523,32 @@ pub trait Rewriter {
         })
     }
 
+    fn rewrite_yul_colon_and_equal(&mut self, source: &YulColonAndEqual) -> YulColonAndEqual {
+        Rc::new(YulColonAndEqualStruct {
+            node_id: source.node_id,
+        })
+    }
+
+    fn rewrite_yul_stack_assignment_statement(
+        &mut self,
+        source: &YulStackAssignmentStatement,
+    ) -> YulStackAssignmentStatement {
+        let assignment = self.rewrite_yul_stack_assignment_operator(&source.assignment);
+        let variable = Rc::clone(&source.variable);
+
+        Rc::new(YulStackAssignmentStatementStruct {
+            node_id: source.node_id,
+            assignment,
+            variable,
+        })
+    }
+
+    fn rewrite_yul_equal_and_colon(&mut self, source: &YulEqualAndColon) -> YulEqualAndColon {
+        Rc::new(YulEqualAndColonStruct {
+            node_id: source.node_id,
+        })
+    }
+
     fn rewrite_yul_if_statement(&mut self, source: &YulIfStatement) -> YulIfStatement {
         let condition = self.rewrite_yul_expression(&source.condition);
         let body = self.rewrite_yul_block(&source.body);
@@ -1569,6 +1624,15 @@ pub trait Rewriter {
     ) -> YulContinueStatement {
         Rc::new(YulContinueStatementStruct {
             node_id: source.node_id,
+        })
+    }
+
+    fn rewrite_yul_label(&mut self, source: &YulLabel) -> YulLabel {
+        let label = Rc::clone(&source.label);
+
+        Rc::new(YulLabelStruct {
+            node_id: source.node_id,
+            label,
         })
     }
 
@@ -1858,6 +1922,11 @@ pub trait Rewriter {
                     self.rewrite_fallback_function_definition(fallback_function_definition),
                 )
             }
+            ContractMember::UnnamedFunctionDefinition(ref unnamed_function_definition) => {
+                ContractMember::UnnamedFunctionDefinition(
+                    self.rewrite_unnamed_function_definition(unnamed_function_definition),
+                )
+            }
             ContractMember::ModifierDefinition(ref modifier_definition) => {
                 ContractMember::ModifierDefinition(
                     self.rewrite_modifier_definition(modifier_definition),
@@ -1942,6 +2011,7 @@ pub trait Rewriter {
                     self.rewrite_override_specifier(override_specifier),
                 )
             }
+            FunctionAttribute::ConstantKeyword => FunctionAttribute::ConstantKeyword,
             FunctionAttribute::ExternalKeyword => FunctionAttribute::ExternalKeyword,
             FunctionAttribute::InternalKeyword => FunctionAttribute::InternalKeyword,
             FunctionAttribute::PayableKeyword => FunctionAttribute::PayableKeyword,
@@ -1977,8 +2047,10 @@ pub trait Rewriter {
                 )
             }
             ConstructorAttribute::InternalKeyword => ConstructorAttribute::InternalKeyword,
+            ConstructorAttribute::OverrideKeyword => ConstructorAttribute::OverrideKeyword,
             ConstructorAttribute::PayableKeyword => ConstructorAttribute::PayableKeyword,
             ConstructorAttribute::PublicKeyword => ConstructorAttribute::PublicKeyword,
+            ConstructorAttribute::VirtualKeyword => ConstructorAttribute::VirtualKeyword,
         }
     }
     fn rewrite_constructor_attribute(
@@ -1986,6 +2058,33 @@ pub trait Rewriter {
         source: &ConstructorAttribute,
     ) -> ConstructorAttribute {
         self.default_rewrite_constructor_attribute(source)
+    }
+
+    fn default_rewrite_unnamed_function_attribute(
+        &mut self,
+        source: &UnnamedFunctionAttribute,
+    ) -> UnnamedFunctionAttribute {
+        match source {
+            UnnamedFunctionAttribute::ModifierInvocation(ref modifier_invocation) => {
+                UnnamedFunctionAttribute::ModifierInvocation(
+                    self.rewrite_modifier_invocation(modifier_invocation),
+                )
+            }
+            UnnamedFunctionAttribute::ConstantKeyword => UnnamedFunctionAttribute::ConstantKeyword,
+            UnnamedFunctionAttribute::ExternalKeyword => UnnamedFunctionAttribute::ExternalKeyword,
+            UnnamedFunctionAttribute::InternalKeyword => UnnamedFunctionAttribute::InternalKeyword,
+            UnnamedFunctionAttribute::PayableKeyword => UnnamedFunctionAttribute::PayableKeyword,
+            UnnamedFunctionAttribute::PrivateKeyword => UnnamedFunctionAttribute::PrivateKeyword,
+            UnnamedFunctionAttribute::PublicKeyword => UnnamedFunctionAttribute::PublicKeyword,
+            UnnamedFunctionAttribute::PureKeyword => UnnamedFunctionAttribute::PureKeyword,
+            UnnamedFunctionAttribute::ViewKeyword => UnnamedFunctionAttribute::ViewKeyword,
+        }
+    }
+    fn rewrite_unnamed_function_attribute(
+        &mut self,
+        source: &UnnamedFunctionAttribute,
+    ) -> UnnamedFunctionAttribute {
+        self.default_rewrite_unnamed_function_attribute(source)
     }
 
     fn default_rewrite_fallback_function_attribute(
@@ -2095,6 +2194,7 @@ pub trait Rewriter {
             FunctionTypeAttribute::ExternalKeyword => FunctionTypeAttribute::ExternalKeyword,
             FunctionTypeAttribute::PrivateKeyword => FunctionTypeAttribute::PrivateKeyword,
             FunctionTypeAttribute::PublicKeyword => FunctionTypeAttribute::PublicKeyword,
+            FunctionTypeAttribute::ConstantKeyword => FunctionTypeAttribute::ConstantKeyword,
             FunctionTypeAttribute::PureKeyword => FunctionTypeAttribute::PureKeyword,
             FunctionTypeAttribute::ViewKeyword => FunctionTypeAttribute::ViewKeyword,
             FunctionTypeAttribute::PayableKeyword => FunctionTypeAttribute::PayableKeyword,
@@ -2132,6 +2232,7 @@ pub trait Rewriter {
             ElementaryType::FixedKeyword(node) => ElementaryType::FixedKeyword(Rc::clone(node)),
             ElementaryType::UfixedKeyword(node) => ElementaryType::UfixedKeyword(Rc::clone(node)),
             ElementaryType::BoolKeyword => ElementaryType::BoolKeyword,
+            ElementaryType::ByteKeyword => ElementaryType::ByteKeyword,
             ElementaryType::StringKeyword => ElementaryType::StringKeyword,
         }
     }
@@ -2161,6 +2262,9 @@ pub trait Rewriter {
             }
             Statement::ReturnStatement(ref return_statement) => {
                 Statement::ReturnStatement(self.rewrite_return_statement(return_statement))
+            }
+            Statement::ThrowStatement(ref throw_statement) => {
+                Statement::ThrowStatement(self.rewrite_throw_statement(throw_statement))
             }
             Statement::EmitStatement(ref emit_statement) => {
                 Statement::EmitStatement(self.rewrite_emit_statement(emit_statement))
@@ -2223,6 +2327,7 @@ pub trait Rewriter {
             VariableDeclarationType::TypeName(ref type_name) => {
                 VariableDeclarationType::TypeName(self.rewrite_type_name(type_name))
             }
+            VariableDeclarationType::VarKeyword => VariableDeclarationType::VarKeyword,
         }
     }
     fn rewrite_variable_declaration_type(
@@ -2448,12 +2553,15 @@ pub trait Rewriter {
         match source {
             NumberUnit::WeiKeyword => NumberUnit::WeiKeyword,
             NumberUnit::GweiKeyword => NumberUnit::GweiKeyword,
+            NumberUnit::SzaboKeyword => NumberUnit::SzaboKeyword,
+            NumberUnit::FinneyKeyword => NumberUnit::FinneyKeyword,
             NumberUnit::EtherKeyword => NumberUnit::EtherKeyword,
             NumberUnit::SecondsKeyword => NumberUnit::SecondsKeyword,
             NumberUnit::MinutesKeyword => NumberUnit::MinutesKeyword,
             NumberUnit::HoursKeyword => NumberUnit::HoursKeyword,
             NumberUnit::DaysKeyword => NumberUnit::DaysKeyword,
             NumberUnit::WeeksKeyword => NumberUnit::WeeksKeyword,
+            NumberUnit::YearsKeyword => NumberUnit::YearsKeyword,
         }
     }
     fn rewrite_number_unit(&mut self, source: &NumberUnit) -> NumberUnit {
@@ -2462,8 +2570,16 @@ pub trait Rewriter {
 
     fn default_rewrite_string_expression(&mut self, source: &StringExpression) -> StringExpression {
         match source {
+            StringExpression::StringLiteral(ref string_literal) => {
+                StringExpression::StringLiteral(self.rewrite_string_literal(string_literal))
+            }
             StringExpression::StringLiterals(ref string_literals) => {
                 StringExpression::StringLiterals(self.rewrite_string_literals(string_literals))
+            }
+            StringExpression::HexStringLiteral(ref hex_string_literal) => {
+                StringExpression::HexStringLiteral(
+                    self.rewrite_hex_string_literal(hex_string_literal),
+                )
             }
             StringExpression::HexStringLiterals(ref hex_string_literals) => {
                 StringExpression::HexStringLiterals(
@@ -2542,6 +2658,11 @@ pub trait Rewriter {
                     self.rewrite_yul_function_definition(yul_function_definition),
                 )
             }
+            YulStatement::YulStackAssignmentStatement(ref yul_stack_assignment_statement) => {
+                YulStatement::YulStackAssignmentStatement(
+                    self.rewrite_yul_stack_assignment_statement(yul_stack_assignment_statement),
+                )
+            }
             YulStatement::YulIfStatement(ref yul_if_statement) => {
                 YulStatement::YulIfStatement(self.rewrite_yul_if_statement(yul_if_statement))
             }
@@ -2575,6 +2696,9 @@ pub trait Rewriter {
                     ),
                 )
             }
+            YulStatement::YulLabel(ref yul_label) => {
+                YulStatement::YulLabel(self.rewrite_yul_label(yul_label))
+            }
             YulStatement::YulVariableDeclarationStatement(
                 ref yul_variable_declaration_statement,
             ) => YulStatement::YulVariableDeclarationStatement(
@@ -2594,6 +2718,11 @@ pub trait Rewriter {
         source: &YulAssignmentOperator,
     ) -> YulAssignmentOperator {
         match source {
+            YulAssignmentOperator::YulColonAndEqual(ref yul_colon_and_equal) => {
+                YulAssignmentOperator::YulColonAndEqual(
+                    self.rewrite_yul_colon_and_equal(yul_colon_and_equal),
+                )
+            }
             YulAssignmentOperator::ColonEqual => YulAssignmentOperator::ColonEqual,
         }
     }
@@ -2602,6 +2731,26 @@ pub trait Rewriter {
         source: &YulAssignmentOperator,
     ) -> YulAssignmentOperator {
         self.default_rewrite_yul_assignment_operator(source)
+    }
+
+    fn default_rewrite_yul_stack_assignment_operator(
+        &mut self,
+        source: &YulStackAssignmentOperator,
+    ) -> YulStackAssignmentOperator {
+        match source {
+            YulStackAssignmentOperator::YulEqualAndColon(ref yul_equal_and_colon) => {
+                YulStackAssignmentOperator::YulEqualAndColon(
+                    self.rewrite_yul_equal_and_colon(yul_equal_and_colon),
+                )
+            }
+            YulStackAssignmentOperator::EqualColon => YulStackAssignmentOperator::EqualColon,
+        }
+    }
+    fn rewrite_yul_stack_assignment_operator(
+        &mut self,
+        source: &YulStackAssignmentOperator,
+    ) -> YulStackAssignmentOperator {
+        self.default_rewrite_yul_stack_assignment_operator(source)
     }
 
     fn default_rewrite_yul_switch_case(&mut self, source: &YulSwitchCase) -> YulSwitchCase {
@@ -2797,6 +2946,16 @@ pub trait Rewriter {
         source
             .iter()
             .map(|item| self.rewrite_constructor_attribute(item))
+            .collect()
+    }
+
+    fn rewrite_unnamed_function_attributes(
+        &mut self,
+        source: &UnnamedFunctionAttributes,
+    ) -> UnnamedFunctionAttributes {
+        source
+            .iter()
+            .map(|item| self.rewrite_unnamed_function_attribute(item))
             .collect()
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_typed_cst/generated/visitor.rs
@@ -190,6 +190,11 @@ pub trait Visitor {
     }
     fn leave_constructor_definition(&mut self, _node: &ConstructorDefinition) {}
 
+    fn enter_unnamed_function_definition(&mut self, _node: &UnnamedFunctionDefinition) -> bool {
+        true
+    }
+    fn leave_unnamed_function_definition(&mut self, _node: &UnnamedFunctionDefinition) {}
+
     fn enter_fallback_function_definition(&mut self, _node: &FallbackFunctionDefinition) -> bool {
         true
     }
@@ -405,6 +410,11 @@ pub trait Visitor {
     }
     fn leave_revert_statement(&mut self, _node: &RevertStatement) {}
 
+    fn enter_throw_statement(&mut self, _node: &ThrowStatement) -> bool {
+        true
+    }
+    fn leave_throw_statement(&mut self, _node: &ThrowStatement) {}
+
     fn enter_assignment_expression(&mut self, _node: &AssignmentExpression) -> bool {
         true
     }
@@ -611,6 +621,24 @@ pub trait Visitor {
     }
     fn leave_yul_variable_assignment_statement(&mut self, _node: &YulVariableAssignmentStatement) {}
 
+    fn enter_yul_colon_and_equal(&mut self, _node: &YulColonAndEqual) -> bool {
+        true
+    }
+    fn leave_yul_colon_and_equal(&mut self, _node: &YulColonAndEqual) {}
+
+    fn enter_yul_stack_assignment_statement(
+        &mut self,
+        _node: &YulStackAssignmentStatement,
+    ) -> bool {
+        true
+    }
+    fn leave_yul_stack_assignment_statement(&mut self, _node: &YulStackAssignmentStatement) {}
+
+    fn enter_yul_equal_and_colon(&mut self, _node: &YulEqualAndColon) -> bool {
+        true
+    }
+    fn leave_yul_equal_and_colon(&mut self, _node: &YulEqualAndColon) {}
+
     fn enter_yul_if_statement(&mut self, _node: &YulIfStatement) -> bool {
         true
     }
@@ -650,6 +678,11 @@ pub trait Visitor {
         true
     }
     fn leave_yul_continue_statement(&mut self, _node: &YulContinueStatement) {}
+
+    fn enter_yul_label(&mut self, _node: &YulLabel) -> bool {
+        true
+    }
+    fn leave_yul_label(&mut self, _node: &YulLabel) {}
 
     fn enter_yul_function_call_expression(&mut self, _node: &YulFunctionCallExpression) -> bool {
         true
@@ -740,6 +773,11 @@ pub trait Visitor {
         true
     }
     fn leave_constructor_attribute(&mut self, _node: &ConstructorAttribute) {}
+
+    fn enter_unnamed_function_attribute(&mut self, _node: &UnnamedFunctionAttribute) -> bool {
+        true
+    }
+    fn leave_unnamed_function_attribute(&mut self, _node: &UnnamedFunctionAttribute) {}
 
     fn enter_fallback_function_attribute(&mut self, _node: &FallbackFunctionAttribute) -> bool {
         true
@@ -851,6 +889,11 @@ pub trait Visitor {
     }
     fn leave_yul_assignment_operator(&mut self, _node: &YulAssignmentOperator) {}
 
+    fn enter_yul_stack_assignment_operator(&mut self, _node: &YulStackAssignmentOperator) -> bool {
+        true
+    }
+    fn leave_yul_stack_assignment_operator(&mut self, _node: &YulStackAssignmentOperator) {}
+
     fn enter_yul_switch_case(&mut self, _node: &YulSwitchCase) -> bool {
         true
     }
@@ -958,6 +1001,11 @@ pub trait Visitor {
         true
     }
     fn leave_constructor_attributes(&mut self, _items: &ConstructorAttributes) {}
+
+    fn enter_unnamed_function_attributes(&mut self, _items: &UnnamedFunctionAttributes) -> bool {
+        true
+    }
+    fn leave_unnamed_function_attributes(&mut self, _items: &UnnamedFunctionAttributes) {}
 
     fn enter_fallback_function_attributes(&mut self, _items: &FallbackFunctionAttributes) -> bool {
         true
@@ -1402,6 +1450,18 @@ pub fn accept_constructor_definition(node: &ConstructorDefinition, visitor: &mut
     }
 }
 
+pub fn accept_unnamed_function_definition(
+    node: &UnnamedFunctionDefinition,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_unnamed_function_definition(node) {
+        accept_parameters_declaration(&node.parameters, visitor);
+        accept_unnamed_function_attributes(&node.attributes, visitor);
+        accept_function_body(&node.body, visitor);
+        visitor.leave_unnamed_function_definition(node);
+    }
+}
+
 pub fn accept_fallback_function_definition(
     node: &FallbackFunctionDefinition,
     visitor: &mut impl Visitor,
@@ -1785,6 +1845,12 @@ pub fn accept_revert_statement(node: &RevertStatement, visitor: &mut impl Visito
     }
 }
 
+pub fn accept_throw_statement(node: &ThrowStatement, visitor: &mut impl Visitor) {
+    if visitor.enter_throw_statement(node) {
+        visitor.leave_throw_statement(node);
+    }
+}
+
 pub fn accept_assignment_expression(node: &AssignmentExpression, visitor: &mut impl Visitor) {
     if visitor.enter_assignment_expression(node) {
         accept_expression(&node.left_operand, visitor);
@@ -2031,6 +2097,9 @@ pub fn accept_array_expression(node: &ArrayExpression, visitor: &mut impl Visito
 
 pub fn accept_hex_number_expression(node: &HexNumberExpression, visitor: &mut impl Visitor) {
     if visitor.enter_hex_number_expression(node) {
+        if let Some(ref unit) = node.unit {
+            accept_number_unit(unit, visitor);
+        }
         visitor.leave_hex_number_expression(node);
     }
 }
@@ -2118,6 +2187,28 @@ pub fn accept_yul_variable_assignment_statement(
     }
 }
 
+pub fn accept_yul_colon_and_equal(node: &YulColonAndEqual, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_colon_and_equal(node) {
+        visitor.leave_yul_colon_and_equal(node);
+    }
+}
+
+pub fn accept_yul_stack_assignment_statement(
+    node: &YulStackAssignmentStatement,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_yul_stack_assignment_statement(node) {
+        accept_yul_stack_assignment_operator(&node.assignment, visitor);
+        visitor.leave_yul_stack_assignment_statement(node);
+    }
+}
+
+pub fn accept_yul_equal_and_colon(node: &YulEqualAndColon, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_equal_and_colon(node) {
+        visitor.leave_yul_equal_and_colon(node);
+    }
+}
+
 pub fn accept_yul_if_statement(node: &YulIfStatement, visitor: &mut impl Visitor) {
     if visitor.enter_yul_if_statement(node) {
         accept_yul_expression(&node.condition, visitor);
@@ -2174,6 +2265,12 @@ pub fn accept_yul_break_statement(node: &YulBreakStatement, visitor: &mut impl V
 pub fn accept_yul_continue_statement(node: &YulContinueStatement, visitor: &mut impl Visitor) {
     if visitor.enter_yul_continue_statement(node) {
         visitor.leave_yul_continue_statement(node);
+    }
+}
+
+pub fn accept_yul_label(node: &YulLabel, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_label(node) {
+        visitor.leave_yul_label(node);
     }
 }
 
@@ -2348,6 +2445,9 @@ pub fn accept_contract_member(node: &ContractMember, visitor: &mut impl Visitor)
         ContractMember::FallbackFunctionDefinition(ref fallback_function_definition) => {
             accept_fallback_function_definition(fallback_function_definition, visitor);
         }
+        ContractMember::UnnamedFunctionDefinition(ref unnamed_function_definition) => {
+            accept_unnamed_function_definition(unnamed_function_definition, visitor);
+        }
         ContractMember::ModifierDefinition(ref modifier_definition) => {
             accept_modifier_definition(modifier_definition, visitor);
         }
@@ -2396,7 +2496,8 @@ pub fn accept_function_attribute(node: &FunctionAttribute, visitor: &mut impl Vi
         FunctionAttribute::OverrideSpecifier(ref override_specifier) => {
             accept_override_specifier(override_specifier, visitor);
         }
-        FunctionAttribute::ExternalKeyword
+        FunctionAttribute::ConstantKeyword
+        | FunctionAttribute::ExternalKeyword
         | FunctionAttribute::InternalKeyword
         | FunctionAttribute::PayableKeyword
         | FunctionAttribute::PrivateKeyword
@@ -2422,8 +2523,29 @@ pub fn accept_constructor_attribute(node: &ConstructorAttribute, visitor: &mut i
             accept_modifier_invocation(modifier_invocation, visitor);
         }
         ConstructorAttribute::InternalKeyword
+        | ConstructorAttribute::OverrideKeyword
         | ConstructorAttribute::PayableKeyword
-        | ConstructorAttribute::PublicKeyword => {}
+        | ConstructorAttribute::PublicKeyword
+        | ConstructorAttribute::VirtualKeyword => {}
+    }
+}
+
+pub fn accept_unnamed_function_attribute(
+    node: &UnnamedFunctionAttribute,
+    visitor: &mut impl Visitor,
+) {
+    match node {
+        UnnamedFunctionAttribute::ModifierInvocation(ref modifier_invocation) => {
+            accept_modifier_invocation(modifier_invocation, visitor);
+        }
+        UnnamedFunctionAttribute::ConstantKeyword
+        | UnnamedFunctionAttribute::ExternalKeyword
+        | UnnamedFunctionAttribute::InternalKeyword
+        | UnnamedFunctionAttribute::PayableKeyword
+        | UnnamedFunctionAttribute::PrivateKeyword
+        | UnnamedFunctionAttribute::PublicKeyword
+        | UnnamedFunctionAttribute::PureKeyword
+        | UnnamedFunctionAttribute::ViewKeyword => {}
     }
 }
 
@@ -2515,7 +2637,9 @@ pub fn accept_elementary_type(node: &ElementaryType, visitor: &mut impl Visitor)
         | ElementaryType::UintKeyword(_)
         | ElementaryType::FixedKeyword(_)
         | ElementaryType::UfixedKeyword(_) => {}
-        ElementaryType::BoolKeyword | ElementaryType::StringKeyword => {}
+        ElementaryType::BoolKeyword
+        | ElementaryType::ByteKeyword
+        | ElementaryType::StringKeyword => {}
     }
 }
 
@@ -2541,6 +2665,9 @@ pub fn accept_statement(node: &Statement, visitor: &mut impl Visitor) {
         }
         Statement::ReturnStatement(ref return_statement) => {
             accept_return_statement(return_statement, visitor);
+        }
+        Statement::ThrowStatement(ref throw_statement) => {
+            accept_throw_statement(throw_statement, visitor);
         }
         Statement::EmitStatement(ref emit_statement) => {
             accept_emit_statement(emit_statement, visitor);
@@ -2591,6 +2718,7 @@ pub fn accept_variable_declaration_type(
         VariableDeclarationType::TypeName(ref type_name) => {
             accept_type_name(type_name, visitor);
         }
+        VariableDeclarationType::VarKeyword => {}
     }
 }
 
@@ -2736,8 +2864,14 @@ pub fn accept_number_unit(_node: &NumberUnit, _visitor: &mut impl Visitor) {}
 
 pub fn accept_string_expression(node: &StringExpression, visitor: &mut impl Visitor) {
     match node {
+        StringExpression::StringLiteral(ref string_literal) => {
+            accept_string_literal(string_literal, visitor);
+        }
         StringExpression::StringLiterals(ref string_literals) => {
             accept_string_literals(string_literals, visitor);
+        }
+        StringExpression::HexStringLiteral(ref hex_string_literal) => {
+            accept_hex_string_literal(hex_string_literal, visitor);
         }
         StringExpression::HexStringLiterals(ref hex_string_literals) => {
             accept_hex_string_literals(hex_string_literals, visitor);
@@ -2762,6 +2896,9 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
         YulStatement::YulFunctionDefinition(ref yul_function_definition) => {
             accept_yul_function_definition(yul_function_definition, visitor);
         }
+        YulStatement::YulStackAssignmentStatement(ref yul_stack_assignment_statement) => {
+            accept_yul_stack_assignment_statement(yul_stack_assignment_statement, visitor);
+        }
         YulStatement::YulIfStatement(ref yul_if_statement) => {
             accept_yul_if_statement(yul_if_statement, visitor);
         }
@@ -2783,6 +2920,9 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
         YulStatement::YulVariableAssignmentStatement(ref yul_variable_assignment_statement) => {
             accept_yul_variable_assignment_statement(yul_variable_assignment_statement, visitor);
         }
+        YulStatement::YulLabel(ref yul_label) => {
+            accept_yul_label(yul_label, visitor);
+        }
         YulStatement::YulVariableDeclarationStatement(ref yul_variable_declaration_statement) => {
             accept_yul_variable_declaration_statement(yul_variable_declaration_statement, visitor);
         }
@@ -2792,7 +2932,26 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
     }
 }
 
-pub fn accept_yul_assignment_operator(_node: &YulAssignmentOperator, _visitor: &mut impl Visitor) {}
+pub fn accept_yul_assignment_operator(node: &YulAssignmentOperator, visitor: &mut impl Visitor) {
+    match node {
+        YulAssignmentOperator::YulColonAndEqual(ref yul_colon_and_equal) => {
+            accept_yul_colon_and_equal(yul_colon_and_equal, visitor);
+        }
+        YulAssignmentOperator::ColonEqual => {}
+    }
+}
+
+pub fn accept_yul_stack_assignment_operator(
+    node: &YulStackAssignmentOperator,
+    visitor: &mut impl Visitor,
+) {
+    match node {
+        YulStackAssignmentOperator::YulEqualAndColon(ref yul_equal_and_colon) => {
+            accept_yul_equal_and_colon(yul_equal_and_colon, visitor);
+        }
+        YulStackAssignmentOperator::EqualColon => {}
+    }
+}
 
 pub fn accept_yul_switch_case(node: &YulSwitchCase, visitor: &mut impl Visitor) {
     match node {
@@ -3016,6 +3175,19 @@ fn accept_constructor_attributes(items: &Vec<ConstructorAttribute>, visitor: &mu
             accept_constructor_attribute(item, visitor);
         }
         visitor.leave_constructor_attributes(items);
+    }
+}
+
+#[inline]
+fn accept_unnamed_function_attributes(
+    items: &Vec<UnnamedFunctionAttribute>,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_unnamed_function_attributes(items) {
+        for item in items {
+            accept_unnamed_function_attribute(item, visitor);
+        }
+        visitor.leave_unnamed_function_attributes(items);
     }
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/nodes.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/nodes.rs
@@ -332,6 +332,16 @@ pub struct ConstructorDefinitionStruct {
     pub body: Block,
 }
 
+pub type UnnamedFunctionDefinition = Rc<UnnamedFunctionDefinitionStruct>;
+
+#[derive(Debug)]
+pub struct UnnamedFunctionDefinitionStruct {
+    pub node_id: NodeId,
+    pub parameters: ParametersDeclaration,
+    pub attributes: UnnamedFunctionAttributes,
+    pub body: FunctionBody,
+}
+
 pub type FallbackFunctionDefinition = Rc<FallbackFunctionDefinitionStruct>;
 
 #[derive(Debug)]
@@ -537,6 +547,7 @@ pub type TupleDeconstructionStatement = Rc<TupleDeconstructionStatementStruct>;
 #[derive(Debug)]
 pub struct TupleDeconstructionStatementStruct {
     pub node_id: NodeId,
+    pub var_keyword: Option<Rc<TerminalNode>>,
     pub elements: TupleDeconstructionElements,
     pub expression: Expression,
 }
@@ -701,6 +712,13 @@ pub struct RevertStatementStruct {
     pub node_id: NodeId,
     pub error: Option<IdentifierPath>,
     pub arguments: ArgumentsDeclaration,
+}
+
+pub type ThrowStatement = Rc<ThrowStatementStruct>;
+
+#[derive(Debug)]
+pub struct ThrowStatementStruct {
+    pub node_id: NodeId,
 }
 
 pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
@@ -961,6 +979,7 @@ pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 pub struct HexNumberExpressionStruct {
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
+    pub unit: Option<NumberUnit>,
 }
 
 pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
@@ -1035,6 +1054,29 @@ pub struct YulVariableAssignmentStatementStruct {
     pub expression: YulExpression,
 }
 
+pub type YulColonAndEqual = Rc<YulColonAndEqualStruct>;
+
+#[derive(Debug)]
+pub struct YulColonAndEqualStruct {
+    pub node_id: NodeId,
+}
+
+pub type YulStackAssignmentStatement = Rc<YulStackAssignmentStatementStruct>;
+
+#[derive(Debug)]
+pub struct YulStackAssignmentStatementStruct {
+    pub node_id: NodeId,
+    pub assignment: YulStackAssignmentOperator,
+    pub variable: Rc<TerminalNode>,
+}
+
+pub type YulEqualAndColon = Rc<YulEqualAndColonStruct>;
+
+#[derive(Debug)]
+pub struct YulEqualAndColonStruct {
+    pub node_id: NodeId,
+}
+
 pub type YulIfStatement = Rc<YulIfStatementStruct>;
 
 #[derive(Debug)]
@@ -1100,6 +1142,14 @@ pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 #[derive(Debug)]
 pub struct YulContinueStatementStruct {
     pub node_id: NodeId,
+}
+
+pub type YulLabel = Rc<YulLabelStruct>;
+
+#[derive(Debug)]
+pub struct YulLabelStruct {
+    pub node_id: NodeId,
+    pub label: Rc<TerminalNode>,
 }
 
 pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
@@ -1220,6 +1270,7 @@ pub enum ContractMember {
     ConstructorDefinition(ConstructorDefinition),
     ReceiveFunctionDefinition(ReceiveFunctionDefinition),
     FallbackFunctionDefinition(FallbackFunctionDefinition),
+    UnnamedFunctionDefinition(UnnamedFunctionDefinition),
     ModifierDefinition(ModifierDefinition),
     StructDefinition(StructDefinition),
     EnumDefinition(EnumDefinition),
@@ -1251,6 +1302,7 @@ pub enum FunctionName {
 pub enum FunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     OverrideSpecifier(OverrideSpecifier),
+    ConstantKeyword,
     ExternalKeyword,
     InternalKeyword,
     PayableKeyword,
@@ -1271,8 +1323,23 @@ pub enum FunctionBody {
 pub enum ConstructorAttribute {
     ModifierInvocation(ModifierInvocation),
     InternalKeyword,
+    OverrideKeyword,
     PayableKeyword,
     PublicKeyword,
+    VirtualKeyword,
+}
+
+#[derive(Debug)]
+pub enum UnnamedFunctionAttribute {
+    ModifierInvocation(ModifierInvocation),
+    ConstantKeyword,
+    ExternalKeyword,
+    InternalKeyword,
+    PayableKeyword,
+    PrivateKeyword,
+    PublicKeyword,
+    PureKeyword,
+    ViewKeyword,
 }
 
 #[derive(Debug)]
@@ -1316,6 +1383,7 @@ pub enum FunctionTypeAttribute {
     ExternalKeyword,
     PrivateKeyword,
     PublicKeyword,
+    ConstantKeyword,
     PureKeyword,
     ViewKeyword,
     PayableKeyword,
@@ -1336,6 +1404,7 @@ pub enum ElementaryType {
     FixedKeyword(Rc<TerminalNode>),
     UfixedKeyword(Rc<TerminalNode>),
     BoolKeyword,
+    ByteKeyword,
     StringKeyword,
 }
 
@@ -1348,6 +1417,7 @@ pub enum Statement {
     ContinueStatement(ContinueStatement),
     BreakStatement(BreakStatement),
     ReturnStatement(ReturnStatement),
+    ThrowStatement(ThrowStatement),
     EmitStatement(EmitStatement),
     TryStatement(TryStatement),
     RevertStatement(RevertStatement),
@@ -1368,6 +1438,7 @@ pub enum TupleMember {
 #[derive(Debug)]
 pub enum VariableDeclarationType {
     TypeName(TypeName),
+    VarKeyword,
 }
 
 #[derive(Debug)]
@@ -1438,17 +1509,22 @@ pub enum ArgumentsDeclaration {
 pub enum NumberUnit {
     WeiKeyword,
     GweiKeyword,
+    SzaboKeyword,
+    FinneyKeyword,
     EtherKeyword,
     SecondsKeyword,
     MinutesKeyword,
     HoursKeyword,
     DaysKeyword,
     WeeksKeyword,
+    YearsKeyword,
 }
 
 #[derive(Debug)]
 pub enum StringExpression {
+    StringLiteral(StringLiteral),
     StringLiterals(StringLiterals),
+    HexStringLiteral(HexStringLiteral),
     HexStringLiterals(HexStringLiterals),
     UnicodeStringLiterals(UnicodeStringLiterals),
 }
@@ -1475,6 +1551,7 @@ pub enum UnicodeStringLiteral {
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),
+    YulStackAssignmentStatement(YulStackAssignmentStatement),
     YulIfStatement(YulIfStatement),
     YulForStatement(YulForStatement),
     YulSwitchStatement(YulSwitchStatement),
@@ -1482,13 +1559,21 @@ pub enum YulStatement {
     YulBreakStatement(YulBreakStatement),
     YulContinueStatement(YulContinueStatement),
     YulVariableAssignmentStatement(YulVariableAssignmentStatement),
+    YulLabel(YulLabel),
     YulVariableDeclarationStatement(YulVariableDeclarationStatement),
     YulExpression(YulExpression),
 }
 
 #[derive(Debug)]
 pub enum YulAssignmentOperator {
+    YulColonAndEqual(YulColonAndEqual),
     ColonEqual,
+}
+
+#[derive(Debug)]
+pub enum YulStackAssignmentOperator {
+    YulEqualAndColon(YulEqualAndColon),
+    EqualColon,
 }
 
 #[derive(Debug)]
@@ -1551,6 +1636,8 @@ pub type FunctionAttributes = Vec<FunctionAttribute>;
 pub type OverridePaths = Vec<IdentifierPath>;
 
 pub type ConstructorAttributes = Vec<ConstructorAttribute>;
+
+pub type UnnamedFunctionAttributes = Vec<UnnamedFunctionAttribute>;
 
 pub type FallbackFunctionAttributes = Vec<FallbackFunctionAttribute>;
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/rewriter.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/rewriter.rs
@@ -471,6 +471,22 @@ pub trait Rewriter {
         })
     }
 
+    fn rewrite_unnamed_function_definition(
+        &mut self,
+        source: &UnnamedFunctionDefinition,
+    ) -> UnnamedFunctionDefinition {
+        let parameters = self.rewrite_parameters_declaration(&source.parameters);
+        let attributes = self.rewrite_unnamed_function_attributes(&source.attributes);
+        let body = self.rewrite_function_body(&source.body);
+
+        Rc::new(UnnamedFunctionDefinitionStruct {
+            node_id: source.node_id,
+            parameters,
+            attributes,
+            body,
+        })
+    }
+
     fn rewrite_fallback_function_definition(
         &mut self,
         source: &FallbackFunctionDefinition,
@@ -763,11 +779,13 @@ pub trait Rewriter {
         &mut self,
         source: &TupleDeconstructionStatement,
     ) -> TupleDeconstructionStatement {
+        let var_keyword = source.var_keyword.as_ref().map(Rc::clone);
         let elements = self.rewrite_tuple_deconstruction_elements(&source.elements);
         let expression = self.rewrite_expression(&source.expression);
 
         Rc::new(TupleDeconstructionStatementStruct {
             node_id: source.node_id,
+            var_keyword,
             elements,
             expression,
         })
@@ -1008,6 +1026,12 @@ pub trait Rewriter {
             node_id: source.node_id,
             error,
             arguments,
+        })
+    }
+
+    fn rewrite_throw_statement(&mut self, source: &ThrowStatement) -> ThrowStatement {
+        Rc::new(ThrowStatementStruct {
+            node_id: source.node_id,
         })
     }
 
@@ -1374,10 +1398,15 @@ pub trait Rewriter {
         source: &HexNumberExpression,
     ) -> HexNumberExpression {
         let literal = Rc::clone(&source.literal);
+        let unit = source
+            .unit
+            .as_ref()
+            .map(|value| self.rewrite_number_unit(value));
 
         Rc::new(HexNumberExpressionStruct {
             node_id: source.node_id,
             literal,
+            unit,
         })
     }
 
@@ -1499,6 +1528,32 @@ pub trait Rewriter {
         })
     }
 
+    fn rewrite_yul_colon_and_equal(&mut self, source: &YulColonAndEqual) -> YulColonAndEqual {
+        Rc::new(YulColonAndEqualStruct {
+            node_id: source.node_id,
+        })
+    }
+
+    fn rewrite_yul_stack_assignment_statement(
+        &mut self,
+        source: &YulStackAssignmentStatement,
+    ) -> YulStackAssignmentStatement {
+        let assignment = self.rewrite_yul_stack_assignment_operator(&source.assignment);
+        let variable = Rc::clone(&source.variable);
+
+        Rc::new(YulStackAssignmentStatementStruct {
+            node_id: source.node_id,
+            assignment,
+            variable,
+        })
+    }
+
+    fn rewrite_yul_equal_and_colon(&mut self, source: &YulEqualAndColon) -> YulEqualAndColon {
+        Rc::new(YulEqualAndColonStruct {
+            node_id: source.node_id,
+        })
+    }
+
     fn rewrite_yul_if_statement(&mut self, source: &YulIfStatement) -> YulIfStatement {
         let condition = self.rewrite_yul_expression(&source.condition);
         let body = self.rewrite_yul_block(&source.body);
@@ -1574,6 +1629,15 @@ pub trait Rewriter {
     ) -> YulContinueStatement {
         Rc::new(YulContinueStatementStruct {
             node_id: source.node_id,
+        })
+    }
+
+    fn rewrite_yul_label(&mut self, source: &YulLabel) -> YulLabel {
+        let label = Rc::clone(&source.label);
+
+        Rc::new(YulLabelStruct {
+            node_id: source.node_id,
+            label,
         })
     }
 
@@ -1863,6 +1927,11 @@ pub trait Rewriter {
                     self.rewrite_fallback_function_definition(fallback_function_definition),
                 )
             }
+            ContractMember::UnnamedFunctionDefinition(ref unnamed_function_definition) => {
+                ContractMember::UnnamedFunctionDefinition(
+                    self.rewrite_unnamed_function_definition(unnamed_function_definition),
+                )
+            }
             ContractMember::ModifierDefinition(ref modifier_definition) => {
                 ContractMember::ModifierDefinition(
                     self.rewrite_modifier_definition(modifier_definition),
@@ -1947,6 +2016,7 @@ pub trait Rewriter {
                     self.rewrite_override_specifier(override_specifier),
                 )
             }
+            FunctionAttribute::ConstantKeyword => FunctionAttribute::ConstantKeyword,
             FunctionAttribute::ExternalKeyword => FunctionAttribute::ExternalKeyword,
             FunctionAttribute::InternalKeyword => FunctionAttribute::InternalKeyword,
             FunctionAttribute::PayableKeyword => FunctionAttribute::PayableKeyword,
@@ -1982,8 +2052,10 @@ pub trait Rewriter {
                 )
             }
             ConstructorAttribute::InternalKeyword => ConstructorAttribute::InternalKeyword,
+            ConstructorAttribute::OverrideKeyword => ConstructorAttribute::OverrideKeyword,
             ConstructorAttribute::PayableKeyword => ConstructorAttribute::PayableKeyword,
             ConstructorAttribute::PublicKeyword => ConstructorAttribute::PublicKeyword,
+            ConstructorAttribute::VirtualKeyword => ConstructorAttribute::VirtualKeyword,
         }
     }
     fn rewrite_constructor_attribute(
@@ -1991,6 +2063,33 @@ pub trait Rewriter {
         source: &ConstructorAttribute,
     ) -> ConstructorAttribute {
         self.default_rewrite_constructor_attribute(source)
+    }
+
+    fn default_rewrite_unnamed_function_attribute(
+        &mut self,
+        source: &UnnamedFunctionAttribute,
+    ) -> UnnamedFunctionAttribute {
+        match source {
+            UnnamedFunctionAttribute::ModifierInvocation(ref modifier_invocation) => {
+                UnnamedFunctionAttribute::ModifierInvocation(
+                    self.rewrite_modifier_invocation(modifier_invocation),
+                )
+            }
+            UnnamedFunctionAttribute::ConstantKeyword => UnnamedFunctionAttribute::ConstantKeyword,
+            UnnamedFunctionAttribute::ExternalKeyword => UnnamedFunctionAttribute::ExternalKeyword,
+            UnnamedFunctionAttribute::InternalKeyword => UnnamedFunctionAttribute::InternalKeyword,
+            UnnamedFunctionAttribute::PayableKeyword => UnnamedFunctionAttribute::PayableKeyword,
+            UnnamedFunctionAttribute::PrivateKeyword => UnnamedFunctionAttribute::PrivateKeyword,
+            UnnamedFunctionAttribute::PublicKeyword => UnnamedFunctionAttribute::PublicKeyword,
+            UnnamedFunctionAttribute::PureKeyword => UnnamedFunctionAttribute::PureKeyword,
+            UnnamedFunctionAttribute::ViewKeyword => UnnamedFunctionAttribute::ViewKeyword,
+        }
+    }
+    fn rewrite_unnamed_function_attribute(
+        &mut self,
+        source: &UnnamedFunctionAttribute,
+    ) -> UnnamedFunctionAttribute {
+        self.default_rewrite_unnamed_function_attribute(source)
     }
 
     fn default_rewrite_fallback_function_attribute(
@@ -2100,6 +2199,7 @@ pub trait Rewriter {
             FunctionTypeAttribute::ExternalKeyword => FunctionTypeAttribute::ExternalKeyword,
             FunctionTypeAttribute::PrivateKeyword => FunctionTypeAttribute::PrivateKeyword,
             FunctionTypeAttribute::PublicKeyword => FunctionTypeAttribute::PublicKeyword,
+            FunctionTypeAttribute::ConstantKeyword => FunctionTypeAttribute::ConstantKeyword,
             FunctionTypeAttribute::PureKeyword => FunctionTypeAttribute::PureKeyword,
             FunctionTypeAttribute::ViewKeyword => FunctionTypeAttribute::ViewKeyword,
             FunctionTypeAttribute::PayableKeyword => FunctionTypeAttribute::PayableKeyword,
@@ -2137,6 +2237,7 @@ pub trait Rewriter {
             ElementaryType::FixedKeyword(node) => ElementaryType::FixedKeyword(Rc::clone(node)),
             ElementaryType::UfixedKeyword(node) => ElementaryType::UfixedKeyword(Rc::clone(node)),
             ElementaryType::BoolKeyword => ElementaryType::BoolKeyword,
+            ElementaryType::ByteKeyword => ElementaryType::ByteKeyword,
             ElementaryType::StringKeyword => ElementaryType::StringKeyword,
         }
     }
@@ -2166,6 +2267,9 @@ pub trait Rewriter {
             }
             Statement::ReturnStatement(ref return_statement) => {
                 Statement::ReturnStatement(self.rewrite_return_statement(return_statement))
+            }
+            Statement::ThrowStatement(ref throw_statement) => {
+                Statement::ThrowStatement(self.rewrite_throw_statement(throw_statement))
             }
             Statement::EmitStatement(ref emit_statement) => {
                 Statement::EmitStatement(self.rewrite_emit_statement(emit_statement))
@@ -2228,6 +2332,7 @@ pub trait Rewriter {
             VariableDeclarationType::TypeName(ref type_name) => {
                 VariableDeclarationType::TypeName(self.rewrite_type_name(type_name))
             }
+            VariableDeclarationType::VarKeyword => VariableDeclarationType::VarKeyword,
         }
     }
     fn rewrite_variable_declaration_type(
@@ -2453,12 +2558,15 @@ pub trait Rewriter {
         match source {
             NumberUnit::WeiKeyword => NumberUnit::WeiKeyword,
             NumberUnit::GweiKeyword => NumberUnit::GweiKeyword,
+            NumberUnit::SzaboKeyword => NumberUnit::SzaboKeyword,
+            NumberUnit::FinneyKeyword => NumberUnit::FinneyKeyword,
             NumberUnit::EtherKeyword => NumberUnit::EtherKeyword,
             NumberUnit::SecondsKeyword => NumberUnit::SecondsKeyword,
             NumberUnit::MinutesKeyword => NumberUnit::MinutesKeyword,
             NumberUnit::HoursKeyword => NumberUnit::HoursKeyword,
             NumberUnit::DaysKeyword => NumberUnit::DaysKeyword,
             NumberUnit::WeeksKeyword => NumberUnit::WeeksKeyword,
+            NumberUnit::YearsKeyword => NumberUnit::YearsKeyword,
         }
     }
     fn rewrite_number_unit(&mut self, source: &NumberUnit) -> NumberUnit {
@@ -2467,8 +2575,16 @@ pub trait Rewriter {
 
     fn default_rewrite_string_expression(&mut self, source: &StringExpression) -> StringExpression {
         match source {
+            StringExpression::StringLiteral(ref string_literal) => {
+                StringExpression::StringLiteral(self.rewrite_string_literal(string_literal))
+            }
             StringExpression::StringLiterals(ref string_literals) => {
                 StringExpression::StringLiterals(self.rewrite_string_literals(string_literals))
+            }
+            StringExpression::HexStringLiteral(ref hex_string_literal) => {
+                StringExpression::HexStringLiteral(
+                    self.rewrite_hex_string_literal(hex_string_literal),
+                )
             }
             StringExpression::HexStringLiterals(ref hex_string_literals) => {
                 StringExpression::HexStringLiterals(
@@ -2547,6 +2663,11 @@ pub trait Rewriter {
                     self.rewrite_yul_function_definition(yul_function_definition),
                 )
             }
+            YulStatement::YulStackAssignmentStatement(ref yul_stack_assignment_statement) => {
+                YulStatement::YulStackAssignmentStatement(
+                    self.rewrite_yul_stack_assignment_statement(yul_stack_assignment_statement),
+                )
+            }
             YulStatement::YulIfStatement(ref yul_if_statement) => {
                 YulStatement::YulIfStatement(self.rewrite_yul_if_statement(yul_if_statement))
             }
@@ -2580,6 +2701,9 @@ pub trait Rewriter {
                     ),
                 )
             }
+            YulStatement::YulLabel(ref yul_label) => {
+                YulStatement::YulLabel(self.rewrite_yul_label(yul_label))
+            }
             YulStatement::YulVariableDeclarationStatement(
                 ref yul_variable_declaration_statement,
             ) => YulStatement::YulVariableDeclarationStatement(
@@ -2599,6 +2723,11 @@ pub trait Rewriter {
         source: &YulAssignmentOperator,
     ) -> YulAssignmentOperator {
         match source {
+            YulAssignmentOperator::YulColonAndEqual(ref yul_colon_and_equal) => {
+                YulAssignmentOperator::YulColonAndEqual(
+                    self.rewrite_yul_colon_and_equal(yul_colon_and_equal),
+                )
+            }
             YulAssignmentOperator::ColonEqual => YulAssignmentOperator::ColonEqual,
         }
     }
@@ -2607,6 +2736,26 @@ pub trait Rewriter {
         source: &YulAssignmentOperator,
     ) -> YulAssignmentOperator {
         self.default_rewrite_yul_assignment_operator(source)
+    }
+
+    fn default_rewrite_yul_stack_assignment_operator(
+        &mut self,
+        source: &YulStackAssignmentOperator,
+    ) -> YulStackAssignmentOperator {
+        match source {
+            YulStackAssignmentOperator::YulEqualAndColon(ref yul_equal_and_colon) => {
+                YulStackAssignmentOperator::YulEqualAndColon(
+                    self.rewrite_yul_equal_and_colon(yul_equal_and_colon),
+                )
+            }
+            YulStackAssignmentOperator::EqualColon => YulStackAssignmentOperator::EqualColon,
+        }
+    }
+    fn rewrite_yul_stack_assignment_operator(
+        &mut self,
+        source: &YulStackAssignmentOperator,
+    ) -> YulStackAssignmentOperator {
+        self.default_rewrite_yul_stack_assignment_operator(source)
     }
 
     fn default_rewrite_yul_switch_case(&mut self, source: &YulSwitchCase) -> YulSwitchCase {
@@ -2795,6 +2944,16 @@ pub trait Rewriter {
         source
             .iter()
             .map(|item| self.rewrite_constructor_attribute(item))
+            .collect()
+    }
+
+    fn rewrite_unnamed_function_attributes(
+        &mut self,
+        source: &UnnamedFunctionAttributes,
+    ) -> UnnamedFunctionAttributes {
+        source
+            .iter()
+            .map(|item| self.rewrite_unnamed_function_attribute(item))
             .collect()
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/transformer.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/transformer.rs
@@ -495,6 +495,22 @@ pub trait Transformer {
         })
     }
 
+    fn transform_unnamed_function_definition(
+        &mut self,
+        source: &input::UnnamedFunctionDefinition,
+    ) -> output::UnnamedFunctionDefinition {
+        let parameters = self.transform_parameters_declaration(&source.parameters);
+        let attributes = self.transform_unnamed_function_attributes(&source.attributes);
+        let body = self.transform_function_body(&source.body);
+
+        Rc::new(output::UnnamedFunctionDefinitionStruct {
+            node_id: source.node_id,
+            parameters,
+            attributes,
+            body,
+        })
+    }
+
     fn transform_fallback_function_definition(
         &mut self,
         source: &input::FallbackFunctionDefinition,
@@ -814,11 +830,13 @@ pub trait Transformer {
         &mut self,
         source: &input::TupleDeconstructionStatement,
     ) -> output::TupleDeconstructionStatement {
+        let var_keyword = source.var_keyword.as_ref().map(Rc::clone);
         let elements = self.transform_tuple_deconstruction_elements(&source.elements);
         let expression = self.transform_expression(&source.expression);
 
         Rc::new(output::TupleDeconstructionStatementStruct {
             node_id: source.node_id,
+            var_keyword,
             elements,
             expression,
         })
@@ -1086,6 +1104,15 @@ pub trait Transformer {
             node_id: source.node_id,
             error,
             arguments,
+        })
+    }
+
+    fn transform_throw_statement(
+        &mut self,
+        source: &input::ThrowStatement,
+    ) -> output::ThrowStatement {
+        Rc::new(output::ThrowStatementStruct {
+            node_id: source.node_id,
         })
     }
 
@@ -1482,10 +1509,15 @@ pub trait Transformer {
         source: &input::HexNumberExpression,
     ) -> output::HexNumberExpression {
         let literal = Rc::clone(&source.literal);
+        let unit = source
+            .unit
+            .as_ref()
+            .map(|value| self.transform_number_unit(value));
 
         Rc::new(output::HexNumberExpressionStruct {
             node_id: source.node_id,
             literal,
+            unit,
         })
     }
 
@@ -1607,6 +1639,38 @@ pub trait Transformer {
         })
     }
 
+    fn transform_yul_colon_and_equal(
+        &mut self,
+        source: &input::YulColonAndEqual,
+    ) -> output::YulColonAndEqual {
+        Rc::new(output::YulColonAndEqualStruct {
+            node_id: source.node_id,
+        })
+    }
+
+    fn transform_yul_stack_assignment_statement(
+        &mut self,
+        source: &input::YulStackAssignmentStatement,
+    ) -> output::YulStackAssignmentStatement {
+        let assignment = self.transform_yul_stack_assignment_operator(&source.assignment);
+        let variable = Rc::clone(&source.variable);
+
+        Rc::new(output::YulStackAssignmentStatementStruct {
+            node_id: source.node_id,
+            assignment,
+            variable,
+        })
+    }
+
+    fn transform_yul_equal_and_colon(
+        &mut self,
+        source: &input::YulEqualAndColon,
+    ) -> output::YulEqualAndColon {
+        Rc::new(output::YulEqualAndColonStruct {
+            node_id: source.node_id,
+        })
+    }
+
     fn transform_yul_if_statement(
         &mut self,
         source: &input::YulIfStatement,
@@ -1700,6 +1764,15 @@ pub trait Transformer {
     ) -> output::YulContinueStatement {
         Rc::new(output::YulContinueStatementStruct {
             node_id: source.node_id,
+        })
+    }
+
+    fn transform_yul_label(&mut self, source: &input::YulLabel) -> output::YulLabel {
+        let label = Rc::clone(&source.label);
+
+        Rc::new(output::YulLabelStruct {
+            node_id: source.node_id,
+            label,
         })
     }
 
@@ -2057,6 +2130,11 @@ pub trait Transformer {
                     self.transform_fallback_function_definition(fallback_function_definition),
                 )
             }
+            input::ContractMember::UnnamedFunctionDefinition(ref unnamed_function_definition) => {
+                output::ContractMember::UnnamedFunctionDefinition(
+                    self.transform_unnamed_function_definition(unnamed_function_definition),
+                )
+            }
             input::ContractMember::ModifierDefinition(ref modifier_definition) => {
                 output::ContractMember::ModifierDefinition(
                     self.transform_modifier_definition(modifier_definition),
@@ -2174,6 +2252,7 @@ pub trait Transformer {
                     self.transform_override_specifier(override_specifier),
                 )
             }
+            input::FunctionAttribute::ConstantKeyword => output::FunctionAttribute::ConstantKeyword,
             input::FunctionAttribute::ExternalKeyword => output::FunctionAttribute::ExternalKeyword,
             input::FunctionAttribute::InternalKeyword => output::FunctionAttribute::InternalKeyword,
             input::FunctionAttribute::PayableKeyword => output::FunctionAttribute::PayableKeyword,
@@ -2221,11 +2300,17 @@ pub trait Transformer {
             input::ConstructorAttribute::InternalKeyword => {
                 output::ConstructorAttribute::InternalKeyword
             }
+            input::ConstructorAttribute::OverrideKeyword => {
+                output::ConstructorAttribute::OverrideKeyword
+            }
             input::ConstructorAttribute::PayableKeyword => {
                 output::ConstructorAttribute::PayableKeyword
             }
             input::ConstructorAttribute::PublicKeyword => {
                 output::ConstructorAttribute::PublicKeyword
+            }
+            input::ConstructorAttribute::VirtualKeyword => {
+                output::ConstructorAttribute::VirtualKeyword
             }
         }
     }
@@ -2234,6 +2319,50 @@ pub trait Transformer {
         source: &input::ConstructorAttribute,
     ) -> output::ConstructorAttribute {
         self.default_transform_constructor_attribute(source)
+    }
+
+    fn default_transform_unnamed_function_attribute(
+        &mut self,
+        source: &input::UnnamedFunctionAttribute,
+    ) -> output::UnnamedFunctionAttribute {
+        #[allow(clippy::match_wildcard_for_single_variants)]
+        match source {
+            input::UnnamedFunctionAttribute::ModifierInvocation(ref modifier_invocation) => {
+                output::UnnamedFunctionAttribute::ModifierInvocation(
+                    self.transform_modifier_invocation(modifier_invocation),
+                )
+            }
+            input::UnnamedFunctionAttribute::ConstantKeyword => {
+                output::UnnamedFunctionAttribute::ConstantKeyword
+            }
+            input::UnnamedFunctionAttribute::ExternalKeyword => {
+                output::UnnamedFunctionAttribute::ExternalKeyword
+            }
+            input::UnnamedFunctionAttribute::InternalKeyword => {
+                output::UnnamedFunctionAttribute::InternalKeyword
+            }
+            input::UnnamedFunctionAttribute::PayableKeyword => {
+                output::UnnamedFunctionAttribute::PayableKeyword
+            }
+            input::UnnamedFunctionAttribute::PrivateKeyword => {
+                output::UnnamedFunctionAttribute::PrivateKeyword
+            }
+            input::UnnamedFunctionAttribute::PublicKeyword => {
+                output::UnnamedFunctionAttribute::PublicKeyword
+            }
+            input::UnnamedFunctionAttribute::PureKeyword => {
+                output::UnnamedFunctionAttribute::PureKeyword
+            }
+            input::UnnamedFunctionAttribute::ViewKeyword => {
+                output::UnnamedFunctionAttribute::ViewKeyword
+            }
+        }
+    }
+    fn transform_unnamed_function_attribute(
+        &mut self,
+        source: &input::UnnamedFunctionAttribute,
+    ) -> output::UnnamedFunctionAttribute {
+        self.default_transform_unnamed_function_attribute(source)
     }
 
     fn default_transform_fallback_function_attribute(
@@ -2373,6 +2502,9 @@ pub trait Transformer {
             input::FunctionTypeAttribute::PublicKeyword => {
                 output::FunctionTypeAttribute::PublicKeyword
             }
+            input::FunctionTypeAttribute::ConstantKeyword => {
+                output::FunctionTypeAttribute::ConstantKeyword
+            }
             input::FunctionTypeAttribute::PureKeyword => output::FunctionTypeAttribute::PureKeyword,
             input::FunctionTypeAttribute::ViewKeyword => output::FunctionTypeAttribute::ViewKeyword,
             input::FunctionTypeAttribute::PayableKeyword => {
@@ -2437,6 +2569,7 @@ pub trait Transformer {
                 output::ElementaryType::UfixedKeyword(Rc::clone(node))
             }
             input::ElementaryType::BoolKeyword => output::ElementaryType::BoolKeyword,
+            input::ElementaryType::ByteKeyword => output::ElementaryType::ByteKeyword,
             input::ElementaryType::StringKeyword => output::ElementaryType::StringKeyword,
         }
     }
@@ -2476,6 +2609,9 @@ pub trait Transformer {
                 output::Statement::ReturnStatement(
                     self.transform_return_statement(return_statement),
                 )
+            }
+            input::Statement::ThrowStatement(ref throw_statement) => {
+                output::Statement::ThrowStatement(self.transform_throw_statement(throw_statement))
             }
             input::Statement::EmitStatement(ref emit_statement) => {
                 output::Statement::EmitStatement(self.transform_emit_statement(emit_statement))
@@ -2550,6 +2686,9 @@ pub trait Transformer {
         match source {
             input::VariableDeclarationType::TypeName(ref type_name) => {
                 output::VariableDeclarationType::TypeName(self.transform_type_name(type_name))
+            }
+            input::VariableDeclarationType::VarKeyword => {
+                output::VariableDeclarationType::VarKeyword
             }
         }
     }
@@ -2802,12 +2941,15 @@ pub trait Transformer {
         match source {
             input::NumberUnit::WeiKeyword => output::NumberUnit::WeiKeyword,
             input::NumberUnit::GweiKeyword => output::NumberUnit::GweiKeyword,
+            input::NumberUnit::SzaboKeyword => output::NumberUnit::SzaboKeyword,
+            input::NumberUnit::FinneyKeyword => output::NumberUnit::FinneyKeyword,
             input::NumberUnit::EtherKeyword => output::NumberUnit::EtherKeyword,
             input::NumberUnit::SecondsKeyword => output::NumberUnit::SecondsKeyword,
             input::NumberUnit::MinutesKeyword => output::NumberUnit::MinutesKeyword,
             input::NumberUnit::HoursKeyword => output::NumberUnit::HoursKeyword,
             input::NumberUnit::DaysKeyword => output::NumberUnit::DaysKeyword,
             input::NumberUnit::WeeksKeyword => output::NumberUnit::WeeksKeyword,
+            input::NumberUnit::YearsKeyword => output::NumberUnit::YearsKeyword,
         }
     }
     fn transform_number_unit(&mut self, source: &input::NumberUnit) -> output::NumberUnit {
@@ -2820,9 +2962,19 @@ pub trait Transformer {
     ) -> output::StringExpression {
         #[allow(clippy::match_wildcard_for_single_variants)]
         match source {
+            input::StringExpression::StringLiteral(ref string_literal) => {
+                output::StringExpression::StringLiteral(
+                    self.transform_string_literal(string_literal),
+                )
+            }
             input::StringExpression::StringLiterals(ref string_literals) => {
                 output::StringExpression::StringLiterals(
                     self.transform_string_literals(string_literals),
+                )
+            }
+            input::StringExpression::HexStringLiteral(ref hex_string_literal) => {
+                output::StringExpression::HexStringLiteral(
+                    self.transform_hex_string_literal(hex_string_literal),
                 )
             }
             input::StringExpression::HexStringLiterals(ref hex_string_literals) => {
@@ -2918,6 +3070,11 @@ pub trait Transformer {
                     self.transform_yul_function_definition(yul_function_definition),
                 )
             }
+            input::YulStatement::YulStackAssignmentStatement(
+                ref yul_stack_assignment_statement,
+            ) => output::YulStatement::YulStackAssignmentStatement(
+                self.transform_yul_stack_assignment_statement(yul_stack_assignment_statement),
+            ),
             input::YulStatement::YulIfStatement(ref yul_if_statement) => {
                 output::YulStatement::YulIfStatement(
                     self.transform_yul_if_statement(yul_if_statement),
@@ -2953,6 +3110,9 @@ pub trait Transformer {
             ) => output::YulStatement::YulVariableAssignmentStatement(
                 self.transform_yul_variable_assignment_statement(yul_variable_assignment_statement),
             ),
+            input::YulStatement::YulLabel(ref yul_label) => {
+                output::YulStatement::YulLabel(self.transform_yul_label(yul_label))
+            }
             input::YulStatement::YulVariableDeclarationStatement(
                 ref yul_variable_declaration_statement,
             ) => output::YulStatement::YulVariableDeclarationStatement(
@@ -2975,6 +3135,11 @@ pub trait Transformer {
     ) -> output::YulAssignmentOperator {
         #[allow(clippy::match_wildcard_for_single_variants)]
         match source {
+            input::YulAssignmentOperator::YulColonAndEqual(ref yul_colon_and_equal) => {
+                output::YulAssignmentOperator::YulColonAndEqual(
+                    self.transform_yul_colon_and_equal(yul_colon_and_equal),
+                )
+            }
             input::YulAssignmentOperator::ColonEqual => output::YulAssignmentOperator::ColonEqual,
         }
     }
@@ -2983,6 +3148,29 @@ pub trait Transformer {
         source: &input::YulAssignmentOperator,
     ) -> output::YulAssignmentOperator {
         self.default_transform_yul_assignment_operator(source)
+    }
+
+    fn default_transform_yul_stack_assignment_operator(
+        &mut self,
+        source: &input::YulStackAssignmentOperator,
+    ) -> output::YulStackAssignmentOperator {
+        #[allow(clippy::match_wildcard_for_single_variants)]
+        match source {
+            input::YulStackAssignmentOperator::YulEqualAndColon(ref yul_equal_and_colon) => {
+                output::YulStackAssignmentOperator::YulEqualAndColon(
+                    self.transform_yul_equal_and_colon(yul_equal_and_colon),
+                )
+            }
+            input::YulStackAssignmentOperator::EqualColon => {
+                output::YulStackAssignmentOperator::EqualColon
+            }
+        }
+    }
+    fn transform_yul_stack_assignment_operator(
+        &mut self,
+        source: &input::YulStackAssignmentOperator,
+    ) -> output::YulStackAssignmentOperator {
+        self.default_transform_yul_stack_assignment_operator(source)
     }
 
     fn default_transform_yul_switch_case(
@@ -3209,6 +3397,16 @@ pub trait Transformer {
         source
             .iter()
             .map(|item| self.transform_constructor_attribute(item))
+            .collect()
+    }
+
+    fn transform_unnamed_function_attributes(
+        &mut self,
+        source: &input::UnnamedFunctionAttributes,
+    ) -> output::UnnamedFunctionAttributes {
+        source
+            .iter()
+            .map(|item| self.transform_unnamed_function_attribute(item))
             .collect()
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/visitor.rs
@@ -190,6 +190,11 @@ pub trait Visitor {
     }
     fn leave_constructor_definition(&mut self, _node: &ConstructorDefinition) {}
 
+    fn enter_unnamed_function_definition(&mut self, _node: &UnnamedFunctionDefinition) -> bool {
+        true
+    }
+    fn leave_unnamed_function_definition(&mut self, _node: &UnnamedFunctionDefinition) {}
+
     fn enter_fallback_function_definition(&mut self, _node: &FallbackFunctionDefinition) -> bool {
         true
     }
@@ -405,6 +410,11 @@ pub trait Visitor {
     }
     fn leave_revert_statement(&mut self, _node: &RevertStatement) {}
 
+    fn enter_throw_statement(&mut self, _node: &ThrowStatement) -> bool {
+        true
+    }
+    fn leave_throw_statement(&mut self, _node: &ThrowStatement) {}
+
     fn enter_assignment_expression(&mut self, _node: &AssignmentExpression) -> bool {
         true
     }
@@ -611,6 +621,24 @@ pub trait Visitor {
     }
     fn leave_yul_variable_assignment_statement(&mut self, _node: &YulVariableAssignmentStatement) {}
 
+    fn enter_yul_colon_and_equal(&mut self, _node: &YulColonAndEqual) -> bool {
+        true
+    }
+    fn leave_yul_colon_and_equal(&mut self, _node: &YulColonAndEqual) {}
+
+    fn enter_yul_stack_assignment_statement(
+        &mut self,
+        _node: &YulStackAssignmentStatement,
+    ) -> bool {
+        true
+    }
+    fn leave_yul_stack_assignment_statement(&mut self, _node: &YulStackAssignmentStatement) {}
+
+    fn enter_yul_equal_and_colon(&mut self, _node: &YulEqualAndColon) -> bool {
+        true
+    }
+    fn leave_yul_equal_and_colon(&mut self, _node: &YulEqualAndColon) {}
+
     fn enter_yul_if_statement(&mut self, _node: &YulIfStatement) -> bool {
         true
     }
@@ -650,6 +678,11 @@ pub trait Visitor {
         true
     }
     fn leave_yul_continue_statement(&mut self, _node: &YulContinueStatement) {}
+
+    fn enter_yul_label(&mut self, _node: &YulLabel) -> bool {
+        true
+    }
+    fn leave_yul_label(&mut self, _node: &YulLabel) {}
 
     fn enter_yul_function_call_expression(&mut self, _node: &YulFunctionCallExpression) -> bool {
         true
@@ -740,6 +773,11 @@ pub trait Visitor {
         true
     }
     fn leave_constructor_attribute(&mut self, _node: &ConstructorAttribute) {}
+
+    fn enter_unnamed_function_attribute(&mut self, _node: &UnnamedFunctionAttribute) -> bool {
+        true
+    }
+    fn leave_unnamed_function_attribute(&mut self, _node: &UnnamedFunctionAttribute) {}
 
     fn enter_fallback_function_attribute(&mut self, _node: &FallbackFunctionAttribute) -> bool {
         true
@@ -851,6 +889,11 @@ pub trait Visitor {
     }
     fn leave_yul_assignment_operator(&mut self, _node: &YulAssignmentOperator) {}
 
+    fn enter_yul_stack_assignment_operator(&mut self, _node: &YulStackAssignmentOperator) -> bool {
+        true
+    }
+    fn leave_yul_stack_assignment_operator(&mut self, _node: &YulStackAssignmentOperator) {}
+
     fn enter_yul_switch_case(&mut self, _node: &YulSwitchCase) -> bool {
         true
     }
@@ -953,6 +996,11 @@ pub trait Visitor {
         true
     }
     fn leave_constructor_attributes(&mut self, _items: &ConstructorAttributes) {}
+
+    fn enter_unnamed_function_attributes(&mut self, _items: &UnnamedFunctionAttributes) -> bool {
+        true
+    }
+    fn leave_unnamed_function_attributes(&mut self, _items: &UnnamedFunctionAttributes) {}
 
     fn enter_fallback_function_attributes(&mut self, _items: &FallbackFunctionAttributes) -> bool {
         true
@@ -1400,6 +1448,18 @@ pub fn accept_constructor_definition(node: &ConstructorDefinition, visitor: &mut
     }
 }
 
+pub fn accept_unnamed_function_definition(
+    node: &UnnamedFunctionDefinition,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_unnamed_function_definition(node) {
+        accept_parameters_declaration(&node.parameters, visitor);
+        accept_unnamed_function_attributes(&node.attributes, visitor);
+        accept_function_body(&node.body, visitor);
+        visitor.leave_unnamed_function_definition(node);
+    }
+}
+
 pub fn accept_fallback_function_definition(
     node: &FallbackFunctionDefinition,
     visitor: &mut impl Visitor,
@@ -1783,6 +1843,12 @@ pub fn accept_revert_statement(node: &RevertStatement, visitor: &mut impl Visito
     }
 }
 
+pub fn accept_throw_statement(node: &ThrowStatement, visitor: &mut impl Visitor) {
+    if visitor.enter_throw_statement(node) {
+        visitor.leave_throw_statement(node);
+    }
+}
+
 pub fn accept_assignment_expression(node: &AssignmentExpression, visitor: &mut impl Visitor) {
     if visitor.enter_assignment_expression(node) {
         accept_expression(&node.left_operand, visitor);
@@ -2029,6 +2095,9 @@ pub fn accept_array_expression(node: &ArrayExpression, visitor: &mut impl Visito
 
 pub fn accept_hex_number_expression(node: &HexNumberExpression, visitor: &mut impl Visitor) {
     if visitor.enter_hex_number_expression(node) {
+        if let Some(ref unit) = node.unit {
+            accept_number_unit(unit, visitor);
+        }
         visitor.leave_hex_number_expression(node);
     }
 }
@@ -2116,6 +2185,28 @@ pub fn accept_yul_variable_assignment_statement(
     }
 }
 
+pub fn accept_yul_colon_and_equal(node: &YulColonAndEqual, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_colon_and_equal(node) {
+        visitor.leave_yul_colon_and_equal(node);
+    }
+}
+
+pub fn accept_yul_stack_assignment_statement(
+    node: &YulStackAssignmentStatement,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_yul_stack_assignment_statement(node) {
+        accept_yul_stack_assignment_operator(&node.assignment, visitor);
+        visitor.leave_yul_stack_assignment_statement(node);
+    }
+}
+
+pub fn accept_yul_equal_and_colon(node: &YulEqualAndColon, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_equal_and_colon(node) {
+        visitor.leave_yul_equal_and_colon(node);
+    }
+}
+
 pub fn accept_yul_if_statement(node: &YulIfStatement, visitor: &mut impl Visitor) {
     if visitor.enter_yul_if_statement(node) {
         accept_yul_expression(&node.condition, visitor);
@@ -2172,6 +2263,12 @@ pub fn accept_yul_break_statement(node: &YulBreakStatement, visitor: &mut impl V
 pub fn accept_yul_continue_statement(node: &YulContinueStatement, visitor: &mut impl Visitor) {
     if visitor.enter_yul_continue_statement(node) {
         visitor.leave_yul_continue_statement(node);
+    }
+}
+
+pub fn accept_yul_label(node: &YulLabel, visitor: &mut impl Visitor) {
+    if visitor.enter_yul_label(node) {
+        visitor.leave_yul_label(node);
     }
 }
 
@@ -2346,6 +2443,9 @@ pub fn accept_contract_member(node: &ContractMember, visitor: &mut impl Visitor)
         ContractMember::FallbackFunctionDefinition(ref fallback_function_definition) => {
             accept_fallback_function_definition(fallback_function_definition, visitor);
         }
+        ContractMember::UnnamedFunctionDefinition(ref unnamed_function_definition) => {
+            accept_unnamed_function_definition(unnamed_function_definition, visitor);
+        }
         ContractMember::ModifierDefinition(ref modifier_definition) => {
             accept_modifier_definition(modifier_definition, visitor);
         }
@@ -2394,7 +2494,8 @@ pub fn accept_function_attribute(node: &FunctionAttribute, visitor: &mut impl Vi
         FunctionAttribute::OverrideSpecifier(ref override_specifier) => {
             accept_override_specifier(override_specifier, visitor);
         }
-        FunctionAttribute::ExternalKeyword
+        FunctionAttribute::ConstantKeyword
+        | FunctionAttribute::ExternalKeyword
         | FunctionAttribute::InternalKeyword
         | FunctionAttribute::PayableKeyword
         | FunctionAttribute::PrivateKeyword
@@ -2420,8 +2521,29 @@ pub fn accept_constructor_attribute(node: &ConstructorAttribute, visitor: &mut i
             accept_modifier_invocation(modifier_invocation, visitor);
         }
         ConstructorAttribute::InternalKeyword
+        | ConstructorAttribute::OverrideKeyword
         | ConstructorAttribute::PayableKeyword
-        | ConstructorAttribute::PublicKeyword => {}
+        | ConstructorAttribute::PublicKeyword
+        | ConstructorAttribute::VirtualKeyword => {}
+    }
+}
+
+pub fn accept_unnamed_function_attribute(
+    node: &UnnamedFunctionAttribute,
+    visitor: &mut impl Visitor,
+) {
+    match node {
+        UnnamedFunctionAttribute::ModifierInvocation(ref modifier_invocation) => {
+            accept_modifier_invocation(modifier_invocation, visitor);
+        }
+        UnnamedFunctionAttribute::ConstantKeyword
+        | UnnamedFunctionAttribute::ExternalKeyword
+        | UnnamedFunctionAttribute::InternalKeyword
+        | UnnamedFunctionAttribute::PayableKeyword
+        | UnnamedFunctionAttribute::PrivateKeyword
+        | UnnamedFunctionAttribute::PublicKeyword
+        | UnnamedFunctionAttribute::PureKeyword
+        | UnnamedFunctionAttribute::ViewKeyword => {}
     }
 }
 
@@ -2513,7 +2635,9 @@ pub fn accept_elementary_type(node: &ElementaryType, visitor: &mut impl Visitor)
         | ElementaryType::UintKeyword(_)
         | ElementaryType::FixedKeyword(_)
         | ElementaryType::UfixedKeyword(_) => {}
-        ElementaryType::BoolKeyword | ElementaryType::StringKeyword => {}
+        ElementaryType::BoolKeyword
+        | ElementaryType::ByteKeyword
+        | ElementaryType::StringKeyword => {}
     }
 }
 
@@ -2539,6 +2663,9 @@ pub fn accept_statement(node: &Statement, visitor: &mut impl Visitor) {
         }
         Statement::ReturnStatement(ref return_statement) => {
             accept_return_statement(return_statement, visitor);
+        }
+        Statement::ThrowStatement(ref throw_statement) => {
+            accept_throw_statement(throw_statement, visitor);
         }
         Statement::EmitStatement(ref emit_statement) => {
             accept_emit_statement(emit_statement, visitor);
@@ -2589,6 +2716,7 @@ pub fn accept_variable_declaration_type(
         VariableDeclarationType::TypeName(ref type_name) => {
             accept_type_name(type_name, visitor);
         }
+        VariableDeclarationType::VarKeyword => {}
     }
 }
 
@@ -2734,8 +2862,14 @@ pub fn accept_number_unit(_node: &NumberUnit, _visitor: &mut impl Visitor) {}
 
 pub fn accept_string_expression(node: &StringExpression, visitor: &mut impl Visitor) {
     match node {
+        StringExpression::StringLiteral(ref string_literal) => {
+            accept_string_literal(string_literal, visitor);
+        }
         StringExpression::StringLiterals(ref string_literals) => {
             accept_string_literals(string_literals, visitor);
+        }
+        StringExpression::HexStringLiteral(ref hex_string_literal) => {
+            accept_hex_string_literal(hex_string_literal, visitor);
         }
         StringExpression::HexStringLiterals(ref hex_string_literals) => {
             accept_hex_string_literals(hex_string_literals, visitor);
@@ -2760,6 +2894,9 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
         YulStatement::YulFunctionDefinition(ref yul_function_definition) => {
             accept_yul_function_definition(yul_function_definition, visitor);
         }
+        YulStatement::YulStackAssignmentStatement(ref yul_stack_assignment_statement) => {
+            accept_yul_stack_assignment_statement(yul_stack_assignment_statement, visitor);
+        }
         YulStatement::YulIfStatement(ref yul_if_statement) => {
             accept_yul_if_statement(yul_if_statement, visitor);
         }
@@ -2781,6 +2918,9 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
         YulStatement::YulVariableAssignmentStatement(ref yul_variable_assignment_statement) => {
             accept_yul_variable_assignment_statement(yul_variable_assignment_statement, visitor);
         }
+        YulStatement::YulLabel(ref yul_label) => {
+            accept_yul_label(yul_label, visitor);
+        }
         YulStatement::YulVariableDeclarationStatement(ref yul_variable_declaration_statement) => {
             accept_yul_variable_declaration_statement(yul_variable_declaration_statement, visitor);
         }
@@ -2790,7 +2930,26 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
     }
 }
 
-pub fn accept_yul_assignment_operator(_node: &YulAssignmentOperator, _visitor: &mut impl Visitor) {}
+pub fn accept_yul_assignment_operator(node: &YulAssignmentOperator, visitor: &mut impl Visitor) {
+    match node {
+        YulAssignmentOperator::YulColonAndEqual(ref yul_colon_and_equal) => {
+            accept_yul_colon_and_equal(yul_colon_and_equal, visitor);
+        }
+        YulAssignmentOperator::ColonEqual => {}
+    }
+}
+
+pub fn accept_yul_stack_assignment_operator(
+    node: &YulStackAssignmentOperator,
+    visitor: &mut impl Visitor,
+) {
+    match node {
+        YulStackAssignmentOperator::YulEqualAndColon(ref yul_equal_and_colon) => {
+            accept_yul_equal_and_colon(yul_equal_and_colon, visitor);
+        }
+        YulStackAssignmentOperator::EqualColon => {}
+    }
+}
 
 pub fn accept_yul_switch_case(node: &YulSwitchCase, visitor: &mut impl Visitor) {
     match node {
@@ -3004,6 +3163,19 @@ fn accept_constructor_attributes(items: &Vec<ConstructorAttribute>, visitor: &mu
             accept_constructor_attribute(item, visitor);
         }
         visitor.leave_constructor_attributes(items);
+    }
+}
+
+#[inline]
+fn accept_unnamed_function_attributes(
+    items: &Vec<UnnamedFunctionAttribute>,
+    visitor: &mut impl Visitor,
+) {
+    if visitor.enter_unnamed_function_attributes(items) {
+        for item in items {
+            accept_unnamed_function_attribute(item, visitor);
+        }
+        visitor.leave_unnamed_function_attributes(items);
     }
 }
 


### PR DESCRIPTION
We will use the IRs/AST to implement the new binder, and we need it to work for every version Slang supports. So the generated AST needs to work for all versions.
