### PR TITLE
Resolve identifiers in assembly blocks to locally imported symbols

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -260,10 +260,8 @@ inherit .star_extension
   node @symbol.import
   edge @symbol.import -> @path.import
 
-  node @symbol.yul_def
-  edge @import.yul_defs -> @symbol.yul_def
-  node @symbol.yul_import
-  edge @symbol.yul_import -> @import.yul_path
+  edge @import.yul_defs -> @symbol.def
+  edge @symbol.import -> @import.yul_path
 }
 
 @symbol [ImportDeconstructionSymbol @name name: [Identifier] .] {
@@ -271,10 +269,6 @@ inherit .star_extension
   attr (@symbol.def) definiens_node = @symbol
   attr (@symbol.import) node_reference = @name
   edge @symbol.def -> @symbol.import
-
-  attr (@symbol.yul_def) pop_symbol = (source-text @name)
-  attr (@symbol.yul_import) push_symbol = (source-text @name)
-  edge @symbol.yul_def -> @symbol.yul_import
 }
 
 @symbol [ImportDeconstructionSymbol
@@ -285,10 +279,6 @@ inherit .star_extension
   attr (@symbol.def) definiens_node = @symbol
   attr (@symbol.import) node_reference = @name
   edge @symbol.def -> @symbol.import
-
-  attr (@symbol.yul_def) pop_symbol = (source-text @alias)
-  attr (@symbol.yul_import) push_symbol = (source-text @name)
-  edge @symbol.yul_def -> @symbol.yul_import
 }
 
 

--- a/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/bindings/generated/binding_rules.rs
@@ -264,10 +264,8 @@ inherit .star_extension
   node @symbol.import
   edge @symbol.import -> @path.import
 
-  node @symbol.yul_def
-  edge @import.yul_defs -> @symbol.yul_def
-  node @symbol.yul_import
-  edge @symbol.yul_import -> @import.yul_path
+  edge @import.yul_defs -> @symbol.def
+  edge @symbol.import -> @import.yul_path
 }
 
 @symbol [ImportDeconstructionSymbol @name name: [Identifier] .] {
@@ -275,10 +273,6 @@ inherit .star_extension
   attr (@symbol.def) definiens_node = @symbol
   attr (@symbol.import) node_reference = @name
   edge @symbol.def -> @symbol.import
-
-  attr (@symbol.yul_def) pop_symbol = (source-text @name)
-  attr (@symbol.yul_import) push_symbol = (source-text @name)
-  edge @symbol.yul_def -> @symbol.yul_import
 }
 
 @symbol [ImportDeconstructionSymbol
@@ -289,10 +283,6 @@ inherit .star_extension
   attr (@symbol.def) definiens_node = @symbol
   attr (@symbol.import) node_reference = @name
   edge @symbol.def -> @symbol.import
-
-  attr (@symbol.yul_def) pop_symbol = (source-text @alias)
-  attr (@symbol.yul_import) push_symbol = (source-text @name)
-  edge @symbol.yul_def -> @symbol.yul_import
 }
 
 

--- a/crates/solidity/outputs/cargo/tests/src/binder/generated/yul.rs
+++ b/crates/solidity/outputs/cargo/tests/src/binder/generated/yul.rs
@@ -77,6 +77,11 @@ fn imported_deconstructed_constants() -> Result<()> {
 }
 
 #[test]
+fn imported_undefined_symbol() -> Result<()> {
+    run(T, "imported_undefined_symbol")
+}
+
+#[test]
 fn inherited_constant() -> Result<()> {
     run(T, "inherited_constant")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/yul.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/yul.rs
@@ -77,6 +77,11 @@ fn imported_deconstructed_constants() -> Result<()> {
 }
 
 #[test]
+fn imported_undefined_symbol() -> Result<()> {
+    run(T, "imported_undefined_symbol")
+}
+
+#[test]
 fn inherited_constant() -> Result<()> {
     run(T, "inherited_constant")
 }

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.4.11-failure.txt
@@ -22,7 +22,7 @@ References and definitions:
    │                       │   │   
    │                       ╰─────── ref: built-in
    │                           │   
-   │                           ╰─── unresolved
+   │                           ╰─── ref: 1
 ───╯
 Definiens: 
    ╭─[main.sol:1:1]

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.6.0-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.6.0-failure.txt
@@ -22,7 +22,7 @@ References and definitions:
    │                       │   │   
    │                       ╰─────── ref: built-in
    │                           │   
-   │                           ╰─── unresolved
+   │                           ╰─── ref: 1
 ───╯
 Definiens: 
    ╭─[main.sol:1:1]

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.7.1-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.7.1-failure.txt
@@ -22,7 +22,7 @@ References and definitions:
    │                       │   │   
    │                       ╰─────── ref: built-in
    │                           │   
-   │                           ╰─── unresolved
+   │                           ╰─── ref: 1
 ───╯
 Definiens: 
    ╭─[main.sol:1:1]

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.7.4-success.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_deconstructed_constants/generated/0.7.4-success.txt
@@ -22,7 +22,7 @@ References and definitions:
    │                       │   │   
    │                       ╰─────── ref: built-in
    │                           │   
-   │                           ╰─── ref: 5
+   │                           ╰─── refs: 1, 5
 ───╯
 Definiens: 
    ╭─[main.sol:1:1]

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_undefined_symbol/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_undefined_symbol/generated/0.4.11-failure.txt
@@ -1,0 +1,66 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ import { slot } from "./slots.sol";  // even if undefined, the local def should have 2 references
+    │          ──┬─  
+    │            ╰─── name: 1
+    │            │   
+    │            ╰─── unresolved
+    │ 
+  3 │ contract Foo {
+    │          ─┬─  
+    │           ╰─── name: 2
+  4 │     function useSlotInAssembly() public {
+    │              ────────┬────────  
+    │                      ╰────────── name: 3
+  5 │         uint value;
+    │              ──┬──  
+    │                ╰──── name: 4
+    │ 
+  7 │             value := sload(slot)
+    │             ──┬──    ──┬── ──┬─  
+    │               ╰────────────────── ref: 4
+    │                        │     │   
+    │                        ╰───────── ref: built-in
+    │                              │   
+    │                              ╰─── ref: 1
+    │ 
+ 11 │     function useSlotInSolidity() public {
+    │              ────────┬────────  
+    │                      ╰────────── name: 5
+ 12 │         uint value = slot;
+    │              ──┬──   ──┬─  
+    │                ╰─────────── name: 6
+    │                        │   
+    │                        ╰─── ref: 1
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ │       import { slot } from "./slots.sol";  // even if undefined, the local def should have 2 references
+    │ │               ──┬──  
+    │ │                 ╰──── definiens: 1
+  2 │ ╭─────▶ 
+    ┆ ┆ ┆     
+  4 │ │ ╭───▶     function useSlotInAssembly() public {
+  5 │ │ │             uint value;
+    │ │ │     ──────────┬─────────  
+    │ │ │               ╰─────────── definiens: 4
+    ┆ ┆ ┆     
+  9 │ │ ├─│ ▶     }
+    │ │ │ │           
+    │ │ ╰───────────── definiens: 3
+ 10 │ │   ╭─▶ 
+    ┆ ┆   ┆   
+ 12 │ │   │           uint value = slot;
+    │ │   │   ─────────────┬─────────────  
+    │ │   │                ╰─────────────── definiens: 6
+ 13 │ │   ├─▶     }
+    │ │   │           
+    │ │   ╰─────────── definiens: 5
+ 14 │ ├─────▶ }
+    │ │           
+    │ ╰─────────── definiens: 2
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/yul/imported_undefined_symbol/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/yul/imported_undefined_symbol/input.sol
@@ -1,0 +1,14 @@
+import { slot } from "./slots.sol";  // even if undefined, the local def should have 2 references
+
+contract Foo {
+    function useSlotInAssembly() public {
+        uint value;
+        assembly {
+            value := sload(slot)
+        }
+    }
+
+    function useSlotInSolidity() public {
+        uint value = slot;
+    }
+}


### PR DESCRIPTION
Fix #1421 

Even if the imported symbol cannot be resolved, the identifier should still resolve to the local definition in the import statement, so that code in assembly blocks is consistent with normal Solidity code.
