### PR TITLE
Unrevert "Add `NonterminalNode.create()` and `TerminalNode.create()` to JS API (#1316)

### DIFF
--- a/.changeset/tricky-streets-marry.md
+++ b/.changeset/tricky-streets-marry.md
@@ -1,0 +1,11 @@
+---
+"@nomicfoundation/slang": minor
+---
+
+Add new TypeScript APIs for creating nodes and edges:
+
+- `NonterminalNode.create(kind: NonterminalKind, children: Edge[]): NonterminalNode`
+- `TerminalNode.create(kind: TerminalKind, text: string): TerminalNode`
+- `createEdge(label: EdgeLabel, node: Node): Edge`
+- `Edge.createWithNonterminal(label: EdgeLabel, node: NonterminalNode): Edge`
+- `Edge.createWithTerminal(label: EdgeLabel, node: TerminalNode): Edge`

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/config.json.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/config.json.jinja2
@@ -70,6 +70,16 @@
         "as_typescript_enum": true
       }
     },
+    "nomic-foundation:slang:cst:edge.label()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
+    "nomic-foundation:slang:cst:edge.node()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
     "nomic-foundation:slang:cst:edge-label": {
       "Enum": {
         "as_typescript_enum": true

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/generated/config.json
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/generated/config.json
@@ -70,6 +70,16 @@
         "as_typescript_enum": true
       }
     },
+    "nomic-foundation:slang:cst:edge.label()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
+    "nomic-foundation:slang:cst:edge.node()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
     "nomic-foundation:slang:cst:edge-label": {
       "Enum": {
         "as_typescript_enum": true

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -97,6 +97,8 @@ interface cst {
     /// Represents a non-terminal node in the syntax tree.
     /// These nodes can have child nodes and represent language constructs.
     resource nonterminal-node {
+        /// Creates a new nonterminal node with the specified `kind` and `children`.
+        create: static func(kind: nonterminal-kind, children: list<edge>) -> nonterminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -123,6 +125,8 @@ interface cst {
     /// Represents a terminal node in the syntax tree.
     /// These are leaf nodes that represent actual tokens from the source code.
     resource terminal-node {
+        /// Creates a new terminal node with the specified `kind` and `text`.
+        create: static func(kind: terminal-kind, text: string) -> terminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -144,11 +148,16 @@ interface cst {
     }
 
     /// Represents a connection between nodes in the syntax tree.
-    record edge {
+    resource edge {
+        /// Creates a new edge connecting a terminal node `node` with the label `label`.
+        create-with-terminal: static func(label: edge-label, node: terminal-node) -> edge;
+        /// Creates a new edge connecting a nonterminal node `node` with the label `label`.
+        create-with-nonterminal: static func(label: edge-label, node: nonterminal-node) -> edge;
+
         /// Describes the relationship between this node and its parent.
-        label: edge-label,
+        label: func() -> edge-label;
         /// The target node of this edge.
-        node: node,
+        node: func() -> node;
     }
 
     /// Provides navigation and traversal capabilities over the syntax tree.

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/generated/cst.wit
@@ -82,6 +82,8 @@ interface cst {
     /// Represents a non-terminal node in the syntax tree.
     /// These nodes can have child nodes and represent language constructs.
     resource nonterminal-node {
+        /// Creates a new nonterminal node with the specified `kind` and `children`.
+        create: static func(kind: nonterminal-kind, children: list<edge>) -> nonterminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -108,6 +110,8 @@ interface cst {
     /// Represents a terminal node in the syntax tree.
     /// These are leaf nodes that represent actual tokens from the source code.
     resource terminal-node {
+        /// Creates a new terminal node with the specified `kind` and `text`.
+        create: static func(kind: terminal-kind, text: string) -> terminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -129,11 +133,16 @@ interface cst {
     }
 
     /// Represents a connection between nodes in the syntax tree.
-    record edge {
+    resource edge {
+        /// Creates a new edge connecting a terminal node `node` with the label `label`.
+        create-with-terminal: static func(label: edge-label, node: terminal-node) -> edge;
+        /// Creates a new edge connecting a nonterminal node `node` with the label `label`.
+        create-with-nonterminal: static func(label: edge-label, node: nonterminal-node) -> edge;
+
         /// Describes the relationship between this node and its parent.
-        label: edge-label,
+        label: func() -> edge-label;
         /// The target node of this edge.
-        node: node,
+        node: func() -> node;
     }
 
     /// Provides navigation and traversal capabilities over the syntax tree.

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/wrappers/cst/mod.rs
@@ -7,12 +7,12 @@ use crate::wasm_crate::utils::{
 mod ffi {
     pub use crate::wasm_crate::bindgen::exports::nomic_foundation::slang::cst::{
         AncestorsIterator, AncestorsIteratorBorrow, Cursor, CursorBorrow, CursorIterator,
-        CursorIteratorBorrow, Edge, EdgeLabel, Guest, GuestAncestorsIterator, GuestCursor,
-        GuestCursorIterator, GuestNonterminalNode, GuestQuery, GuestQueryMatchIterator,
-        GuestTerminalKindExtensions, GuestTerminalNode, Node, NonterminalKind, NonterminalNode,
-        NonterminalNodeBorrow, Query, QueryBorrow, QueryError, QueryMatch, QueryMatchIterator,
-        QueryMatchIteratorBorrow, TerminalKind, TerminalNode, TerminalNodeBorrow, TextIndex,
-        TextRange,
+        CursorIteratorBorrow, Edge, EdgeBorrow, EdgeLabel, Guest, GuestAncestorsIterator,
+        GuestCursor, GuestCursorIterator, GuestEdge, GuestNonterminalNode, GuestQuery,
+        GuestQueryMatchIterator, GuestTerminalKindExtensions, GuestTerminalNode, Node,
+        NonterminalKind, NonterminalNode, NonterminalNodeBorrow, Query, QueryBorrow, QueryError,
+        QueryMatch, QueryMatchIterator, QueryMatchIteratorBorrow, TerminalKind, TerminalNode,
+        TerminalNodeBorrow, TextIndex, TextRange,
     };
 }
 
@@ -26,6 +26,8 @@ mod rust {
 
 impl ffi::Guest for crate::wasm_crate::World {
     type TerminalKindExtensions = TerminalKindExtensionsWrapper;
+
+    type Edge = EdgeWrapper;
 
     type NonterminalNode = NonterminalNodeWrapper;
     type TerminalNode = TerminalNodeWrapper;
@@ -117,6 +119,13 @@ impl FromFFI<rust::Node> for ffi::Node {
 //================================================
 
 define_rc_wrapper! { NonterminalNode {
+    fn create(kind: ffi::NonterminalKind, children: Vec<ffi::Edge>) -> ffi::NonterminalNode {
+        rust::NonterminalNode::create(
+            kind._from_ffi(),
+            children.into_iter().map(|child| child._from_ffi()).collect(),
+        )._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -157,6 +166,10 @@ define_rc_wrapper! { NonterminalNode {
 //================================================
 
 define_rc_wrapper! { TerminalNode {
+    fn create(kind: ffi::TerminalKind, text: String) -> ffi::TerminalNode {
+        rust::TerminalNode::create(kind._from_ffi(), text)._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -192,25 +205,23 @@ define_rc_wrapper! { TerminalNode {
 //
 //================================================
 
-impl IntoFFI<ffi::Edge> for rust::Edge {
-    #[inline]
-    fn _into_ffi(self) -> ffi::Edge {
-        ffi::Edge {
-            label: self.label._into_ffi(),
-            node: self.node._into_ffi(),
-        }
+define_wrapper! { Edge {
+    fn label(&self) -> ffi::EdgeLabel {
+        self._borrow_ffi().label._into_ffi()
     }
-}
 
-impl FromFFI<rust::Edge> for ffi::Edge {
-    #[inline]
-    fn _from_ffi(self) -> rust::Edge {
-        rust::Edge {
-            label: self.label._from_ffi(),
-            node: self.node._from_ffi(),
-        }
+    fn node(&self) -> ffi::Node {
+        self._borrow_ffi().node.clone()._into_ffi()
     }
-}
+
+    fn create_with_terminal(label: ffi::EdgeLabel, node: ffi::TerminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Terminal(node._from_ffi()) }._into_ffi()
+    }
+
+    fn create_with_nonterminal(label: ffi::EdgeLabel, node: ffi::NonterminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Nonterminal(node._from_ffi()) }._into_ffi()
+    }
+} }
 
 //================================================
 //

--- a/crates/codegen/runtime/npm/package/src/runtime/cst/extensions.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/cst/extensions.mts
@@ -1,0 +1,10 @@
+import { EdgeLabel, Edge, Node } from "./index.mjs";
+
+/** Create a new `Edge` with the label `label` and node `node`. */
+export function createEdge(label: EdgeLabel, node: Node): Edge {
+  if (node.isNonterminalNode()) {
+    return Edge.createWithNonterminal(label, node.asNonterminalNode());
+  } else {
+    return Edge.createWithTerminal(label, node.asTerminalNode());
+  }
+}

--- a/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
+++ b/crates/codegen/runtime/npm/package/src/runtime/cst/index.mts
@@ -1,6 +1,7 @@
 import * as wasm from "../../../wasm/index.mjs";
 
 export * from "./assertions.mjs";
+export * from "./extensions.mjs";
 
 /** {@inheritDoc wasm.cst.NonterminalKind} */
 export const NonterminalKind = wasm.cst.NonterminalKind;
@@ -40,6 +41,8 @@ export const TerminalNode = wasm.cst.TerminalNode;
 /** {@inheritDoc wasm.cst.TerminalNode} */
 export type TerminalNode = wasm.cst.TerminalNode;
 
+/** {@inheritDoc wasm.cst.Edge} */
+export const Edge = wasm.cst.Edge;
 /** {@inheritDoc wasm.cst.Edge} */
 export type Edge = wasm.cst.Edge;
 

--- a/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/codegen/runtime/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -4,6 +4,7 @@ export namespace NomicFoundationSlangCst {
   export { TerminalKindExtensions };
   export { NonterminalNode };
   export { TerminalNode };
+  export { Edge };
   export { Cursor };
   export { CursorIterator };
   export { AncestorsIterator };
@@ -140,19 +141,6 @@ export enum NodeType {
    * Represents a variant of type `TerminalNode`.
    */
   TerminalNode = "TerminalNode",
-}
-/**
- * Represents a connection between nodes in the syntax tree.
- */
-export interface Edge {
-  /**
-   * Describes the relationship between this node and its parent.
-   */
-  label: EdgeLabel;
-  /**
-   * The target node of this edge.
-   */
-  node: Node;
 }
 /**
  * Represents a match found by executing queries on a cursor.
@@ -404,6 +392,33 @@ export class CursorIterator {
 }
 
 /**
+ * Represents a connection between nodes in the syntax tree.
+ */
+
+export class Edge {
+  /**
+   * This type does not have a public constructor.
+   */
+  private constructor();
+  /**
+   * Creates a new edge connecting a terminal node `node` with the label `label`.
+   */
+  static createWithTerminal(label: EdgeLabel, node: TerminalNode): Edge;
+  /**
+   * Creates a new edge connecting a nonterminal node `node` with the label `label`.
+   */
+  static createWithNonterminal(label: EdgeLabel, node: NonterminalNode): Edge;
+  /**
+   * Describes the relationship between this node and its parent.
+   */
+  get label(): EdgeLabel;
+  /**
+   * The target node of this edge.
+   */
+  get node(): Node;
+}
+
+/**
  * Represents a non-terminal node in the syntax tree.
  * These nodes can have child nodes and represent language constructs.
  */
@@ -439,6 +454,10 @@ export class NonterminalNode {
    */
   isTerminalNode(): false;
 
+  /**
+   * Creates a new nonterminal node with the specified `kind` and `children`.
+   */
+  static create(kind: NonterminalKind, children: Array<Edge>): NonterminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.
@@ -571,6 +590,10 @@ export class TerminalNode {
    */
   isNonterminalNode(): false;
 
+  /**
+   * Creates a new terminal node with the specified `kind` and `text`.
+   */
+  static create(kind: TerminalKind, text: string): TerminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.

--- a/crates/solidity/outputs/cargo/wasm/src/generated/generated/config.json
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/generated/config.json
@@ -70,6 +70,16 @@
         "as_typescript_enum": true
       }
     },
+    "nomic-foundation:slang:cst:edge.label()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
+    "nomic-foundation:slang:cst:edge.node()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
     "nomic-foundation:slang:cst:edge-label": {
       "Enum": {
         "as_typescript_enum": true

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -4340,6 +4340,8 @@ interface cst {
     /// Represents a non-terminal node in the syntax tree.
     /// These nodes can have child nodes and represent language constructs.
     resource nonterminal-node {
+        /// Creates a new nonterminal node with the specified `kind` and `children`.
+        create: static func(kind: nonterminal-kind, children: list<edge>) -> nonterminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -4366,6 +4368,8 @@ interface cst {
     /// Represents a terminal node in the syntax tree.
     /// These are leaf nodes that represent actual tokens from the source code.
     resource terminal-node {
+        /// Creates a new terminal node with the specified `kind` and `text`.
+        create: static func(kind: terminal-kind, text: string) -> terminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -4387,11 +4391,16 @@ interface cst {
     }
 
     /// Represents a connection between nodes in the syntax tree.
-    record edge {
+    resource edge {
+        /// Creates a new edge connecting a terminal node `node` with the label `label`.
+        create-with-terminal: static func(label: edge-label, node: terminal-node) -> edge;
+        /// Creates a new edge connecting a nonterminal node `node` with the label `label`.
+        create-with-nonterminal: static func(label: edge-label, node: nonterminal-node) -> edge;
+
         /// Describes the relationship between this node and its parent.
-        label: edge-label,
+        label: func() -> edge-label;
         /// The target node of this edge.
-        node: node,
+        node: func() -> node;
     }
 
     /// Provides navigation and traversal capabilities over the syntax tree.

--- a/crates/solidity/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
@@ -9,12 +9,12 @@ use crate::wasm_crate::utils::{
 mod ffi {
     pub use crate::wasm_crate::bindgen::exports::nomic_foundation::slang::cst::{
         AncestorsIterator, AncestorsIteratorBorrow, Cursor, CursorBorrow, CursorIterator,
-        CursorIteratorBorrow, Edge, EdgeLabel, Guest, GuestAncestorsIterator, GuestCursor,
-        GuestCursorIterator, GuestNonterminalNode, GuestQuery, GuestQueryMatchIterator,
-        GuestTerminalKindExtensions, GuestTerminalNode, Node, NonterminalKind, NonterminalNode,
-        NonterminalNodeBorrow, Query, QueryBorrow, QueryError, QueryMatch, QueryMatchIterator,
-        QueryMatchIteratorBorrow, TerminalKind, TerminalNode, TerminalNodeBorrow, TextIndex,
-        TextRange,
+        CursorIteratorBorrow, Edge, EdgeBorrow, EdgeLabel, Guest, GuestAncestorsIterator,
+        GuestCursor, GuestCursorIterator, GuestEdge, GuestNonterminalNode, GuestQuery,
+        GuestQueryMatchIterator, GuestTerminalKindExtensions, GuestTerminalNode, Node,
+        NonterminalKind, NonterminalNode, NonterminalNodeBorrow, Query, QueryBorrow, QueryError,
+        QueryMatch, QueryMatchIterator, QueryMatchIteratorBorrow, TerminalKind, TerminalNode,
+        TerminalNodeBorrow, TextIndex, TextRange,
     };
 }
 
@@ -28,6 +28,8 @@ mod rust {
 
 impl ffi::Guest for crate::wasm_crate::World {
     type TerminalKindExtensions = TerminalKindExtensionsWrapper;
+
+    type Edge = EdgeWrapper;
 
     type NonterminalNode = NonterminalNodeWrapper;
     type TerminalNode = TerminalNodeWrapper;
@@ -119,6 +121,13 @@ impl FromFFI<rust::Node> for ffi::Node {
 //================================================
 
 define_rc_wrapper! { NonterminalNode {
+    fn create(kind: ffi::NonterminalKind, children: Vec<ffi::Edge>) -> ffi::NonterminalNode {
+        rust::NonterminalNode::create(
+            kind._from_ffi(),
+            children.into_iter().map(|child| child._from_ffi()).collect(),
+        )._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -159,6 +168,10 @@ define_rc_wrapper! { NonterminalNode {
 //================================================
 
 define_rc_wrapper! { TerminalNode {
+    fn create(kind: ffi::TerminalKind, text: String) -> ffi::TerminalNode {
+        rust::TerminalNode::create(kind._from_ffi(), text)._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -194,25 +207,23 @@ define_rc_wrapper! { TerminalNode {
 //
 //================================================
 
-impl IntoFFI<ffi::Edge> for rust::Edge {
-    #[inline]
-    fn _into_ffi(self) -> ffi::Edge {
-        ffi::Edge {
-            label: self.label._into_ffi(),
-            node: self.node._into_ffi(),
-        }
+define_wrapper! { Edge {
+    fn label(&self) -> ffi::EdgeLabel {
+        self._borrow_ffi().label._into_ffi()
     }
-}
 
-impl FromFFI<rust::Edge> for ffi::Edge {
-    #[inline]
-    fn _from_ffi(self) -> rust::Edge {
-        rust::Edge {
-            label: self.label._from_ffi(),
-            node: self.node._from_ffi(),
-        }
+    fn node(&self) -> ffi::Node {
+        self._borrow_ffi().node.clone()._into_ffi()
     }
-}
+
+    fn create_with_terminal(label: ffi::EdgeLabel, node: ffi::TerminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Terminal(node._from_ffi()) }._into_ffi()
+    }
+
+    fn create_with_nonterminal(label: ffi::EdgeLabel, node: ffi::NonterminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Nonterminal(node._from_ffi()) }._into_ffi()
+    }
+} }
 
 //================================================
 //

--- a/crates/solidity/outputs/npm/package/src/generated/cst/extensions.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/cst/extensions.mts
@@ -1,0 +1,12 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+import { EdgeLabel, Edge, Node } from "./index.mjs";
+
+/** Create a new `Edge` with the label `label` and node `node`. */
+export function createEdge(label: EdgeLabel, node: Node): Edge {
+  if (node.isNonterminalNode()) {
+    return Edge.createWithNonterminal(label, node.asNonterminalNode());
+  } else {
+    return Edge.createWithTerminal(label, node.asTerminalNode());
+  }
+}

--- a/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/cst/index.mts
@@ -3,6 +3,7 @@
 import * as wasm from "../../../wasm/index.mjs";
 
 export * from "./assertions.mjs";
+export * from "./extensions.mjs";
 
 /** {@inheritDoc wasm.cst.NonterminalKind} */
 export const NonterminalKind = wasm.cst.NonterminalKind;
@@ -42,6 +43,8 @@ export const TerminalNode = wasm.cst.TerminalNode;
 /** {@inheritDoc wasm.cst.TerminalNode} */
 export type TerminalNode = wasm.cst.TerminalNode;
 
+/** {@inheritDoc wasm.cst.Edge} */
+export const Edge = wasm.cst.Edge;
 /** {@inheritDoc wasm.cst.Edge} */
 export type Edge = wasm.cst.Edge;
 

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -4,6 +4,7 @@ export namespace NomicFoundationSlangCst {
   export { TerminalKindExtensions };
   export { NonterminalNode };
   export { TerminalNode };
+  export { Edge };
   export { Cursor };
   export { CursorIterator };
   export { AncestorsIterator };
@@ -5662,19 +5663,6 @@ export enum NodeType {
   TerminalNode = "TerminalNode",
 }
 /**
- * Represents a connection between nodes in the syntax tree.
- */
-export interface Edge {
-  /**
-   * Describes the relationship between this node and its parent.
-   */
-  label: EdgeLabel;
-  /**
-   * The target node of this edge.
-   */
-  node: Node;
-}
-/**
  * Represents a match found by executing queries on a cursor.
  */
 export interface QueryMatch {
@@ -5924,6 +5912,33 @@ export class CursorIterator {
 }
 
 /**
+ * Represents a connection between nodes in the syntax tree.
+ */
+
+export class Edge {
+  /**
+   * This type does not have a public constructor.
+   */
+  private constructor();
+  /**
+   * Creates a new edge connecting a terminal node `node` with the label `label`.
+   */
+  static createWithTerminal(label: EdgeLabel, node: TerminalNode): Edge;
+  /**
+   * Creates a new edge connecting a nonterminal node `node` with the label `label`.
+   */
+  static createWithNonterminal(label: EdgeLabel, node: NonterminalNode): Edge;
+  /**
+   * Describes the relationship between this node and its parent.
+   */
+  get label(): EdgeLabel;
+  /**
+   * The target node of this edge.
+   */
+  get node(): Node;
+}
+
+/**
  * Represents a non-terminal node in the syntax tree.
  * These nodes can have child nodes and represent language constructs.
  */
@@ -5959,6 +5974,10 @@ export class NonterminalNode {
    */
   isTerminalNode(): false;
 
+  /**
+   * Creates a new nonterminal node with the specified `kind` and `children`.
+   */
+  static create(kind: NonterminalKind, children: Array<Edge>): NonterminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.
@@ -6091,6 +6110,10 @@ export class TerminalNode {
    */
   isNonterminalNode(): false;
 
+  /**
+   * Creates a new terminal node with the specified `kind` and `text`.
+   */
+  static create(kind: TerminalKind, text: string): TerminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.

--- a/crates/solidity/outputs/npm/tests/src/cst/create_nodes.test.mts
+++ b/crates/solidity/outputs/npm/tests/src/cst/create_nodes.test.mts
@@ -1,0 +1,46 @@
+import assert from "node:assert";
+import {
+  NonterminalNode,
+  TerminalNode,
+  TerminalKind,
+  NonterminalKind,
+  EdgeLabel,
+  Edge,
+  createEdge,
+} from "@nomicfoundation/slang/cst";
+
+test("Create TerminalNode", () => {
+  const terminalNode = TerminalNode.create(TerminalKind.ContractKeyword, "contract");
+  assert(terminalNode.isTerminalNode());
+  assert.equal(terminalNode.kind, TerminalKind.ContractKeyword);
+  assert.equal(terminalNode.unparse(), "contract");
+});
+
+test("Create NonterminalNode without children", () => {
+  const nonterminalNode = NonterminalNode.create(NonterminalKind.ArrayExpression, []);
+
+  assert(nonterminalNode.isNonterminalNode());
+  assert.equal(nonterminalNode.asNonterminalNode().kind, NonterminalKind.ArrayExpression);
+  assert.equal(nonterminalNode.asNonterminalNode().unparse(), "");
+  assert.deepEqual(nonterminalNode.asNonterminalNode().children(), []);
+});
+
+test("Create NonterminalNode with children", () => {
+  const child = TerminalNode.create(TerminalKind.OpenBracket, "[");
+
+  const childEdge = Edge.createWithTerminal(EdgeLabel.OpenBracket, child);
+
+  const nonterminalNode = NonterminalNode.create(NonterminalKind.ArrayExpression, [childEdge]);
+
+  assert(nonterminalNode.isNonterminalNode());
+  assert.equal(nonterminalNode.asNonterminalNode().kind, NonterminalKind.ArrayExpression);
+  assert.equal(nonterminalNode.asNonterminalNode().unparse(), "[");
+  assert.deepEqual(nonterminalNode.asNonterminalNode().children(), [childEdge]);
+});
+
+test("Create Edge using top-level createEdge() function", () => {
+  const node = TerminalNode.create(TerminalKind.IfKeyword, "if");
+  const childEdge = createEdge(EdgeLabel.IfKeyword, node);
+
+  assert.deepEqual(childEdge.node, node);
+});

--- a/crates/testlang/outputs/cargo/wasm/src/generated/generated/config.json
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/generated/config.json
@@ -70,6 +70,16 @@
         "as_typescript_enum": true
       }
     },
+    "nomic-foundation:slang:cst:edge.label()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
+    "nomic-foundation:slang:cst:edge.node()": {
+      "Function": {
+        "as_getter": true
+      }
+    },
     "nomic-foundation:slang:cst:edge-label": {
       "Enum": {
         "as_typescript_enum": true

--- a/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -268,6 +268,8 @@ interface cst {
     /// Represents a non-terminal node in the syntax tree.
     /// These nodes can have child nodes and represent language constructs.
     resource nonterminal-node {
+        /// Creates a new nonterminal node with the specified `kind` and `children`.
+        create: static func(kind: nonterminal-kind, children: list<edge>) -> nonterminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -294,6 +296,8 @@ interface cst {
     /// Represents a terminal node in the syntax tree.
     /// These are leaf nodes that represent actual tokens from the source code.
     resource terminal-node {
+        /// Creates a new terminal node with the specified `kind` and `text`.
+        create: static func(kind: terminal-kind, text: string) -> terminal-node;
         /// Returns a unique numerical identifier of the node.
         /// It is only valid for the lifetime of the enclosing tree.
         /// It can change between multiple parses, even for the same source code input.
@@ -315,11 +319,16 @@ interface cst {
     }
 
     /// Represents a connection between nodes in the syntax tree.
-    record edge {
+    resource edge {
+        /// Creates a new edge connecting a terminal node `node` with the label `label`.
+        create-with-terminal: static func(label: edge-label, node: terminal-node) -> edge;
+        /// Creates a new edge connecting a nonterminal node `node` with the label `label`.
+        create-with-nonterminal: static func(label: edge-label, node: nonterminal-node) -> edge;
+
         /// Describes the relationship between this node and its parent.
-        label: edge-label,
+        label: func() -> edge-label;
         /// The target node of this edge.
-        node: node,
+        node: func() -> node;
     }
 
     /// Provides navigation and traversal capabilities over the syntax tree.

--- a/crates/testlang/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
+++ b/crates/testlang/outputs/cargo/wasm/src/generated/wrappers/cst/mod.rs
@@ -9,12 +9,12 @@ use crate::wasm_crate::utils::{
 mod ffi {
     pub use crate::wasm_crate::bindgen::exports::nomic_foundation::slang::cst::{
         AncestorsIterator, AncestorsIteratorBorrow, Cursor, CursorBorrow, CursorIterator,
-        CursorIteratorBorrow, Edge, EdgeLabel, Guest, GuestAncestorsIterator, GuestCursor,
-        GuestCursorIterator, GuestNonterminalNode, GuestQuery, GuestQueryMatchIterator,
-        GuestTerminalKindExtensions, GuestTerminalNode, Node, NonterminalKind, NonterminalNode,
-        NonterminalNodeBorrow, Query, QueryBorrow, QueryError, QueryMatch, QueryMatchIterator,
-        QueryMatchIteratorBorrow, TerminalKind, TerminalNode, TerminalNodeBorrow, TextIndex,
-        TextRange,
+        CursorIteratorBorrow, Edge, EdgeBorrow, EdgeLabel, Guest, GuestAncestorsIterator,
+        GuestCursor, GuestCursorIterator, GuestEdge, GuestNonterminalNode, GuestQuery,
+        GuestQueryMatchIterator, GuestTerminalKindExtensions, GuestTerminalNode, Node,
+        NonterminalKind, NonterminalNode, NonterminalNodeBorrow, Query, QueryBorrow, QueryError,
+        QueryMatch, QueryMatchIterator, QueryMatchIteratorBorrow, TerminalKind, TerminalNode,
+        TerminalNodeBorrow, TextIndex, TextRange,
     };
 }
 
@@ -28,6 +28,8 @@ mod rust {
 
 impl ffi::Guest for crate::wasm_crate::World {
     type TerminalKindExtensions = TerminalKindExtensionsWrapper;
+
+    type Edge = EdgeWrapper;
 
     type NonterminalNode = NonterminalNodeWrapper;
     type TerminalNode = TerminalNodeWrapper;
@@ -119,6 +121,13 @@ impl FromFFI<rust::Node> for ffi::Node {
 //================================================
 
 define_rc_wrapper! { NonterminalNode {
+    fn create(kind: ffi::NonterminalKind, children: Vec<ffi::Edge>) -> ffi::NonterminalNode {
+        rust::NonterminalNode::create(
+            kind._from_ffi(),
+            children.into_iter().map(|child| child._from_ffi()).collect(),
+        )._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -159,6 +168,10 @@ define_rc_wrapper! { NonterminalNode {
 //================================================
 
 define_rc_wrapper! { TerminalNode {
+    fn create(kind: ffi::TerminalKind, text: String) -> ffi::TerminalNode {
+        rust::TerminalNode::create(kind._from_ffi(), text)._into_ffi()
+    }
+
     fn id(&self) -> u32 {
         self._borrow_ffi().id().try_into().unwrap()
     }
@@ -194,25 +207,23 @@ define_rc_wrapper! { TerminalNode {
 //
 //================================================
 
-impl IntoFFI<ffi::Edge> for rust::Edge {
-    #[inline]
-    fn _into_ffi(self) -> ffi::Edge {
-        ffi::Edge {
-            label: self.label._into_ffi(),
-            node: self.node._into_ffi(),
-        }
+define_wrapper! { Edge {
+    fn label(&self) -> ffi::EdgeLabel {
+        self._borrow_ffi().label._into_ffi()
     }
-}
 
-impl FromFFI<rust::Edge> for ffi::Edge {
-    #[inline]
-    fn _from_ffi(self) -> rust::Edge {
-        rust::Edge {
-            label: self.label._from_ffi(),
-            node: self.node._from_ffi(),
-        }
+    fn node(&self) -> ffi::Node {
+        self._borrow_ffi().node.clone()._into_ffi()
     }
-}
+
+    fn create_with_terminal(label: ffi::EdgeLabel, node: ffi::TerminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Terminal(node._from_ffi()) }._into_ffi()
+    }
+
+    fn create_with_nonterminal(label: ffi::EdgeLabel, node: ffi::NonterminalNode) -> ffi::Edge {
+        rust::Edge{ label: label._from_ffi(), node: rust::Node::Nonterminal(node._from_ffi()) }._into_ffi()
+    }
+} }
 
 //================================================
 //

--- a/crates/testlang/outputs/npm/package/src/generated/cst/extensions.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/cst/extensions.mts
@@ -1,0 +1,12 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+import { EdgeLabel, Edge, Node } from "./index.mjs";
+
+/** Create a new `Edge` with the label `label` and node `node`. */
+export function createEdge(label: EdgeLabel, node: Node): Edge {
+  if (node.isNonterminalNode()) {
+    return Edge.createWithNonterminal(label, node.asNonterminalNode());
+  } else {
+    return Edge.createWithTerminal(label, node.asTerminalNode());
+  }
+}

--- a/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
+++ b/crates/testlang/outputs/npm/package/src/generated/cst/index.mts
@@ -3,6 +3,7 @@
 import * as wasm from "../../../wasm/index.mjs";
 
 export * from "./assertions.mjs";
+export * from "./extensions.mjs";
 
 /** {@inheritDoc wasm.cst.NonterminalKind} */
 export const NonterminalKind = wasm.cst.NonterminalKind;
@@ -42,6 +43,8 @@ export const TerminalNode = wasm.cst.TerminalNode;
 /** {@inheritDoc wasm.cst.TerminalNode} */
 export type TerminalNode = wasm.cst.TerminalNode;
 
+/** {@inheritDoc wasm.cst.Edge} */
+export const Edge = wasm.cst.Edge;
 /** {@inheritDoc wasm.cst.Edge} */
 export type Edge = wasm.cst.Edge;
 

--- a/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/testlang/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -4,6 +4,7 @@ export namespace NomicFoundationSlangCst {
   export { TerminalKindExtensions };
   export { NonterminalNode };
   export { TerminalNode };
+  export { Edge };
   export { Cursor };
   export { CursorIterator };
   export { AncestorsIterator };
@@ -384,19 +385,6 @@ export enum NodeType {
   TerminalNode = "TerminalNode",
 }
 /**
- * Represents a connection between nodes in the syntax tree.
- */
-export interface Edge {
-  /**
-   * Describes the relationship between this node and its parent.
-   */
-  label: EdgeLabel;
-  /**
-   * The target node of this edge.
-   */
-  node: Node;
-}
-/**
  * Represents a match found by executing queries on a cursor.
  */
 export interface QueryMatch {
@@ -646,6 +634,33 @@ export class CursorIterator {
 }
 
 /**
+ * Represents a connection between nodes in the syntax tree.
+ */
+
+export class Edge {
+  /**
+   * This type does not have a public constructor.
+   */
+  private constructor();
+  /**
+   * Creates a new edge connecting a terminal node `node` with the label `label`.
+   */
+  static createWithTerminal(label: EdgeLabel, node: TerminalNode): Edge;
+  /**
+   * Creates a new edge connecting a nonterminal node `node` with the label `label`.
+   */
+  static createWithNonterminal(label: EdgeLabel, node: NonterminalNode): Edge;
+  /**
+   * Describes the relationship between this node and its parent.
+   */
+  get label(): EdgeLabel;
+  /**
+   * The target node of this edge.
+   */
+  get node(): Node;
+}
+
+/**
  * Represents a non-terminal node in the syntax tree.
  * These nodes can have child nodes and represent language constructs.
  */
@@ -681,6 +696,10 @@ export class NonterminalNode {
    */
   isTerminalNode(): false;
 
+  /**
+   * Creates a new nonterminal node with the specified `kind` and `children`.
+   */
+  static create(kind: NonterminalKind, children: Array<Edge>): NonterminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.
@@ -813,6 +832,10 @@ export class TerminalNode {
    */
   isNonterminalNode(): false;
 
+  /**
+   * Creates a new terminal node with the specified `kind` and `text`.
+   */
+  static create(kind: TerminalKind, text: string): TerminalNode;
   /**
    * Returns a unique numerical identifier of the node.
    * It is only valid for the lifetime of the enclosing tree.


### PR DESCRIPTION
Brings back #1316 after it was removed in #1382 to unblock the release pipeline. See #1382 for more information.