### PR TITLE
Revert path display lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ must_use_candidate = { level = "allow", priority = 1 }                 # Overzea
 needless_continue = { level = "allow", priority = 1 }                  # The `continue` keyword serves to communicate intention, let's keep them
 needless_raw_string_hashes = { level = "allow", priority = 1 }         # It is easier to use hashes consistently on all tests/examples in a file
 redundant_closure_for_method_calls = { level = "allow", priority = 1 } # Not always clearer, let's not pepper `allow`s whenever needed
+unnecessary_debug_formatting = { level = "allow", priority = 1 }       # `Path::display()` doesn't produce the same output as the debug fmt
 # Nursery
 collection_is_never_read = "warn" # Lint against collections not used after creation
 equatable_if_let = "warn"         # Prefer regular `==` checks over Yoda `if let $pat = $value`

--- a/crates/codegen/testing/src/common.rs
+++ b/crates/codegen/testing/src/common.rs
@@ -18,8 +18,7 @@ pub(crate) fn collect_snapshot_tests(
         if let Ok(generated_dir) = file.generated_dir() {
             assert!(
                 generated_dir.unwrap_parent().join("input.sol").exists(),
-                "Each snapshot should have a matching input.sol test file: {file}",
-                file = file.display()
+                "Each snapshot should have a matching input.sol test file: {file:?}",
             );
 
             // skip generated files

--- a/crates/infra/cli/src/commands/perf/benchmark/mod.rs
+++ b/crates/infra/cli/src/commands/perf/benchmark/mod.rs
@@ -113,10 +113,10 @@ impl BenchmarkController {
 Bencher Run is complete...
 Test Results: [https://bencher.dev/console/projects/slang/reports]
 
-Reports/Logs: {reports_dir}
+Reports/Logs: {reports_dir:?}
 - Callgrind flamegraphs (callgrind.*.svg) can be viewed directly in the browser.
 - DHAT traces (dhat.*.out) can be viewed using the [dhat/dh_view.html] tool from the Valgrind release [https://valgrind.org/downloads/].
 
-", reports_dir = reports_dir.display());
+");
     }
 }

--- a/crates/infra/cli/src/commands/publish/changesets/mod.rs
+++ b/crates/infra/cli/src/commands/publish/changesets/mod.rs
@@ -79,7 +79,7 @@ impl ChangesetsController {
 
         for destination_changelog in FileWalker::from_repo_root().find(["**/CHANGELOG.md"])? {
             if source_changelog != destination_changelog {
-                println!("Updating: {}", destination_changelog.display());
+                println!("Updating: {destination_changelog:?}");
                 std::fs::copy(&source_changelog, &destination_changelog)?;
             }
         }

--- a/crates/infra/cli/src/commands/publish/npm/mod.rs
+++ b/crates/infra/cli/src/commands/publish/npm/mod.rs
@@ -21,7 +21,7 @@ impl NpmController {
 
         package.build()?;
 
-        println!("Publishing: {}", package_dir.display());
+        println!("Publishing: {package_dir:?}");
 
         let local_version = Npm::local_version(&package_dir)?;
         println!("Local version: {local_version}");

--- a/crates/infra/cli/src/toolchains/public_api/mod.rs
+++ b/crates/infra/cli/src/toolchains/public_api/mod.rs
@@ -39,12 +39,7 @@ fn generate_public_api(crate_name: UserFacingCrate) -> Result<()> {
         .omit_auto_trait_impls(true)
         .omit_blanket_impls(true)
         .build()
-        .with_context(|| {
-            format!(
-                "Failed to generate public API from {}",
-                rustdoc_json.display()
-            )
-        })?;
+        .with_context(|| format!("Failed to generate public API from {rustdoc_json:?}"))?;
 
     let output_path = crate_dir.join("generated/public_api.txt");
 

--- a/crates/infra/utils/src/cargo/manifest.rs
+++ b/crates/infra/utils/src/cargo/manifest.rs
@@ -37,12 +37,8 @@ impl WorkspaceManifest {
     pub fn load() -> Result<Self> {
         let manifest_path = Path::repo_path("Cargo.toml");
 
-        toml::from_str(&manifest_path.read_to_string()?).with_context(|| {
-            format!(
-                "Failed to deserialize manifest: {}",
-                manifest_path.display()
-            )
-        })
+        toml::from_str(&manifest_path.read_to_string()?)
+            .with_context(|| format!("Failed to deserialize manifest: {manifest_path:?}"))
     }
 
     pub fn version(&self) -> &Version {

--- a/crates/infra/utils/src/codegen/file_system.rs
+++ b/crates/infra/utils/src/codegen/file_system.rs
@@ -74,15 +74,10 @@ impl Drop for CodegenFileSystem {
                 }
 
                 if GitHub::is_running_in_ci() {
-                    panic!(
-                        "File was not generated in this context: {}",
-                        file_path.display()
-                    );
+                    panic!("File was not generated in this context: {file_path:?}");
                 } else {
                     std::fs::remove_file(&file_path)
-                        .with_context(|| {
-                            format!("Failed to delete source file: {}", file_path.display())
-                        })
+                        .with_context(|| format!("Failed to delete source file: {file_path:?}"))
                         .unwrap();
                 }
             }
@@ -92,7 +87,7 @@ impl Drop for CodegenFileSystem {
 
 fn write_contents(file_path: &Path, contents: &str) -> Result<()> {
     std::fs::create_dir_all(file_path.unwrap_parent())
-        .with_context(|| format!("Cannot create parent directory of: {}", file_path.display()))?;
+        .with_context(|| format!("Cannot create parent directory of: {file_path:?}"))?;
 
     // To respect Cargo incrementability, don't touch the file if it is already up to date.
     if file_path.exists() && contents == file_path.read_to_string()? {

--- a/crates/infra/utils/src/codegen/formatting.rs
+++ b/crates/infra/utils/src/codegen/formatting.rs
@@ -12,7 +12,7 @@ pub fn format_source_file(file_path: &Path, contents: &str) -> Result<String> {
             // Still write the unformatted version to disk, to be able to debug what went wrong:
             file_path.write_string(contents)?;
 
-            Err(formatter_error).context(format!("Failed to format {}", file_path.display()))
+            Err(formatter_error).context(format!("Failed to format {file_path:?}"))
         }
     }
 }
@@ -31,10 +31,7 @@ pub fn generate_header(file_path: &Path) -> Option<String> {
         // Does not support comments:
         (_, "json") => return None,
 
-        _ => panic!(
-            "Unsupported path to generate a header for: {}",
-            file_path.display()
-        ),
+        _ => panic!("Unsupported path to generate a header for: {file_path:?}"),
     })
 }
 
@@ -47,7 +44,7 @@ fn run_formatter(file_path: &Path, contents: &str) -> Result<String> {
         // No formatters available for these yet:
         (_, "wit") => Ok(contents.to_owned()),
 
-        _ => panic!("Unsupported path to format: {}", file_path.display()),
+        _ => panic!("Unsupported path to format: {file_path:?}"),
     }
 }
 

--- a/crates/infra/utils/src/paths/extensions.rs
+++ b/crates/infra/utils/src/paths/extensions.rs
@@ -39,7 +39,7 @@ impl PathExtensions for Path {
 
         for entry in self
             .read_dir()
-            .with_context(|| format!("Failed to read directory: {}", self.display()))?
+            .with_context(|| format!("Failed to read directory: {self:?}"))?
         {
             let entry = entry.unwrap().file_name();
             let file_name = entry.to_str().unwrap();
@@ -77,7 +77,7 @@ impl PathExtensions for Path {
         let repo_root = Path::repo_root();
 
         self.strip_prefix(&repo_root)
-            .with_context(|| format!("Failed to strip repo root from: {}", self.display()))
+            .with_context(|| format!("Failed to strip repo root from: {self:?}"))
     }
 
     fn replace_prefix(
@@ -90,13 +90,7 @@ impl PathExtensions for Path {
 
         let suffix = self
             .strip_prefix(old_prefix)
-            .with_context(|| {
-                format!(
-                    "Failed to strip prefix: {old_prefix} from: {self_}",
-                    old_prefix = old_prefix.display(),
-                    self_ = self.display()
-                )
-            })
+            .with_context(|| format!("Failed to strip prefix: {old_prefix:?} from: {self:?}"))
             .unwrap();
 
         new_prefix.join(suffix)
@@ -104,7 +98,7 @@ impl PathExtensions for Path {
 
     fn unwrap_str(&self) -> &str {
         self.to_str()
-            .with_context(|| format!("Failed to convert path to str: {}", self.display()))
+            .with_context(|| format!("Failed to convert path to str: {self:?}"))
             .unwrap()
     }
 
@@ -114,16 +108,16 @@ impl PathExtensions for Path {
 
     fn unwrap_name(&self) -> &str {
         self.file_name()
-            .with_context(|| format!("Failed to extract file name of: {}", self.display()))
+            .with_context(|| format!("Failed to extract file name of: {self:?}"))
             .unwrap()
             .to_str()
-            .with_context(|| format!("Failed convert path to str: {}", self.display()))
+            .with_context(|| format!("Failed convert path to str: {self:?}"))
             .unwrap()
     }
 
     fn unwrap_parent(&self) -> &Path {
         self.parent()
-            .with_context(|| format!("Failed to extract parent directory of: {}", self.display()))
+            .with_context(|| format!("Failed to extract parent directory of: {self:?}"))
             .unwrap()
     }
 
@@ -131,18 +125,17 @@ impl PathExtensions for Path {
         self.extension()
             .unwrap_or_default()
             .to_str()
-            .with_context(|| format!("Failed to convert extension to str: {}", self.display()))
+            .with_context(|| format!("Failed to convert extension to str: {self:?}"))
             .unwrap()
     }
 
     fn read_to_string(&self) -> Result<String> {
-        std::fs::read_to_string(self)
-            .with_context(|| format!("Failed to read file: {}", self.display()))
+        std::fs::read_to_string(self).with_context(|| format!("Failed to read file: {self:?}"))
     }
 
     fn write_string(&self, contents: impl AsRef<str>) -> Result<()> {
         std::fs::write(self, contents.as_ref())
-            .with_context(|| format!("Failed to write file: {}", self.display()))
+            .with_context(|| format!("Failed to write file: {self:?}"))
     }
 }
 

--- a/crates/solidity/outputs/cargo/cli/src/parse.rs
+++ b/crates/solidity/outputs/cargo/cli/src/parse.rs
@@ -29,7 +29,7 @@ impl ParseCommand {
 
         let file_path = file_path
             .canonicalize()
-            .unwrap_or_else(|_| panic!("File not found: {}", file_path.display()));
+            .unwrap_or_else(|_| panic!("File not found: {file_path:?}"));
 
         let input = fs::read_to_string(&file_path).unwrap();
         let parser = Parser::create(version).unwrap();

--- a/crates/solidity/testing/sanctuary/src/main.rs
+++ b/crates/solidity/testing/sanctuary/src/main.rs
@@ -137,7 +137,7 @@ fn run_test_command(command: TestCommand) -> Result<()> {
 
         std::fs::create_dir_all(output_path.parent().unwrap())?;
         output_path.write_string(value)?;
-        println!("Wrote results to {}", output_path.display());
+        println!("Wrote results to {output_path:?}");
     }
 
     let failure_count = events.failure_count();
@@ -166,11 +166,11 @@ fn run_with_traces(
         let compiler = &file.compiler;
         let path = file.path.strip_repo_root()?;
 
-        events.trace(format!("[{compiler}] Starting: {}", path.display()));
+        events.trace(format!("[{compiler}] Starting: {path:?}"));
 
         run_test(file, events, check_bindings, check_infer_version)?;
 
-        events.trace(format!("[{compiler}] Finished: {}", path.display()));
+        events.trace(format!("[{compiler}] Finished: {path:?}"));
     }
 
     Ok(())

--- a/crates/solidity/testing/sourcify/src/main.rs
+++ b/crates/solidity/testing/sourcify/src/main.rs
@@ -96,7 +96,7 @@ fn run_test_command(cmd: command::TestCommand) -> Result<()> {
 
         std::fs::create_dir_all(output_path.parent().unwrap())?;
         output_path.write_string(value)?;
-        println!("Wrote results to {}", output_path.display());
+        println!("Wrote results to {output_path:?}");
     }
 
     let failure_count = events.failure_count();


### PR DESCRIPTION
This PR reverts d70b61d266d4e75fa9b89869ec0e46073a2d337d, which introduced the "fix" mentioned in https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting for displaying paths.  However, `Path::display(&self)` produces a different output, as evidenced in our runners:
https://github.com/NomicFoundation/slang/actions/runs/16112167084/job/45458106910#step:5:178

Therefore, we ignore the lint.