### PR TITLE
fix double-casing pascal identifiers

### DIFF
--- a/crates/codegen/runtime/cargo/crate/src/ir/builder.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/ir/builder.rs.jinja2
@@ -74,18 +74,18 @@
       let variant = helper.accept_label(EdgeLabel::Variant)?;
       let item = match variant.kind() {
         {% for type in choice.nonterminal_types -%}
-          NodeKind::Nonterminal(NonterminalKind::{{ type }}) => {{ parent_type }}::{{ type | pascal_case }}(build_{{ type | snake_case }}(nonterminal_node(variant))?),
+          NodeKind::Nonterminal(NonterminalKind::{{ type }}) => {{ parent_type }}::{{ type }}(build_{{ type | snake_case }}(nonterminal_node(variant))?),
         {%- endfor -%}
 
         {% for type in choice.non_unique_terminal_types -%}
           NodeKind::Terminal(TerminalKind::{{ type }}) => {
-            {{ parent_type }}::{{ type | pascal_case }}(terminal_node_cloned(variant))
+            {{ parent_type }}::{{ type }}(terminal_node_cloned(variant))
           },
         {%- endfor -%}
 
         {% for type in choice.unique_terminal_types -%}
           NodeKind::Terminal(TerminalKind::{{ type }}) => {
-            {{ parent_type }}::{{ type | pascal_case }}
+            {{ parent_type }}::{{ type }}
           },
         {%- endfor -%}
 

--- a/crates/codegen/runtime/cargo/crate/src/ir/nodes.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/ir/nodes.rs.jinja2
@@ -26,9 +26,9 @@
           {%- endif -%}
         {%- else -%}
           {%- if field.is_optional -%}
-            Option<{{ field.type | pascal_case }}>,
+            Option<{{ field.type }}>,
           {%- else -%}
-            {{ field.type | pascal_case }},
+            {{ field.type }},
           {%- endif -%}
         {%- endif -%}
       {% endfor -%}
@@ -44,7 +44,7 @@
     #[derive(Debug)]
     pub enum {{ parent_type }} {
       {% for nonterminal in choice.nonterminal_types -%}
-        {{ nonterminal }}({{ nonterminal | pascal_case }}),
+        {{ nonterminal }}({{ nonterminal }}),
       {%- endfor -%}
       {% for terminal in choice.non_unique_terminal_types -%}
         {{ terminal }}(Rc<TerminalNode>),
@@ -64,7 +64,7 @@
       {%- if collection.is_terminal -%}
         Rc<TerminalNode>
       {%- else -%}
-        {{ collection.item_type | pascal_case }}
+        {{ collection.item_type }}
       {%- endif -%}
     >;
   {% endfor %}

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/nonterminal_kind.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/nonterminal_kind.rs.jinja2
@@ -24,14 +24,14 @@ pub enum NonterminalKind {
         Stub3,
     {%- else -%}
         {%- for variant in model.kinds.nonterminal_kinds -%}
-            /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+            /// Represents a node with kind `{{ variant.id }}`, having the following structure:
             ///
             /// ```ebnf
             {%- for line in variant.documentation | split(pat="\n") %}
             /// {{ line }}
             {%- endfor %}
             /// ```
-            {{ variant.id | pascal_case }},
+            {{ variant.id }},
         {%- endfor -%}
     {%- endif -%}
 }

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/terminal_kind.rs.jinja2
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/terminal_kind.rs.jinja2
@@ -31,14 +31,14 @@ pub enum TerminalKind {
         Stub3,
     {%- else -%}
         {%- for variant in model.kinds.terminal_kinds -%}
-            /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+            /// Represents a node with kind `{{ variant.id }}`, having the following structure:
             ///
             /// ```ebnf
             {%- for line in variant.documentation | split(pat="\n") %}
             /// {{ line }}
             {%- endfor %}
             /// ```
-            {{ variant.id | pascal_case }},
+            {{ variant.id }},
         {%- endfor -%}
     {%- endif -%}
 }

--- a/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
+++ b/crates/codegen/runtime/cargo/wasm/src/runtime/interface/cst.wit.jinja2
@@ -11,7 +11,7 @@ interface cst {
             stub3,
         {%- else %}
             {%- for variant in model.kinds.nonterminal_kinds %}
-                /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+                /// Represents a node with kind `{{ variant.id }}`, having the following structure:
                 ///
                 /// ```ebnf
                 {%- for line in variant.documentation | split(pat="\n") %}
@@ -42,7 +42,7 @@ interface cst {
             stub3,
         {%- else %}
             {%- for variant in model.kinds.terminal_kinds %}
-                /// Represents a node with kind `{{ variant.id | pascal_case }}`, having the following structure:
+                /// Represents a node with kind `{{ variant.id }}`, having the following structure:
                 ///
                 /// ```ebnf
                 {%- for line in variant.documentation | split(pat="\n") %}

--- a/crates/codegen/runtime/generator/src/parser/codegen/precedence_parser_definition.rs
+++ b/crates/codegen/runtime/generator/src/parser/codegen/precedence_parser_definition.rs
@@ -20,10 +20,9 @@ pub trait PrecedenceParserDefinitionCodegen {
 
 impl PrecedenceParserDefinitionCodegen for PrecedenceParserDefinitionRef {
     fn to_parser_code(&self) -> TokenStream {
-        let code = self.node().to_parser_code(
-            self.context(),
-            format_ident!("{name}", name = self.name().to_pascal_case()),
-        );
+        let code = self
+            .node()
+            .to_parser_code(self.context(), format_ident!("{}", self.name()));
 
         let nonterminal_kind = format_ident!("{}", self.name());
         quote! { #code.with_kind(NonterminalKind::#nonterminal_kind) }
@@ -31,10 +30,10 @@ impl PrecedenceParserDefinitionCodegen for PrecedenceParserDefinitionRef {
 
     fn to_precedence_expression_parser_code(&self) -> Vec<(Identifier, TokenStream)> {
         let parser_name = format_ident!("{}", self.name().to_snake_case());
-        let nonterminal_name = format_ident!("{}", self.name().to_pascal_case());
+        let nonterminal_name = format_ident!("{}", self.name());
 
         self.node().precedence_expression_names.iter().map(|name| {
-            let op_nonterminal_name = format_ident!("{}", name.to_pascal_case());
+            let op_nonterminal_name = format_ident!("{name}");
 
             // Ensure that the parser correctly identifies a single node of the expected type,
             // which contains a single child node representing the expected precedence operator.


### PR DESCRIPTION
Context: https://github.com/NomicFoundation/slang/pull/1388/files/d3dae389c231441b4ba9a684b4be3b7c5dca73fd#r2248599409

> Looks like a few places in the codebase were converting already PascalCase identifiers, which will override the capitalization in the grammar like this. Luckily, fixing it doesn't break existing source code, so we can just do it. I submitted #1403 with the fixes.