### PR TITLE
re-enable publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,13 +71,11 @@ jobs:
         env:
           NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
 
-      # __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-      #
-      # - name: "infra publish cargo"
-      #   if: "${{ steps.runChangesets.outputs.hasChangesets == 'false' }}"
-      #   run: "./scripts/bin/infra publish cargo"
-      #   env:
-      #     CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      - name: "infra publish cargo"
+        if: "${{ steps.runChangesets.outputs.hasChangesets == 'false' }}"
+        run: "./scripts/bin/infra publish cargo"
+        env:
+          CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: "infra publish github-release"
         if: "${{ steps.runChangesets.outputs.hasChangesets == 'false' }}"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 [![release](https://img.shields.io/github/v/tag/NomicFoundation/slang?label=GitHub%20Release&logo=github&sort=semver&logoColor=white)](https://github.com/NomicFoundation/slang/releases)
 [![npm](https://img.shields.io/npm/v/@nomicfoundation/slang?label=NPM%20Package&logo=npm&logoColor=white)](https://www.npmjs.com/package/@nomicfoundation/slang)
-
-<!--
-  __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-  [![crate](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
--->
+[![cargo](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
 
 ## Solidity compiler tooling by [@NomicFoundation](https://github.com/NomicFoundation)
 

--- a/crates/infra/cli/src/commands/publish/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/publish/cargo/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use anyhow::Result;
 use clap::Parser;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::commands::Command;
@@ -15,11 +15,6 @@ pub struct CargoController {
 
 impl CargoController {
     pub fn execute(&self) -> Result<()> {
-        ensure!(
-            false,
-            "__SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)"
-        );
-
         let mut changed_crates = vec![];
 
         for crate_name in UserFacingCrate::iter() {

--- a/crates/metaslang/bindings/Cargo.toml
+++ b/crates/metaslang/bindings/Cargo.toml
@@ -2,8 +2,7 @@
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-# __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-# publish = true
+publish = true
 
 name = "metaslang_bindings"
 description = "Computes semantic language bindings from parsed source code"

--- a/crates/metaslang/cst/Cargo.toml
+++ b/crates/metaslang/cst/Cargo.toml
@@ -2,8 +2,7 @@
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-# __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-# publish = true
+publish = true
 
 name = "metaslang_cst"
 description = "A generic library for building, navigating and querying concrete syntax trees."

--- a/crates/metaslang/graph_builder/Cargo.toml
+++ b/crates/metaslang/graph_builder/Cargo.toml
@@ -2,8 +2,7 @@
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-# __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-# publish = true
+publish = true
 
 name = "metaslang_graph_builder"
 description = "Construct graphs from parsed source code"

--- a/crates/solidity/outputs/cargo/cli/Cargo.toml
+++ b/crates/solidity/outputs/cargo/cli/Cargo.toml
@@ -2,8 +2,7 @@
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-# __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-# publish = true
+publish = true
 
 name = "slang_solidity_cli"
 description = "This crate contains the 'slang_solidity' CLI/cargo binary. Please see the 'slang_solidity' crate for more information."

--- a/crates/solidity/outputs/cargo/cli/README.md
+++ b/crates/solidity/outputs/cargo/cli/README.md
@@ -4,11 +4,7 @@
 
 [![release](https://img.shields.io/github/v/tag/NomicFoundation/slang?label=GitHub%20Release&logo=github&sort=semver&logoColor=white)](https://github.com/NomicFoundation/slang/releases)
 [![npm](https://img.shields.io/npm/v/@nomicfoundation/slang?label=NPM%20Package&logo=npm&logoColor=white)](https://www.npmjs.com/package/@nomicfoundation/slang)
-
-<!--
-  __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-  [![crate](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
--->
+[![cargo](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
 
 ## Solidity compiler tooling by [@NomicFoundation](https://github.com/NomicFoundation)
 

--- a/crates/solidity/outputs/cargo/crate/Cargo.toml
+++ b/crates/solidity/outputs/cargo/crate/Cargo.toml
@@ -2,8 +2,7 @@
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-# __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-# publish = true
+publish = true
 
 name = "slang_solidity"
 description = "A modular set of compiler APIs empowering the next generation of Solidity code analysis and developer tooling. Written in Rust and distributed in multiple languages."

--- a/crates/solidity/outputs/cargo/crate/README.md
+++ b/crates/solidity/outputs/cargo/crate/README.md
@@ -4,11 +4,7 @@
 
 [![release](https://img.shields.io/github/v/tag/NomicFoundation/slang?label=GitHub%20Release&logo=github&sort=semver&logoColor=white)](https://github.com/NomicFoundation/slang/releases)
 [![npm](https://img.shields.io/npm/v/@nomicfoundation/slang?label=NPM%20Package&logo=npm&logoColor=white)](https://www.npmjs.com/package/@nomicfoundation/slang)
-
-<!--
-  __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-  [![crate](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
--->
+[![cargo](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
 
 ## Solidity compiler tooling by [@NomicFoundation](https://github.com/NomicFoundation)
 

--- a/crates/solidity/outputs/npm/package/README.md
+++ b/crates/solidity/outputs/npm/package/README.md
@@ -4,11 +4,7 @@
 
 [![release](https://img.shields.io/github/v/tag/NomicFoundation/slang?label=GitHub%20Release&logo=github&sort=semver&logoColor=white)](https://github.com/NomicFoundation/slang/releases)
 [![npm](https://img.shields.io/npm/v/@nomicfoundation/slang?label=NPM%20Package&logo=npm&logoColor=white)](https://www.npmjs.com/package/@nomicfoundation/slang)
-
-<!--
-  __SLANG_CARGO_PUBLISH_TEMPORARILY_DISABLED__ (keep in sync)
-  [![crate](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
--->
+[![cargo](https://img.shields.io/crates/v/slang_solidity?label=Rust%20Crate&logo=rust&logoColor=white)](https://crates.io/crates/slang_solidity)
 
 ## Solidity compiler tooling by [@NomicFoundation](https://github.com/NomicFoundation)
 


### PR DESCRIPTION
This will still not execute until we merge the most recent `Bump Version` PR.