### PR TITLE
Changing the name of pragma keywords to make them jco-compatible

### DIFF
--- a/crates/solidity/inputs/language/src/definition.rs
+++ b/crates/solidity/inputs/language/src/definition.rs
@@ -126,8 +126,8 @@ codegen_language_macros::compile!(Language(
                             name = ExperimentalFeature,
                             enabled = From("0.4.16"),
                             variants = [
-                                EnumVariant(reference = ABIEncoderV2Keyword),
-                                EnumVariant(reference = SMTCheckerKeyword),
+                                EnumVariant(reference = AbiencoderV2Keyword),
+                                EnumVariant(reference = SmtcheckerKeyword),
                                 EnumVariant(reference = StringLiteral)
                             ]
                         ),
@@ -489,7 +489,7 @@ codegen_language_macros::compile!(Language(
                             )]
                         ),
                         Keyword(
-                            name = ABIEncoderV2Keyword,
+                            name = AbiencoderV2Keyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
                                 enabled = From("0.4.16"),
@@ -1421,7 +1421,7 @@ codegen_language_macros::compile!(Language(
                             )]
                         ),
                         Keyword(
-                            name = SMTCheckerKeyword,
+                            name = SmtcheckerKeyword,
                             identifier = Identifier,
                             definitions = [KeywordDefinition(
                                 enabled = From("0.4.16"),

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -486,10 +486,10 @@ pub fn slang_solidity::cst::NonterminalKind::serialize<__S>(&self, __serializer:
 impl<'_derivative_strum> core::convert::From<&'_derivative_strum slang_solidity::cst::NonterminalKind> for &'static str
 pub fn &'static str::from(x: &'_derivative_strum slang_solidity::cst::NonterminalKind) -> &'static str
 #[repr(u16)] pub enum slang_solidity::cst::TerminalKind
-pub slang_solidity::cst::TerminalKind::ABIEncoderV2Keyword
 pub slang_solidity::cst::TerminalKind::AbicoderKeyword
 pub slang_solidity::cst::TerminalKind::AbicoderV1Keyword
 pub slang_solidity::cst::TerminalKind::AbicoderV2Keyword
+pub slang_solidity::cst::TerminalKind::AbiencoderV2Keyword
 pub slang_solidity::cst::TerminalKind::AbstractKeyword
 pub slang_solidity::cst::TerminalKind::AddressKeyword
 pub slang_solidity::cst::TerminalKind::AfterKeyword
@@ -633,7 +633,6 @@ pub slang_solidity::cst::TerminalKind::RelocatableKeyword
 pub slang_solidity::cst::TerminalKind::ReturnKeyword
 pub slang_solidity::cst::TerminalKind::ReturnsKeyword
 pub slang_solidity::cst::TerminalKind::RevertKeyword
-pub slang_solidity::cst::TerminalKind::SMTCheckerKeyword
 pub slang_solidity::cst::TerminalKind::SealedKeyword
 pub slang_solidity::cst::TerminalKind::SecondsKeyword
 pub slang_solidity::cst::TerminalKind::Semicolon
@@ -646,6 +645,7 @@ pub slang_solidity::cst::TerminalKind::SingleQuotedVersionLiteral
 pub slang_solidity::cst::TerminalKind::SizeOfKeyword
 pub slang_solidity::cst::TerminalKind::Slash
 pub slang_solidity::cst::TerminalKind::SlashEqual
+pub slang_solidity::cst::TerminalKind::SmtcheckerKeyword
 pub slang_solidity::cst::TerminalKind::SolidityKeyword
 pub slang_solidity::cst::TerminalKind::StaticKeyword
 pub slang_solidity::cst::TerminalKind::StorageKeyword

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/builder.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/builder.rs
@@ -2671,11 +2671,11 @@ pub fn build_experimental_feature(node: &Rc<NonterminalNode>) -> Option<Experime
         NodeKind::Nonterminal(NonterminalKind::StringLiteral) => {
             ExperimentalFeature::StringLiteral(build_string_literal(nonterminal_node(variant))?)
         }
-        NodeKind::Terminal(TerminalKind::ABIEncoderV2Keyword) => {
-            ExperimentalFeature::ABIEncoderV2Keyword
+        NodeKind::Terminal(TerminalKind::AbiencoderV2Keyword) => {
+            ExperimentalFeature::AbiencoderV2Keyword
         }
-        NodeKind::Terminal(TerminalKind::SMTCheckerKeyword) => {
-            ExperimentalFeature::SMTCheckerKeyword
+        NodeKind::Terminal(TerminalKind::SmtcheckerKeyword) => {
+            ExperimentalFeature::SmtcheckerKeyword
         }
         NodeKind::Nonterminal(_) | NodeKind::Terminal(_) => {
             unreachable!(

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/nodes.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/nodes.rs
@@ -1206,8 +1206,8 @@ pub enum AbicoderVersion {
 #[derive(Debug)]
 pub enum ExperimentalFeature {
     StringLiteral(StringLiteral),
-    ABIEncoderV2Keyword,
-    SMTCheckerKeyword,
+    AbiencoderV2Keyword,
+    SmtcheckerKeyword,
 }
 
 #[derive(Debug)]

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/rewriter.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/rewriter.rs
@@ -1771,8 +1771,8 @@ pub trait Rewriter {
             ExperimentalFeature::StringLiteral(ref string_literal) => {
                 ExperimentalFeature::StringLiteral(self.rewrite_string_literal(string_literal))
             }
-            ExperimentalFeature::ABIEncoderV2Keyword => ExperimentalFeature::ABIEncoderV2Keyword,
-            ExperimentalFeature::SMTCheckerKeyword => ExperimentalFeature::SMTCheckerKeyword,
+            ExperimentalFeature::AbiencoderV2Keyword => ExperimentalFeature::AbiencoderV2Keyword,
+            ExperimentalFeature::SmtcheckerKeyword => ExperimentalFeature::SmtcheckerKeyword,
         }
     }
     fn rewrite_experimental_feature(

--- a/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l1_structured_ast/generated/visitor.rs
@@ -2500,7 +2500,7 @@ pub fn accept_experimental_feature(node: &ExperimentalFeature, visitor: &mut imp
         ExperimentalFeature::StringLiteral(ref string_literal) => {
             accept_string_literal(string_literal, visitor);
         }
-        ExperimentalFeature::ABIEncoderV2Keyword | ExperimentalFeature::SMTCheckerKeyword => {}
+        ExperimentalFeature::AbiencoderV2Keyword | ExperimentalFeature::SmtcheckerKeyword => {}
     }
     visitor.leave_experimental_feature(node);
 }

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/nodes.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/nodes.rs
@@ -1207,8 +1207,8 @@ pub enum AbicoderVersion {
 #[derive(Debug)]
 pub enum ExperimentalFeature {
     StringLiteral(StringLiteral),
-    ABIEncoderV2Keyword,
-    SMTCheckerKeyword,
+    AbiencoderV2Keyword,
+    SmtcheckerKeyword,
 }
 
 #[derive(Debug)]

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/rewriter.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/rewriter.rs
@@ -1776,8 +1776,8 @@ pub trait Rewriter {
             ExperimentalFeature::StringLiteral(ref string_literal) => {
                 ExperimentalFeature::StringLiteral(self.rewrite_string_literal(string_literal))
             }
-            ExperimentalFeature::ABIEncoderV2Keyword => ExperimentalFeature::ABIEncoderV2Keyword,
-            ExperimentalFeature::SMTCheckerKeyword => ExperimentalFeature::SMTCheckerKeyword,
+            ExperimentalFeature::AbiencoderV2Keyword => ExperimentalFeature::AbiencoderV2Keyword,
+            ExperimentalFeature::SmtcheckerKeyword => ExperimentalFeature::SmtcheckerKeyword,
         }
     }
     fn rewrite_experimental_feature(

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/transformer.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/transformer.rs
@@ -1942,11 +1942,11 @@ pub trait Transformer {
                     self.transform_string_literal(string_literal),
                 )
             }
-            input::ExperimentalFeature::ABIEncoderV2Keyword => {
-                output::ExperimentalFeature::ABIEncoderV2Keyword
+            input::ExperimentalFeature::AbiencoderV2Keyword => {
+                output::ExperimentalFeature::AbiencoderV2Keyword
             }
-            input::ExperimentalFeature::SMTCheckerKeyword => {
-                output::ExperimentalFeature::SMTCheckerKeyword
+            input::ExperimentalFeature::SmtcheckerKeyword => {
+                output::ExperimentalFeature::SmtcheckerKeyword
             }
         }
     }

--- a/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/l2_flat_contracts/generated/visitor.rs
@@ -2498,7 +2498,7 @@ pub fn accept_experimental_feature(node: &ExperimentalFeature, visitor: &mut imp
         ExperimentalFeature::StringLiteral(ref string_literal) => {
             accept_string_literal(string_literal, visitor);
         }
-        ExperimentalFeature::ABIEncoderV2Keyword | ExperimentalFeature::SMTCheckerKeyword => {}
+        ExperimentalFeature::AbiencoderV2Keyword | ExperimentalFeature::SmtcheckerKeyword => {}
     }
     visitor.leave_experimental_feature(node);
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/nonterminal_kind.rs
@@ -529,8 +529,8 @@ pub enum NonterminalKind {
     ///
     /// ```ebnf
     /// (* Introduced in 0.4.16 *)
-    /// ExperimentalFeature = (* variant: *) ABI_ENCODER_V2_KEYWORD
-    ///                     | (* variant: *) SMT_CHECKER_KEYWORD
+    /// ExperimentalFeature = (* variant: *) ABIENCODER_V2_KEYWORD
+    ///                     | (* variant: *) SMTCHECKER_KEYWORD
     ///                     | (* variant: *) StringLiteral;
     /// ```
     ExperimentalFeature,

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/generated/terminal_kind.rs
@@ -29,14 +29,6 @@ pub enum TerminalKind {
     /// Adding the missing input in this position may allow the parser to produce a valid tree there.
     MISSING,
 
-    /// Represents a node with kind `ABIEncoderV2Keyword`, having the following structure:
-    ///
-    /// ```ebnf
-    /// (* Introduced in 0.4.16 *)
-    /// (* Never reserved *)
-    /// ABI_ENCODER_V2_KEYWORD = "ABIEncoderV2";
-    /// ```
-    ABIEncoderV2Keyword,
     /// Represents a node with kind `AbicoderKeyword`, having the following structure:
     ///
     /// ```ebnf
@@ -61,6 +53,14 @@ pub enum TerminalKind {
     /// ABICODER_V2_KEYWORD = "v2";
     /// ```
     AbicoderV2Keyword,
+    /// Represents a node with kind `AbiencoderV2Keyword`, having the following structure:
+    ///
+    /// ```ebnf
+    /// (* Introduced in 0.4.16 *)
+    /// (* Never reserved *)
+    /// ABIENCODER_V2_KEYWORD = "ABIEncoderV2";
+    /// ```
+    AbiencoderV2Keyword,
     /// Represents a node with kind `AbstractKeyword`, having the following structure:
     ///
     /// ```ebnf
@@ -990,14 +990,6 @@ pub enum TerminalKind {
     /// REVERT_KEYWORD = "revert";
     /// ```
     RevertKeyword,
-    /// Represents a node with kind `SMTCheckerKeyword`, having the following structure:
-    ///
-    /// ```ebnf
-    /// (* Introduced in 0.4.16 *)
-    /// (* Never reserved *)
-    /// SMT_CHECKER_KEYWORD = "SMTChecker";
-    /// ```
-    SMTCheckerKeyword,
     /// Represents a node with kind `SealedKeyword`, having the following structure:
     ///
     /// ```ebnf
@@ -1079,6 +1071,14 @@ pub enum TerminalKind {
     /// SLASH_EQUAL = "/=";
     /// ```
     SlashEqual,
+    /// Represents a node with kind `SmtcheckerKeyword`, having the following structure:
+    ///
+    /// ```ebnf
+    /// (* Introduced in 0.4.16 *)
+    /// (* Never reserved *)
+    /// SMTCHECKER_KEYWORD = "SMTChecker";
+    /// ```
+    SmtcheckerKeyword,
     /// Represents a node with kind `SolidityKeyword`, having the following structure:
     ///
     /// ```ebnf

--- a/crates/solidity/outputs/cargo/crate/src/generated/parser/generated/parser.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/parser/generated/parser.rs
@@ -1978,12 +1978,12 @@ impl Parser {
             ChoiceHelper::run(input, |mut choice, input| {
                 let result = self.parse_terminal_with_trivia::<LexicalContextType::Pragma>(
                     input,
-                    TerminalKind::ABIEncoderV2Keyword,
+                    TerminalKind::AbiencoderV2Keyword,
                 );
                 choice.consider(input, result)?;
                 let result = self.parse_terminal_with_trivia::<LexicalContextType::Pragma>(
                     input,
-                    TerminalKind::SMTCheckerKeyword,
+                    TerminalKind::SmtcheckerKeyword,
                 );
                 choice.consider(input, result)?;
                 let result = self.string_literal(input);
@@ -9425,7 +9425,7 @@ impl Lexer for Parser {
                                 input, 'B', 'I', 'E', 'n', 'c', 'o', 'd', 'e', 'r', 'V', '2'
                             ) {
                                 if self.version_is_at_least_0_4_16 {
-                                    KeywordScan::Present(TerminalKind::ABIEncoderV2Keyword)
+                                    KeywordScan::Present(TerminalKind::AbiencoderV2Keyword)
                                 } else {
                                     KeywordScan::Absent
                                 }
@@ -9436,7 +9436,7 @@ impl Lexer for Parser {
                         Some('S') => {
                             if scan_chars!(input, 'M', 'T', 'C', 'h', 'e', 'c', 'k', 'e', 'r') {
                                 if self.version_is_at_least_0_4_16 {
-                                    KeywordScan::Present(TerminalKind::SMTCheckerKeyword)
+                                    KeywordScan::Present(TerminalKind::SmtcheckerKeyword)
                                 } else {
                                     KeywordScan::Absent
                                 }
@@ -10866,7 +10866,7 @@ impl Lexer for Parser {
                                 input, 'B', 'I', 'E', 'n', 'c', 'o', 'd', 'e', 'r', 'V', '2'
                             ) {
                                 if self.version_is_at_least_0_4_16 {
-                                    KeywordScan::Present(TerminalKind::ABIEncoderV2Keyword)
+                                    KeywordScan::Present(TerminalKind::AbiencoderV2Keyword)
                                 } else {
                                     KeywordScan::Absent
                                 }
@@ -10877,7 +10877,7 @@ impl Lexer for Parser {
                         Some('S') => {
                             if scan_chars!(input, 'M', 'T', 'C', 'h', 'e', 'c', 'k', 'e', 'r') {
                                 if self.version_is_at_least_0_4_16 {
-                                    KeywordScan::Present(TerminalKind::SMTCheckerKeyword)
+                                    KeywordScan::Present(TerminalKind::SmtcheckerKeyword)
                                 } else {
                                     KeywordScan::Absent
                                 }

--- a/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
+++ b/crates/solidity/outputs/cargo/wasm/src/generated/interface/generated/cst.wit
@@ -512,8 +512,8 @@ interface cst {
                 ///
                 /// ```ebnf
                 /// (* Introduced in 0.4.16 *)
-                /// ExperimentalFeature = (* variant: *) ABI_ENCODER_V2_KEYWORD
-                ///                     | (* variant: *) SMT_CHECKER_KEYWORD
+                /// ExperimentalFeature = (* variant: *) ABIENCODER_V2_KEYWORD
+                ///                     | (* variant: *) SMTCHECKER_KEYWORD
                 ///                     | (* variant: *) StringLiteral;
                 /// ```
                 %experimental-feature,
@@ -2047,14 +2047,6 @@ interface cst {
         /// This terminal is created when the parser is expecting a certain terminal but does not find it.
         /// Adding the missing input in this position may allow the parser to produce a valid tree there.
         missing,
-                /// Represents a node with kind `ABIEncoderV2Keyword`, having the following structure:
-                ///
-                /// ```ebnf
-                /// (* Introduced in 0.4.16 *)
-                /// (* Never reserved *)
-                /// ABI_ENCODER_V2_KEYWORD = "ABIEncoderV2";
-                /// ```
-                %abiencoder-v2-keyword,
                 /// Represents a node with kind `AbicoderKeyword`, having the following structure:
                 ///
                 /// ```ebnf
@@ -2079,6 +2071,14 @@ interface cst {
                 /// ABICODER_V2_KEYWORD = "v2";
                 /// ```
                 %abicoder-v2-keyword,
+                /// Represents a node with kind `AbiencoderV2Keyword`, having the following structure:
+                ///
+                /// ```ebnf
+                /// (* Introduced in 0.4.16 *)
+                /// (* Never reserved *)
+                /// ABIENCODER_V2_KEYWORD = "ABIEncoderV2";
+                /// ```
+                %abiencoder-v2-keyword,
                 /// Represents a node with kind `AbstractKeyword`, having the following structure:
                 ///
                 /// ```ebnf
@@ -3008,14 +3008,6 @@ interface cst {
                 /// REVERT_KEYWORD = "revert";
                 /// ```
                 %revert-keyword,
-                /// Represents a node with kind `SMTCheckerKeyword`, having the following structure:
-                ///
-                /// ```ebnf
-                /// (* Introduced in 0.4.16 *)
-                /// (* Never reserved *)
-                /// SMT_CHECKER_KEYWORD = "SMTChecker";
-                /// ```
-                %smtchecker-keyword,
                 /// Represents a node with kind `SealedKeyword`, having the following structure:
                 ///
                 /// ```ebnf
@@ -3097,6 +3089,14 @@ interface cst {
                 /// SLASH_EQUAL = "/=";
                 /// ```
                 %slash-equal,
+                /// Represents a node with kind `SmtcheckerKeyword`, having the following structure:
+                ///
+                /// ```ebnf
+                /// (* Introduced in 0.4.16 *)
+                /// (* Never reserved *)
+                /// SMTCHECKER_KEYWORD = "SMTChecker";
+                /// ```
+                %smtchecker-keyword,
                 /// Represents a node with kind `SolidityKeyword`, having the following structure:
                 ///
                 /// ```ebnf

--- a/crates/solidity/outputs/npm/package/src/generated/ast/generated/nodes.mts
+++ b/crates/solidity/outputs/npm/package/src/generated/ast/generated/nodes.mts
@@ -7647,8 +7647,8 @@ export class AbicoderVersion {
  *
  * ```ebnf
  * (* Introduced in 0.4.16 *)
- * ExperimentalFeature = (* variant: *) ABI_ENCODER_V2_KEYWORD
- *                     | (* variant: *) SMT_CHECKER_KEYWORD
+ * ExperimentalFeature = (* variant: *) ABIENCODER_V2_KEYWORD
+ *                     | (* variant: *) SMTCHECKER_KEYWORD
  *                     | (* variant: *) StringLiteral;
  * ```
  */

--- a/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
+++ b/crates/solidity/outputs/npm/package/wasm/generated/interfaces/nomic-foundation-slang-cst.d.ts
@@ -630,8 +630,8 @@ export declare enum NonterminalKind {
    *
    * ```ebnf
    * (* Introduced in 0.4.16 *)
-   * ExperimentalFeature = (* variant: *) ABI_ENCODER_V2_KEYWORD
-   *                     | (* variant: *) SMT_CHECKER_KEYWORD
+   * ExperimentalFeature = (* variant: *) ABIENCODER_V2_KEYWORD
+   *                     | (* variant: *) SMTCHECKER_KEYWORD
    *                     | (* variant: *) StringLiteral;
    * ```
    */
@@ -2510,16 +2510,6 @@ export declare enum TerminalKind {
    */
   Missing = "Missing",
   /**
-   * Represents a node with kind `ABIEncoderV2Keyword`, having the following structure:
-   *
-   * ```ebnf
-   * (* Introduced in 0.4.16 *)
-   * (* Never reserved *)
-   * ABI_ENCODER_V2_KEYWORD = "ABIEncoderV2";
-   * ```
-   */
-  AbiencoderV2Keyword = "AbiencoderV2Keyword",
-  /**
    * Represents a node with kind `AbicoderKeyword`, having the following structure:
    *
    * ```ebnf
@@ -2549,6 +2539,16 @@ export declare enum TerminalKind {
    * ```
    */
   AbicoderV2Keyword = "AbicoderV2Keyword",
+  /**
+   * Represents a node with kind `AbiencoderV2Keyword`, having the following structure:
+   *
+   * ```ebnf
+   * (* Introduced in 0.4.16 *)
+   * (* Never reserved *)
+   * ABIENCODER_V2_KEYWORD = "ABIEncoderV2";
+   * ```
+   */
+  AbiencoderV2Keyword = "AbiencoderV2Keyword",
   /**
    * Represents a node with kind `AbstractKeyword`, having the following structure:
    *
@@ -3763,16 +3763,6 @@ export declare enum TerminalKind {
    */
   RevertKeyword = "RevertKeyword",
   /**
-   * Represents a node with kind `SMTCheckerKeyword`, having the following structure:
-   *
-   * ```ebnf
-   * (* Introduced in 0.4.16 *)
-   * (* Never reserved *)
-   * SMT_CHECKER_KEYWORD = "SMTChecker";
-   * ```
-   */
-  SmtcheckerKeyword = "SmtcheckerKeyword",
-  /**
    * Represents a node with kind `SealedKeyword`, having the following structure:
    *
    * ```ebnf
@@ -3877,6 +3867,16 @@ export declare enum TerminalKind {
    * ```
    */
   SlashEqual = "SlashEqual",
+  /**
+   * Represents a node with kind `SmtcheckerKeyword`, having the following structure:
+   *
+   * ```ebnf
+   * (* Introduced in 0.4.16 *)
+   * (* Never reserved *)
+   * SMTCHECKER_KEYWORD = "SMTChecker";
+   * ```
+   */
+  SmtcheckerKeyword = "SmtcheckerKeyword",
   /**
    * Represents a node with kind `SolidityKeyword`, having the following structure:
    *

--- a/crates/solidity/outputs/spec/generated/grammar.ebnf
+++ b/crates/solidity/outputs/spec/generated/grammar.ebnf
@@ -47,8 +47,8 @@ AbicoderVersion = (* variant: *) ABICODER_V1_KEYWORD
                 | (* variant: *) ABICODER_V2_KEYWORD;
 
 (* Introduced in 0.4.16 *)
-ExperimentalFeature = (* variant: *) ABI_ENCODER_V2_KEYWORD
-                    | (* variant: *) SMT_CHECKER_KEYWORD
+ExperimentalFeature = (* variant: *) ABIENCODER_V2_KEYWORD
+                    | (* variant: *) SMTCHECKER_KEYWORD
                     | (* variant: *) StringLiteral;
 
 VersionPragma = (* solidity_keyword: *) SOLIDITY_KEYWORD
@@ -200,7 +200,7 @@ ABICODER_V2_KEYWORD = "v2";
 
 (* Introduced in 0.4.16 *)
 (* Never reserved *)
-ABI_ENCODER_V2_KEYWORD = "ABIEncoderV2";
+ABIENCODER_V2_KEYWORD = "ABIEncoderV2";
 
 (* Introduced in 0.6.0 *)
 ABSTRACT_KEYWORD = "abstract";
@@ -437,7 +437,7 @@ SIZE_OF_KEYWORD = "sizeof";
 
 (* Introduced in 0.4.16 *)
 (* Never reserved *)
-SMT_CHECKER_KEYWORD = "SMTChecker";
+SMTCHECKER_KEYWORD = "SMTChecker";
 
 (* Never reserved *)
 SOLIDITY_KEYWORD = "solidity";

--- a/crates/solidity/outputs/spec/generated/language-definition.json
+++ b/crates/solidity/outputs/spec/generated/language-definition.json
@@ -226,8 +226,8 @@
                   "name": "ExperimentalFeature",
                   "enabled": { "From": { "from": "0.4.16" } },
                   "variants": [
-                    { "reference": "ABIEncoderV2Keyword" },
-                    { "reference": "SMTCheckerKeyword" },
+                    { "reference": "AbiencoderV2Keyword" },
+                    { "reference": "SmtcheckerKeyword" },
                     { "reference": "StringLiteral" }
                   ]
                 }
@@ -831,7 +831,7 @@
             {
               "Keyword": {
                 "item": {
-                  "name": "ABIEncoderV2Keyword",
+                  "name": "AbiencoderV2Keyword",
                   "identifier": "Identifier",
                   "definitions": [
                     {
@@ -2223,7 +2223,7 @@
             {
               "Keyword": {
                 "item": {
-                  "name": "SMTCheckerKeyword",
+                  "name": "SmtcheckerKeyword",
                   "identifier": "Identifier",
                   "definitions": [
                     {

--- a/crates/solidity/outputs/spec/generated/public/01-file-structure/02-pragma-directives.md
+++ b/crates/solidity/outputs/spec/generated/public/01-file-structure/02-pragma-directives.md
@@ -36,7 +36,7 @@
 
 ```
 
-<pre ebnf-snippet="ExperimentalFeature" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><a href="#ExperimentalFeature"><span class="k">ExperimentalFeature</span></a><span class="o"> = </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../06-keywords#ABIEncoderV2Keyword"><span class="k">ABI_ENCODER_V2_KEYWORD</span></a><br /><span class="o">                    | </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../06-keywords#SMTCheckerKeyword"><span class="k">SMT_CHECKER_KEYWORD</span></a><br /><span class="o">                    | </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../../05-expressions/05-strings#StringLiteral"><span class="k">StringLiteral</span></a><span class="o">;</span></pre>
+<pre ebnf-snippet="ExperimentalFeature" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><a href="#ExperimentalFeature"><span class="k">ExperimentalFeature</span></a><span class="o"> = </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../06-keywords#AbiencoderV2Keyword"><span class="k">ABIENCODER_V2_KEYWORD</span></a><br /><span class="o">                    | </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../06-keywords#SmtcheckerKeyword"><span class="k">SMTCHECKER_KEYWORD</span></a><br /><span class="o">                    | </span><span class="cm">(* variant: *)</span><span class="o"> </span><a href="../../05-expressions/05-strings#StringLiteral"><span class="k">StringLiteral</span></a><span class="o">;</span></pre>
 
 ```{ .ebnf #VersionPragma }
 

--- a/crates/solidity/outputs/spec/generated/public/01-file-structure/06-keywords.md
+++ b/crates/solidity/outputs/spec/generated/public/01-file-structure/06-keywords.md
@@ -20,11 +20,11 @@
 
 <pre ebnf-snippet="AbicoderV2Keyword" style="display: none;"><span class="cm">(* Introduced in 0.7.5 *)</span><br /><span class="cm">(* Never reserved *)</span><br /><a href="#AbicoderV2Keyword"><span class="k">ABICODER_V2_KEYWORD</span></a><span class="o"> = </span><span class="s2">"v2"</span><span class="o">;</span></pre>
 
-```{ .ebnf #ABIEncoderV2Keyword }
+```{ .ebnf #AbiencoderV2Keyword }
 
 ```
 
-<pre ebnf-snippet="ABIEncoderV2Keyword" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><span class="cm">(* Never reserved *)</span><br /><a href="#ABIEncoderV2Keyword"><span class="k">ABI_ENCODER_V2_KEYWORD</span></a><span class="o"> = </span><span class="s2">"ABIEncoderV2"</span><span class="o">;</span></pre>
+<pre ebnf-snippet="AbiencoderV2Keyword" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><span class="cm">(* Never reserved *)</span><br /><a href="#AbiencoderV2Keyword"><span class="k">ABIENCODER_V2_KEYWORD</span></a><span class="o"> = </span><span class="s2">"ABIEncoderV2"</span><span class="o">;</span></pre>
 
 ```{ .ebnf #AbstractKeyword }
 
@@ -554,11 +554,11 @@
 
 <pre ebnf-snippet="SizeOfKeyword" style="display: none;"><span class="cm">(* Reserved in 0.5.0 *)</span><br /><a href="#SizeOfKeyword"><span class="k">SIZE_OF_KEYWORD</span></a><span class="o"> = </span><span class="s2">"sizeof"</span><span class="o">;</span></pre>
 
-```{ .ebnf #SMTCheckerKeyword }
+```{ .ebnf #SmtcheckerKeyword }
 
 ```
 
-<pre ebnf-snippet="SMTCheckerKeyword" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><span class="cm">(* Never reserved *)</span><br /><a href="#SMTCheckerKeyword"><span class="k">SMT_CHECKER_KEYWORD</span></a><span class="o"> = </span><span class="s2">"SMTChecker"</span><span class="o">;</span></pre>
+<pre ebnf-snippet="SmtcheckerKeyword" style="display: none;"><span class="cm">(* Introduced in 0.4.16 *)</span><br /><span class="cm">(* Never reserved *)</span><br /><a href="#SmtcheckerKeyword"><span class="k">SMTCHECKER_KEYWORD</span></a><span class="o"> = </span><span class="s2">"SMTChecker"</span><span class="o">;</span></pre>
 
 ```{ .ebnf #SolidityKeyword }
 


### PR DESCRIPTION
Fixes #1408 by selecting a casing that is JCO-compatible.

`ABIEncoderV2Keyword` -> `AbiencoderV2Keyword`
`SMTCheckerKeyword` -> `SmtcheckerKeyword`

An alternative that also works can be
`AbiEncoderV2Keyword`
`SmtCheckerKeyword`

But given that we have `Abicoder` already, I think the first ones are better.