### PR TITLE
use localized `git config` calls

### DIFF
--- a/crates/infra/cli/src/commands/publish/changesets/mod.rs
+++ b/crates/infra/cli/src/commands/publish/changesets/mod.rs
@@ -85,6 +85,8 @@ impl ChangesetsController {
         }
 
         Command::new("git")
+            .property("-c", "user.name=github-actions")
+            .property("-c", "user.email=github-actions@users.noreply.github.com")
             .args(["stash", "push"])
             .flag("--include-untracked")
             .property("--message", "applied changesets")

--- a/crates/infra/cli/src/commands/setup/git/mod.rs
+++ b/crates/infra/cli/src/commands/setup/git/mod.rs
@@ -1,19 +1,6 @@
 use infra_utils::commands::Command;
-use infra_utils::github::GitHub;
 
 pub fn setup_git() {
-    if GitHub::is_running_in_ci() {
-        Command::new("git")
-            .arg("config")
-            .property("user.name", "github-actions")
-            .run();
-
-        Command::new("git")
-            .arg("config")
-            .property("user.email", "github-actions@users.noreply.github.com")
-            .run();
-    }
-
     Command::new("git")
         .args(["submodule", "update"])
         .flag("--init")


### PR DESCRIPTION
The repo-wide config causes issues in other workflows when debugging CI failures.