### PR TITLE
hide `Query` and `QueryMatch` private APIs

### DIFF
--- a/.changeset/tall-towns-tan.md
+++ b/.changeset/tall-towns-tan.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": patch
+---
+
+fix CST query matches to return an empty array for unmatched named captures, instead of `undefined`.

--- a/crates/codegen/runtime/cargo/crate/src/runtime/cst/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/cst/mod.rs
@@ -78,7 +78,7 @@ pub type AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<KindTypes>
 /// for detailed information about the query syntax and how to use queries to find matches.
 pub type Query = metaslang_cst::query::Query<KindTypes>;
 
-pub use metaslang_cst::query::QueryError;
+pub use metaslang_cst::query::{CaptureQuantifier, QueryError};
 /// Represents a match found by executing queries on a cursor.
 pub type QueryMatch = metaslang_cst::query::QueryMatch<KindTypes>;
 /// Iterator over query matches in the syntax tree.

--- a/crates/metaslang/cst/generated/public_api.txt
+++ b/crates/metaslang/cst/generated/public_api.txt
@@ -224,9 +224,8 @@ pub fn metaslang_cst::query::CaptureQuantifier::fmt(&self, f: &mut core::fmt::Fo
 impl core::marker::Copy for metaslang_cst::query::CaptureQuantifier
 impl core::marker::StructuralPartialEq for metaslang_cst::query::CaptureQuantifier
 pub struct metaslang_cst::query::Query<T: metaslang_cst::kinds::KindTypes>
-pub metaslang_cst::query::Query::ast_node: metaslang_cst::query::model::ASTNode<T>
-pub metaslang_cst::query::Query::capture_quantifiers: alloc::collections::btree::map::BTreeMap<alloc::string::String, metaslang_cst::query::CaptureQuantifier>
 impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::query::Query<T>
+pub fn metaslang_cst::query::Query<T>::capture_quantifiers(&self) -> &alloc::collections::btree::map::BTreeMap<alloc::string::String, metaslang_cst::query::CaptureQuantifier>
 pub fn metaslang_cst::query::Query<T>::create(text: &str) -> core::result::Result<Self, metaslang_cst::query::QueryError>
 impl<T: core::clone::Clone + metaslang_cst::kinds::KindTypes> core::clone::Clone for metaslang_cst::query::Query<T>
 pub fn metaslang_cst::query::Query<T>::clone(&self) -> metaslang_cst::query::Query<T>
@@ -245,15 +244,13 @@ pub fn metaslang_cst::query::QueryError::fmt(&self, f: &mut core::fmt::Formatter
 impl core::fmt::Display for metaslang_cst::query::QueryError
 pub fn metaslang_cst::query::QueryError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct metaslang_cst::query::QueryMatch<T: metaslang_cst::kinds::KindTypes>
-pub metaslang_cst::query::QueryMatch::captures: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::vec::Vec<metaslang_cst::cursor::Cursor<T>>>
-pub metaslang_cst::query::QueryMatch::queries: alloc::rc::Rc<alloc::vec::Vec<metaslang_cst::query::Query<T>>>
-pub metaslang_cst::query::QueryMatch::query_index: usize
-pub metaslang_cst::query::QueryMatch::root_cursor: metaslang_cst::cursor::Cursor<T>
 impl<T: metaslang_cst::kinds::KindTypes> metaslang_cst::query::QueryMatch<T>
 pub fn metaslang_cst::query::QueryMatch<T>::capture(&self, name: &str) -> core::option::Option<(metaslang_cst::query::CaptureQuantifier, impl core::iter::traits::iterator::Iterator<Item = metaslang_cst::cursor::Cursor<T>>)>
 pub fn metaslang_cst::query::QueryMatch<T>::capture_names(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
 pub fn metaslang_cst::query::QueryMatch<T>::captures(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&alloc::string::String, metaslang_cst::query::CaptureQuantifier, impl core::iter::traits::iterator::Iterator<Item = metaslang_cst::cursor::Cursor<T>>)>
 pub fn metaslang_cst::query::QueryMatch<T>::query(&self) -> &metaslang_cst::query::Query<T>
+pub fn metaslang_cst::query::QueryMatch<T>::query_index(&self) -> usize
+pub fn metaslang_cst::query::QueryMatch<T>::root_cursor(&self) -> &metaslang_cst::cursor::Cursor<T>
 pub struct metaslang_cst::query::QueryMatchIterator<T: metaslang_cst::kinds::KindTypes>
 impl<T: metaslang_cst::kinds::KindTypes + 'static> core::iter::traits::iterator::Iterator for metaslang_cst::query::QueryMatchIterator<T>
 pub type metaslang_cst::query::QueryMatchIterator<T>::Item = metaslang_cst::query::QueryMatch<T>

--- a/crates/metaslang/cst/src/query/model.rs
+++ b/crates/metaslang/cst/src/query/model.rs
@@ -17,10 +17,8 @@ use crate::text_index::TextIndex;
 /// for detailed information about the query syntax and how to use queries to find matches.
 #[derive(Clone, Debug)]
 pub struct Query<T: KindTypes> {
-    /// The abstract syntax tree (AST) representation of the query.
-    pub ast_node: ASTNode<T>,
-    /// A map of capture names to their quantifiers, used to define how many times a capture can occur.
-    pub capture_quantifiers: BTreeMap<String, CaptureQuantifier>,
+    ast_node: ASTNode<T>,
+    capture_quantifiers: BTreeMap<String, CaptureQuantifier>,
 }
 
 impl<T: KindTypes> Query<T> {
@@ -107,6 +105,16 @@ impl<T: KindTypes> Query<T> {
             ast_node,
             capture_quantifiers,
         })
+    }
+
+    /// The abstract syntax tree (AST) representation of the query.
+    pub(crate) fn ast_node(&self) -> &ASTNode<T> {
+        &self.ast_node
+    }
+
+    /// A map of capture names to their quantifiers, used to define how many times a capture can occur.
+    pub fn capture_quantifiers(&self) -> &BTreeMap<String, CaptureQuantifier> {
+        &self.capture_quantifiers
     }
 }
 

--- a/crates/metaslang/graph_builder/src/checker.rs
+++ b/crates/metaslang/graph_builder/src/checker.rs
@@ -163,7 +163,7 @@ impl<KT: KindTypes> ast::Stanza<KT> {
 
         let all_captures = self
             .query
-            .capture_quantifiers
+            .capture_quantifiers()
             .keys()
             .into_iter()
             .map(|cn| Identifier::from(cn.as_str()))
@@ -607,7 +607,7 @@ impl ast::Capture {
         ctx: &mut StanzaCheckContext<'_, KT>,
     ) -> Result<ExpressionResult, CheckError> {
         let name = self.name.to_string();
-        if let Some(quantifier) = ctx.stanza_query.capture_quantifiers.get(&name) {
+        if let Some(quantifier) = ctx.stanza_query.capture_quantifiers().get(&name) {
             self.quantifier = *quantifier;
             ctx.used_captures.insert(self.name.clone());
             Ok(ExpressionResult {

--- a/crates/metaslang/graph_builder/src/execution.rs
+++ b/crates/metaslang/graph_builder/src/execution.rs
@@ -143,7 +143,7 @@ pub struct Match<KT: KindTypes> {
 impl<KT: KindTypes> Match<KT> {
     /// Return the top-level matched node.
     pub fn full_capture(&self) -> metaslang_cst::cursor::Cursor<KT> {
-        self.mat.root_cursor.clone()
+        self.mat.root_cursor().clone()
     }
 
     /// Return the matched nodes for a named capture.

--- a/crates/metaslang/graph_builder/src/execution/lazy.rs
+++ b/crates/metaslang/graph_builder/src/execution/lazy.rs
@@ -108,7 +108,7 @@ impl<KT: KindTypes + 'static> ast::File<KT> {
             .collect();
         let matches = tree.clone().query(queries);
         for mat in matches {
-            let stanza = &self.stanzas[mat.query_index];
+            let stanza = &self.stanzas[mat.query_index()];
             visit(stanza, mat)?;
         }
         Ok(())
@@ -169,7 +169,7 @@ impl<KT: KindTypes> ast::Stanza<KT> {
     ) -> Result<(), ExecutionError> {
         let current_regex_captures = vec![];
         locals.clear();
-        let root_cursor = mat.root_cursor.clone();
+        let root_cursor = mat.root_cursor().clone();
         debug!("match {:?} at {}", root_cursor.node(), self.range.start);
         trace!("{{");
         for statement in &self.statements {
@@ -260,7 +260,7 @@ impl ast::CreateGraphNode {
         self.node
             .add_debug_attrs(&mut exec.graph[graph_node].attributes, exec.config)?;
         if let Some(match_node_attr) = &exec.config.match_node_attr {
-            let root_cursor = exec.mat.root_cursor.clone();
+            let root_cursor = exec.mat.root_cursor().clone();
             let syn_node = exec.graph.add_syntax_node(root_cursor);
             exec.graph[graph_node]
                 .attributes
@@ -688,8 +688,8 @@ impl ast::Capture {
         &self,
         exec: &mut ExecutionContext<'_, '_, '_, KT>,
     ) -> Result<LazyValue, ExecutionError> {
-        let capture = &exec.mat.captures[&*self.name.0];
-        Ok(Value::from_nodes(exec.graph, capture.iter().cloned(), self.quantifier).into())
+        let cursors = exec.mat.capture(&self.name.0).unwrap().1;
+        Ok(Value::from_nodes(exec.graph, cursors, self.quantifier).into())
     }
 }
 

--- a/crates/metaslang/graph_builder/src/execution/strict.rs
+++ b/crates/metaslang/graph_builder/src/execution/strict.rs
@@ -138,7 +138,7 @@ impl<KT: KindTypes + 'static> Stanza<KT> {
         locals.clear();
         for statement in &self.statements {
             let error_context = {
-                let cursor = &mat.root_cursor;
+                let cursor = &mat.root_cursor();
                 StatementContext::new(&statement, &self, cursor)
             };
             let mut exec = ExecutionContext {
@@ -254,7 +254,7 @@ impl CreateGraphNode {
         self.node
             .add_debug_attrs(&mut exec.graph[graph_node].attributes, exec.config)?;
         if let Some(match_node_attr) = &exec.config.match_node_attr {
-            let cursor = exec.mat.root_cursor.clone();
+            let cursor = exec.mat.root_cursor().clone();
             let syn_node = exec.graph.add_syntax_node(cursor);
             exec.graph[graph_node]
                 .attributes
@@ -662,8 +662,8 @@ impl Capture {
         &self,
         exec: &mut ExecutionContext<'_, '_, '_, '_, KT>,
     ) -> Result<Value, ExecutionError> {
-        let capture = &exec.mat.captures[&*self.name.0];
-        Ok(Value::from_nodes(exec.graph, capture.iter().cloned(), self.quantifier).into())
+        let cursors = exec.mat.capture(&self.name.0).unwrap().1;
+        Ok(Value::from_nodes(exec.graph, cursors, self.quantifier).into())
     }
 }
 

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -41,6 +41,7 @@ pub type slang_solidity::compilation::CompilationBuilderConfig::Error
 pub fn slang_solidity::compilation::CompilationBuilderConfig::read_file(&mut self, file_id: &str) -> core::result::Result<core::option::Option<alloc::string::String>, Self::Error>
 pub fn slang_solidity::compilation::CompilationBuilderConfig::resolve_import(&mut self, source_file_id: &str, import_path_cursor: &slang_solidity::cst::Cursor) -> core::result::Result<core::option::Option<alloc::string::String>, Self::Error>
 pub mod slang_solidity::cst
+pub use slang_solidity::cst::CaptureQuantifier
 pub use slang_solidity::cst::NodeId
 pub use slang_solidity::cst::QueryError
 pub use slang_solidity::cst::TerminalKindExtensions

--- a/crates/solidity/outputs/cargo/crate/src/extensions/compilation/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/extensions/compilation/mod.rs
@@ -33,11 +33,7 @@ impl ImportPathsExtractor {
     pub fn extract(&self, cursor: Cursor) -> Vec<Cursor> {
         cursor
             .query(self.queries.clone())
-            .flat_map(|query_match| query_match.captures)
-            .flat_map(|(match_name, cursors)| {
-                assert_eq!(match_name, "variant");
-                cursors
-            })
+            .flat_map(|query_match| query_match.capture("variant").unwrap().1)
             .collect()
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/generated/cst/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/cst/mod.rs
@@ -80,7 +80,7 @@ pub type AncestorsIterator = metaslang_cst::cursor::AncestorsIterator<KindTypes>
 /// for detailed information about the query syntax and how to use queries to find matches.
 pub type Query = metaslang_cst::query::Query<KindTypes>;
 
-pub use metaslang_cst::query::QueryError;
+pub use metaslang_cst::query::{CaptureQuantifier, QueryError};
 /// Represents a match found by executing queries on a cursor.
 pub type QueryMatch = metaslang_cst::query::QueryMatch<KindTypes>;
 /// Iterator over query matches in the syntax tree.

--- a/crates/solidity/outputs/cargo/tests/src/bindings/binding_resolver.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/binding_resolver.rs
@@ -16,30 +16,30 @@ contract Middle is Base {}
 contract Test is Base, Middle {}
 "##;
 
-fn find_first_match(root_cursor: Cursor, query_string: &str, capture_name: &str) -> Result<Cursor> {
-    let query = Query::create(query_string)?;
+fn find_first_match(root_cursor: Cursor, query_string: &str, capture_name: &str) -> Cursor {
+    let query = Query::create(query_string).expect("query to be valid");
     let query_match = root_cursor.query(vec![query]).next();
     let query_match = query_match.expect("query to succeed");
-    Ok(query_match.captures[capture_name]
-        .first()
+    query_match
+        .capture(capture_name)
         .expect("query to capture identifier")
-        .clone())
+        .1
+        .next()
+        .expect("query to capture identifier")
+        .clone()
 }
 
-fn find_all_matches(
-    root_cursor: Cursor,
-    query_string: &str,
-    capture_name: &str,
-) -> Result<Vec<Cursor>> {
-    let query = Query::create(query_string)?;
+fn find_all_matches(root_cursor: Cursor, query_string: &str, capture_name: &str) -> Vec<Cursor> {
+    let query = Query::create(query_string).expect("query to be valid");
     let mut results = Vec::new();
     for query_match in root_cursor.query(vec![query]) {
-        let cursor = query_match.captures[capture_name]
-            .first()
-            .expect("query to capture identifier");
-        results.push(cursor.clone());
+        let cursors = query_match
+            .capture(capture_name)
+            .expect("query to capture identifier")
+            .1;
+        results.extend(cursors);
     }
-    Ok(results)
+    results
 }
 
 fn setup() -> Result<(Cursor, Rc<BindingGraph>)> {
@@ -66,7 +66,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[ContractDefinition @identifier [\"Base\"]]",
         "identifier",
-    )?;
+    );
     let base_definition = binding_graph
         .definition_at(&base_cursor)
         .expect("Base definition to be found");
@@ -77,7 +77,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[IdentifierPath @identifier [\"Base\"]]",
         "identifier",
-    )?;
+    );
     for base_ref in &base_references {
         assert!(base_ref_cursors.contains(base_ref.get_cursor()));
     }
@@ -87,7 +87,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[ContractDefinition @identifier [\"Middle\"]]",
         "identifier",
-    )?;
+    );
     let middle_definition = binding_graph
         .definition_at(&middle_cursor)
         .expect("Middle definition to be found");
@@ -98,7 +98,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[IdentifierPath @identifier [\"Middle\"]]",
         "identifier",
-    )?;
+    );
     for middle_ref in &middle_references {
         assert!(middle_ref_cursors.contains(middle_ref.get_cursor()));
     }
@@ -108,7 +108,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[ContractDefinition @identifier [\"Test\"]]",
         "identifier",
-    )?;
+    );
     let test_definition = binding_graph
         .definition_at(&test_cursor)
         .expect("Test definition to be found");
@@ -119,7 +119,7 @@ fn test_resolve_references_from_definition() -> Result<()> {
         root_cursor.clone(),
         "[IdentifierPath @identifier [\"Test\"]]",
         "identifier",
-    )?;
+    );
     assert!(test_ref_cursors.is_empty());
 
     Ok(())
@@ -134,7 +134,7 @@ fn test_find_definitions_at_cursors() -> Result<()> {
         root_cursor.clone(),
         "[ContractDefinition @identifier [\"Base\"]]",
         "identifier",
-    )?;
+    );
     let base_definition = binding_graph
         .definition_by_node_id(base_identifier_cursor.node().id())
         .expect("Base definition to be found");
@@ -144,7 +144,7 @@ fn test_find_definitions_at_cursors() -> Result<()> {
         root_cursor.clone(),
         "@contract [ContractDefinition [\"Base\"]]",
         "contract",
-    )?;
+    );
     let base_contract_definition = binding_graph
         .definition_at(&base_contract_cursor)
         .expect("Base contract found via its definiens");
@@ -165,7 +165,7 @@ fn test_find_definitions_and_references_by_node_id() -> Result<()> {
         root_cursor.clone(),
         "@contract [ContractDefinition [\"Base\"]]",
         "contract",
-    )?;
+    );
     let contract_definition = binding_graph
         .definition_by_node_id(contract_cursor.node().id())
         .expect("Contract definition can be found by its node id");
@@ -185,7 +185,7 @@ fn test_find_definitions_and_references_by_node_id() -> Result<()> {
         root_cursor.clone(),
         "[IdentifierPath @identifier [\"Base\"]]",
         "identifier",
-    )?;
+    );
     for base_ref_cursor in &base_ref_cursors {
         let reference = binding_graph
             .reference_by_node_id(base_ref_cursor.node().id())

--- a/crates/solidity/outputs/cargo/tests/src/cst/queries/engine_tests.rs
+++ b/crates/solidity/outputs/cargo/tests/src/cst/queries/engine_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use slang_solidity::cst::{
-    Cursor, Edge, EdgeLabel, Node, NonterminalKind, Query, QueryMatch, TerminalKind, TextIndex,
+    Edge, EdgeLabel, Node, NonterminalKind, Query, QueryMatch, TerminalKind, TextIndex,
 };
 
 fn terminal(label: EdgeLabel, kind: TerminalKind, text: &str) -> Edge {
@@ -22,18 +22,13 @@ fn nonterminal<const N: usize>(
     }
 }
 
-fn capture_cursors_to_strings(
-    captures: BTreeMap<String, Vec<Cursor>>,
-) -> BTreeMap<String, Vec<String>> {
-    captures
-        .into_iter()
-        .map(|(key, values)| {
+fn capture_cursors_to_strings(query_match: &QueryMatch) -> BTreeMap<String, Vec<String>> {
+    query_match
+        .captures()
+        .map(|(name, _, cursors)| {
             (
-                key,
-                values
-                    .iter()
-                    .map(|v| v.node().unparse())
-                    .collect::<Vec<_>>(),
+                name.clone(),
+                cursors.map(|c| c.node().unparse()).collect::<Vec<_>>(),
             )
         })
         .collect::<BTreeMap<_, _>>()
@@ -82,19 +77,19 @@ macro_rules! query_matches {
 
 }
 
-fn run_query_test(tree: Edge, query: &str, matches: Vec<BTreeMap<String, Vec<String>>>) {
+fn run_query_test(tree: Edge, query: &str, expected_matches: Vec<BTreeMap<String, Vec<String>>>) {
     let cursor = tree.node.create_cursor(TextIndex::ZERO);
     let query = vec![Query::create(query).unwrap()];
-    let mut matches = matches.into_iter();
-    for QueryMatch { captures, .. } in cursor.query(query) {
-        let captures = capture_cursors_to_strings(captures);
-        if let Some(expected_captures) = matches.next() {
+    let mut expected_matches = expected_matches.into_iter();
+    for query_match in cursor.query(query) {
+        let captures = capture_cursors_to_strings(&query_match);
+        if let Some(expected_captures) = expected_matches.next() {
             assert_eq!(captures, expected_captures);
         } else {
             panic!("Unexpected query match: {captures:?}");
         }
     }
-    if let Some(expected_captures) = matches.next() {
+    if let Some(expected_captures) = expected_matches.next() {
         panic!("Missing query match: {expected_captures:?}");
     }
 }
@@ -313,7 +308,7 @@ fn test_zero_or_more() {
             {y: ["A", "B", "C"]}
             {y: ["B", "C"]}
             {y: ["C"]}
-            {}
+            {y: []}
         },
     );
 }
@@ -325,7 +320,7 @@ fn test_optional() {
         "[ContractDefinition (@z [Identifier])? . [_] .]",
         query_matches! {
             {z: ["C"]}
-            {}
+            {z: []}
         },
     );
 }
@@ -347,11 +342,11 @@ fn test_alternatives() {
         common_test_tree(),
         "(@x name:[_] | @y [Identifier] . @z [Identifier])",
         query_matches! {
-            {x: ["A"]}
-            {y: ["A"], z: ["B"]}
-            {y: ["B"], z: ["C"]}
-            {y: ["D"], z: ["E"]}
-            {x: ["E"]}
+            {x: ["A"], y: [], z: []}
+            {x: [], y: ["A"], z: ["B"]}
+            {x: [], y: ["B"], z: ["C"]}
+            {x: [], y: ["D"], z: ["E"]}
+            {x: ["E"], y: [], z: []}
         },
     );
 }
@@ -398,11 +393,11 @@ fn test_ellipsis_followed_by_optional_grouping() {
         query_matches! {
             {x: ["A"], y: ["B"], z: ["C"]}
             {x: ["A"], y: ["C"], z: ["D"]}
-            {x: ["A"]}
+            {x: ["A"], y: [], z:[]}
             {x: ["B"], y: ["C"], z: ["D"]}
-            {x: ["B"]}
-            {x: ["C"]}
-            {x: ["D"]}
+            {x: ["B"], y: [], z:[]}
+            {x: ["C"], y: [], z:[]}
+            {x: ["D"], y: [], z:[]}
         },
     );
 }
@@ -413,12 +408,12 @@ fn test_adjacency_followed_by_optional_grouping() {
         flat_tree(),
         "[ContractDefinition @x [Identifier] . (@y [Identifier] . @z [Identifier])?]",
         query_matches! {
-            {x: ["A"]}
+            {x: ["A"], y: [], z:[]}
             {x: ["A"], y: ["B"], z: ["C"]}
-            {x: ["B"]}
+            {x: ["B"], y: [], z:[]}
             {x: ["B"], y: ["C"], z: ["D"]}
-            {x: ["C"]}
-            {x: ["D"]}
+            {x: ["C"], y: [], z:[]}
+            {x: ["D"], y: [], z:[]}
         },
     );
 }
@@ -484,13 +479,13 @@ fn test_captures_followed_by_captured_optional_matchers() {
             {x: ["A"], y: ["B"]}
             {x: ["A"], y: ["C"]}
             {x: ["A"], y: ["D"]}
-            {x: ["A"]}
+            {x: ["A"], y: []}
             {x: ["B"], y: ["C"]}
             {x: ["B"], y: ["D"]}
-            {x: ["B"]}
+            {x: ["B"], y: []}
             {x: ["C"], y: ["D"]}
-            {x: ["C"]}
-            {x: ["D"]}
+            {x: ["C"], y: []}
+            {x: ["D"], y: []}
         },
     );
 }

--- a/crates/solidity/outputs/cargo/wasm/src/wasm_crate/wrappers/cst/mod.rs
+++ b/crates/solidity/outputs/cargo/wasm/src/wasm_crate/wrappers/cst/mod.rs
@@ -430,19 +430,17 @@ define_refcell_wrapper! { QueryMatchIterator {
 impl IntoFFI<ffi::QueryMatch> for rust::QueryMatch {
     #[inline]
     fn _into_ffi(self) -> ffi::QueryMatch {
-        let rust::QueryMatch {
-            queries: _,
-            query_index,
-            root_cursor,
-            captures,
-        } = self;
-
         ffi::QueryMatch {
-            query_index: query_index.try_into().unwrap(),
-            root: root_cursor._into_ffi(),
-            captures: captures
-                .into_iter()
-                .map(|(k, v)| (k, v.into_iter().map(IntoFFI::_into_ffi).collect()))
+            query_index: self.query_index().try_into().unwrap(),
+            root: self.root_cursor().clone()._into_ffi(),
+            captures: self
+                .captures()
+                .map(|(name, _, cursors)| {
+                    (
+                        name.clone(),
+                        cursors.into_iter().map(IntoFFI::_into_ffi).collect(),
+                    )
+                })
                 .collect(),
         }
     }

--- a/documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts
+++ b/documentation/public/user-guide/06-query-language/01-query-syntax/examples/01-queries.test.mts
@@ -232,7 +232,7 @@ test("quantification-3", () => {
 
   assert.strictEqual(matches.length, 2);
   assert.strictEqual(matches[0].captures["arg"].length, 1);
-  assert.strictEqual(matches[1].captures["arg"], undefined);
+  assert.strictEqual(matches[1].captures["arg"].length, 0);
 });
 
 test("alternations-1", () => {
@@ -254,14 +254,14 @@ test("alternations-1", () => {
 
     assert.strictEqual(matches.length, 1);
     assert.strictEqual(matches[0].captures["function"].length, 1);
-    assert.strictEqual(matches[0].captures["method"], undefined);
+    assert.strictEqual(matches[0].captures["method"].length, 0);
   }
 
   {
     const matches = extractMatches(query, NonterminalKind.FunctionCallExpression, "a.call(1)");
 
     assert.strictEqual(matches.length, 1);
-    assert.strictEqual(matches[0].captures["function"], undefined);
+    assert.strictEqual(matches[0].captures["function"].length, 0);
     assert.strictEqual(matches[0].captures["method"].length, 1);
   }
 });


### PR DESCRIPTION
also fixed a minor bug where CST query matches used to return `undefined` instead of empty arrays for unmatched named captures.