### PR TITLE
dedupe sourcify runner artifact names

### DIFF
--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Save Test Binary"
         uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
         with:
-          name: "solidity_testing_sourcify"
+          name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
           path: "./target/release/solidity_testing_sourcify"
           overwrite: true
           retention-days: 1
@@ -142,11 +142,18 @@ jobs:
       - name: "Restore Test Binary"
         uses: "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
         with:
-          name: "solidity_testing_sourcify"
+          name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
+
       - name: "Run Tests"
         run: |
           chmod +x solidity_testing_sourcify
-          ./scripts/bin/with-hermit ./solidity_testing_sourcify test --shard-count ${{ env.SHARD_COUNT }} --shard-index ${{ matrix.shard_index }} ${{ inputs.check_bindings == true && '--check-bindings' || '' }} ${{ inputs.check_infer_version == true && '--check-infer-version' || '' }} --chain-id ${{ inputs.chain_id }} ${{ inputs.network }}
+          ./scripts/bin/with-hermit ./solidity_testing_sourcify test \
+              --chain-id ${{ inputs.chain_id }} \
+              --shard-count ${{ env.SHARD_COUNT }} \
+              --shard-index ${{ matrix.shard_index }} \
+              ${{ inputs.check_bindings == true && '--check-bindings' || '' }} \
+              ${{ inputs.check_infer_version == true && '--check-infer-version' || '' }}
+
       - name: "Write shard results to output"
         if: "!cancelled()"
         id: "output-shard-results"
@@ -168,7 +175,7 @@ jobs:
       - name: "Restore Test Binary"
         uses: "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
         with:
-          name: "solidity_testing_sourcify"
+          name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
 
       - name: "Output shards results"
         run: "echo '${{ toJSON(needs.singleShard.outputs) }}' > __SLANG_SOURCIFY_MATRIX_RESULTS__.json"


### PR DESCRIPTION
minor fixes after #1348:

- deduplicate the uploaded artifact name, as they are shared between workflows.
- remove an extra `inputs.network` argument from the command.