### PR TITLE
Fixing missing feature for `infra perf cargo`

### DIFF
--- a/crates/solidity/testing/perf/Cargo.toml
+++ b/crates/solidity/testing/perf/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 infra_utils = { workspace = true }
 semver = { workspace = true }
 metaslang_bindings = { workspace = true }
-slang_solidity = { workspace = true }
+slang_solidity = { workspace = true, features = ["__private_testing_utils"] }
 
 [dev-dependencies]
 iai-callgrind = { workspace = true }


### PR DESCRIPTION
This error went oddly unnoticed by CI: doing `cargo check` succeeds, even for the problematic package, even when `cargo check -p solidity_testing_perf` fails.