### PR TITLE
rename `CompilationBuilder::new()` to `create()`

### DIFF
--- a/crates/codegen/runtime/cargo/crate/src/runtime/compilation/builder.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/compilation/builder.rs
@@ -58,7 +58,7 @@ pub enum CompilationInitializationError {
 
 impl<E, C: CompilationBuilderConfig<Error = E>> CompilationBuilder<E, C> {
     /// Creates a new compilation builder for the specified language version and callbacks.
-    pub fn new(
+    pub fn create(
         version: Version,
         config: C,
     ) -> Result<CompilationBuilder<E, C>, CompilationInitializationError> {

--- a/crates/codegen/runtime/cargo/crate/src/runtime/compilation/mod.rs
+++ b/crates/codegen/runtime/cargo/crate/src/runtime/compilation/mod.rs
@@ -43,7 +43,7 @@
 //! }
 //!
 //! let config = MyProjectConfig::default();
-//! let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, config).unwrap();
+//! let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, config).unwrap();
 //! builder.add_file("b.sol").unwrap();
 //! let unit = builder.build();
 //!

--- a/crates/solidity/outputs/cargo/crate/generated/public_api.txt
+++ b/crates/solidity/outputs/cargo/crate/generated/public_api.txt
@@ -21,7 +21,7 @@ pub slang_solidity::compilation::CompilationBuilder::config: C
 impl<E, C: slang_solidity::compilation::CompilationBuilderConfig<Error = E>> slang_solidity::compilation::CompilationBuilder<E, C>
 pub fn slang_solidity::compilation::CompilationBuilder<E, C>::add_file(&mut self, file_id: &str) -> core::result::Result<(), E>
 pub fn slang_solidity::compilation::CompilationBuilder<E, C>::build(&self) -> slang_solidity::compilation::CompilationUnit
-pub fn slang_solidity::compilation::CompilationBuilder<E, C>::new(version: semver::Version, config: C) -> core::result::Result<slang_solidity::compilation::CompilationBuilder<E, C>, slang_solidity::compilation::CompilationInitializationError>
+pub fn slang_solidity::compilation::CompilationBuilder<E, C>::create(version: semver::Version, config: C) -> core::result::Result<slang_solidity::compilation::CompilationBuilder<E, C>, slang_solidity::compilation::CompilationInitializationError>
 pub struct slang_solidity::compilation::CompilationUnit
 impl slang_solidity::compilation::CompilationUnit
 pub fn slang_solidity::compilation::CompilationUnit::binding_graph(&self) -> &alloc::rc::Rc<slang_solidity::bindings::BindingGraph>

--- a/crates/solidity/outputs/cargo/crate/src/generated/compilation/builder.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/compilation/builder.rs
@@ -60,7 +60,7 @@ pub enum CompilationInitializationError {
 
 impl<E, C: CompilationBuilderConfig<Error = E>> CompilationBuilder<E, C> {
     /// Creates a new compilation builder for the specified language version and callbacks.
-    pub fn new(
+    pub fn create(
         version: Version,
         config: C,
     ) -> Result<CompilationBuilder<E, C>, CompilationInitializationError> {

--- a/crates/solidity/outputs/cargo/crate/src/generated/compilation/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/generated/compilation/mod.rs
@@ -45,7 +45,7 @@
 //! }
 //!
 //! let config = MyProjectConfig::default();
-//! let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, config).unwrap();
+//! let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, config).unwrap();
 //! builder.add_file("b.sol").unwrap();
 //! let unit = builder.build();
 //!

--- a/crates/solidity/outputs/cargo/tests/src/backend/passes/p1_flatten_contracts.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/passes/p1_flatten_contracts.rs
@@ -31,7 +31,7 @@ contract Test is Base layout at 0 {}
         }
     }
 
-    let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, Config {})?;
+    let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, Config {})?;
     assert!(builder.add_file("main.sol").is_ok());
     let compilation_unit = builder.build();
 

--- a/crates/solidity/outputs/cargo/tests/src/backend/passes/p3_linearise_contracts.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/passes/p3_linearise_contracts.rs
@@ -34,7 +34,7 @@ interface A is C {}
         }
     }
 
-    let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, Config {})?;
+    let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, Config {})?;
     assert!(builder.add_file("main.sol").is_ok());
     let compilation_unit = builder.build();
     Ok(compilation_unit)

--- a/crates/solidity/outputs/cargo/tests/src/backend/passes/pipeline.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/passes/pipeline.rs
@@ -85,7 +85,7 @@ impl CompilationBuilderConfig for Config {
 }
 
 fn build_compilation_unit() -> Result<CompilationUnit> {
-    let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, Config {})?;
+    let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, Config {})?;
 
     builder.add_file(MAIN_ID)?;
 

--- a/crates/solidity/outputs/cargo/tests/src/compilation/compilation_builder.rs
+++ b/crates/solidity/outputs/cargo/tests/src/compilation/compilation_builder.rs
@@ -46,7 +46,7 @@ impl CompilationBuilderConfig for Config {
 
 #[test]
 fn test_build_compilation_unit() -> Result<()> {
-    let mut builder = CompilationBuilder::new(LanguageFacts::LATEST_VERSION, Config {})?;
+    let mut builder = CompilationBuilder::create(LanguageFacts::LATEST_VERSION, Config {})?;
 
     let main_add_file_response = builder.add_file(MAIN_ID);
     assert!(main_add_file_response.is_ok());

--- a/crates/solidity/outputs/cargo/tests/src/compilation/compilation_unit.rs
+++ b/crates/solidity/outputs/cargo/tests/src/compilation/compilation_unit.rs
@@ -49,7 +49,7 @@ pub(crate) fn build_compilation_unit_from_multi_part_file(
 ) -> Result<CompilationUnit> {
     let multi_part = split_multi_file(contents);
     let mut builder =
-        CompilationBuilder::new(version.clone(), MultiPartBuildConfig::new(&multi_part))?;
+        CompilationBuilder::create(version.clone(), MultiPartBuildConfig::new(&multi_part))?;
 
     for part in &multi_part.parts {
         builder.add_file(part.name)?;

--- a/crates/solidity/testing/perf/cargo/src/dataset.rs
+++ b/crates/solidity/testing/perf/cargo/src/dataset.rs
@@ -153,7 +153,7 @@ impl SolidityProject {
         version.pre = Prerelease::EMPTY;
         version.build = BuildMetadata::EMPTY;
 
-        let mut builder = CompilationBuilder::new(version, self)?;
+        let mut builder = CompilationBuilder::create(version, self)?;
 
         builder.add_file(&self.entrypoint)?;
 

--- a/crates/solidity/testing/sourcify/src/sourcify.rs
+++ b/crates/solidity/testing/sourcify/src/sourcify.rs
@@ -311,7 +311,7 @@ impl Contract {
         )))?;
 
         let mut builder =
-            CompilationBuilder::new(self.version.clone(), ContractConfig { contract: self })?;
+            CompilationBuilder::create(self.version.clone(), ContractConfig { contract: self })?;
 
         builder.add_file(&entrypoint).map_err(|e| anyhow!(e))?;
         Ok(builder.build())


### PR DESCRIPTION
to match the TypeScript API.