### PR TITLE
absorb `NomicFoundation/stack-graphs` fork

### DIFF
--- a/crates/metaslang/stack_graphs/Cargo.toml
+++ b/crates/metaslang/stack_graphs/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "stack-graphs"
+version = "0.14.1"
+description = "Name binding for arbitrary programming languages"
+homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs"
+repository = "https://github.com/github/stack-graphs/"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+authors = [
+  "GitHub <opensource+stack-graphs@github.com>",
+  "Douglas Creager <dcreager@dcreager.net>"
+]
+edition = "2018"
+
+[features]
+bincode = ["dep:bincode", "lsp-positions/bincode"]
+copious-debugging = []
+serde = ["dep:serde", "serde_with", "lsp-positions/serde"]
+storage = ["bincode", "rusqlite"]
+visualization = ["serde", "serde_json"]
+
+[lib]
+# All of our tests are in the tests/it "integration" test executable.
+test = false
+
+[dependencies]
+bincode = { version = "2.0.0-rc.3", optional = true }
+bitvec = "1.0.1"
+controlled-option = "0.4.1"
+either = "1.6"
+enumset = "1.1"
+fxhash = "0.2"
+itertools = "0.10.2"
+libc = "0.2"
+lsp-positions = { version = "0.3", path = "../lsp-positions" } # explicit version is required to be able to publish crate
+rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
+serde_with = { version = "3.1", optional = true }
+smallvec = { version = "1.6", features = ["union"] }
+thiserror = { version = "1.0" }
+
+[dev-dependencies]
+assert-json-diff = "2"
+maplit = "1.0"
+pretty_assertions = "0.7"
+serde_json = { version = "1.0" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/metaslang/stack_graphs/src/arena.rs
+++ b/crates/metaslang/stack_graphs/src/arena.rs
@@ -1,0 +1,1139 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Cache-friendly arena allocation for stack graph data.
+//!
+//! A stack graph is composed of instances of many different data types, and to store the graph
+//! structure itself, we need cyclic or self-referential data types.  The typical way to achieve
+//! this in Rust is to use [arena allocation][], where all of the instances of a particular type
+//! are stored in a single vector.  You then use indexes into this vector to store references to a
+//! data instance.  Because indexes are just numbers, you don't run afoul of borrow checker.  And
+//! because all instances live together in a continguous region of memory, your data access
+//! patterns are very cache-friendly.
+//!
+//! This module implements a simple arena allocation scheme for stack graphs.  An
+//! [`Arena<T>`][`Arena`] is an arena that holds all of the instances of type `T` for a stack
+//! graph.  A [`Handle<T>`][`Handle`] holds the index of a particular instance of `T` in its arena.
+//! All of our stack graph data types then use handles to refer to other parts of the stack graph.
+//!
+//! Note that our arena implementation does not support deletion!  Any content that you add to a
+//! [`StackGraph`][] will live as long as the stack graph itself does.  The entire region of memory
+//! for each arena will be freed in a single operation when the stack graph is dropped.
+//!
+//! [arena allocation]: https://en.wikipedia.org/wiki/Region-based_memory_management
+//! [`Arena`]: struct.Arena.html
+//! [`Handle`]: struct.Handle.html
+//! [`StackGraph`]: ../graph/struct.StackGraph.html
+
+use std::cell::Cell;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::num::NonZeroU32;
+use std::ops::Index;
+use std::ops::IndexMut;
+
+use bitvec::vec::BitVec;
+use controlled_option::Niche;
+
+use crate::utils::cmp_option;
+use crate::utils::equals_option;
+
+//-------------------------------------------------------------------------------------------------
+// Arenas and handles
+
+/// A handle to an instance of type `T` that was allocated from an [`Arena`][].
+///
+/// #### Safety
+///
+/// Because of the type parameter `T`, the compiler can ensure that you don't use a handle for one
+/// type to index into an arena of another type.  However, if you have multiple arenas for the
+/// _same type_, we do not do anything to ensure that you only use a handle with the corresponding
+/// arena.
+#[repr(transparent)]
+pub struct Handle<T> {
+    index: NonZeroU32,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Handle<T> {
+    pub(crate) fn new(index: NonZeroU32) -> Handle<T> {
+        Handle {
+            index,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn as_u32(self) -> u32 {
+        self.index.get()
+    }
+
+    #[inline(always)]
+    pub fn as_usize(self) -> usize {
+        self.index.get() as usize
+    }
+}
+
+impl<T> Niche for Handle<T> {
+    type Output = u32;
+
+    #[inline]
+    fn none() -> Self::Output {
+        0
+    }
+
+    #[inline]
+    fn is_none(value: &Self::Output) -> bool {
+        *value == 0
+    }
+
+    #[inline]
+    fn into_some(value: Self) -> Self::Output {
+        value.index.get()
+    }
+
+    #[inline]
+    fn from_some(value: Self::Output) -> Self {
+        Self::new(unsafe { NonZeroU32::new_unchecked(value) })
+    }
+}
+
+// Normally we would #[derive] all of these traits, but the auto-derived implementations all
+// require that T implement the trait as well.  We don't store any real instances of T inside of
+// Handle, so our implementations do _not_ require that.
+
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Handle<T> {
+        Handle::new(self.index)
+    }
+}
+
+impl<T> Copy for Handle<T> {}
+
+impl<T> Debug for Handle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Handle")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl<T> Eq for Handle<T> {}
+
+impl<T> Hash for Handle<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl<T> Ord for Handle<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.index.cmp(&other.index)
+    }
+}
+
+impl<T> PartialEq for Handle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> PartialOrd for Handle<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.index.partial_cmp(&other.index)
+    }
+}
+
+// Handles are always Send and Sync, even if the underlying types are not.  After all, a handle is
+// just a number!  And you _also_ need access to the Arena (which _won't_ be Send/Sync if T isn't)
+// to dereference the handle.
+unsafe impl<T> Send for Handle<T> {}
+unsafe impl<T> Sync for Handle<T> {}
+
+/// Manages the life cycle of instances of type `T`.  You can allocate new instances of `T` from
+/// the arena.  All of the instances managed by this arena will be dropped as a single operation
+/// when the arena itself is dropped.
+pub struct Arena<T> {
+    items: Vec<MaybeUninit<T>>,
+}
+
+impl<T> Drop for Arena<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let items = std::mem::transmute::<_, &mut [T]>(&mut self.items[1..]) as *mut [T];
+            items.drop_in_place();
+        }
+    }
+}
+
+impl<T> Arena<T> {
+    /// Creates a new arena.
+    pub fn new() -> Arena<T> {
+        Arena {
+            items: vec![MaybeUninit::uninit()],
+        }
+    }
+
+    /// Clear the arena, keeping underlying allocated capacity.  After this, all previous handles into
+    /// the arena are invalid.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.items.truncate(1);
+    }
+
+    /// Adds a new instance to this arena, returning a stable handle to it.
+    ///
+    /// Note that we do not deduplicate instances of `T` in any way.  If you add two instances that
+    /// have the same content, you will get distinct handles for each one.
+    pub fn add(&mut self, item: T) -> Handle<T> {
+        let index = self.items.len() as u32;
+        self.items.push(MaybeUninit::new(item));
+        Handle::new(unsafe { NonZeroU32::new_unchecked(index) })
+    }
+
+    /// Dereferences a handle to an instance owned by this arena, returning a reference to it.
+    pub fn get(&self, handle: Handle<T>) -> &T {
+        unsafe { std::mem::transmute(&self.items[handle.as_usize()]) }
+    }
+    ///
+    /// Dereferences a handle to an instance owned by this arena, returning a mutable reference to
+    /// it.
+    pub fn get_mut(&mut self, handle: Handle<T>) -> &mut T {
+        unsafe { std::mem::transmute(&mut self.items[handle.as_usize()]) }
+    }
+
+    /// Returns an iterator of all of the handles in this arena.  (Note that this iterator does not
+    /// retain a reference to the arena!)
+    pub fn iter_handles(&self) -> impl Iterator<Item = Handle<T>> {
+        (1..self.items.len())
+            .into_iter()
+            .map(|index| Handle::new(unsafe { NonZeroU32::new_unchecked(index as u32) }))
+    }
+
+    /// Returns a pointer to this arena's storage.
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.items.as_ptr() as *const T
+    }
+
+    /// Returns the number of instances stored in this arena.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Supplemental arenas
+
+/// A supplemental arena lets you store additional data about some data type that is itself stored
+/// in an [`Arena`][].
+///
+/// We implement `Index` and `IndexMut` for a more ergonomic syntax.  Please note that when
+/// indexing in an _immutable_ context, we **_panic_** if you try to access data for a handle that
+/// doesn't exist in the arena.  (Use the [`get`][] method if you don't know whether the value
+/// exists or not.)  In a _mutable_ context, we automatically create a `Default` instance of the
+/// type if there isn't already an instance for that handle in the arena.
+///
+/// ```
+/// # use stack_graphs::arena::Arena;
+/// # use stack_graphs::arena::SupplementalArena;
+/// // We need an Arena to create handles.
+/// let mut arena = Arena::<u32>::new();
+/// let handle = arena.add(1);
+///
+/// let mut supplemental = SupplementalArena::<u32, String>::new();
+///
+/// // But indexing will panic if the element doesn't already exist.
+/// // assert_eq!(supplemental[handle].as_str(), "");
+///
+/// // The `get` method is always safe, since it returns an Option.
+/// assert_eq!(supplemental.get(handle), None);
+///
+/// // Once we've added the element to the supplemental arena, indexing
+/// // won't panic anymore.
+/// supplemental[handle] = "hello".to_string();
+/// assert_eq!(supplemental[handle].as_str(), "hello");
+/// ```
+///
+/// [`Arena`]: struct.Arena.html
+/// [`get`]: #method.get
+pub struct SupplementalArena<H, T> {
+    items: Vec<MaybeUninit<T>>,
+    _phantom: PhantomData<H>,
+}
+
+impl<H, T> Drop for SupplementalArena<H, T> {
+    fn drop(&mut self) {
+        unsafe {
+            let items = std::mem::transmute::<_, &mut [T]>(&mut self.items[1..]) as *mut [T];
+            items.drop_in_place();
+        }
+    }
+}
+
+impl<H, T> SupplementalArena<H, T> {
+    /// Creates a new, empty supplemental arena.
+    pub fn new() -> SupplementalArena<H, T> {
+        SupplementalArena {
+            items: vec![MaybeUninit::uninit()],
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Clear the supplemantal arena, keeping underlying allocated capacity.  After this,
+    /// all previous handles into the arena are invalid.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.items.truncate(1);
+    }
+
+    /// Creates a new, empty supplemental arena, preallocating enough space to store supplemental
+    /// data for all of the instances that have already been allocated in a (regular) arena.
+    pub fn with_capacity(arena: &Arena<H>) -> SupplementalArena<H, T> {
+        let mut items = Vec::with_capacity(arena.items.len());
+        items[0] = MaybeUninit::uninit();
+        SupplementalArena {
+            items,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns the item belonging to a particular handle, if it exists.
+    pub fn get(&self, handle: Handle<H>) -> Option<&T> {
+        self.items
+            .get(handle.as_usize())
+            .map(|x| unsafe { &*(x.as_ptr()) })
+    }
+
+    /// Returns a mutable reference to the item belonging to a particular handle, if it exists.
+    pub fn get_mut(&mut self, handle: Handle<H>) -> Option<&mut T> {
+        self.items
+            .get_mut(handle.as_usize())
+            .map(|x| unsafe { &mut *(x.as_mut_ptr()) })
+    }
+
+    /// Returns a pointer to this arena's storage.
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.items.as_ptr() as *const T
+    }
+
+    /// Returns the number of instances stored in this arena.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Iterate over the items in this arena.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (Handle<T>, &T)> {
+        self.items
+            .iter()
+            .enumerate()
+            .skip(1)
+            .map(|(i, x)| (Handle::from_some(i as u32), unsafe { &*(x.as_ptr()) }))
+    }
+}
+
+impl<H, T> SupplementalArena<H, T>
+where
+    T: Default,
+{
+    /// Returns a mutable reference to the item belonging to a particular handle, creating it first
+    /// (using the type's `Default` implementation) if it doesn't already exist.
+    pub fn get_mut_or_default(&mut self, handle: Handle<H>) -> &mut T {
+        let index = handle.as_usize();
+        if self.items.len() <= index {
+            self.items
+                .resize_with(index + 1, || MaybeUninit::new(T::default()));
+        }
+        unsafe { std::mem::transmute(&mut self.items[handle.as_usize()]) }
+    }
+}
+
+impl<H, T> Default for SupplementalArena<H, T> {
+    fn default() -> SupplementalArena<H, T> {
+        SupplementalArena::new()
+    }
+}
+
+impl<H, T> Index<Handle<H>> for SupplementalArena<H, T> {
+    type Output = T;
+    fn index(&self, handle: Handle<H>) -> &T {
+        unsafe { std::mem::transmute(&self.items[handle.as_usize()]) }
+    }
+}
+
+impl<H, T> IndexMut<Handle<H>> for SupplementalArena<H, T>
+where
+    T: Default,
+{
+    fn index_mut(&mut self, handle: Handle<H>) -> &mut T {
+        self.get_mut_or_default(handle)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Handle sets
+
+/// Contains a set of handles, encoded efficiently using a bit set.
+#[repr(C)]
+pub struct HandleSet<T> {
+    elements: BitVec<u32, bitvec::order::Lsb0>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> HandleSet<T> {
+    /// Creates a new, empty handle set.
+    pub fn new() -> HandleSet<T> {
+        HandleSet::default()
+    }
+
+    /// Removes all elements from this handle set.
+    pub fn clear(&mut self) {
+        self.elements.clear();
+    }
+
+    /// Returns whether this set contains a particular handle.
+    pub fn contains(&self, handle: Handle<T>) -> bool {
+        let index = handle.as_usize();
+        self.elements.get(index).map(|bit| *bit).unwrap_or(false)
+    }
+
+    /// Adds a handle to this set.
+    pub fn add(&mut self, handle: Handle<T>) {
+        let index = handle.as_usize();
+        if self.elements.len() <= index {
+            self.elements.resize(index + 1, false);
+        }
+        let mut bit = unsafe { self.elements.get_unchecked_mut(index) };
+        *bit = true;
+    }
+
+    /// Removes a handle from this set.
+    pub fn remove(&mut self, handle: Handle<T>) {
+        let index = handle.as_usize();
+        if let Some(mut bit) = self.elements.get_mut(index) {
+            *bit = false;
+        }
+    }
+
+    /// Returns an iterator of all of the handles in this set.
+    pub fn iter(&self) -> impl Iterator<Item = Handle<T>> + '_ {
+        self.elements
+            .iter_ones()
+            .map(|index| Handle::new(unsafe { NonZeroU32::new_unchecked(index as u32) }))
+    }
+
+    /// Returns a pointer to this set's storage.
+    pub(crate) fn as_ptr(&self) -> *const u32 {
+        self.elements.as_bitptr().pointer()
+    }
+
+    /// Returns the number of instances stored in this arena.
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.elements.as_raw_slice().len()
+    }
+}
+
+impl<T> Default for HandleSet<T> {
+    fn default() -> HandleSet<T> {
+        HandleSet {
+            elements: BitVec::default(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Arena-allocated lists
+
+/// An arena-allocated singly-linked list.
+///
+/// Linked lists are often a poor choice because they aren't very cache-friendly.  However, this
+/// linked list implementation _should_ be cache-friendly, since the individual cells are allocated
+/// out of an arena.
+#[repr(C)]
+#[derive(Niche)]
+pub struct List<T> {
+    // The value of this handle will be EMPTY_LIST_HANDLE if the list is empty.  For an
+    // Option<List<T>>, the value will be zero (via the Option<NonZero> optimization) if the list
+    // is None.
+    #[niche]
+    cells: Handle<ListCell<T>>,
+}
+
+#[doc(hidden)]
+#[repr(C)]
+pub struct ListCell<T> {
+    head: T,
+    // The value of this handle will be EMPTY_LIST_HANDLE if this is the last element of the list.
+    tail: Handle<ListCell<T>>,
+}
+
+const EMPTY_LIST_HANDLE: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(u32::MAX) };
+
+// An arena that's used to manage `List<T>` instances.
+//
+// (Note that the arena doesn't store `List<T>` itself; it stores the `ListCell<T>`s that the lists
+// are made of.)
+pub type ListArena<T> = Arena<ListCell<T>>;
+
+impl<T> List<T> {
+    /// Creates a new `ListArena` that will manage lists of this type.
+    pub fn new_arena() -> ListArena<T> {
+        ListArena::new()
+    }
+
+    /// Returns whether this list is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.cells.index == EMPTY_LIST_HANDLE
+    }
+
+    /// Returns an empty list.
+    pub fn empty() -> List<T> {
+        List {
+            cells: Handle::new(EMPTY_LIST_HANDLE),
+        }
+    }
+
+    pub fn from_handle(handle: Handle<ListCell<T>>) -> List<T> {
+        List { cells: handle }
+    }
+
+    /// Returns a handle to the head of the list.
+    pub fn handle(&self) -> Handle<ListCell<T>> {
+        self.cells
+    }
+
+    /// Pushes a new element onto the front of this list.
+    pub fn push_front(&mut self, arena: &mut ListArena<T>, head: T) {
+        self.cells = arena.add(ListCell {
+            head,
+            tail: self.cells,
+        });
+    }
+
+    /// Removes and returns the element at the front of this list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_front<'a>(&mut self, arena: &'a ListArena<T>) -> Option<&'a T> {
+        if self.is_empty() {
+            return None;
+        }
+        let cell = arena.get(self.cells);
+        self.cells = cell.tail;
+        Some(&cell.head)
+    }
+
+    /// Returns an iterator over the elements of this list.
+    pub fn iter<'a>(mut self, arena: &'a ListArena<T>) -> impl Iterator<Item = &'a T> + 'a {
+        std::iter::from_fn(move || self.pop_front(arena))
+    }
+}
+
+impl<T> List<T> {
+    pub fn equals_with<F>(mut self, arena: &ListArena<T>, mut other: List<T>, mut eq: F) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
+    {
+        loop {
+            if self.cells == other.cells {
+                return true;
+            }
+            if !equals_option(self.pop_front(arena), other.pop_front(arena), &mut eq) {
+                return false;
+            }
+        }
+    }
+
+    pub fn cmp_with<F>(
+        mut self,
+        arena: &ListArena<T>,
+        mut other: List<T>,
+        mut cmp: F,
+    ) -> std::cmp::Ordering
+    where
+        F: FnMut(&T, &T) -> std::cmp::Ordering,
+    {
+        use std::cmp::Ordering;
+        loop {
+            if self.cells == other.cells {
+                return Ordering::Equal;
+            }
+            match cmp_option(self.pop_front(arena), other.pop_front(arena), &mut cmp) {
+                Ordering::Equal => (),
+                result @ _ => return result,
+            }
+        }
+    }
+}
+
+impl<T> List<T>
+where
+    T: Eq,
+{
+    pub fn equals(self, arena: &ListArena<T>, other: List<T>) -> bool {
+        self.equals_with(arena, other, |a, b| *a == *b)
+    }
+}
+
+impl<T> List<T>
+where
+    T: Ord,
+{
+    pub fn cmp(self, arena: &ListArena<T>, other: List<T>) -> std::cmp::Ordering {
+        self.cmp_with(arena, other, |a, b| a.cmp(b))
+    }
+}
+
+// Normally we would #[derive] all of these traits, but the auto-derived implementations all
+// require that T implement the trait as well.  We don't store any real instances of T inside of
+// List, so our implementations do _not_ require that.
+
+impl<T> Clone for List<T> {
+    fn clone(&self) -> List<T> {
+        List { cells: self.cells }
+    }
+}
+
+impl<T> Copy for List<T> {}
+
+//-------------------------------------------------------------------------------------------------
+// Reversible arena-allocated list
+
+/// An arena-allocated list that can be reversed.
+///
+/// Well, that is, you can reverse a [`List`][] just fine by yourself.  This type takes care of
+/// doing that for you, and importantly, _saves the result_ so that if you only have to compute the
+/// reversal once even if you need to access it multiple times.
+///
+/// [`List`]: struct.List.html
+#[repr(C)]
+#[derive(Niche)]
+pub struct ReversibleList<T> {
+    #[niche]
+    cells: Handle<ReversibleListCell<T>>,
+}
+
+#[repr(C)]
+#[doc(hidden)]
+pub struct ReversibleListCell<T> {
+    head: T,
+    tail: Handle<ReversibleListCell<T>>,
+    reversed: Cell<Option<Handle<ReversibleListCell<T>>>>,
+}
+
+// An arena that's used to manage `ReversibleList<T>` instances.
+//
+// (Note that the arena doesn't store `ReversibleList<T>` itself; it stores the
+// `ReversibleListCell<T>`s that the lists are made of.)
+pub type ReversibleListArena<T> = Arena<ReversibleListCell<T>>;
+
+impl<T> ReversibleList<T> {
+    /// Creates a new `ReversibleListArena` that will manage lists of this type.
+    pub fn new_arena() -> ReversibleListArena<T> {
+        ReversibleListArena::new()
+    }
+
+    /// Returns whether this list is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        ReversibleListCell::is_empty_handle(self.cells)
+    }
+
+    /// Returns an empty list.
+    pub fn empty() -> ReversibleList<T> {
+        ReversibleList {
+            cells: ReversibleListCell::empty_handle(),
+        }
+    }
+
+    /// Returns whether we have already calculated the reversal of this list.
+    pub fn have_reversal(&self, arena: &ReversibleListArena<T>) -> bool {
+        if self.is_empty() {
+            // The empty list is already reversed.
+            return true;
+        }
+        arena.get(self.cells).reversed.get().is_some()
+    }
+
+    /// Pushes a new element onto the front of this list.
+    pub fn push_front(&mut self, arena: &mut ReversibleListArena<T>, head: T) {
+        self.cells = arena.add(ReversibleListCell::new(head, self.cells, None));
+    }
+
+    /// Removes and returns the element at the front of this list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_front<'a>(&mut self, arena: &'a ReversibleListArena<T>) -> Option<&'a T> {
+        if self.is_empty() {
+            return None;
+        }
+        let cell = arena.get(self.cells);
+        self.cells = cell.tail;
+        Some(&cell.head)
+    }
+
+    /// Returns an iterator over the elements of this list.
+    pub fn iter<'a>(
+        mut self,
+        arena: &'a ReversibleListArena<T>,
+    ) -> impl Iterator<Item = &'a T> + 'a {
+        std::iter::from_fn(move || self.pop_front(arena))
+    }
+}
+
+impl<T> ReversibleList<T>
+where
+    T: Clone,
+{
+    /// Reverses the list.  Since we're already caching everything in an arena, we make sure to
+    /// only calculate the reversal once, returning it as-is if you call this function multiple
+    /// times.
+    pub fn reverse(&mut self, arena: &mut ReversibleListArena<T>) {
+        if self.is_empty() {
+            return;
+        }
+        self.ensure_reversal_available(arena);
+        self.cells = arena.get(self.cells).reversed.get().unwrap();
+    }
+
+    /// Ensures that the reversal of this list is available.  It can be useful to precalculate this
+    /// when you have mutable access to the arena, so that you can then reverse and un-reverse the
+    /// list later when you only have shared access to it.
+    pub fn ensure_reversal_available(&mut self, arena: &mut ReversibleListArena<T>) {
+        // First check to see if the list has already been reversed.
+        if self.is_empty() {
+            // The empty list is already reversed.
+            return;
+        }
+        if arena.get(self.cells).reversed.get().is_some() {
+            return;
+        }
+
+        // If not, reverse the list and cache the result.
+        let new_reversed = ReversibleListCell::reverse(self.cells, arena);
+        arena.get(self.cells).reversed.set(Some(new_reversed));
+    }
+}
+
+impl<T> ReversibleList<T> {
+    /// Reverses the list, assuming that the reversal has already been computed.  If it hasn't we
+    /// return an error.
+    pub fn reverse_reused(&mut self, arena: &ReversibleListArena<T>) -> Result<(), ()> {
+        if self.is_empty() {
+            // The empty list is already reversed.
+            return Ok(());
+        }
+        self.cells = arena.get(self.cells).reversed.get().ok_or(())?;
+        Ok(())
+    }
+}
+
+impl<T> ReversibleListCell<T> {
+    fn new(
+        head: T,
+        tail: Handle<ReversibleListCell<T>>,
+        reversed: Option<Handle<ReversibleListCell<T>>>,
+    ) -> ReversibleListCell<T> {
+        ReversibleListCell {
+            head,
+            tail,
+            reversed: Cell::new(reversed),
+        }
+    }
+
+    fn empty_handle() -> Handle<ReversibleListCell<T>> {
+        Handle::new(EMPTY_LIST_HANDLE)
+    }
+
+    fn is_empty_handle(handle: Handle<ReversibleListCell<T>>) -> bool {
+        handle.index == EMPTY_LIST_HANDLE
+    }
+}
+
+impl<T> ReversibleListCell<T>
+where
+    T: Clone,
+{
+    fn reverse(
+        forwards: Handle<ReversibleListCell<T>>,
+        arena: &mut ReversibleListArena<T>,
+    ) -> Handle<ReversibleListCell<T>> {
+        let mut reversed = ReversibleListCell::empty_handle();
+        let mut current = forwards;
+        while !ReversibleListCell::is_empty_handle(current) {
+            let cell = arena.get(current);
+            let head = cell.head.clone();
+            current = cell.tail;
+            reversed = arena.add(Self::new(
+                head,
+                reversed,
+                // The reversal of the reversal that we just calculated is our original list!  Go
+                // ahead and cache that away preemptively.
+                if ReversibleListCell::is_empty_handle(current) {
+                    Some(forwards)
+                } else {
+                    None
+                },
+            ));
+        }
+        reversed
+    }
+}
+
+impl<T> ReversibleList<T> {
+    pub fn equals_with<F>(
+        mut self,
+        arena: &ReversibleListArena<T>,
+        mut other: ReversibleList<T>,
+        mut eq: F,
+    ) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
+    {
+        loop {
+            if self.cells == other.cells {
+                return true;
+            }
+            if !equals_option(self.pop_front(arena), other.pop_front(arena), &mut eq) {
+                return false;
+            }
+        }
+    }
+
+    pub fn cmp_with<F>(
+        mut self,
+        arena: &ReversibleListArena<T>,
+        mut other: ReversibleList<T>,
+        mut cmp: F,
+    ) -> std::cmp::Ordering
+    where
+        F: FnMut(&T, &T) -> std::cmp::Ordering,
+    {
+        use std::cmp::Ordering;
+        loop {
+            if self.cells == other.cells {
+                return Ordering::Equal;
+            }
+            match cmp_option(self.pop_front(arena), other.pop_front(arena), &mut cmp) {
+                Ordering::Equal => (),
+                result @ _ => return result,
+            }
+        }
+    }
+}
+
+impl<T> ReversibleList<T>
+where
+    T: Eq,
+{
+    pub fn equals(self, arena: &ReversibleListArena<T>, other: ReversibleList<T>) -> bool {
+        self.equals_with(arena, other, |a, b| *a == *b)
+    }
+}
+
+impl<T> ReversibleList<T>
+where
+    T: Ord,
+{
+    pub fn cmp(
+        self,
+        arena: &ReversibleListArena<T>,
+        other: ReversibleList<T>,
+    ) -> std::cmp::Ordering {
+        self.cmp_with(arena, other, |a, b| a.cmp(b))
+    }
+}
+
+// Normally we would #[derive] all of these traits, but the auto-derived implementations all
+// require that T implement the trait as well.  We don't store any real instances of T inside of
+// ReversibleList, so our implementations do _not_ require that.
+
+impl<T> Clone for ReversibleList<T> {
+    fn clone(&self) -> ReversibleList<T> {
+        ReversibleList { cells: self.cells }
+    }
+}
+
+impl<T> Copy for ReversibleList<T> {}
+
+//-------------------------------------------------------------------------------------------------
+// Arena-allocated deque
+
+/// An arena-allocated deque.
+///
+/// Under the covers, this is implemented as a [`List`][].  Because these lists are singly-linked,
+/// we can only add elements to, and remove them from, one side of the list.
+///
+/// To handle this, each deque stores its contents either _forwards_ or _backwards_.  We
+/// automatically shift between these two representations as needed, depending on the requirements
+/// of each method.
+///
+/// Note that we cache the result of reversing the list, so it should be quick to switch back and
+/// forth between representations _as long as you have not added any additional elements to the
+/// deque_!  If performance is critical, you should ensure that you don't call methods in a pattern
+/// that causes the deque to reverse itself each time you add an element.
+///
+/// [`List`]: struct.List.html
+#[repr(C)]
+#[derive(Niche)]
+pub struct Deque<T> {
+    #[niche]
+    list: ReversibleList<T>,
+    direction: DequeDirection,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum DequeDirection {
+    Forwards,
+    Backwards,
+}
+
+impl std::ops::Not for DequeDirection {
+    type Output = DequeDirection;
+    fn not(self) -> DequeDirection {
+        match self {
+            DequeDirection::Forwards => DequeDirection::Backwards,
+            DequeDirection::Backwards => DequeDirection::Forwards,
+        }
+    }
+}
+
+// An arena that's used to manage `Deque<T>` instances.
+pub type DequeArena<T> = ReversibleListArena<T>;
+
+impl<T> Deque<T> {
+    /// Creates a new `DequeArena` that will manage deques of this type.
+    pub fn new_arena() -> DequeArena<T> {
+        ReversibleList::new_arena()
+    }
+
+    /// Returns whether this deque is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    /// Returns an empty deque.
+    pub fn empty() -> Deque<T> {
+        Deque {
+            list: ReversibleList::empty(),
+            // A philosophical question for you: is the empty list forwards or backwards?  It
+            // doesn't really matter which one we choose here; if we immediately start pushing onto
+            // the back, we'll "reverse" the current list before proceeding, but reversing the
+            // empty list is a no-op.
+            direction: DequeDirection::Forwards,
+        }
+    }
+
+    /// Returns whether we have already calculated the reversal of this deque.
+    pub fn have_reversal(&self, arena: &DequeArena<T>) -> bool {
+        self.list.have_reversal(arena)
+    }
+
+    fn is_backwards(&self) -> bool {
+        matches!(self.direction, DequeDirection::Backwards)
+    }
+
+    fn is_forwards(&self) -> bool {
+        matches!(self.direction, DequeDirection::Forwards)
+    }
+
+    /// Returns an iterator over the contents of this deque, with no guarantee about the ordering of
+    /// the elements.  (By not caring about the ordering of the elements, you can call this method
+    /// regardless of which direction the deque's elements are currently stored.  And that, in
+    /// turn, means that we only need shared access to the arena, and not mutable access to it.)
+    pub fn iter_unordered<'a>(&self, arena: &'a DequeArena<T>) -> impl Iterator<Item = &'a T> + 'a {
+        self.list.iter(arena)
+    }
+}
+
+impl<T> Deque<T>
+where
+    T: Clone,
+{
+    /// Ensures that this deque has computed its backwards-facing list of elements.
+    pub fn ensure_backwards(&mut self, arena: &mut DequeArena<T>) {
+        if self.is_backwards() {
+            return;
+        }
+        self.list.reverse(arena);
+        self.direction = DequeDirection::Backwards;
+    }
+
+    /// Ensures that this deque has computed its forwards-facing list of elements.
+    pub fn ensure_forwards(&mut self, arena: &mut DequeArena<T>) {
+        if self.is_forwards() {
+            return;
+        }
+        self.list.reverse(arena);
+        self.direction = DequeDirection::Forwards;
+    }
+
+    /// Pushes a new element onto the front of this deque.
+    pub fn push_front(&mut self, arena: &mut DequeArena<T>, element: T) {
+        self.ensure_forwards(arena);
+        self.list.push_front(arena, element);
+    }
+
+    /// Pushes a new element onto the back of this deque.
+    pub fn push_back(&mut self, arena: &mut DequeArena<T>, element: T) {
+        self.ensure_backwards(arena);
+        self.list.push_front(arena, element);
+    }
+
+    /// Removes and returns the element from the front of this deque.  If the deque is empty,
+    /// returns `None`.
+    pub fn pop_front<'a>(&mut self, arena: &'a mut DequeArena<T>) -> Option<&'a T> {
+        self.ensure_forwards(arena);
+        self.list.pop_front(arena)
+    }
+
+    /// Removes and returns the element from the back of this deque.  If the deque is empty,
+    /// returns `None`.
+    pub fn pop_back<'a>(&mut self, arena: &'a mut DequeArena<T>) -> Option<&'a T> {
+        self.ensure_backwards(arena);
+        self.list.pop_front(arena)
+    }
+
+    /// Returns an iterator over the contents of this deque in a forwards direction.
+    pub fn iter<'a>(&self, arena: &'a mut DequeArena<T>) -> impl Iterator<Item = &'a T> + 'a {
+        let mut list = self.list;
+        if self.is_backwards() {
+            list.reverse(arena);
+        }
+        list.iter(arena)
+    }
+
+    /// Returns an iterator over the contents of this deque in a backwards direction.
+    pub fn iter_reversed<'a>(
+        &self,
+        arena: &'a mut DequeArena<T>,
+    ) -> impl Iterator<Item = &'a T> + 'a {
+        let mut list = self.list;
+        if self.is_forwards() {
+            list.reverse(arena);
+        }
+        list.iter(arena)
+    }
+
+    /// Ensures that both deques are stored in the same direction.  It doesn't matter _which_
+    /// direction, as long as they're the same, so do the minimum amount of work to bring this
+    /// about.  (In particular, if we've already calculated the reversal of one of the deques,
+    /// reverse that one.)
+    fn ensure_same_direction(&mut self, arena: &mut DequeArena<T>, other: &mut Deque<T>) {
+        if self.direction == other.direction {
+            return;
+        }
+        if self.list.have_reversal(arena) {
+            self.list.reverse(arena);
+            self.direction = !self.direction;
+        } else {
+            other.list.reverse(arena);
+            other.direction = !other.direction;
+        }
+    }
+}
+
+impl<T> Deque<T>
+where
+    T: Clone,
+{
+    pub fn equals_with<F>(mut self, arena: &mut DequeArena<T>, mut other: Deque<T>, eq: F) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
+    {
+        self.ensure_same_direction(arena, &mut other);
+        self.list.equals_with(arena, other.list, eq)
+    }
+
+    pub fn cmp_with<F>(
+        mut self,
+        arena: &mut DequeArena<T>,
+        mut other: Deque<T>,
+        cmp: F,
+    ) -> std::cmp::Ordering
+    where
+        F: FnMut(&T, &T) -> std::cmp::Ordering,
+    {
+        // To compare, we need boths deques to specifically be pointing forwards, and not just in
+        // the same direction, so that we get the lexicographic comparison correct.
+        self.ensure_forwards(arena);
+        other.ensure_forwards(arena);
+        self.list.cmp_with(arena, other.list, cmp)
+    }
+}
+
+impl<T> Deque<T>
+where
+    T: Clone + Eq,
+{
+    pub fn equals(self, arena: &mut DequeArena<T>, other: Deque<T>) -> bool {
+        self.equals_with(arena, other, |a, b| *a == *b)
+    }
+}
+
+impl<T> Deque<T>
+where
+    T: Clone + Ord,
+{
+    pub fn cmp(self, arena: &mut DequeArena<T>, other: Deque<T>) -> std::cmp::Ordering {
+        self.cmp_with(arena, other, |a, b| a.cmp(b))
+    }
+}
+
+impl<T> Deque<T> {
+    /// Returns an iterator over the contents of this deque in a forwards direction, assuming that
+    /// we have already computed its forwards-facing list of elements via [`ensure_forwards`][].
+    /// Panics if we haven't already computed it.
+    ///
+    /// [`ensure_forwards`]: #method.ensure_forwards
+    pub fn iter_reused<'a>(&self, arena: &'a DequeArena<T>) -> impl Iterator<Item = &'a T> + 'a {
+        let mut list = self.list;
+        if self.is_backwards() {
+            list.reverse_reused(arena)
+                .expect("Forwards deque hasn't been calculated");
+        }
+        list.iter(arena)
+    }
+
+    /// Returns an iterator over the contents of this deque in a backwards direction, assuming that
+    /// we have already computed its backwards-facing list of elements via [`ensure_backwards`][].
+    /// Panics if we haven't already computed it.
+    ///
+    /// [`ensure_backwards`]: #method.ensure_backwards
+    pub fn iter_reversed_reused<'a>(
+        &self,
+        arena: &'a DequeArena<T>,
+    ) -> impl Iterator<Item = &'a T> + 'a {
+        let mut list = self.list;
+        if self.is_forwards() {
+            list.reverse_reused(arena)
+                .expect("Backwards deque hasn't been calculated");
+        }
+        list.iter(arena)
+    }
+}
+
+// Normally we would #[derive] all of these traits, but the auto-derived implementations all
+// require that T implement the trait as well.  We don't store any real instances of T inside of
+// Deque, so our implementations do _not_ require that.
+
+impl<T> Clone for Deque<T> {
+    fn clone(&self) -> Deque<T> {
+        Deque {
+            list: self.list,
+            direction: self.direction,
+        }
+    }
+}
+
+impl<T> Copy for Deque<T> {}

--- a/crates/metaslang/stack_graphs/src/assert.rs
+++ b/crates/metaslang/stack_graphs/src/assert.rs
@@ -1,0 +1,304 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines assertions that can be run against a stack graph.
+
+use itertools::Itertools;
+use lsp_positions::Position;
+
+use crate::arena::Handle;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::stitching::Database;
+use crate::stitching::DatabaseCandidates;
+use crate::stitching::ForwardPartialPathStitcher;
+use crate::stitching::StitcherConfig;
+use crate::CancellationError;
+use crate::CancellationFlag;
+
+/// A stack graph assertion
+#[derive(Debug, Clone)]
+pub enum Assertion {
+    Defined {
+        source: AssertionSource,
+        targets: Vec<AssertionTarget>,
+    },
+    Defines {
+        source: AssertionSource,
+        symbols: Vec<Handle<Symbol>>,
+    },
+    Refers {
+        source: AssertionSource,
+        symbols: Vec<Handle<Symbol>>,
+    },
+}
+
+/// Source position of an assertion
+#[derive(Debug, Clone)]
+pub struct AssertionSource {
+    pub file: Handle<File>,
+    pub position: Position,
+}
+
+impl AssertionSource {
+    /// Return an iterator over definitions at this position.
+    pub fn iter_definitions<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+        graph.nodes_for_file(self.file).filter(move |n| {
+            graph[*n].is_definition()
+                && graph
+                    .source_info(*n)
+                    .map(|s| s.span.contains(&self.position))
+                    .unwrap_or(false)
+        })
+    }
+
+    /// Return an iterator over references at this position.
+    pub fn iter_references<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+        graph.nodes_for_file(self.file).filter(move |n| {
+            graph[*n].is_reference()
+                && graph
+                    .source_info(*n)
+                    .map(|s| s.span.contains(&self.position))
+                    .unwrap_or(false)
+        })
+    }
+
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl std::fmt::Display + 'a {
+        struct Displayer<'a>(&'a AssertionSource, &'a StackGraph);
+        impl std::fmt::Display for Displayer<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "{}:{}:{}",
+                    self.1[self.0.file],
+                    self.0.position.line + 1,
+                    self.0.position.column.grapheme_offset + 1
+                )
+            }
+        }
+        Displayer(self, graph)
+    }
+}
+
+/// Target line of an assertion
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AssertionTarget {
+    pub file: Handle<File>,
+    pub line: usize,
+}
+
+impl AssertionTarget {
+    /// Checks if the target matches the node corresponding to the handle in the given graph.
+    pub fn matches_node(&self, node: Handle<Node>, graph: &StackGraph) -> bool {
+        let file = graph[node].file().unwrap();
+        let si = graph.source_info(node).unwrap();
+        let start_line = si.span.start.line;
+        let end_line = si.span.end.line;
+        file == self.file && start_line <= self.line && self.line <= end_line
+    }
+}
+
+/// Error describing assertion failures.
+#[derive(Clone)]
+pub enum AssertionError {
+    NoReferences {
+        source: AssertionSource,
+    },
+    IncorrectlyDefined {
+        source: AssertionSource,
+        references: Vec<Handle<Node>>,
+        missing_targets: Vec<AssertionTarget>,
+        unexpected_paths: Vec<PartialPath>,
+    },
+    IncorrectDefinitions {
+        source: AssertionSource,
+        missing_symbols: Vec<Handle<Symbol>>,
+        unexpected_symbols: Vec<Handle<Symbol>>,
+    },
+    IncorrectReferences {
+        source: AssertionSource,
+        missing_symbols: Vec<Handle<Symbol>>,
+        unexpected_symbols: Vec<Handle<Symbol>>,
+    },
+    Cancelled(CancellationError),
+}
+
+impl From<CancellationError> for AssertionError {
+    fn from(value: CancellationError) -> Self {
+        Self::Cancelled(value)
+    }
+}
+
+impl Assertion {
+    /// Run this assertion against the given graph, using the given paths object for path search.
+    pub fn run(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        stitcher_config: StitcherConfig,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<(), AssertionError> {
+        match self {
+            Self::Defined { source, targets } => self.run_defined(
+                graph,
+                partials,
+                db,
+                source,
+                targets,
+                stitcher_config,
+                cancellation_flag,
+            ),
+            Self::Defines { source, symbols } => self.run_defines(graph, source, symbols),
+            Self::Refers { source, symbols } => self.run_refers(graph, source, symbols),
+        }
+    }
+
+    fn run_defined(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        source: &AssertionSource,
+        expected_targets: &Vec<AssertionTarget>,
+        stitcher_config: StitcherConfig,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<(), AssertionError> {
+        let references = source.iter_references(graph).collect::<Vec<_>>();
+        if references.is_empty() {
+            return Err(AssertionError::NoReferences {
+                source: source.clone(),
+            });
+        }
+
+        let mut actual_paths = Vec::new();
+        for reference in &references {
+            let mut reference_paths = Vec::new();
+            ForwardPartialPathStitcher::find_all_complete_partial_paths(
+                &mut DatabaseCandidates::new(graph, partials, db),
+                vec![*reference],
+                stitcher_config,
+                cancellation_flag,
+                |_, _, p| {
+                    reference_paths.push(p.clone());
+                },
+            )?;
+            for reference_path in &reference_paths {
+                if reference_paths
+                    .iter()
+                    .all(|other| !other.shadows(partials, reference_path))
+                {
+                    actual_paths.push(reference_path.clone());
+                }
+            }
+        }
+
+        let missing_targets = expected_targets
+            .iter()
+            .filter(|t| {
+                !actual_paths
+                    .iter()
+                    .any(|p| t.matches_node(p.end_node, graph))
+            })
+            .cloned()
+            .unique()
+            .collect::<Vec<_>>();
+        let unexpected_paths = actual_paths
+            .iter()
+            .filter(|p| {
+                !expected_targets
+                    .iter()
+                    .any(|t| t.matches_node(p.end_node, graph))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_targets.is_empty() || !unexpected_paths.is_empty() {
+            return Err(AssertionError::IncorrectlyDefined {
+                source: source.clone(),
+                references,
+                missing_targets,
+                unexpected_paths,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn run_defines(
+        &self,
+        graph: &StackGraph,
+        source: &AssertionSource,
+        expected_symbols: &Vec<Handle<Symbol>>,
+    ) -> Result<(), AssertionError> {
+        let actual_symbols = source
+            .iter_definitions(graph)
+            .filter_map(|d| graph[d].symbol())
+            .collect::<Vec<_>>();
+        let missing_symbols = expected_symbols
+            .iter()
+            .filter(|x| !actual_symbols.contains(*x))
+            .cloned()
+            .unique()
+            .collect::<Vec<_>>();
+        let unexpected_symbols = actual_symbols
+            .iter()
+            .filter(|x| !expected_symbols.contains(*x))
+            .cloned()
+            .unique()
+            .collect::<Vec<_>>();
+        if !missing_symbols.is_empty() || !unexpected_symbols.is_empty() {
+            return Err(AssertionError::IncorrectDefinitions {
+                source: source.clone(),
+                missing_symbols,
+                unexpected_symbols,
+            });
+        }
+        Ok(())
+    }
+
+    fn run_refers(
+        &self,
+        graph: &StackGraph,
+        source: &AssertionSource,
+        expected_symbols: &Vec<Handle<Symbol>>,
+    ) -> Result<(), AssertionError> {
+        let actual_symbols = source
+            .iter_references(graph)
+            .filter_map(|d| graph[d].symbol())
+            .collect::<Vec<_>>();
+        let missing_symbols = expected_symbols
+            .iter()
+            .filter(|x| !actual_symbols.contains(*x))
+            .cloned()
+            .unique()
+            .collect::<Vec<_>>();
+        let unexpected_symbols = actual_symbols
+            .iter()
+            .filter(|x| !expected_symbols.contains(*x))
+            .cloned()
+            .unique()
+            .collect::<Vec<_>>();
+        if !missing_symbols.is_empty() || !unexpected_symbols.is_empty() {
+            return Err(AssertionError::IncorrectReferences {
+                source: source.clone(),
+                missing_symbols,
+                unexpected_symbols,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/metaslang/stack_graphs/src/c.rs
+++ b/crates/metaslang/stack_graphs/src/c.rs
@@ -1,0 +1,1606 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines a C API for working with stack graphs in other languages.
+
+#![allow(non_camel_case_types)]
+
+use std::convert::TryInto;
+use std::sync::atomic::AtomicUsize;
+
+use libc::c_char;
+
+use crate::arena::Handle;
+use crate::graph::File;
+use crate::graph::InternedString;
+use crate::graph::Node;
+use crate::graph::NodeID;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::partial::PartialPath;
+use crate::partial::PartialPathEdge;
+use crate::partial::PartialPathEdgeList;
+use crate::partial::PartialPaths;
+use crate::partial::PartialScopeStack;
+use crate::partial::PartialScopedSymbol;
+use crate::partial::PartialSymbolStack;
+use crate::stitching::Database;
+use crate::stitching::DatabaseCandidates;
+use crate::stitching::ForwardPartialPathStitcher;
+use crate::stitching::GraphEdgeCandidates;
+use crate::stitching::StitcherConfig;
+use crate::CancellationError;
+use crate::CancellationFlag;
+
+/// Contains all of the nodes and edges that make up a stack graph.
+pub struct sg_stack_graph {
+    pub inner: StackGraph,
+}
+
+/// Creates a new, initially empty stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_new() -> *mut sg_stack_graph {
+    Box::into_raw(Box::new(sg_stack_graph {
+        inner: StackGraph::new(),
+    }))
+}
+
+/// Frees a stack graph, and all of its contents.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_free(graph: *mut sg_stack_graph) {
+    drop(unsafe { Box::from_raw(graph) })
+}
+
+/// Manages the state of a collection of partial paths to be used in the path-stitching algorithm.
+pub struct sg_partial_path_arena {
+    pub inner: PartialPaths,
+}
+
+/// Creates a new, initially empty partial path arena.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_new() -> *mut sg_partial_path_arena {
+    Box::into_raw(Box::new(sg_partial_path_arena {
+        inner: PartialPaths::new(),
+    }))
+}
+
+/// Frees a path arena, and all of its contents.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_free(partials: *mut sg_partial_path_arena) {
+    drop(unsafe { Box::from_raw(partials) })
+}
+
+/// Contains a "database" of partial paths.
+///
+/// This type is meant to be a lazily loaded "view" into a proper storage layer.  During the
+/// path-stitching algorithm, we repeatedly try to extend a currently incomplete path with any
+/// partial paths that are compatible with it.  For large codebases, or projects with a large
+/// number of dependencies, it can be prohibitive to load in _all_ of the partial paths up-front.
+/// We've written the path-stitching algorithm so that you have a chance to only load in the
+/// partial paths that are actually needed, placing them into a sg_partial_path_database instance
+/// as they're needed.
+pub struct sg_partial_path_database {
+    pub inner: Database,
+}
+
+/// Creates a new, initially empty partial path database.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_new() -> *mut sg_partial_path_database {
+    Box::into_raw(Box::new(sg_partial_path_database {
+        inner: Database::new(),
+    }))
+}
+
+/// Frees a partial path database, and all of its contents.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_free(db: *mut sg_partial_path_database) {
+    drop(unsafe { Box::from_raw(db) })
+}
+
+/// The null value for all of our handles.
+pub const SG_NULL_HANDLE: u32 = 0;
+
+/// The handle of an empty list.
+pub const SG_LIST_EMPTY_HANDLE: u32 = 0xffffffff;
+
+/// Describes in which direction the content of a deque is stored in memory.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum sg_deque_direction {
+    SG_DEQUE_FORWARDS,
+    SG_DEQUE_BACKWARDS,
+}
+
+impl Default for sg_deque_direction {
+    fn default() -> sg_deque_direction {
+        sg_deque_direction::SG_DEQUE_FORWARDS
+    }
+}
+
+/// Ensures all partial paths in the database are availabe in both forwards and backwards orientation.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_ensure_both_directions(
+    db: *mut sg_partial_path_database,
+    partials: *mut sg_partial_path_arena,
+) {
+    let db = unsafe { &mut (*db).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    db.ensure_both_directions(partials);
+}
+
+/// Ensures all partial paths in the database are in forwards orientation.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_ensure_forwards(
+    db: *mut sg_partial_path_database,
+    partials: *mut sg_partial_path_arena,
+) {
+    let db = unsafe { &mut (*db).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    db.ensure_forwards(partials);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Symbols
+
+/// A name that we are trying to resolve using stack graphs.
+///
+/// This typically represents a portion of an identifier as it appears in the source language.  It
+/// can also represent some other "operation" that can occur in source code, and which needs to be
+/// modeled in a stack graph — for instance, many languages will use a "fake" symbol named `.` to
+/// represent member access.
+#[repr(C)]
+pub struct sg_symbol {
+    pub symbol: *const c_char,
+    pub symbol_len: usize,
+}
+
+/// A handle to a symbol in a stack graph.  A zero handle represents a missing symbol.
+///
+/// We deduplicate symbols in a stack graph — that is, we ensure that there are never multiple
+/// `struct sg_symbol` instances with the same content.  That means that you can compare symbol
+/// handles using simple equality, without having to dereference them.
+pub type sg_symbol_handle = u32;
+
+/// An array of all of the symbols in a stack graph.  Symbol handles are indices into this array.
+/// There will never be a valid symbol at index 0; a handle with the value 0 represents a missing
+/// symbol.
+#[repr(C)]
+pub struct sg_symbols {
+    pub symbols: *const sg_symbol,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of symbol data in this stack graph.  The resulting array
+/// pointer is only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_symbols(graph: *const sg_stack_graph) -> sg_symbols {
+    let graph = unsafe { &(*graph).inner };
+    sg_symbols {
+        symbols: graph.symbols.as_ptr() as *const sg_symbol,
+        count: graph.symbols.len(),
+    }
+}
+
+/// Adds new symbols to the stack graph.  You provide all of the symbol content concatenated
+/// together into a single string, and an array of the lengths of each symbol.  You also provide an
+/// output array, which must have the same size as `lengths`.  We will place each symbol's handle
+/// in the output array.
+///
+/// We ensure that there is only ever one copy of a particular symbol stored in the graph — we
+/// guarantee that identical symbols will have the same handles, meaning that you can compare the
+/// handles using simple integer equality.
+///
+/// We copy the symbol data into the stack graph.  The symbol content you pass in does not need to
+/// outlive the call to this function.
+///
+/// Each symbol must be a valid UTF-8 string.  If any symbol isn't valid UTF-8, it won't be added
+/// to the stack graph, and the corresponding entry in the output array will be the null handle.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_symbols(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    symbols: *const c_char,
+    lengths: *const usize,
+    handles_out: *mut sg_symbol_handle,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let mut symbols = symbols as *const u8;
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let handles_out = unsafe {
+        std::slice::from_raw_parts_mut(handles_out as *mut Option<Handle<Symbol>>, count)
+    };
+    for i in 0..count {
+        let symbol = unsafe { std::slice::from_raw_parts(symbols, lengths[i]) };
+        handles_out[i] = match std::str::from_utf8(symbol) {
+            Ok(symbol) => Some(graph.add_symbol(symbol)),
+            Err(_) => None,
+        };
+        unsafe { symbols = symbols.add(lengths[i]) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Interned strings
+
+/// Arbitrary string content associated with some part of a stack graph.
+#[repr(C)]
+pub struct sg_string {
+    pub content: *const c_char,
+    pub length: usize,
+}
+
+/// A handle to an interned string in a stack graph.  A zero handle represents a missing string.
+///
+/// We deduplicate strings in a stack graph — that is, we ensure that there are never multiple
+/// `struct sg_string` instances with the same content.  That means that you can compare string
+/// handles using simple equality, without having to dereference them.
+pub type sg_string_handle = u32;
+
+/// An array of all of the interned strings in a stack graph.  String handles are indices into this
+/// array. There will never be a valid string at index 0; a handle with the value 0 represents a
+/// missing string.
+#[repr(C)]
+pub struct sg_strings {
+    pub strings: *const sg_string,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of string data in this stack graph.  The resulting array
+/// pointer is only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_strings(graph: *const sg_stack_graph) -> sg_strings {
+    let graph = unsafe { &(*graph).inner };
+    sg_strings {
+        strings: graph.strings.as_ptr() as *const sg_string,
+        count: graph.strings.len(),
+    }
+}
+
+/// Adds new strings to the stack graph.  You provide all of the string content concatenated
+/// together into a single string, and an array of the lengths of each string.  You also provide an
+/// output array, which must have the same size as `lengths`.  We will place each string's handle
+/// in the output array.
+///
+/// We ensure that there is only ever one copy of a particular string stored in the graph — we
+/// guarantee that identical strings will have the same handles, meaning that you can compare the
+/// handles using simple integer equality.
+///
+/// We copy the string data into the stack graph.  The string content you pass in does not need to
+/// outlive the call to this function.
+///
+/// Each string must be a valid UTF-8 string.  If any string isn't valid UTF-8, it won't be added
+/// to the stack graph, and the corresponding entry in the output array will be the null handle.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_strings(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    strings: *const c_char,
+    lengths: *const usize,
+    handles_out: *mut sg_string_handle,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let mut strings = strings as *const u8;
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let handles_out = unsafe {
+        std::slice::from_raw_parts_mut(handles_out as *mut Option<Handle<InternedString>>, count)
+    };
+    for i in 0..count {
+        let string = unsafe { std::slice::from_raw_parts(strings, lengths[i]) };
+        handles_out[i] = match std::str::from_utf8(string) {
+            Ok(string) => Some(graph.add_string(string)),
+            Err(_) => None,
+        };
+        unsafe { strings = strings.add(lengths[i]) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Files
+
+/// A source file that we have extracted stack graph data from.
+///
+/// It's up to you to choose what names to use for your files, but they must be unique within a
+/// stack graph.  If you are analyzing files from the local filesystem, the file's path is a good
+/// choice.  If your files belong to packages or repositories, they should include the package or
+/// repository IDs to make sure that files in different packages or repositories don't clash with
+/// each other.
+#[repr(C)]
+pub struct sg_file {
+    pub name: *const c_char,
+    pub name_len: usize,
+}
+
+/// A handle to a file in a stack graph.  A zero handle represents a missing file.
+///
+/// We deduplicate files in a stack graph — that is, we ensure that there are never multiple
+/// `struct sg_file` instances with the same filename.  That means that you can compare file
+/// handles using simple equality, without having to dereference them.
+pub type sg_file_handle = u32;
+
+impl Into<Handle<File>> for sg_file_handle {
+    fn into(self) -> Handle<File> {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// An array of all of the files in a stack graph.  File handles are indices into this array.
+/// There will never be a valid file at index 0; a handle with the value 0 represents a missing
+/// file.
+#[repr(C)]
+pub struct sg_files {
+    pub files: *const sg_file,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of file data in this stack graph.  The resulting array pointer
+/// is only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_files(graph: *const sg_stack_graph) -> sg_files {
+    let graph = unsafe { &(*graph).inner };
+    sg_files {
+        files: graph.files.as_ptr() as *const sg_file,
+        count: graph.files.len(),
+    }
+}
+
+/// Adds new files to the stack graph.  You provide all of the file content concatenated together
+/// into a single string, and an array of the lengths of each file.  You also provide an output
+/// array, which must have the same size as `lengths`.  We will place each file's handle in the
+/// output array.
+///
+/// There can only ever be one file with a particular name in the graph.  If you try to add a file
+/// with a name that already exists, you'll get the same handle as a result.
+///
+/// We copy the filenames into the stack graph.  The filenames you pass in do not need to outlive
+/// the call to this function.
+///
+/// Each filename must be a valid UTF-8 string.  If any filename isn't valid UTF-8, it won't be
+/// added to the stack graph, and the corresponding entry in the output array will be the null
+/// handle.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_files(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    files: *const c_char,
+    lengths: *const usize,
+    handles_out: *mut sg_file_handle,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let mut files = files as *const u8;
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let handles_out =
+        unsafe { std::slice::from_raw_parts_mut(handles_out as *mut Option<Handle<File>>, count) };
+    for i in 0..count {
+        let file = unsafe { std::slice::from_raw_parts(files, lengths[i]) };
+        handles_out[i] = match std::str::from_utf8(file) {
+            Ok(file) => Some(graph.get_or_create_file(file)),
+            Err(_) => None,
+        };
+        unsafe { files = files.add(lengths[i]) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Nodes
+
+/// Uniquely identifies a node in a stack graph.
+///
+/// Each node (except for the _root node_ and _jump to scope_ node) lives in a file, and has a
+/// _local ID_ that must be unique within its file.
+#[repr(C)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+pub struct sg_node_id {
+    pub file: sg_file_handle,
+    pub local_id: u32,
+}
+
+impl sg_node_id {
+    fn is_empty(self) -> bool {
+        self.file == 0 && self.local_id == 0
+    }
+}
+
+impl Into<NodeID> for sg_node_id {
+    fn into(self) -> NodeID {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// The local_id of the singleton root node.
+pub const SG_ROOT_NODE_ID: u32 = 1;
+
+/// The local_id of the singleton "jump to scope" node.
+pub const SG_JUMP_TO_NODE_ID: u32 = 2;
+
+/// A node in a stack graph.
+#[repr(C)]
+#[derive(Clone)]
+pub struct sg_node {
+    pub kind: sg_node_kind,
+    pub id: sg_node_id,
+    /// The symbol associated with this node.  For push nodes, this is the symbol that will be
+    /// pushed onto the symbol stack.  For pop nodes, this is the symbol that we expect to pop off
+    /// the symbol stack.  For all other node types, this will be null.
+    pub symbol: sg_symbol_handle,
+    /// The scope associated with this node.  For push scope nodes, this is the scope that will be
+    /// attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
+    /// this will be null.
+    pub scope: sg_node_id,
+    /// Whether this node is an endpoint.  For push nodes, this indicates that the node represents
+    /// a reference in the source.  For pop nodes, this indicates that the node represents a
+    /// definition in the source.  For scopes, this indicates that the scope is exported. For all
+    /// other node types, this field will be unused.
+    pub is_endpoint: bool,
+}
+
+impl Into<Node> for sg_node {
+    fn into(self) -> Node {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// The different kinds of node that can appear in a stack graph.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum sg_node_kind {
+    /// Removes everything from the current scope stack.
+    SG_NODE_KIND_DROP_SCOPES,
+    /// The singleton "jump to" node, which allows a name binding path to jump back to another part
+    /// of the graph.
+    SG_NODE_KIND_JUMP_TO,
+    /// Pops a scoped symbol from the symbol stack.  If the top of the symbol stack doesn't match
+    /// the requested symbol, or if the top of the symbol stack doesn't have an attached scope
+    /// list, then the path is not allowed to enter this node.
+    SG_NODE_KIND_POP_SCOPED_SYMBOL,
+    /// Pops a symbol from the symbol stack.  If the top of the symbol stack doesn't match the
+    /// requested symbol, then the path is not allowed to enter this node.
+    SG_NODE_KIND_POP_SYMBOL,
+    /// Pushes a scoped symbol onto the symbol stack.
+    SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
+    /// Pushes a symbol onto the symbol stack.
+    SG_NODE_KIND_PUSH_SYMBOL,
+    /// The singleton root node, which allows a name binding path to cross between files.
+    SG_NODE_KIND_ROOT,
+    /// A node that adds structure to the graph. If the node is exported, it can be
+    /// referred to on the scope stack, which allows "jump to" nodes in any other
+    /// part of the graph can jump back here.
+    SG_NODE_KIND_SCOPE,
+}
+
+/// A handle to a node in a stack graph.  A zero handle represents a missing node.
+pub type sg_node_handle = u32;
+
+impl Into<Handle<Node>> for sg_node_handle {
+    fn into(self) -> Handle<Node> {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// The handle of the singleton root node.
+pub const SG_ROOT_NODE_HANDLE: sg_node_handle = 1;
+
+/// The handle of the singleton "jump to scope" node.
+pub const SG_JUMP_TO_NODE_HANDLE: sg_node_handle = 2;
+
+/// An array of all of the nodes in a stack graph.  Node handles are indices into this array.
+/// There will never be a valid node at index 0; a handle with the value 0 represents a missing
+/// node.
+#[repr(C)]
+pub struct sg_nodes {
+    pub nodes: *const sg_node,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of nodes in this stack graph.  The resulting array pointer is
+/// only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_nodes(graph: *const sg_stack_graph) -> sg_nodes {
+    let graph = unsafe { &(*graph).inner };
+    sg_nodes {
+        nodes: graph.nodes.as_ptr() as *const sg_node,
+        count: graph.nodes.len(),
+    }
+}
+
+/// Adds new nodes to the stack graph.  You provide an array of `struct sg_node` instances.  You
+/// also provide an output array, which must have the same length as `nodes`, in which we will
+/// place each node's handle in the stack graph.
+///
+/// We copy the node content into the stack graph.  The array you pass in does not need to outlive
+/// the call to this function.
+///
+/// You cannot add new instances of the root node or "jump to scope" node, since those are
+/// singletons and already exist in the stack graph.
+///
+/// If you try to add a new node that has the same ID as an existing node in the stack graph, the
+/// new node will be ignored, and the corresponding entry in the `handles_out` array will contain
+/// the handle of the _existing_ node with that ID.
+///
+/// If any node that you pass in is invalid, it will not be added to the graph, and the
+/// corresponding entry in the `handles_out` array will be null.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_get_or_create_nodes(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    nodes: *const sg_node,
+    handles_out: *mut sg_node_handle,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let nodes = unsafe { std::slice::from_raw_parts(nodes, count) };
+    let handles_out =
+        unsafe { std::slice::from_raw_parts_mut(handles_out as *mut Option<Handle<Node>>, count) };
+    for i in 0..count {
+        let node_id = nodes[i].id;
+        handles_out[i] = validate_node(graph, &nodes[i])
+            .map(|node| graph.get_or_create_node(node_id.into(), node));
+    }
+}
+
+fn validate_node_id(graph: &StackGraph, node_id: sg_node_id) -> Option<()> {
+    if node_id.file == 0 || node_id.file >= (graph.files.len() as u32) {
+        return None;
+    }
+    Some(())
+}
+
+fn validate_node(graph: &StackGraph, node: &sg_node) -> Option<Node> {
+    if matches!(
+        &node.kind,
+        sg_node_kind::SG_NODE_KIND_JUMP_TO | sg_node_kind::SG_NODE_KIND_ROOT
+    ) {
+        // You can never add a singleton node, since there already is one!
+        return None;
+    }
+
+    // Every node must have a valid ID, which refers to an existing file.
+    validate_node_id(graph, node.id)?;
+
+    // Push and pop nodes must have a non-null symbol, and all other nodes must have a null symbol.
+    if (node.symbol != 0)
+        != matches!(
+            &node.kind,
+            sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL
+                | sg_node_kind::SG_NODE_KIND_POP_SYMBOL
+                | sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL
+                | sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL
+        )
+    {
+        return None;
+    }
+
+    // Push scoped symbol nodes must have a non-null scope, and all other nodes must have a null
+    // scope.
+    if (node.scope.is_empty())
+        == matches!(&node.kind, sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL)
+    {
+        return None;
+    }
+
+    Some(node.clone().into())
+}
+
+//-------------------------------------------------------------------------------------------------
+// Edges
+
+/// Connects two nodes in a stack graph.
+///
+/// These edges provide the basic graph connectivity that allow us to search for name binding paths
+/// in a stack graph.  (Though not all sequence of edges is a well-formed name binding: the nodes
+/// that you encounter along the path must also satisfy all of the rules for maintaining correct
+/// symbol and scope stacks.)
+#[repr(C)]
+pub struct sg_edge {
+    pub source: sg_node_handle,
+    pub sink: sg_node_handle,
+    pub precedence: i32,
+}
+
+/// Adds new edges to the stack graph.  You provide an array of `struct sg_edges` instances.  A
+/// stack graph can contain at most one edge between any two nodes.  It is not an error if you try
+/// to add an edge that already exists, but it won't have any effect on the graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_edges(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    edges: *const sg_edge,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let edges = unsafe { std::slice::from_raw_parts(edges, count) };
+    for i in 0..count {
+        let source = unsafe { std::mem::transmute(edges[i].source) };
+        let sink = unsafe { std::mem::transmute(edges[i].sink) };
+        graph.add_edge(source, sink, edges[i].precedence);
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Source info
+
+/// Contains information about a range of code in a source code file.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct sg_source_info {
+    /// The location in its containing file of the source code that this node represents.
+    pub span: sg_span,
+    /// The kind of syntax entity this node represents (e.g. `function`, `class`, `method`, etc.).
+    pub syntax_type: sg_string_handle,
+    /// The full content of the line containing this node in its source file.
+    pub containing_line: sg_string_handle,
+    /// The location in its containing file of the source code that this node's definiens represents.
+    /// This is used for things like the bodies of functions, rather than the RHSes of equations.
+    /// If you need one of these to make the type checker happy, but you don't have one, just use
+    /// sg_span::default(), as this will correspond to the all-0s spans which mean "no definiens".
+    pub definiens_span: sg_span,
+    /// The fully qualified name is a representation of the symbol that captures its name and its
+    /// embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
+    pub fully_qualified_name: sg_string_handle,
+}
+
+/// All of the position information that we have about a range of content in a source file
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct sg_span {
+    pub start: sg_position,
+    pub end: sg_position,
+}
+
+/// All of the position information that we have about a character in a source file
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct sg_position {
+    /// The 0-indexed line number containing the character
+    pub line: usize,
+    /// The offset of the character within its containing line, expressed as both a UTF-8 byte
+    /// index and a UTF-16 code point index
+    pub column: sg_offset,
+    /// The UTF-8 byte indexes (within the file) of the start and end of the line containing the
+    /// character
+    pub containing_line: sg_utf8_bounds,
+    /// The UTF-8 byte indexes (within the file) of the start and end of the line containing the
+    /// character, with any leading and trailing whitespace removed
+    pub trimmed_line: sg_utf8_bounds,
+}
+
+/// The offset of a character within a string (typically a line of source code), using several
+/// different units
+///
+/// All offsets are 0-indexed.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct sg_offset {
+    /// The number of UTF-8-encoded bytes appearing before this character in the string
+    pub utf8_offset: usize,
+    /// The number of UTF-16 code units appearing before this character in the string
+    pub utf16_offset: usize,
+    /// The number of graphemes appearing before this character in the string
+    pub grapheme_offset: usize,
+}
+
+/// A half-open range identifying a range of characters in a string.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct sg_utf8_bounds {
+    /// The UTF-8 byte index of the first character in the range.
+    pub start: usize,
+    /// The UTF-8 byte index of the first character _after_ the range.
+    pub end: usize,
+}
+
+/// An array of all of the source information in a stack graph.  Source information is associated
+/// with nodes, so node handles are indices into this array.  It is _not_ guaranteed that there
+/// will an entry in this array for every node handle; if you have a node handle whose value is
+/// larger than `count`, then use a 0-valued `sg_source_info` if you need source information for
+/// that node.
+///
+/// There will never be a valid entry at index 0; a handle with the value 0 represents a missing
+/// node.
+#[repr(C)]
+pub struct sg_source_infos {
+    pub infos: *const sg_source_info,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of source information in this stack graph.  The resulting
+/// array pointer is only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_source_infos(graph: *const sg_stack_graph) -> sg_source_infos {
+    let graph = unsafe { &(*graph).inner };
+    sg_source_infos {
+        infos: graph.source_info.as_ptr() as *const sg_source_info,
+        count: graph.source_info.len(),
+    }
+}
+
+/// A tuple of a node handle and source information for that node.  Used with the
+/// `sg_add_source_info` function to add source information to a stack graph.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct sg_node_source_info {
+    pub node: sg_node_handle,
+    pub source_info: sg_source_info,
+}
+
+/// Adds new source information to the stack graph.  You provide an array of `sg_node_source_info`
+/// instances.  Any existing source information for any node mentioned in the array is overwritten.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_source_infos(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    infos: *const sg_node_source_info,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let infos = unsafe { std::slice::from_raw_parts(infos, count) };
+    for i in 0..count {
+        let node = unsafe { std::mem::transmute(infos[i].node) };
+        let info = graph.source_info_mut(node);
+        *info = unsafe { std::mem::transmute(infos[i].source_info) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial symbol stacks
+
+/// Represents an unknown list of scoped symbols.
+pub type sg_symbol_stack_variable = u32;
+
+/// A symbol with an unknown, but possibly empty, list of exported scopes attached to it.
+#[repr(C)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct sg_partial_scoped_symbol {
+    pub symbol: sg_symbol_handle,
+    pub scopes: sg_partial_scope_stack,
+}
+
+impl Into<PartialScopedSymbol> for sg_partial_scoped_symbol {
+    fn into(self) -> PartialScopedSymbol {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// A pattern that might match against a symbol stack.  Consists of a (possibly empty) list of
+/// partial scoped symbols.
+///
+/// (Note that unlike partial scope stacks, we don't store any "symbol stack variable" here.  We
+/// could!  But with our current path-finding rules, every partial path will always have exactly
+/// one symbol stack variable, which will appear at the end of its precondition and postcondition.
+/// So for simplicity we just leave it out.  At some point in the future we might add it in so that
+/// the symbol and scope stack formalisms and implementations are more obviously symmetric.)
+#[repr(C)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+pub struct sg_partial_symbol_stack {
+    /// The handle of the first element in the partial symbol stack, or SG_LIST_EMPTY_HANDLE if the
+    /// list is empty, or 0 if the list is null.
+    pub cells: sg_partial_symbol_stack_cell_handle,
+    pub direction: sg_deque_direction,
+    pub length: u32,
+    /// The symbol stack variable representing the unknown content of a partial symbol stack, or 0
+    /// if the variable is missing.  (If so, this partial symbol stack can only match a symbol
+    /// stack with exactly the list of symbols in `cells`, instead of any symbol stack with those
+    /// symbols as a prefix.)
+    pub variable: sg_symbol_stack_variable,
+}
+
+impl From<PartialSymbolStack> for sg_partial_symbol_stack {
+    fn from(stack: PartialSymbolStack) -> sg_partial_symbol_stack {
+        unsafe { std::mem::transmute(stack) }
+    }
+}
+
+/// A handle to an element of a partial symbol stack.  A zero handle represents a missing partial
+/// symbol stack.  A UINT32_MAX handle represents an empty partial symbol stack.
+pub type sg_partial_symbol_stack_cell_handle = u32;
+
+/// An element of a partial symbol stack.
+#[repr(C)]
+pub struct sg_partial_symbol_stack_cell {
+    /// The partial scoped symbol at this position in the partial symbol stack.
+    pub head: sg_partial_scoped_symbol,
+    /// The handle of the next element in the partial symbol stack, or SG_LIST_EMPTY_HANDLE if this
+    /// is the last element.
+    pub tail: sg_partial_symbol_stack_cell_handle,
+    /// The handle of the reversal of this partial scope stack.
+    pub reversed: sg_partial_symbol_stack_cell_handle,
+}
+
+/// The array of all of the partial symbol stack content in a partial path arena.
+#[repr(C)]
+pub struct sg_partial_symbol_stack_cells {
+    pub cells: *const sg_partial_symbol_stack_cell,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of partial symbol stack content in a partial path arena.  The
+/// resulting array pointer is only valid until the next call to any function that mutates the path
+/// arena.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_partial_symbol_stack_cells(
+    partials: *const sg_partial_path_arena,
+) -> sg_partial_symbol_stack_cells {
+    let partials = unsafe { &(*partials).inner };
+    sg_partial_symbol_stack_cells {
+        cells: partials.partial_symbol_stacks.as_ptr() as *const sg_partial_symbol_stack_cell,
+        count: partials.partial_symbol_stacks.len(),
+    }
+}
+
+/// Adds new partial symbol stacks to the partial path arena.  `count` is the number of partial
+/// symbol stacks you want to create.  The content of each partial symbol stack comes from two
+/// arrays.  The `lengths` array must have `count` elements, and provides the number of symbols in
+/// each partial symbol stack.  The `symbols` array contains the contents of each of these partial
+/// symbol stacks in one contiguous array.  Its length must be the sum of all of the counts in the
+/// `lengths` array.  The `variables` array must have `count` elements, and provides the optional
+/// symbol stack variable for each partial symbol stack.
+///
+/// You must also provide an `out` array, which must also have room for `count` elements.  We will
+/// fill this array in with the `sg_partial_symbol_stack` instances for each partial symbol stack
+/// that is created.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_add_partial_symbol_stacks(
+    partials: *mut sg_partial_path_arena,
+    count: usize,
+    mut symbols: *const sg_partial_scoped_symbol,
+    lengths: *const usize,
+    variables: *const sg_symbol_stack_variable,
+    out: *mut sg_partial_symbol_stack,
+) {
+    let partials = unsafe { &mut (*partials).inner };
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let variables = unsafe { std::slice::from_raw_parts(variables, count) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out, count) };
+    for i in 0..count {
+        let length = lengths[i];
+        let symbols_slice = unsafe { std::slice::from_raw_parts(symbols, length) };
+        let mut stack = if variables[i] == 0 {
+            PartialSymbolStack::empty()
+        } else {
+            PartialSymbolStack::from_variable(variables[i].try_into().unwrap())
+        };
+        for j in 0..length {
+            let symbol = symbols_slice[j].into();
+            stack.push_back(partials, symbol);
+        }
+        // We pushed the edges onto the list in reverse order.  Requesting a forwards iterator
+        // before we return ensures that it will also be available in forwards order.
+        let _ = stack.iter(partials);
+        out[i] = stack.into();
+        unsafe { symbols = symbols.add(length) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial scope stacks
+
+/// Represents an unknown list of exported scopes.
+pub type sg_scope_stack_variable = u32;
+
+/// A pattern that might match against a scope stack.  Consists of a (possibly empty) list of
+/// exported scopes, along with an optional scope stack variable.
+#[repr(C)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+pub struct sg_partial_scope_stack {
+    /// The handle of the first element in the partial scope stack, or SG_LIST_EMPTY_HANDLE if the
+    /// list is empty, or 0 if the list is null.
+    pub cells: sg_partial_scope_stack_cell_handle,
+    pub direction: sg_deque_direction,
+    pub length: u32,
+    /// The scope stack variable representing the unknown content of a partial scope stack, or 0 if
+    /// the variable is missing.  (If so, this partial scope stack can only match a scope stack
+    /// with exactly the list of scopes in `cells`, instead of any scope stack with those scopes as
+    /// a prefix.)
+    pub variable: sg_scope_stack_variable,
+}
+
+impl From<PartialScopeStack> for sg_partial_scope_stack {
+    fn from(stack: PartialScopeStack) -> sg_partial_scope_stack {
+        unsafe { std::mem::transmute(stack) }
+    }
+}
+
+/// A handle to an element of a partial scope stack.  A zero handle represents a missing partial
+/// scope stack.  A UINT32_MAX handle represents an empty partial scope stack.
+pub type sg_partial_scope_stack_cell_handle = u32;
+
+/// An element of a partial scope stack.
+#[repr(C)]
+pub struct sg_partial_scope_stack_cell {
+    /// The exported scope at this position in the partial scope stack.
+    pub head: sg_node_handle,
+    /// The handle of the next element in the partial scope stack, or SG_LIST_EMPTY_HANDLE if this
+    /// is the last element.
+    pub tail: sg_partial_scope_stack_cell_handle,
+    /// The handle of the reversal of this partial scope stack.
+    pub reversed: sg_partial_scope_stack_cell_handle,
+}
+
+/// The array of all of the partial scope stack content in a partial path arena.
+#[repr(C)]
+pub struct sg_partial_scope_stack_cells {
+    pub cells: *const sg_partial_scope_stack_cell,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of partial scope stack content in a partial path arena.  The
+/// resulting array pointer is only valid until the next call to any function that mutates the
+/// partial path arena.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_partial_scope_stack_cells(
+    partials: *const sg_partial_path_arena,
+) -> sg_partial_scope_stack_cells {
+    let partials = unsafe { &(*partials).inner };
+    sg_partial_scope_stack_cells {
+        cells: partials.partial_scope_stacks.as_ptr() as *const sg_partial_scope_stack_cell,
+        count: partials.partial_scope_stacks.len(),
+    }
+}
+
+/// Adds new partial scope stacks to the partial path arena.  `count` is the number of partial
+/// scope stacks you want to create.  The content of each partial scope stack comes from three
+/// arrays.  The `lengths` array must have `count` elements, and provides the number of scopes in
+/// each scope stack.  The `scopes` array contains the contents of each of these scope stacks in
+/// one contiguous array.  Its length must be the sum of all of the counts in the `lengths` array.
+/// The `variables` array must have `count` elements, and provides the optional scope stack
+/// variable for each partial scope stack.
+///
+/// You must also provide an `out` array, which must also have room for `count` elements.  We will
+/// fill this array in with the `sg_partial_scope_stack` instances for each partial scope stack
+/// that is created.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_add_partial_scope_stacks(
+    partials: *mut sg_partial_path_arena,
+    count: usize,
+    mut scopes: *const sg_node_handle,
+    lengths: *const usize,
+    variables: *const sg_scope_stack_variable,
+    out: *mut sg_partial_scope_stack,
+) {
+    let partials = unsafe { &mut (*partials).inner };
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let variables = unsafe { std::slice::from_raw_parts(variables, count) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out, count) };
+    for i in 0..count {
+        let length = lengths[i];
+        let scopes_slice = unsafe { std::slice::from_raw_parts(scopes, length) };
+        let mut stack = if variables[i] == 0 {
+            PartialScopeStack::empty()
+        } else {
+            PartialScopeStack::from_variable(variables[i].try_into().unwrap())
+        };
+        for j in 0..length {
+            let node = scopes_slice[j].into();
+            stack.push_back(partials, node);
+        }
+        // We pushed the edges onto the list in reverse order.  Requesting a forwards iterator
+        // before we return ensures that it will also be available in forwards order.
+        let _ = stack.iter_scopes(partials);
+        out[i] = stack.into();
+        unsafe { scopes = scopes.add(length) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial edge lists
+
+/// Details about one of the edges in a partial path
+#[repr(C)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct sg_partial_path_edge {
+    pub source_node_id: sg_node_id,
+    pub precedence: i32,
+}
+
+impl Into<PartialPathEdge> for sg_partial_path_edge {
+    fn into(self) -> PartialPathEdge {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// The edges in a path keep track of precedence information so that we can correctly handle
+/// shadowed definitions.
+#[repr(C)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+pub struct sg_partial_path_edge_list {
+    /// The handle of the first element in the edge list, or SG_LIST_EMPTY_HANDLE if the list is
+    /// empty, or 0 if the list is null.
+    pub cells: sg_partial_path_edge_list_cell_handle,
+    pub direction: sg_deque_direction,
+    pub length: u32,
+}
+
+impl From<PartialPathEdgeList> for sg_partial_path_edge_list {
+    fn from(edges: PartialPathEdgeList) -> sg_partial_path_edge_list {
+        unsafe { std::mem::transmute(edges) }
+    }
+}
+
+/// A handle to an element of a partial path edge list.  A zero handle represents a missing partial
+/// path edge list.  A UINT32_MAX handle represents an empty partial path edge list.
+pub type sg_partial_path_edge_list_cell_handle = u32;
+
+/// An element of a partial path edge list.
+#[repr(C)]
+pub struct sg_partial_path_edge_list_cell {
+    /// The partial path edge at this position in the partial path edge list.
+    pub head: sg_partial_path_edge,
+    /// The handle of the next element in the partial path edge list, or SG_LIST_EMPTY_HANDLE if
+    /// this is the last element.
+    pub tail: sg_partial_path_edge_list_cell_handle,
+    /// The handle of the reversal of this list.
+    pub reversed: sg_partial_path_edge_list_cell_handle,
+}
+
+/// The array of all of the partial path edge list content in a partial path arena.
+#[repr(C)]
+pub struct sg_partial_path_edge_list_cells {
+    pub cells: *const sg_partial_path_edge_list_cell,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of partial path edge list content in a partial path arena.
+/// The resulting array pointer is only valid until the next call to any function that mutates the
+/// partial path arena.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_partial_path_edge_list_cells(
+    partials: *const sg_partial_path_arena,
+) -> sg_partial_path_edge_list_cells {
+    let partials = unsafe { &(*partials).inner };
+    sg_partial_path_edge_list_cells {
+        cells: partials.partial_path_edges.as_ptr() as *const sg_partial_path_edge_list_cell,
+        count: partials.partial_path_edges.len(),
+    }
+}
+
+/// Adds new partial path edge lists to the partial path arena.  `count` is the number of partial
+/// path edge lists you want to create.  The content of each partial path edge list comes from two
+/// arrays.  The `lengths` array must have `count` elements, and provides the number of edges in
+/// each partial path edge list.  The `edges` array contains the contents of each of these partial
+/// path edge lists in one contiguous array.  Its length must be the sum of all of the counts in
+/// the `lengths` array.
+///
+/// You must also provide an `out` array, which must also have room for `count` elements.  We will
+/// fill this array in with the `sg_partial_path_edge_list` instances for each partial path edge
+/// list that is created.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_add_partial_path_edge_lists(
+    partials: *mut sg_partial_path_arena,
+    count: usize,
+    mut edges: *const sg_partial_path_edge,
+    lengths: *const usize,
+    out: *mut sg_partial_path_edge_list,
+) {
+    let partials = unsafe { &mut (*partials).inner };
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out, count) };
+    for i in 0..count {
+        let length = lengths[i];
+        let edges_slice = unsafe { std::slice::from_raw_parts(edges, length) };
+        let mut list = PartialPathEdgeList::empty();
+        for j in 0..length {
+            let edge: PartialPathEdge = edges_slice[j].into();
+            list.push_back(partials, edge);
+        }
+        // We pushed the edges onto the list in reverse order.  Requesting a forwards iterator
+        // before we return ensures that it will also be available in forwards order.
+        let _ = list.iter(partials);
+        out[i] = list.into();
+        unsafe { edges = edges.add(length) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial paths
+
+/// A portion of a name-binding path.
+///
+/// Partial paths can be computed _incrementally_, in which case all of the edges in the partial
+/// path belong to a single file.  At query time, we can efficiently concatenate partial paths to
+/// yield a name-binding path.
+///
+/// Paths describe the contents of the symbol stack and scope stack at the end of the path.
+/// Partial paths, on the other hand, have _preconditions_ and _postconditions_ for each stack.
+/// The precondition describes what the stack must look like for us to be able to concatenate this
+/// partial path onto the end of a path.  The postcondition describes what the resulting stack
+/// looks like after doing so.
+///
+/// The preconditions can contain _scope stack variables_, which describe parts of the scope stack
+/// (or parts of a scope symbol's attached scope list) whose contents we don't care about.  The
+/// postconditions can _also_ refer to those variables, and describe how those variable parts of
+/// the input scope stacks are carried through unmodified into the resulting scope stack.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct sg_partial_path {
+    pub start_node: sg_node_handle,
+    pub end_node: sg_node_handle,
+    pub symbol_stack_precondition: sg_partial_symbol_stack,
+    pub symbol_stack_postcondition: sg_partial_symbol_stack,
+    pub scope_stack_precondition: sg_partial_scope_stack,
+    pub scope_stack_postcondition: sg_partial_scope_stack,
+    pub edges: sg_partial_path_edge_list,
+}
+
+impl Into<PartialPath> for sg_partial_path {
+    fn into(self) -> PartialPath {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+/// A list of paths found by the path-finding algorithm.
+#[derive(Default)]
+pub struct sg_partial_path_list {
+    partial_paths: Vec<PartialPath>,
+}
+
+/// Creates a new, empty sg_partial_path_list.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_list_new() -> *mut sg_partial_path_list {
+    Box::into_raw(Box::new(sg_partial_path_list::default()))
+}
+
+#[no_mangle]
+pub extern "C" fn sg_partial_path_list_free(partial_path_list: *mut sg_partial_path_list) {
+    drop(unsafe { Box::from_raw(partial_path_list) });
+}
+
+#[no_mangle]
+pub extern "C" fn sg_partial_path_list_count(
+    partial_path_list: *const sg_partial_path_list,
+) -> usize {
+    let partial_path_list = unsafe { &*partial_path_list };
+    partial_path_list.partial_paths.len()
+}
+
+#[no_mangle]
+pub extern "C" fn sg_partial_path_list_paths(
+    partial_path_list: *const sg_partial_path_list,
+) -> *const sg_partial_path {
+    let partial_path_list = unsafe { &*partial_path_list };
+    partial_path_list.partial_paths.as_ptr() as *const _
+}
+
+/// Finds all partial paths in a file that are _productive_ and _as complete as possible_, placing
+/// the result into the `partial_path_list` output parameter.  You must free the path list when you
+/// are done with it by calling `sg_partial_path_list_done`.
+///
+/// This function will not return until all reachable paths have been processed, so `graph` must
+/// already contain a complete stack graph.  If you have a very large stack graph stored in some
+/// other storage system, and want more control over lazily loading only the necessary pieces, then
+/// you should use sg_forward_path_stitcher.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_find_partial_paths_in_file(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    file: sg_file_handle,
+    partial_path_list: *mut sg_partial_path_list,
+    stitcher_config: *const sg_stitcher_config,
+    cancellation_flag: *const usize,
+) -> sg_result {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let file = file.into();
+    let partial_path_list = unsafe { &mut *partial_path_list };
+    let stitcher_config = unsafe { *stitcher_config };
+    let cancellation_flag: Option<&AtomicUsize> =
+        unsafe { std::mem::transmute(cancellation_flag.as_ref()) };
+    ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+        graph,
+        partials,
+        file,
+        stitcher_config.into(),
+        &AtomicUsizeCancellationFlag(cancellation_flag),
+        |_graph, partials, path| {
+            let mut path = path.clone();
+            path.ensure_both_directions(partials);
+            partial_path_list.partial_paths.push(path);
+        },
+    )
+    .into()
+}
+
+/// Finds all complete paths reachable from a set of starting nodes, placing the result into the
+/// `path_list` output parameter.  You must free the path list when you are done with it by calling
+/// `sg_path_list_done`.
+///
+/// This function will not return until all reachable paths have been processed, so `graph` must
+/// already contain a complete stack graph.  If you have a very large stack graph stored in some
+/// other storage system, and want more control over lazily loading only the necessary pieces, then
+/// you should use sg_forward_path_stitcher.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_arena_find_all_complete_paths(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    starting_node_count: usize,
+    starting_nodes: *const sg_node_handle,
+    path_list: *mut sg_partial_path_list,
+    stitcher_config: *const sg_stitcher_config,
+    cancellation_flag: *const usize,
+) -> sg_result {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let starting_nodes = unsafe { std::slice::from_raw_parts(starting_nodes, starting_node_count) };
+    let stitcher_config = unsafe { *stitcher_config };
+    let path_list = unsafe { &mut *path_list };
+    let cancellation_flag: Option<&AtomicUsize> =
+        unsafe { std::mem::transmute(cancellation_flag.as_ref()) };
+    ForwardPartialPathStitcher::find_all_complete_partial_paths(
+        &mut GraphEdgeCandidates::new(graph, partials, None),
+        starting_nodes.iter().copied().map(sg_node_handle::into),
+        stitcher_config.into(),
+        &AtomicUsizeCancellationFlag(cancellation_flag),
+        |graph, _partials, path| {
+            if path.is_complete(graph) {
+                path_list.partial_paths.push(path.clone());
+            }
+        },
+    )
+    .into()
+}
+
+/// A handle to a partial path in a partial path database.  A zero handle represents a missing
+/// partial path.
+pub type sg_partial_path_handle = u32;
+
+/// An array of all of the partial paths in a partial path database.  Partial path handles are
+/// indices into this array.  There will never be a valid partial path at index 0; a handle with
+/// the value 0 represents a missing partial path.
+#[repr(C)]
+pub struct sg_partial_paths {
+    pub paths: *const sg_partial_path,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of partial path data in this partial path database.  The
+/// resulting array pointer is only valid until the next call to any function that mutates the
+/// partial path database.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_partial_paths(
+    db: *const sg_partial_path_database,
+) -> sg_partial_paths {
+    let db = unsafe { &(*db).inner };
+    sg_partial_paths {
+        paths: db.partial_paths.as_ptr() as *const sg_partial_path,
+        count: db.partial_paths.len(),
+    }
+}
+
+/// Adds new partial paths to the partial path database.  `paths` is the array of partial paths
+/// that you want to add; `count` is the number of them.
+///
+/// We copy the partial path content into the partial path database.  The array you pass in does
+/// not need to outlive the call to this function.
+///
+/// You should take care not to add a partial path to the database multiple times.  This won't
+/// cause an _error_, in that nothing will break, but it will probably cause you to get duplicate
+/// paths from the path-stitching algorithm.
+///
+/// You must also provide an `out` array, which must also have room for `count` elements.  We will
+/// fill this array in with the `sg_partial_path_edge_list` instances for each partial path edge
+/// list that is created.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_add_partial_paths(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    db: *mut sg_partial_path_database,
+    count: usize,
+    paths: *const sg_partial_path,
+    out: *mut sg_partial_path_handle,
+) {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let db = unsafe { &mut (*db).inner };
+    let paths = unsafe { std::slice::from_raw_parts(paths, count) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out as *mut Handle<PartialPath>, count) };
+    for i in 0..count {
+        out[i] = db.add_partial_path(graph, partials, paths[i].into());
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Local nodes
+
+/// Encodes a set of node handles.
+///
+/// The elements are encoded in a bit set.  Use the traditional mask and shift pattern to determine
+/// if a particular handle is in the set:
+///
+/// ``` c
+/// size_t element_index = handle / 32;
+/// size_t bit_index = handle % 32;
+/// size_t bit_mask = 1 << bit_index;
+/// bool bit_is_set =
+///     element_index < set.length &&
+///     (set.elements[element_index] & bit_mask) != 0;
+/// ```
+#[repr(C)]
+pub struct sg_node_handle_set {
+    pub elements: *const u32,
+    /// Note that this is the number of uint32_t's in `elements`, NOT the number of bits in the set.
+    pub length: usize,
+}
+
+/// Determines which nodes in the stack graph are “local”, taking into account the partial paths in
+/// this database.  The result is valid until the next call to this function, or until the database
+/// is freed.
+///
+/// A local node has no partial path that connects it to the root node in either direction. That
+/// means that it cannot participate in any paths that leave the file.
+///
+/// This method is meant to be used at index time, to calculate the set of nodes that are local
+/// after having just calculated the set of partial paths for the file.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_find_local_nodes(db: *mut sg_partial_path_database) {
+    let db = unsafe { &mut (*db).inner };
+    db.find_local_nodes();
+}
+
+/// Marks that a list of stack graph nodes are local.
+///
+/// This method is meant to be used at query time.  You will have precalculated the set of local
+/// nodes for a file at index time; at query time, you will load this information from your storage
+/// layer and use this method to update our internal view of which nodes are local.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_mark_local_nodes(
+    db: *mut sg_partial_path_database,
+    count: usize,
+    nodes: *const sg_node_handle,
+) {
+    let db = unsafe { &mut (*db).inner };
+    let nodes = unsafe { std::slice::from_raw_parts(nodes, count) };
+    for node in nodes {
+        db.mark_local_node(node.clone().into());
+    }
+}
+
+/// Returns a reference to the set of stack graph nodes that are local, according to this database
+/// of partial paths.  The resulting set is only valid until the next call to any function that
+/// mutates the partial path database.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_local_nodes(
+    db: *const sg_partial_path_database,
+) -> sg_node_handle_set {
+    let db = unsafe { &(*db).inner };
+    sg_node_handle_set {
+        elements: db.local_nodes.as_ptr(),
+        length: db.local_nodes.len(),
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Forward partial path stitching
+
+/// Implements a phased forward partial path stitching algorithm.
+///
+/// Our overall goal is to start with a set of _seed_ partial paths, and to repeatedly extend each
+/// partial path by concatenating another, compatible partial path onto the end of it.  (If there
+/// are multiple compatible partial paths, we concatenate each of them separately, resulting in
+/// more than one extension for the current path.)
+///
+/// We perform this processing in _phases_.  At the start of each phase, we have a _current set_ of
+/// partial paths that need to be processed.  As we extend those partial paths, we add the
+/// extensions to the set of partial paths to process in the _next_ phase.  Phases are processed
+/// one at a time, each time you invoke `sg_forward_partial_path_stitcher_process_next_phase`.
+///
+/// After each phase has completed, the `previous_phase_paths` and `previous_phase_paths_length`
+/// fields give you all of the partial paths that were discovered during that phase.  That gives
+/// you a chance to add to the `sg_partial_path_database` all of the other partial paths that we
+/// might need to extend those partial paths with before invoking the next phase.
+#[repr(C)]
+pub struct sg_forward_partial_path_stitcher {
+    /// The new candidate partial paths that were discovered in the most recent phase.
+    pub previous_phase_partial_paths: *const sg_partial_path,
+    /// The number of new candidate partial paths that were discovered in the most recent phase.
+    /// If this is 0, then the partial path stitching algorithm is complete.
+    pub previous_phase_partial_paths_length: usize,
+    /// Whether the stitching algorithm is complete.  You should keep calling
+    /// `sg_forward_partial_path_stitcher_process_next_phase` until this field is true.
+    pub is_complete: bool,
+}
+
+// Configuration for partial path stitchers.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct sg_stitcher_config {
+    /// Enables similar path detection during stiching.
+    pub detect_similar_paths: bool,
+}
+
+impl Into<StitcherConfig> for sg_stitcher_config {
+    fn into(self) -> StitcherConfig {
+        StitcherConfig::default().with_detect_similar_paths(self.detect_similar_paths)
+    }
+}
+
+// This is the Rust equivalent of a common C trick, where you have two versions of a struct — a
+// publicly visible one and a private one containing internal implementation details.  In our case,
+// `sg_forward_partial_path_stitcher` is the public struct, and
+// `InternalForwardPartialPathStitcher` is the internal one.  The main requirement is that the
+// private struct must start with a copy of all of the fields in the public struct — ensuring that
+// those fields occur at the same offset in both.  The private struct can contain additional
+// (private) fields, but they must appear _after_ all of the publicly visible fields.
+//
+// In our case, we do this because we don't want to expose the existence or details of the
+// ForwardPartialPathStitcher type via the C API.
+#[repr(C)]
+struct InternalForwardPartialPathStitcher {
+    previous_phase_partial_paths: *const PartialPath,
+    previous_phase_partial_paths_length: usize,
+    is_complete: bool,
+    stitcher: ForwardPartialPathStitcher<Handle<PartialPath>>,
+}
+
+impl InternalForwardPartialPathStitcher {
+    fn new(
+        stitcher: ForwardPartialPathStitcher<Handle<PartialPath>>,
+        partials: &mut PartialPaths,
+    ) -> InternalForwardPartialPathStitcher {
+        let mut this = InternalForwardPartialPathStitcher {
+            previous_phase_partial_paths: std::ptr::null(),
+            previous_phase_partial_paths_length: 0,
+            is_complete: false,
+            stitcher,
+        };
+        this.update_previous_phase_partial_paths(partials);
+        this
+    }
+
+    fn update_previous_phase_partial_paths(&mut self, partials: &mut PartialPaths) {
+        for path in self.stitcher.previous_phase_partial_paths_slice_mut() {
+            path.ensure_both_directions(partials);
+        }
+        let slice = self.stitcher.previous_phase_partial_paths_slice();
+        self.previous_phase_partial_paths = slice.as_ptr();
+        self.previous_phase_partial_paths_length = slice.len();
+        self.is_complete = self.stitcher.is_complete();
+    }
+}
+
+/// Creates a new forward partial path stitcher that is "seeded" with a set of starting stack graph
+/// nodes. The path stitcher will be set up to find complete paths only.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_from_nodes(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    count: usize,
+    starting_nodes: *const sg_node_handle,
+) -> *mut sg_forward_partial_path_stitcher {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let starting_nodes = unsafe { std::slice::from_raw_parts(starting_nodes, count) };
+    let initial_paths = starting_nodes
+        .iter()
+        .copied()
+        .map(sg_node_handle::into)
+        .map(|n| {
+            let mut p = PartialPath::from_node(graph, partials, n);
+            p.eliminate_precondition_stack_variables(partials);
+            p
+        })
+        .collect::<Vec<_>>();
+    let stitcher = ForwardPartialPathStitcher::from_partial_paths(graph, partials, initial_paths);
+    Box::into_raw(Box::new(InternalForwardPartialPathStitcher::new(
+        stitcher, partials,
+    ))) as *mut _
+}
+
+/// Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
+/// paths.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_from_partial_paths(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    count: usize,
+    initial_partial_paths: *const sg_partial_path,
+) -> *mut sg_forward_partial_path_stitcher {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let initial_partial_paths =
+        unsafe { std::slice::from_raw_parts(initial_partial_paths as *const PartialPath, count) };
+    let stitcher = ForwardPartialPathStitcher::from_partial_paths(
+        graph,
+        partials,
+        initial_partial_paths.to_vec(),
+    );
+    Box::into_raw(Box::new(InternalForwardPartialPathStitcher::new(
+        stitcher, partials,
+    ))) as *mut _
+}
+
+/// Sets whether similar path detection should be enabled during path stitching. Paths are similar
+/// if start and end node, and pre- and postconditions are the same. The presence of similar paths
+/// can lead to exponential blow up during path stitching. Similar path detection is disabled by
+/// default because of the accociated preformance cost.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_set_similar_path_detection(
+    stitcher: *mut sg_forward_partial_path_stitcher,
+    detect_similar_paths: bool,
+) {
+    let stitcher = unsafe { &mut *(stitcher as *mut InternalForwardPartialPathStitcher) };
+    stitcher
+        .stitcher
+        .set_similar_path_detection(detect_similar_paths);
+}
+
+/// Sets the maximum amount of work that can be performed during each phase of the algorithm. By
+/// bounding our work this way, you can ensure that it's not possible for our CPU-bound algorithm
+/// to starve any worker threads or processes that you might be using.  If you don't call this
+/// method, then we allow ourselves to process all of the extensions of all of the paths found in
+/// the previous phase, with no additional bound.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_set_max_work_per_phase(
+    stitcher: *mut sg_forward_partial_path_stitcher,
+    max_work: usize,
+) {
+    let stitcher = unsafe { &mut *(stitcher as *mut InternalForwardPartialPathStitcher) };
+    stitcher.stitcher.set_max_work_per_phase(max_work);
+}
+
+/// Runs the next phase of the algorithm.  We will have built up a set of incomplete partial paths
+/// during the _previous_ phase.  Before calling this function, you must ensure that `db` contains
+/// all of the possible partial paths that we might want to extend any of those candidate partial
+/// paths with.
+///
+/// After this method returns, you can retrieve a list of the (possibly incomplete) partial paths
+/// that were encountered during this phase via the `previous_phase_partial_paths` and
+/// `previous_phase_partial_paths_length` fields.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_process_next_phase(
+    graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    db: *mut sg_partial_path_database,
+    stitcher: *mut sg_forward_partial_path_stitcher,
+) {
+    let graph = unsafe { &(*graph).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    let db = unsafe { &mut (*db).inner };
+    let stitcher = unsafe { &mut *(stitcher as *mut InternalForwardPartialPathStitcher) };
+    stitcher.stitcher.process_next_phase(
+        &mut DatabaseCandidates::new(graph, partials, db),
+        |_, _, _| true,
+    );
+    stitcher.update_previous_phase_partial_paths(partials);
+}
+
+/// Frees a forward path stitcher.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_free(
+    stitcher: *mut sg_forward_partial_path_stitcher,
+) {
+    drop(unsafe { Box::from_raw(stitcher as *mut InternalForwardPartialPathStitcher) });
+}
+
+//-------------------------------------------------------------------------------------------------
+// Cancellation
+
+struct AtomicUsizeCancellationFlag<'a>(Option<&'a AtomicUsize>);
+impl CancellationFlag for AtomicUsizeCancellationFlag<'_> {
+    fn check(&self, at: &'static str) -> Result<(), crate::CancellationError> {
+        self.0
+            .map(|flag| {
+                if flag.fetch_and(0b0, std::sync::atomic::Ordering::Relaxed) != 0 {
+                    Err(CancellationError(at))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_or(Ok(()))
+    }
+}
+
+/// Describes the result of a computation
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum sg_result {
+    SG_RESULT_SUCCESS,
+    SG_RESULT_CANCELLED,
+}
+
+impl<T> From<Result<T, CancellationError>> for sg_result {
+    fn from(result: Result<T, CancellationError>) -> Self {
+        match result {
+            Ok(_) => Self::SG_RESULT_SUCCESS,
+            Err(_) => Self::SG_RESULT_CANCELLED,
+        }
+    }
+}

--- a/crates/metaslang/stack_graphs/src/cycles.rs
+++ b/crates/metaslang/stack_graphs/src/cycles.rs
@@ -1,0 +1,406 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Detect and avoid cycles in our path-finding algorithm.
+//!
+//! Cycles in a stack graph can indicate many things.  Your language might allow mutually recursive
+//! imports.  If you are modeling dataflow through function calls, then any recursion in your
+//! function calls will lead to cycles in your stack graph.  And if you have any control-flow paths
+//! that lead to infinite loops at runtime, we'll probably discover those as stack graph paths
+//! during the path-finding algorithm.
+//!
+//! (Note that we're only considering cycles in well-formed paths.  For instance, _pop symbol_
+//! nodes are "guards" that don't allow you to progress into a node if the top of the symbol stack
+//! doesn't match.  We don't consider that a valid path, and so we don't have to worry about
+//! whether it contains any cycles.)
+//!
+//! This module implements a cycle detector that lets us detect these situations and "cut off"
+//! these paths, not trying to extend them any further.  Note that any cycle detection logic we
+//! implement will be a heuristic.  In particular, since our path-finding algorithm will mimic any
+//! runtime recursion, a "complete" cycle detection logic would be equivalent to the Halting
+//! Problem.
+//!
+//! Right now, we implement a simple heuristic where we limit the number of distinct paths that we
+//! process that have the same start and end nodes.  We do not make any guarantees that we will
+//! always use this particular heuristic, however!  We reserve the right to change the heuristic at
+//! any time.
+
+use enumset::EnumSet;
+use smallvec::SmallVec;
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use crate::arena::Arena;
+use crate::arena::Handle;
+use crate::arena::List;
+use crate::arena::ListArena;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::partial::Cyclicity;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::paths::PathResolutionError;
+use crate::stats::FrequencyDistribution;
+use crate::stitching::Appendable;
+use crate::stitching::ToAppendable;
+
+/// Helps detect similar paths in the path-finding algorithm.
+pub struct SimilarPathDetector<P> {
+    paths: HashMap<PathKey, SmallVec<[P; 4]>>,
+    counts: Option<HashMap<PathKey, SmallVec<[usize; 4]>>>,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct PathKey {
+    start_node: Handle<Node>,
+    end_node: Handle<Node>,
+    symbol_stack_precondition_len: usize,
+    scope_stack_precondition_len: usize,
+    symbol_stack_postcondition_len: usize,
+    scope_stack_postcondition_len: usize,
+}
+
+#[doc(hidden)]
+pub trait HasPathKey: Clone {
+    type Arena;
+    fn key(&self) -> PathKey;
+}
+
+impl HasPathKey for PartialPath {
+    type Arena = PartialPaths;
+
+    fn key(&self) -> PathKey {
+        PathKey {
+            start_node: self.start_node,
+            end_node: self.end_node,
+            symbol_stack_precondition_len: self.symbol_stack_precondition.len(),
+            scope_stack_precondition_len: self.scope_stack_precondition.len(),
+            symbol_stack_postcondition_len: self.symbol_stack_postcondition.len(),
+            scope_stack_postcondition_len: self.scope_stack_postcondition.len(),
+        }
+    }
+}
+
+impl<P> SimilarPathDetector<P>
+where
+    P: HasPathKey,
+{
+    /// Creates a new, empty cycle detector.
+    pub fn new() -> SimilarPathDetector<P> {
+        SimilarPathDetector {
+            paths: HashMap::new(),
+            counts: None,
+        }
+    }
+
+    /// Set whether to collect statistics for this similar path detector.
+    pub fn set_collect_stats(&mut self, collect_stats: bool) {
+        if !collect_stats {
+            self.counts = None;
+        } else if self.counts.is_none() {
+            self.counts = Some(HashMap::new());
+        }
+    }
+
+    /// Add a path, and determine whether we should process this path during the path-finding algorithm.
+    /// If we have seen a path with the same start and end node, and the same pre- and postcondition, then
+    /// we return false. Otherwise, we return true.
+    pub fn add_path<Cmp>(
+        &mut self,
+        _graph: &StackGraph,
+        arena: &mut P::Arena,
+        path: &P,
+        cmp: Cmp,
+    ) -> bool
+    where
+        Cmp: Fn(&mut P::Arena, &P, &P) -> Option<Ordering>,
+    {
+        let key = path.key();
+
+        // Iterate through the bucket to determine if this paths is better than any already known
+        // path. Note that the bucket might be modified during the loop if a path is removed which
+        // is shadowed by the new path!
+        let possibly_similar_paths = self.paths.entry(key.clone()).or_default();
+        let mut possible_similar_counts = self
+            .counts
+            .as_mut()
+            .map(move |cs| cs.entry(key).or_default());
+        let mut idx = 0;
+        let mut count = 0;
+        while idx < possibly_similar_paths.len() {
+            let other_path = &mut possibly_similar_paths[idx];
+            match cmp(arena, path, other_path) {
+                Some(Ordering::Less) => {
+                    // the new path is better, remove the old one
+                    possibly_similar_paths.remove(idx);
+                    if let Some(possible_similar_counts) = possible_similar_counts.as_mut() {
+                        count += possible_similar_counts[idx];
+                        possible_similar_counts.remove(idx);
+                    }
+                    // keep `idx` which now points to the next element
+                    continue;
+                }
+                Some(_) => {
+                    // the new path is equal or worse, and ignored
+                    if let Some(possible_similar_counts) = possible_similar_counts {
+                        possible_similar_counts[idx] += 1;
+                    }
+                    return true;
+                }
+                None => {
+                    idx += 1;
+                }
+            }
+        }
+
+        // this path is either new or better, keep it
+        possibly_similar_paths.push(path.clone());
+        if let Some(possible_similar_counts) = possible_similar_counts {
+            possible_similar_counts.push(count);
+        }
+        false
+    }
+
+    #[cfg(feature = "copious-debugging")]
+    pub fn max_bucket_size(&self) -> usize {
+        self.paths.iter().map(|b| b.1.len()).max().unwrap_or(0)
+    }
+
+    // Returns the distribution of similar path counts.
+    pub fn stats(&self) -> SimilarPathStats {
+        let mut stats = SimilarPathStats::default();
+        if let Some(counts) = &self.counts {
+            for bucket in counts.values() {
+                stats.similar_path_bucket_size.record(bucket.len());
+                for count in bucket.iter() {
+                    stats.similar_path_count.record(*count);
+                }
+            }
+        }
+        stats
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SimilarPathStats {
+    // The distribution of the number of similar paths detected
+    pub similar_path_count: FrequencyDistribution<usize>,
+    // The distribution of the internal bucket sizes in the similar path detector
+    pub similar_path_bucket_size: FrequencyDistribution<usize>,
+}
+
+impl std::ops::AddAssign<Self> for SimilarPathStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.similar_path_bucket_size += rhs.similar_path_bucket_size;
+        self.similar_path_count += rhs.similar_path_count;
+    }
+}
+
+impl std::ops::AddAssign<&Self> for SimilarPathStats {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.similar_path_bucket_size += &rhs.similar_path_bucket_size;
+        self.similar_path_count += &rhs.similar_path_count;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Cycle detector
+
+/// An arena used by [`AppendingCycleDetector`][] to store the path component lists.
+/// The arena is shared between all cycle detectors in a path stitching run, so that
+/// the cycle detectors themselves can be small and cheaply cloned.
+pub struct Appendables<H> {
+    /// List arena for appendable lists
+    elements: ListArena<InternedOrHandle<H>>,
+    /// Arena for interned partial paths
+    interned: Arena<PartialPath>,
+}
+
+impl<H> Appendables<H> {
+    pub fn new() -> Self {
+        Self {
+            elements: ListArena::new(),
+            interned: Arena::new(),
+        }
+    }
+}
+
+/// Enum that unifies handles to initial paths interned in the cycle detector, and appended
+/// handles to appendables in the external database.
+#[derive(Clone)]
+enum InternedOrHandle<H> {
+    Interned(Handle<PartialPath>),
+    Database(H),
+}
+
+impl<H> InternedOrHandle<H>
+where
+    H: Clone,
+{
+    fn append_to<'a, A, Db>(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &'a Db,
+        interned: &Arena<PartialPath>,
+        path: &mut PartialPath,
+    ) -> Result<(), PathResolutionError>
+    where
+        A: Appendable + 'a,
+        Db: ToAppendable<H, A>,
+    {
+        match self {
+            Self::Interned(h) => interned.get(*h).append_to(graph, partials, path),
+            Self::Database(h) => db.get_appendable(h).append_to(graph, partials, path),
+        }
+    }
+
+    fn start_node<'a, A, Db>(&self, db: &'a Db, interned: &Arena<PartialPath>) -> Handle<Node>
+    where
+        A: Appendable + 'a,
+        Db: ToAppendable<H, A>,
+    {
+        match self {
+            Self::Interned(h) => interned.get(*h).start_node,
+            Self::Database(h) => db.get_appendable(h).start_node(),
+        }
+    }
+
+    fn end_node<'a, A, Db>(&self, db: &'a Db, interned: &Arena<PartialPath>) -> Handle<Node>
+    where
+        A: Appendable + 'a,
+        Db: ToAppendable<H, A>,
+    {
+        match self {
+            Self::Interned(h) => interned.get(*h).end_node,
+            Self::Database(h) => db.get_appendable(h).end_node(),
+        }
+    }
+}
+
+/// A cycle detector that builds up paths by appending elements to it.
+/// Path elements are stored in a shared arena that must be provided
+/// when calling methods, so that cloning the cycle detector itself is
+/// cheap.
+#[derive(Clone)]
+pub struct AppendingCycleDetector<H> {
+    appendages: List<InternedOrHandle<H>>,
+}
+
+impl<H> AppendingCycleDetector<H> {
+    pub fn new() -> Self {
+        Self {
+            appendages: List::empty(),
+        }
+    }
+
+    pub fn from(appendables: &mut Appendables<H>, path: PartialPath) -> Self {
+        let h = appendables.interned.add(path);
+        let mut result = Self::new();
+        result
+            .appendages
+            .push_front(&mut appendables.elements, InternedOrHandle::Interned(h));
+        result
+    }
+
+    pub fn append(&mut self, appendables: &mut Appendables<H>, appendage: H) {
+        self.appendages.push_front(
+            &mut appendables.elements,
+            InternedOrHandle::Database(appendage),
+        );
+    }
+}
+
+impl<H> AppendingCycleDetector<H>
+where
+    H: Clone,
+{
+    /// Tests if the path is cyclic. Returns a vector indicating the kind of cycles that were found.
+    /// If appending or concatenating all fragments succeeds, this function will never raise and error.
+    pub fn is_cyclic<'a, A, Db>(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &'a Db,
+        appendables: &mut Appendables<H>,
+    ) -> Result<EnumSet<Cyclicity>, PathResolutionError>
+    where
+        A: Appendable + 'a,
+        Db: ToAppendable<H, A>,
+    {
+        let mut cycles = EnumSet::new();
+
+        let end_node = match self.appendages.clone().pop_front(&mut appendables.elements) {
+            Some(appendage) => appendage.end_node(db, &appendables.interned),
+            None => return Ok(cycles),
+        };
+
+        let mut maybe_cyclic_path = None;
+        let mut remaining_appendages = self.appendages;
+        // Unlike the stored appendages, which are stored in a shared arena, we use a _local_
+        // buffer to collect the prefix appendages that we collect for possible cycles. This is
+        // to prevent adding elements to the shared arena for every invocation of this method,
+        // because they would remain in the arena after the method returns. We take care to
+        // minimize (re)allocations by (a) only allocating when a possible cycle is detected,
+        // (b) reserving all necessary space before adding elements, and (c) reusing the buffer
+        // between loop iterations.
+        let mut prefix_appendages = Vec::new();
+        loop {
+            // find cycle length
+            let mut counting_appendages = remaining_appendages;
+            let mut cycle_length = 0usize;
+            loop {
+                let appendable = counting_appendages.pop_front(&mut appendables.elements);
+                match appendable {
+                    Some(appendage) => {
+                        cycle_length += 1;
+                        let is_cycle = appendage.start_node(db, &appendables.interned) == end_node;
+                        if is_cycle {
+                            break;
+                        }
+                    }
+                    None => return Ok(cycles),
+                }
+            }
+
+            // collect prefix elements (reversing their order)
+            prefix_appendages.clear();
+            prefix_appendages.reserve(cycle_length);
+            for _ in 0..cycle_length {
+                let appendable = remaining_appendages
+                    .pop_front(&mut appendables.elements)
+                    .expect("")
+                    .clone();
+                prefix_appendages.push(appendable);
+            }
+
+            // build prefix path -- prefix starts at end_node, because this is a cycle
+            let mut prefix_path = PartialPath::from_node(graph, partials, end_node);
+            while let Some(appendage) = prefix_appendages.pop() {
+                appendage.append_to(
+                    graph,
+                    partials,
+                    db,
+                    &appendables.interned,
+                    &mut prefix_path,
+                )?;
+            }
+
+            // build cyclic path
+            let cyclic_path = maybe_cyclic_path
+                .unwrap_or_else(|| PartialPath::from_node(graph, partials, end_node));
+            cyclic_path.append_to(graph, partials, &mut prefix_path)?;
+            if prefix_path.edges.len() > 0 {
+                if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {
+                    cycles |= cyclicity;
+                }
+            }
+            maybe_cyclic_path = Some(prefix_path);
+        }
+    }
+}

--- a/crates/metaslang/stack_graphs/src/debugging.rs
+++ b/crates/metaslang/stack_graphs/src/debugging.rs
@@ -1,0 +1,19 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "copious-debugging")]
+#[macro_export]
+macro_rules! copious_debugging {
+    ($($arg:tt)*) => {{ ::std::eprintln!($($arg)*); }}
+
+}
+
+#[cfg(not(feature = "copious-debugging"))]
+#[macro_export]
+macro_rules! copious_debugging {
+    ($($arg:tt)*) => {};
+}

--- a/crates/metaslang/stack_graphs/src/graph.rs
+++ b/crates/metaslang/stack_graphs/src/graph.rs
@@ -1,0 +1,1682 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines the structure of a stack graph.
+//!
+//! This module contains all of the types that you need to define the structure of a particular
+//! stack graph.
+//!
+//! The stack graph as a whole lives in an instance of [`StackGraph`][].  This type contains
+//! several [`Arena`s][`Arena`], which are used to manage the life cycle of the data instances that
+//! comprise the stack graph.  You cannot delete anything from the stack graph; all of its contents
+//! are dropped in a single operation when the graph itself is dropped.
+//!
+//! [`Arena`]: ../arena/struct.Arena.html
+//! [`StackGraph`]: struct.StackGraph.html
+//!
+//! There are several different kinds of node that can appear in a stack graph.  As we search for a
+//! path representing a name binding, each kind of node has different rules for how it interacts
+//! with the symbol and scope stacks:
+//!
+//!   - the singleton [_root node_][`RootNode`], which allows name binding paths to cross between
+//!     files
+//!   - [_scope_][`ScopeNode`] nodes, which define the name binding structure within a single file
+//!   - [_push symbol_][`PushSymbolNode`] and [_push scoped symbol_][`PushScopedSymbolNode`] nodes,
+//!     which push onto the symbol stack new things for us to look for
+//!   - [_pop symbol_][`PopSymbolNode`] and [_pop scoped symbol_][`PopScopedSymbolNode`] nodes,
+//!     which pop things off the symbol stack once they've been found
+//!   - [_drop scopes_][`DropScopesNode`] and [_jump to scope_][`JumpToNode`] nodes, which
+//!     manipulate the scope stack
+//!
+//! [`DropScopesNode`]: struct.DropScopesNode.html
+//! [`JumpToNode`]: struct.JumpToNode.html
+//! [`PushScopedSymbolNode`]: struct.PushScopedSymbolNode.html
+//! [`PushSymbolNode`]: struct.PushSymbolNode.html
+//! [`PopScopedSymbolNode`]: struct.PopScopedSymbolNode.html
+//! [`PopSymbolNode`]: struct.PopSymbolNode.html
+//! [`RootNode`]: struct.RootNode.html
+//! [`ScopeNode`]: struct.ScopeNode.html
+//!
+//! All nodes except for the singleton _root node_ and _jump to scope_ node belong to
+//! [files][`File`].
+//!
+//! Nodes are connected via [edges][`Edge`].
+//!
+//! [`Edge`]: struct.Edge.html
+//! [`File`]: struct.File.html
+
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::num::NonZeroU32;
+use std::ops::Index;
+use std::ops::IndexMut;
+
+use controlled_option::ControlledOption;
+use either::Either;
+use fxhash::FxHashMap;
+use smallvec::SmallVec;
+
+use crate::arena::Arena;
+use crate::arena::Handle;
+use crate::arena::SupplementalArena;
+
+//-------------------------------------------------------------------------------------------------
+// String content
+
+#[repr(C)]
+struct InternedStringContent {
+    // See InternedStringArena below for how we fill in these fields safely.
+    start: *const u8,
+    len: usize,
+}
+
+const INITIAL_STRING_CAPACITY: usize = 512;
+
+/// The content of each interned string is stored in one of the buffers inside of a
+/// `InternedStringArena` instance, following the trick [described by Aleksey Kladov][interner].
+///
+/// The buffers stored in this type are preallocated, and are never allowed to grow.  That ensures
+/// that pointers into the buffer are stable, as long as the buffer has not been destroyed.
+/// (`InternedStringContent` instances are also stored in an arena, ensuring that the strings that
+/// we hand out don't outlive the buffers.)
+///
+/// [interner]: https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html
+struct InternedStringArena {
+    current_buffer: Vec<u8>,
+    full_buffers: Vec<Vec<u8>>,
+}
+
+impl InternedStringArena {
+    fn new() -> InternedStringArena {
+        InternedStringArena {
+            current_buffer: Vec::with_capacity(INITIAL_STRING_CAPACITY),
+            full_buffers: Vec::new(),
+        }
+    }
+
+    // Adds a new string.  This does not check whether we've already stored a string with the same
+    // content; that is handled down below in `StackGraph::add_symbol` and `add_file`.
+    fn add(&mut self, value: &str) -> InternedStringContent {
+        // Is there enough room in current_buffer to hold this string?
+        let value = value.as_bytes();
+        let len = value.len();
+        let capacity = self.current_buffer.capacity();
+        let remaining_capacity = capacity - self.current_buffer.len();
+        if len > remaining_capacity {
+            // If not, move current_buffer over into full_buffers (so that we hang onto it until
+            // we're dropped) and allocate a new current_buffer that's at least big enough to hold
+            // this string.
+            let new_capacity = (capacity.max(len) + 1).next_power_of_two();
+            let new_buffer = Vec::with_capacity(new_capacity);
+            let old_buffer = std::mem::replace(&mut self.current_buffer, new_buffer);
+            self.full_buffers.push(old_buffer);
+        }
+
+        // Copy the string's content into current_buffer and return a pointer to it.  That pointer
+        // is stable since we never allow the current_buffer to be resized — once we run out of
+        // room, we allocate a _completely new buffer_ to replace it.
+        let start_index = self.current_buffer.len();
+        self.current_buffer.extend_from_slice(value);
+        let start = unsafe { self.current_buffer.as_ptr().add(start_index) };
+        InternedStringContent { start, len }
+    }
+}
+
+impl InternedStringContent {
+    /// Returns the content of this string as a `str`.  This is safe as long as the lifetime of the
+    /// InternedStringContent is outlived by the lifetime of the InternedStringArena that holds its
+    /// data.  That is guaranteed because we store the InternedStrings in an Arena alongside the
+    /// InternedStringArena, and only hand out references to them.
+    fn as_str(&self) -> &str {
+        unsafe {
+            let bytes = std::slice::from_raw_parts(self.start, self.len);
+            std::str::from_utf8_unchecked(bytes)
+        }
+    }
+
+    // Returns a supposedly 'static reference to the string's data.  The string data isn't really
+    // static, but we are careful only to use this as a key in the HashMap that StackGraph uses to
+    // track whether we've stored a particular symbol already.  That HashMap lives alongside the
+    // InternedStringArena that holds the data, so we can get away with a technically incorrect
+    // 'static lifetime here.  As an extra precaution, this method is is marked as unsafe so that
+    // we don't inadvertently call it from anywhere else in the crate.
+    unsafe fn as_hash_key(&self) -> &'static str {
+        let bytes = std::slice::from_raw_parts(self.start, self.len);
+        std::str::from_utf8_unchecked(bytes)
+    }
+}
+
+unsafe impl Send for InternedStringContent {}
+unsafe impl Sync for InternedStringContent {}
+
+//-------------------------------------------------------------------------------------------------
+// Symbols
+
+/// A name that we are trying to resolve using stack graphs.
+///
+/// This typically represents a portion of an identifier as it appears in the source language.  It
+/// can also represent some other "operation" that can occur in source code, and which needs to be
+/// modeled in a stack graph — for instance, many languages will use a "fake" symbol named `.` to
+/// represent member access.
+///
+/// We deduplicate `Symbol` instances in a `StackGraph` — that is, we ensure that there are never
+/// multiple `Symbol` instances with the same content.  That means that you can compare _handles_
+/// to symbols using simple equality, without having to dereference into the `StackGraph` arena.
+#[repr(C)]
+pub struct Symbol {
+    content: InternedStringContent,
+}
+
+impl Symbol {
+    pub fn as_str(&self) -> &str {
+        self.content.as_str()
+    }
+}
+
+impl PartialEq<&str> for Symbol {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl StackGraph {
+    /// Adds a symbol to the stack graph, ensuring that there's only ever one copy of a particular
+    /// symbol stored in the graph.
+    pub fn add_symbol<S: AsRef<str> + ?Sized>(&mut self, symbol: &S) -> Handle<Symbol> {
+        let symbol = symbol.as_ref();
+        if let Some(handle) = self.symbol_handles.get(symbol) {
+            return *handle;
+        }
+
+        let interned = self.interned_strings.add(symbol);
+        let hash_key = unsafe { interned.as_hash_key() };
+        let handle = self.symbols.add(Symbol { content: interned });
+        self.symbol_handles.insert(hash_key, handle);
+        handle
+    }
+
+    /// Returns an iterator over all of the handles of all of the symbols in this stack graph.
+    /// (Note that because we're only returning _handles_, this iterator does not retain a
+    /// reference to the `StackGraph`.)
+    pub fn iter_symbols(&self) -> impl Iterator<Item = Handle<Symbol>> {
+        self.symbols.iter_handles()
+    }
+}
+
+impl Index<Handle<Symbol>> for StackGraph {
+    type Output = str;
+    #[inline(always)]
+    fn index(&self, handle: Handle<Symbol>) -> &str {
+        self.symbols.get(handle).as_str()
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplaySymbol<'a> {
+    wrapped: Handle<Symbol>,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplaySymbol<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", &self.graph[self.wrapped])
+    }
+}
+
+impl Handle<Symbol> {
+    pub fn display(self, graph: &StackGraph) -> impl Display + '_ {
+        DisplaySymbol {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Interned strings
+
+/// Arbitrary string content associated with some part of a stack graph.
+#[repr(C)]
+pub struct InternedString {
+    content: InternedStringContent,
+}
+
+impl InternedString {
+    fn as_str(&self) -> &str {
+        self.content.as_str()
+    }
+}
+
+impl PartialEq<&str> for InternedString {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl StackGraph {
+    /// Adds an interned string to the stack graph, ensuring that there's only ever one copy of a
+    /// particular string stored in the graph.
+    pub fn add_string<S: AsRef<str> + ?Sized>(&mut self, string: &S) -> Handle<InternedString> {
+        let string = string.as_ref();
+        if let Some(handle) = self.string_handles.get(string) {
+            return *handle;
+        }
+
+        let interned = self.interned_strings.add(string);
+        let hash_key = unsafe { interned.as_hash_key() };
+        let handle = self.strings.add(InternedString { content: interned });
+        self.string_handles.insert(hash_key, handle);
+        handle
+    }
+
+    /// Returns an iterator over all of the handles of all of the interned strings in this stack
+    /// graph. (Note that because we're only returning _handles_, this iterator does not retain a
+    /// reference to the `StackGraph`.)
+    pub fn iter_strings(&self) -> impl Iterator<Item = Handle<InternedString>> {
+        self.strings.iter_handles()
+    }
+}
+
+impl Index<Handle<InternedString>> for StackGraph {
+    type Output = str;
+    #[inline(always)]
+    fn index(&self, handle: Handle<InternedString>) -> &str {
+        self.strings.get(handle).as_str()
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayInternedString<'a> {
+    wrapped: Handle<InternedString>,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayInternedString<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", &self.graph[self.wrapped])
+    }
+}
+
+impl Handle<InternedString> {
+    pub fn display(self, graph: &StackGraph) -> impl Display + '_ {
+        DisplayInternedString {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Files
+
+/// A source file that we have extracted stack graph data from.
+///
+/// It's up to you to choose what names to use for your files, but they must be unique within a
+/// stack graph.  If you are analyzing files from the local filesystem, the file's path is a good
+/// choice.  If your files belong to packages or repositories, they should include the package or
+/// repository IDs to make sure that files in different packages or repositories don't clash with
+/// each other.
+pub struct File {
+    /// The name of this source file.
+    name: InternedStringContent,
+}
+
+impl File {
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl StackGraph {
+    /// Adds a file to the stack graph.  There can only ever be one file with a particular name in
+    /// the graph.  If a file with the requested name already exists, we return `Err`; if it
+    /// doesn't already exist, we return `Ok`.  In both cases, the value of the result is the
+    /// file's handle.
+    pub fn add_file<S: AsRef<str> + ?Sized>(
+        &mut self,
+        name: &S,
+    ) -> Result<Handle<File>, Handle<File>> {
+        let name = name.as_ref();
+        if let Some(handle) = self.file_handles.get(name) {
+            return Err(*handle);
+        }
+
+        let interned = self.interned_strings.add(name);
+        let hash_key = unsafe { interned.as_hash_key() };
+        let handle = self.files.add(File { name: interned });
+        self.file_handles.insert(hash_key, handle);
+        Ok(handle)
+    }
+
+    /// Adds a file to the stack graph, returning its handle.  There can only ever be one file with
+    /// a particular name in the graph, so if you call this multiple times with the same name,
+    /// you'll get the same handle each time.
+    #[inline(always)]
+    pub fn get_or_create_file<S: AsRef<str> + ?Sized>(&mut self, name: &S) -> Handle<File> {
+        self.add_file(name).unwrap_or_else(|handle| handle)
+    }
+
+    /// Returns the file with a particular name, if it exists.
+    pub fn get_file<S: AsRef<str> + ?Sized>(&self, name: &S) -> Option<Handle<File>> {
+        let name = name.as_ref();
+        self.file_handles.get(name).copied()
+    }
+}
+
+impl StackGraph {
+    /// Returns an iterator of all of the nodes that belong to a particular file.  Note that this
+    /// does **_not_** include the singleton _root_ or _jump to scope_ nodes.
+    pub fn nodes_for_file(&self, file: Handle<File>) -> impl Iterator<Item = Handle<Node>> + '_ {
+        self.node_id_handles.nodes_for_file(file)
+    }
+
+    /// Returns an iterator over all of the handles of all of the files in this stack graph.  (Note
+    /// that because we're only returning _handles_, this iterator does not retain a reference to
+    /// the `StackGraph`.)
+    pub fn iter_files(&self) -> impl Iterator<Item = Handle<File>> + '_ {
+        self.files.iter_handles()
+    }
+}
+
+impl Display for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl Index<Handle<File>> for StackGraph {
+    type Output = File;
+    #[inline(always)]
+    fn index(&self, handle: Handle<File>) -> &File {
+        &self.files.get(handle)
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayFile<'a> {
+    wrapped: Handle<File>,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayFile<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.graph[self.wrapped])
+    }
+}
+
+impl Handle<File> {
+    pub fn display(self, graph: &StackGraph) -> impl Display + '_ {
+        DisplayFile {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Nodes
+
+/// Uniquely identifies a node in a stack graph.
+///
+/// Each node (except for the _root node_ and _jump to scope_ node) lives in a file, and has a
+/// _local ID_ that must be unique within its file.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NodeID {
+    file: ControlledOption<Handle<File>>,
+    local_id: u32,
+}
+
+pub(crate) const ROOT_NODE_ID: u32 = 1;
+pub(crate) const JUMP_TO_NODE_ID: u32 = 2;
+
+impl NodeID {
+    /// Returns the ID of the singleton _root node_.
+    #[inline(always)]
+    pub fn root() -> NodeID {
+        NodeID {
+            file: ControlledOption::none(),
+            local_id: ROOT_NODE_ID,
+        }
+    }
+
+    /// Returns the ID of the singleton _jump to scope_ node.
+    #[inline(always)]
+    pub fn jump_to() -> NodeID {
+        NodeID {
+            file: ControlledOption::none(),
+            local_id: JUMP_TO_NODE_ID,
+        }
+    }
+
+    /// Creates a new file-local node ID.
+    #[inline(always)]
+    pub fn new_in_file(file: Handle<File>, local_id: u32) -> NodeID {
+        NodeID {
+            file: ControlledOption::some(file),
+            local_id,
+        }
+    }
+
+    /// Returns whether this ID refers to the singleton _root node_.
+    #[inline(always)]
+    pub fn is_root(self) -> bool {
+        self.file.is_none() && self.local_id == ROOT_NODE_ID
+    }
+
+    /// Returns whether this ID refers to the singleton _jump to scope_ node.
+    #[inline(always)]
+    pub fn is_jump_to(self) -> bool {
+        self.file.is_none() && self.local_id == JUMP_TO_NODE_ID
+    }
+
+    /// Returns the file that this node belongs to.  Returns `None` for the singleton _root_ and
+    /// _jump to scope_ nodes, which belong to all files.
+    #[inline(always)]
+    pub fn file(self) -> Option<Handle<File>> {
+        self.file.into()
+    }
+
+    /// Returns the local ID of this node within its file.  Panics if this node ID refers to the
+    /// singleton _root_ or _jump to scope_ nodes.
+    #[inline(always)]
+    pub fn local_id(self) -> u32 {
+        self.local_id
+    }
+
+    /// Returns whether this node belongs to a particular file.  Always returns `true` for the
+    /// singleton _root_ and _jump to scope_ nodes, which belong to all files.
+    #[inline(always)]
+    pub fn is_in_file(self, file: Handle<File>) -> bool {
+        match self.file.into_option() {
+            Some(this_file) => this_file == file,
+            _ => true,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayNodeID<'a> {
+    wrapped: NodeID,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayNodeID<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.wrapped.file.into_option() {
+            Some(file) => write!(f, "{}({})", file.display(self.graph), self.wrapped.local_id),
+            None => {
+                if self.wrapped.is_root() {
+                    write!(f, "[root]")
+                } else if self.wrapped.is_jump_to() {
+                    write!(f, "[jump]")
+                } else {
+                    unreachable!();
+                }
+            }
+        }
+    }
+}
+
+impl NodeID {
+    pub fn display(self, graph: &StackGraph) -> impl Display + '_ {
+        DisplayNodeID {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+/// A node in a stack graph.
+#[repr(C)]
+pub enum Node {
+    DropScopes(DropScopesNode),
+    JumpTo(JumpToNode),
+    PopScopedSymbol(PopScopedSymbolNode),
+    PopSymbol(PopSymbolNode),
+    PushScopedSymbol(PushScopedSymbolNode),
+    PushSymbol(PushSymbolNode),
+    Root(RootNode),
+    Scope(ScopeNode),
+}
+
+impl Node {
+    #[inline(always)]
+    pub fn is_exported_scope(&self) -> bool {
+        match self {
+            Node::Scope(node) => node.is_exported,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_definition(&self) -> bool {
+        match self {
+            Node::PopScopedSymbol(node) => node.is_definition,
+            Node::PopSymbol(node) => node.is_definition,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_reference(&self) -> bool {
+        match self {
+            Node::PushScopedSymbol(node) => node.is_reference,
+            Node::PushSymbol(node) => node.is_reference,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_jump_to(&self) -> bool {
+        matches!(self, Node::JumpTo(_))
+    }
+
+    #[inline(always)]
+    pub fn is_root(&self) -> bool {
+        matches!(self, Node::Root(_))
+    }
+
+    #[inline(always)]
+    pub fn is_endpoint(&self) -> bool {
+        self.is_definition() || self.is_exported_scope() || self.is_reference() || self.is_root()
+    }
+
+    /// Returns this node's symbol, if it has one.  (_Pop symbol_, _pop scoped symbol_, _push
+    /// symbol_, and _push scoped symbol_ nodes have symbols.)
+    pub fn symbol(&self) -> Option<Handle<Symbol>> {
+        match self {
+            Node::PushScopedSymbol(node) => Some(node.symbol),
+            Node::PushSymbol(node) => Some(node.symbol),
+            Node::PopScopedSymbol(node) => Some(node.symbol),
+            Node::PopSymbol(node) => Some(node.symbol),
+            _ => None,
+        }
+    }
+
+    /// Returns this node's attached scope, if it has one.  (_Push scoped symbol_ nodes have
+    /// attached scopes.)
+    pub fn scope(&self) -> Option<NodeID> {
+        match self {
+            Node::PushScopedSymbol(node) => Some(node.scope),
+            _ => None,
+        }
+    }
+
+    /// Returns the ID of this node.
+    pub fn id(&self) -> NodeID {
+        match self {
+            Node::DropScopes(node) => node.id,
+            Node::JumpTo(node) => node.id,
+            Node::PushScopedSymbol(node) => node.id,
+            Node::PushSymbol(node) => node.id,
+            Node::PopScopedSymbol(node) => node.id,
+            Node::PopSymbol(node) => node.id,
+            Node::Root(node) => node.id,
+            Node::Scope(node) => node.id,
+        }
+    }
+
+    /// Returns the file that this node belongs to.  Returns `None` for the singleton _root_ and
+    /// _jump to scope_ nodes, which belong to all files.
+    #[inline(always)]
+    pub fn file(&self) -> Option<Handle<File>> {
+        self.id().file()
+    }
+
+    /// Returns whether this node belongs to a particular file.  Always returns `true` for the
+    /// singleton _root_ and _jump to scope_ nodes, which belong to all files.
+    #[inline(always)]
+    pub fn is_in_file(&self, file: Handle<File>) -> bool {
+        self.id().is_in_file(file)
+    }
+
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+impl StackGraph {
+    /// Returns a handle to the stack graph's singleton _jump to scope_ node.
+    #[inline(always)]
+    pub fn jump_to_node() -> Handle<Node> {
+        Handle::new(unsafe { NonZeroU32::new_unchecked(2) })
+    }
+
+    /// Returns a handle to the stack graph's singleton _root node_.
+    #[inline(always)]
+    pub fn root_node() -> Handle<Node> {
+        Handle::new(unsafe { NonZeroU32::new_unchecked(1) })
+    }
+
+    /// Returns an unused [`NodeID`][] for the given file.
+    ///
+    /// [`NodeID`]: struct.NodeID.html
+    pub fn new_node_id(&mut self, file: Handle<File>) -> NodeID {
+        self.node_id_handles.unused_id(file)
+    }
+
+    /// Returns an iterator of all of the nodes in the graph.  (Note that because we're only
+    /// returning _handles_, this iterator does not retain a reference to the `StackGraph`.)
+    pub fn iter_nodes(&self) -> impl Iterator<Item = Handle<Node>> {
+        self.nodes.iter_handles()
+    }
+
+    /// Returns the handle to the node with a particular ID, if it exists.
+    pub fn node_for_id(&self, id: NodeID) -> Option<Handle<Node>> {
+        if id.file().is_some() {
+            self.node_id_handles.try_handle_for_id(id)
+        } else if id.is_root() {
+            Some(StackGraph::root_node())
+        } else if id.is_jump_to() {
+            Some(StackGraph::jump_to_node())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn add_node(&mut self, id: NodeID, node: Node) -> Option<Handle<Node>> {
+        if let Some(_) = self.node_id_handles.handle_for_id(id) {
+            return None;
+        }
+        let handle = self.nodes.add(node);
+        self.node_id_handles.set_handle_for_id(id, handle);
+        Some(handle)
+    }
+
+    pub(crate) fn get_or_create_node(&mut self, id: NodeID, node: Node) -> Handle<Node> {
+        if let Some(handle) = self.node_id_handles.handle_for_id(id) {
+            return handle;
+        }
+        let handle = self.nodes.add(node);
+        self.node_id_handles.set_handle_for_id(id, handle);
+        handle
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayNode<'a> {
+    wrapped: &'a Node,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.wrapped {
+            Node::DropScopes(node) => node.display(self.graph).fmt(f),
+            Node::JumpTo(node) => node.fmt(f),
+            Node::PushScopedSymbol(node) => node.display(self.graph).fmt(f),
+            Node::PushSymbol(node) => node.display(self.graph).fmt(f),
+            Node::PopScopedSymbol(node) => node.display(self.graph).fmt(f),
+            Node::PopSymbol(node) => node.display(self.graph).fmt(f),
+            Node::Root(node) => node.fmt(f),
+            Node::Scope(node) => node.display(self.graph).fmt(f),
+        }
+    }
+}
+
+impl Handle<Node> {
+    pub fn display(self, graph: &StackGraph) -> impl Display + '_ {
+        DisplayNode {
+            wrapped: &graph[self],
+            graph,
+        }
+    }
+}
+
+impl Index<Handle<Node>> for StackGraph {
+    type Output = Node;
+    #[inline(always)]
+    fn index(&self, handle: Handle<Node>) -> &Node {
+        self.nodes.get(handle)
+    }
+}
+
+impl IndexMut<Handle<Node>> for StackGraph {
+    #[inline(always)]
+    fn index_mut(&mut self, handle: Handle<Node>) -> &mut Node {
+        self.nodes.get_mut(handle)
+    }
+}
+
+/// Removes everything from the current scope stack.
+#[repr(C)]
+pub struct DropScopesNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    _symbol: ControlledOption<Handle<Symbol>>,
+    _scope: NodeID,
+    _is_endpoint: bool,
+}
+
+impl From<DropScopesNode> for Node {
+    fn from(node: DropScopesNode) -> Node {
+        Node::DropScopes(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _drop scopes_ node to the stack graph.
+    pub fn add_drop_scopes_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
+        let node = DropScopesNode {
+            id,
+            _symbol: ControlledOption::none(),
+            _scope: NodeID::default(),
+            _is_endpoint: false,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl DropScopesNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayDropScopesNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayDropScopesNode<'a> {
+    wrapped: &'a DropScopesNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayDropScopesNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(f, "[{} drop scopes]", self.wrapped.id.display(self.graph))
+        }
+    }
+}
+
+/// The singleton "jump to" node, which allows a name binding path to jump back to another part of
+/// the graph.
+#[repr(C)]
+pub struct JumpToNode {
+    id: NodeID,
+    _symbol: ControlledOption<Handle<Symbol>>,
+    _scope: NodeID,
+    _is_endpoint: bool,
+}
+
+impl From<JumpToNode> for Node {
+    fn from(node: JumpToNode) -> Node {
+        Node::JumpTo(node)
+    }
+}
+
+impl JumpToNode {
+    fn new() -> JumpToNode {
+        JumpToNode {
+            id: NodeID::jump_to(),
+            _symbol: ControlledOption::none(),
+            _scope: NodeID::default(),
+            _is_endpoint: false,
+        }
+    }
+}
+
+impl Display for JumpToNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "[jump to scope]")
+    }
+}
+
+/// Pops a scoped symbol from the symbol stack.  If the top of the symbol stack doesn't match the
+/// requested symbol, or if the top of the symbol stack doesn't have an attached scope list, then
+/// the path is not allowed to enter this node.
+#[repr(C)]
+pub struct PopScopedSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to pop off the symbol stack.
+    pub symbol: Handle<Symbol>,
+    _scope: NodeID,
+    /// Whether this node represents a reference in the source language.
+    pub is_definition: bool,
+}
+
+impl From<PopScopedSymbolNode> for Node {
+    fn from(node: PopScopedSymbolNode) -> Node {
+        Node::PopScopedSymbol(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _pop scoped symbol_ node to the stack graph.
+    pub fn add_pop_scoped_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_definition: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PopScopedSymbolNode {
+            id,
+            symbol,
+            _scope: NodeID::default(),
+            is_definition,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl PopScopedSymbolNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayPopScopedSymbolNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayPopScopedSymbolNode<'a> {
+    wrapped: &'a PopScopedSymbolNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayPopScopedSymbolNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{} {} {}]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_definition {
+                    "scoped definition"
+                } else {
+                    "pop scoped"
+                },
+                self.wrapped.symbol.display(self.graph),
+            )
+        }
+    }
+}
+
+/// Pops a symbol from the symbol stack.  If the top of the symbol stack doesn't match the
+/// requested symbol, then the path is not allowed to enter this node.
+#[repr(C)]
+pub struct PopSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to pop off the symbol stack.
+    pub symbol: Handle<Symbol>,
+    _scope: NodeID,
+    /// Whether this node represents a reference in the source language.
+    pub is_definition: bool,
+}
+
+impl From<PopSymbolNode> for Node {
+    fn from(node: PopSymbolNode) -> Node {
+        Node::PopSymbol(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _pop symbol_ node to the stack graph.
+    pub fn add_pop_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_definition: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PopSymbolNode {
+            id,
+            symbol,
+            _scope: NodeID::default(),
+            is_definition,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl PopSymbolNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayPopSymbolNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayPopSymbolNode<'a> {
+    wrapped: &'a PopSymbolNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayPopSymbolNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{} {} {}]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_definition {
+                    "definition"
+                } else {
+                    "pop"
+                },
+                self.wrapped.symbol.display(self.graph),
+            )
+        }
+    }
+}
+
+/// Pushes a scoped symbol onto the symbol stack.
+#[repr(C)]
+pub struct PushScopedSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to push onto the symbol stack.
+    pub symbol: Handle<Symbol>,
+    /// The exported scope node that should be attached to the scoped symbol.  The node ID must
+    /// refer to an exported scope node.
+    pub scope: NodeID,
+    /// Whether this node represents a reference in the source language.
+    pub is_reference: bool,
+    _phantom: (),
+}
+
+impl From<PushScopedSymbolNode> for Node {
+    fn from(node: PushScopedSymbolNode) -> Node {
+        Node::PushScopedSymbol(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _push scoped symbol_ node to the stack graph.
+    pub fn add_push_scoped_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        scope: NodeID,
+        is_reference: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PushScopedSymbolNode {
+            id,
+            symbol,
+            scope,
+            is_reference,
+            _phantom: (),
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl PushScopedSymbolNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayPushScopedSymbolNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayPushScopedSymbolNode<'a> {
+    wrapped: &'a PushScopedSymbolNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayPushScopedSymbolNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{} {} {} {}]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_reference {
+                    "scoped reference"
+                } else {
+                    "push scoped"
+                },
+                self.wrapped.symbol.display(self.graph),
+                self.wrapped.scope.display(self.graph),
+            )
+        }
+    }
+}
+
+/// Pushes a symbol onto the symbol stack.
+#[repr(C)]
+pub struct PushSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to push onto the symbol stack.
+    pub symbol: Handle<Symbol>,
+    _scope: NodeID,
+    /// Whether this node represents a reference in the source language.
+    pub is_reference: bool,
+}
+
+impl From<PushSymbolNode> for Node {
+    fn from(node: PushSymbolNode) -> Node {
+        Node::PushSymbol(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _push symbol_ node to the stack graph.
+    pub fn add_push_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_reference: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PushSymbolNode {
+            id,
+            symbol,
+            _scope: NodeID::default(),
+            is_reference,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl PushSymbolNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayPushSymbolNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayPushSymbolNode<'a> {
+    wrapped: &'a PushSymbolNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayPushSymbolNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{} {} {}]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_reference {
+                    "reference"
+                } else {
+                    "push"
+                },
+                self.wrapped.symbol.display(self.graph),
+            )
+        }
+    }
+}
+
+/// The singleton root node, which allows a name binding path to cross between files.
+#[repr(C)]
+pub struct RootNode {
+    id: NodeID,
+    _symbol: ControlledOption<Handle<Symbol>>,
+    _scope: NodeID,
+    _is_endpoint: bool,
+}
+
+impl From<RootNode> for Node {
+    fn from(node: RootNode) -> Node {
+        Node::Root(node)
+    }
+}
+
+impl RootNode {
+    fn new() -> RootNode {
+        RootNode {
+            id: NodeID::root(),
+            _symbol: ControlledOption::none(),
+            _scope: NodeID::default(),
+            _is_endpoint: false,
+        }
+    }
+}
+
+impl Display for RootNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "[root]")
+    }
+}
+
+struct NodeIDHandles {
+    files: SupplementalArena<File, Vec<Option<Handle<Node>>>>,
+}
+
+impl NodeIDHandles {
+    fn new() -> NodeIDHandles {
+        NodeIDHandles {
+            files: SupplementalArena::new(),
+        }
+    }
+
+    fn try_handle_for_id(&self, node_id: NodeID) -> Option<Handle<Node>> {
+        let file_entry = self.files.get(node_id.file().unwrap())?;
+        let node_index = node_id.local_id as usize;
+        if node_index >= file_entry.len() {
+            return None;
+        }
+        file_entry[node_index]
+    }
+
+    fn handle_for_id(&mut self, node_id: NodeID) -> Option<Handle<Node>> {
+        let file_entry = &mut self.files[node_id.file().unwrap()];
+        let node_index = node_id.local_id as usize;
+        if node_index >= file_entry.len() {
+            file_entry.resize(node_index + 1, None);
+        }
+        file_entry[node_index]
+    }
+
+    fn set_handle_for_id(&mut self, node_id: NodeID, handle: Handle<Node>) {
+        let file_entry = &mut self.files[node_id.file().unwrap()];
+        let node_index = node_id.local_id as usize;
+        file_entry[node_index] = Some(handle);
+    }
+
+    fn unused_id(&mut self, file: Handle<File>) -> NodeID {
+        let local_id = self
+            .files
+            .get(file)
+            .map(|file_entry| file_entry.len() as u32)
+            .unwrap_or(0);
+        NodeID::new_in_file(file, local_id)
+    }
+
+    fn nodes_for_file(&self, file: Handle<File>) -> impl Iterator<Item = Handle<Node>> + '_ {
+        let file_entry = match self.files.get(file) {
+            Some(file_entry) => file_entry,
+            None => return Either::Left(std::iter::empty()),
+        };
+        Either::Right(file_entry.iter().filter_map(|entry| *entry))
+    }
+}
+
+/// A node that adds structure to the graph. If the node is exported, it can be
+/// referred to on the scope stack, which allows "jump to" nodes in any other
+/// part of the graph can jump back here.
+#[repr(C)]
+pub struct ScopeNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    _symbol: ControlledOption<Handle<Symbol>>,
+    _scope: NodeID,
+    pub is_exported: bool,
+}
+
+impl From<ScopeNode> for Node {
+    fn from(node: ScopeNode) -> Node {
+        Node::Scope(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _scope_ node to the stack graph.
+    pub fn add_scope_node(&mut self, id: NodeID, is_exported: bool) -> Option<Handle<Node>> {
+        let node = ScopeNode {
+            id,
+            _symbol: ControlledOption::none(),
+            _scope: NodeID::default(),
+            is_exported,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl ScopeNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayScopeNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayScopeNode<'a> {
+    wrapped: &'a ScopeNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayScopeNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{}{} scope]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_exported {
+                    " exported"
+                } else {
+                    ""
+                },
+            )
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Edges
+
+/// Connects two nodes in a stack graph.
+///
+/// These edges provide the basic graph connectivity that allow us to search for name binding paths
+/// in a stack graph.  (Though not all sequence of edges is a well-formed name binding: the nodes
+/// that you encounter along the path must also satisfy all of the rules for maintaining correct
+/// symbol and scope stacks.)
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Edge {
+    pub source: Handle<Node>,
+    pub sink: Handle<Node>,
+    pub precedence: i32,
+}
+
+pub(crate) struct OutgoingEdge {
+    sink: Handle<Node>,
+    precedence: i32,
+}
+
+impl StackGraph {
+    /// Adds a new edge to the stack graph.
+    pub fn add_edge(&mut self, source: Handle<Node>, sink: Handle<Node>, precedence: i32) {
+        let edges = &mut self.outgoing_edges[source];
+        if let Err(index) = edges.binary_search_by_key(&sink, |o| o.sink) {
+            edges.insert(index, OutgoingEdge { sink, precedence });
+            self.incoming_edges[sink] += Degree::One;
+        }
+    }
+
+    /// Sets edge precedence of the given edge.
+    pub fn set_edge_precedence(
+        &mut self,
+        source: Handle<Node>,
+        sink: Handle<Node>,
+        precedence: i32,
+    ) {
+        let edges = &mut self.outgoing_edges[source];
+        if let Ok(index) = edges.binary_search_by_key(&sink, |o| o.sink) {
+            edges[index].precedence = precedence;
+        }
+    }
+
+    /// Returns an iterator of all of the edges that begin at a particular source node.
+    pub fn outgoing_edges(&self, source: Handle<Node>) -> impl Iterator<Item = Edge> + '_ {
+        match self.outgoing_edges.get(source) {
+            Some(edges) => Either::Right(edges.iter().map(move |o| Edge {
+                source,
+                sink: o.sink,
+                precedence: o.precedence,
+            })),
+            None => Either::Left(std::iter::empty()),
+        }
+    }
+
+    /// Returns the number of edges that end at a particular sink node.
+    pub fn incoming_edge_degree(&self, sink: Handle<Node>) -> Degree {
+        self.incoming_edges
+            .get(sink)
+            .cloned()
+            .unwrap_or(Degree::Zero)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Source code
+
+/// Contains information about a range of code in a source code file.
+#[repr(C)]
+#[derive(Default)]
+pub struct SourceInfo {
+    /// The location in its containing file of the source code that this node represents.
+    pub span: lsp_positions::Span,
+    /// The kind of syntax entity this node represents (e.g. `function`, `class`, `method`, etc.).
+    pub syntax_type: ControlledOption<Handle<InternedString>>,
+    /// The full content of the line containing this node in its source file.
+    pub containing_line: ControlledOption<Handle<InternedString>>,
+    /// The location in its containing file of the source code that this node's definiens represents.
+    /// This is used for things like the bodies of functions, rather than the RHSes of equations.
+    /// If you need one of these to make the type checker happy, but you don't have one, just use
+    /// lsp_positions::Span::default(), as this will correspond to the all-0s spans which mean "no definiens".
+    pub definiens_span: lsp_positions::Span,
+    /// The fully qualified name is a representation of the symbol that captures its name and its
+    /// embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
+    pub fully_qualified_name: ControlledOption<Handle<InternedString>>,
+}
+
+impl StackGraph {
+    /// Returns information about the source code that a stack graph node represents.
+    pub fn source_info(&self, node: Handle<Node>) -> Option<&SourceInfo> {
+        self.source_info.get(node)
+    }
+
+    /// Returns a mutable reference to the information about the source code that a stack graph
+    /// node represents.
+    pub fn source_info_mut(&mut self, node: Handle<Node>) -> &mut SourceInfo {
+        &mut self.source_info[node]
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Debug info
+
+/// Contains debug info about a stack graph node as key-value pairs of strings.
+#[derive(Default)]
+pub struct DebugInfo {
+    entries: Vec<DebugEntry>,
+}
+
+impl DebugInfo {
+    pub fn add(&mut self, key: Handle<InternedString>, value: Handle<InternedString>) {
+        self.entries.push(DebugEntry { key, value });
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<DebugEntry> {
+        self.entries.iter()
+    }
+}
+
+/// A debug entry consisting of a string key-value air of strings.
+pub struct DebugEntry {
+    pub key: Handle<InternedString>,
+    pub value: Handle<InternedString>,
+}
+
+impl StackGraph {
+    /// Returns debug information about the stack graph node.
+    pub fn node_debug_info(&self, node: Handle<Node>) -> Option<&DebugInfo> {
+        self.node_debug_info.get(node)
+    }
+
+    /// Returns a mutable reference to the debug info about the stack graph node.
+    pub fn node_debug_info_mut(&mut self, node: Handle<Node>) -> &mut DebugInfo {
+        &mut self.node_debug_info[node]
+    }
+
+    /// Returns debug information about the stack graph edge.
+    pub fn edge_debug_info(&self, source: Handle<Node>, sink: Handle<Node>) -> Option<&DebugInfo> {
+        self.edge_debug_info.get(source).and_then(|es| {
+            match es.binary_search_by_key(&sink, |e| e.0) {
+                Ok(idx) => Some(&es[idx].1),
+                Err(_) => None,
+            }
+        })
+    }
+
+    /// Returns a mutable reference to the debug info about the stack graph edge.
+    pub fn edge_debug_info_mut(
+        &mut self,
+        source: Handle<Node>,
+        sink: Handle<Node>,
+    ) -> &mut DebugInfo {
+        let es = &mut self.edge_debug_info[source];
+        let idx = match es.binary_search_by_key(&sink, |e| e.0) {
+            Ok(idx) => idx,
+            Err(idx) => {
+                es.insert(idx, (sink, DebugInfo::default()));
+                idx
+            }
+        };
+        &mut es[idx].1
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Stack graphs
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Degree {
+    Zero,
+    One,
+    Multiple,
+}
+
+impl Default for Degree {
+    fn default() -> Self {
+        Self::Zero
+    }
+}
+
+impl std::ops::Add for Degree {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Zero, result) | (result, Self::Zero) => result,
+            _ => Self::Multiple,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Degree {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+/// Contains all of the nodes and edges that make up a stack graph.
+pub struct StackGraph {
+    interned_strings: InternedStringArena,
+    pub(crate) symbols: Arena<Symbol>,
+    symbol_handles: FxHashMap<&'static str, Handle<Symbol>>,
+    pub(crate) strings: Arena<InternedString>,
+    string_handles: FxHashMap<&'static str, Handle<InternedString>>,
+    pub(crate) files: Arena<File>,
+    file_handles: FxHashMap<&'static str, Handle<File>>,
+    pub(crate) nodes: Arena<Node>,
+    pub(crate) source_info: SupplementalArena<Node, SourceInfo>,
+    node_id_handles: NodeIDHandles,
+    outgoing_edges: SupplementalArena<Node, SmallVec<[OutgoingEdge; 4]>>,
+    incoming_edges: SupplementalArena<Node, Degree>,
+    pub(crate) node_debug_info: SupplementalArena<Node, DebugInfo>,
+    pub(crate) edge_debug_info: SupplementalArena<Node, SmallVec<[(Handle<Node>, DebugInfo); 4]>>,
+}
+
+impl StackGraph {
+    /// Creates a new, initially empty stack graph.
+    pub fn new() -> StackGraph {
+        StackGraph::default()
+    }
+
+    /// Copies the given stack graph into this stack graph. Panics if any of the files
+    /// in the other stack graph are already defined in the current one.
+    pub fn add_from_graph(
+        &mut self,
+        other: &StackGraph,
+    ) -> Result<Vec<Handle<File>>, Handle<File>> {
+        let mut files = HashMap::new();
+        for other_file in other.iter_files() {
+            let file = self.add_file(other[other_file].name())?;
+            files.insert(other_file, file);
+        }
+        let files = files;
+        let node_id = |other_node_id: NodeID| {
+            if other_node_id.is_root() {
+                NodeID::root()
+            } else if other_node_id.is_jump_to() {
+                NodeID::jump_to()
+            } else {
+                NodeID::new_in_file(
+                    files[&other_node_id.file.into_option().unwrap()],
+                    other_node_id.local_id,
+                )
+            }
+        };
+        let mut nodes = HashMap::new();
+        nodes.insert(Self::root_node(), Self::root_node());
+        nodes.insert(Self::jump_to_node(), Self::jump_to_node());
+        for other_file in files.keys().cloned() {
+            let file = files[&other_file];
+            for other_node in other.nodes_for_file(other_file) {
+                let value: Node = match other[other_node] {
+                    Node::DropScopes(DropScopesNode { id, .. }) => DropScopesNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::JumpTo(JumpToNode { .. }) => JumpToNode {
+                        id: NodeID::jump_to(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::PopScopedSymbol(PopScopedSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PopSymbol(PopSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PushScopedSymbol(PushScopedSymbolNode {
+                        id,
+                        symbol,
+                        scope,
+                        is_reference,
+                        ..
+                    }) => PushScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        scope: node_id(scope),
+                        is_reference: is_reference,
+                        _phantom: (),
+                    }
+                    .into(),
+                    Node::PushSymbol(PushSymbolNode {
+                        id,
+                        symbol,
+                        is_reference,
+                        ..
+                    }) => PushSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_reference: is_reference,
+                    }
+                    .into(),
+                    Node::Root(RootNode { .. }) => RootNode {
+                        id: NodeID::root(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::Scope(ScopeNode {
+                        id, is_exported, ..
+                    }) => ScopeNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        is_exported: is_exported,
+                    }
+                    .into(),
+                };
+                let node = self.add_node(value.id(), value).unwrap();
+                nodes.insert(other_node, node);
+                if let Some(source_info) = other.source_info(other_node) {
+                    *self.source_info_mut(node) = SourceInfo {
+                        span: source_info.span.clone(),
+                        syntax_type: source_info
+                            .syntax_type
+                            .into_option()
+                            .map(|st| self.add_string(&other[st]))
+                            .into(),
+                        containing_line: source_info
+                            .containing_line
+                            .into_option()
+                            .map(|cl| self.add_string(&other[cl]))
+                            .into(),
+                        definiens_span: source_info.definiens_span.clone(),
+                        fully_qualified_name: ControlledOption::default(),
+                    };
+                }
+                if let Some(debug_info) = other.node_debug_info(other_node) {
+                    *self.node_debug_info_mut(node) = DebugInfo {
+                        entries: debug_info
+                            .entries
+                            .iter()
+                            .map(|e| DebugEntry {
+                                key: self.add_string(&other[e.key]),
+                                value: self.add_string(&other[e.value]),
+                            })
+                            .collect::<Vec<_>>(),
+                    };
+                }
+            }
+            for other_node in nodes.keys().cloned() {
+                for other_edge in other.outgoing_edges(other_node) {
+                    self.add_edge(
+                        nodes[&other_edge.source],
+                        nodes[&other_edge.sink],
+                        other_edge.precedence,
+                    );
+                }
+            }
+        }
+        Ok(files.into_values().collect())
+    }
+}
+
+impl Default for StackGraph {
+    fn default() -> StackGraph {
+        let mut nodes = Arena::new();
+        nodes.add(RootNode::new().into());
+        nodes.add(JumpToNode::new().into());
+
+        StackGraph {
+            interned_strings: InternedStringArena::new(),
+            symbols: Arena::new(),
+            symbol_handles: FxHashMap::default(),
+            strings: Arena::new(),
+            string_handles: FxHashMap::default(),
+            files: Arena::new(),
+            file_handles: FxHashMap::default(),
+            nodes,
+            source_info: SupplementalArena::new(),
+            node_id_handles: NodeIDHandles::new(),
+            outgoing_edges: SupplementalArena::new(),
+            incoming_edges: SupplementalArena::new(),
+            node_debug_info: SupplementalArena::new(),
+            edge_debug_info: SupplementalArena::new(),
+        }
+    }
+}

--- a/crates/metaslang/stack_graphs/src/lib.rs
+++ b/crates/metaslang/stack_graphs/src/lib.rs
@@ -1,0 +1,117 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Stack graphs provide a single framework for performing name resolution for any programming
+//! language, while abstracting away the specific name resolution rules for each of those
+//! languages. The basic idea is to represent the _definitions_ and _references_ in a program using
+//! graph.  A _name binding_ maps a reference to all of the possible definitions that the reference
+//! could refer to.  Because we’ve represented definitions and references as a graph, bindings are
+//! represented by paths within that graph.
+//!
+//! While searching for a path in an incremental stack graph, we keep track of two stacks: a
+//! _symbol stack_ and a _scope stack_. Broadly speaking, the symbol stack keeps track of what
+//! symbols we’re trying to resolve, while the scope stack gives us control over which particular
+//! scopes we look for those symbols in.
+//!
+//! ## Relationship to scope graphs
+//!
+//! Stack graphs are based in the [scope graphs][] formalism from Eelco Visser's group at TU Delft.
+//! Scope graphs also model the name binding structure of a program using a graph, and uses paths
+//! within that graph to represent which definitions a reference might refer to.
+//!
+//! [scope graphs]: https://pl.ewi.tudelft.nl/research/projects/scope-graphs/
+//!
+//! Stack graphs add _incrementality_ to scope graphs.  An incremental analysis is one where we
+//! can reuse analysis results for source code files that haven't changed.  In a non-incremental
+//! analysis, we have to reanalyze the entire contents of a repository or package when _any_ file
+//! is changed.
+//!
+//! As one example, the [_Scopes as Types_][] paper presents some rewrite rules that let you handle
+//! field access in a record or object type — for instance, being able to resolve the `foo` part of
+//! `A.foo`. In _Scopes as Types_, we’d handle this by performing the path-finding algorithm _when
+//! constructing the graph_, to find out what `A` resolves to. Once we find its definition, we then
+//! attach the reference to `foo` to that result.
+//!
+//! [_Scopes as Types_]: https://eelcovisser.org/blog/video/paper/2018/10/27/scopes-as-types/
+//!
+//! This is not incremental because the reference to `foo` “lives” over in some unrelated part of
+//! the graph.  If `A` is defined in a different file (or worse, a different package), then we have
+//! to update that distant part of the graph with the node representing the reference.  We end up
+//! cluttering the graph for a class definition with nodes representing _all_ of its field
+//! references, which is especially problematic for popular packages with lots of downstream
+//! dependencies.
+//!
+//! Our key insight is to recognize that when resolving `A.foo`, we have to “pause” the resolution
+//! of `foo` to start resolving `A`.  Once we’ve found the binding for `A`, we can resume the
+//! original resolution of `foo`.  This describes a stack!  So instead of having our path-finding
+//! algorithm look for exactly one symbol, we can keep track of a _stack_ of things to look for.
+//! To correctly resolve `foo`, we do still have to eventually make our way over to the part of the
+//! graph where `A` is defined.  But by having a stack of path-finding targets, we can resolve the
+//! reference to `A.foo` with a _single_ execution of the path-finding algorithm.  And most
+//! importantly, each “chunk” of the overall graph only depends on “local” information from the
+//! original source file.  (a.k.a., it’s incremental!)
+
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+pub mod arena;
+pub mod assert;
+pub mod c;
+pub mod cycles;
+#[macro_use]
+mod debugging;
+pub mod graph;
+pub mod partial;
+pub mod paths;
+pub mod serde;
+pub mod stats;
+pub mod stitching;
+#[cfg(feature = "storage")]
+pub mod storage;
+pub(crate) mod utils;
+#[cfg(feature = "visualization")]
+pub mod visualization;
+
+/// Trait to signal that the execution is cancelled
+pub trait CancellationFlag {
+    fn check(&self, at: &'static str) -> Result<(), CancellationError>;
+}
+
+pub struct NoCancellation;
+impl CancellationFlag for NoCancellation {
+    fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
+        Ok(())
+    }
+}
+
+pub struct CancelAfterDuration {
+    limit: Duration,
+    start: Instant,
+}
+
+impl CancelAfterDuration {
+    pub fn new(limit: Duration) -> Self {
+        Self {
+            limit,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl CancellationFlag for CancelAfterDuration {
+    fn check(&self, at: &'static str) -> Result<(), CancellationError> {
+        if self.start.elapsed() > self.limit {
+            return Err(CancellationError(at));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("Cancelled at \"{0}\"")]
+pub struct CancellationError(pub &'static str);

--- a/crates/metaslang/stack_graphs/src/partial.rs
+++ b/crates/metaslang/stack_graphs/src/partial.rs
@@ -1,0 +1,2634 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Partial paths are "snippets" of paths that we can precalculate for each file that we analyze.
+//!
+//! Stack graphs are _incremental_, since we can produce a subgraph for each file without having
+//! to look at the contents of any other file in the repo, or in any upstream or downstream
+//! dependencies.
+//!
+//! This is great, because it means that when we receive a new commit for a repository, we only
+//! have to examine, and generate new stack subgraphs for, the files that are changed as part of
+//! that commit.
+//!
+//! Having done that, one possible way to find name binding paths would be to load in all of the
+//! subgraphs for the files that belong to the current commit, union them together into the
+//! combined graph for that commit, and run the [path-finding algorithm][] on that combined graph.
+//! However, we think that this will require too much computation at query time.
+//!
+//! [path-finding algorithm]: ../paths/index.html
+//!
+//! Instead, we want to precompute parts of the path-finding algorithm, by calculating _partial
+//! paths_ for each file.  Because stack graphs have limited places where a path can cross from one
+//! file into another, we can calculate all of the possible partial paths that reach those
+//! “import/export” points.
+//!
+//! At query time, we can then load in the _partial paths_ for each file, instead of the files'
+//! full stack graph structure.  We can efficiently [concatenate][] partial paths together,
+//! producing the original "full" path that represents a name binding.
+//!
+//! [concatenate]: struct.PartialPath.html#method.concatenate
+
+use std::convert::TryFrom;
+use std::fmt::Display;
+use std::num::NonZeroU32;
+
+use controlled_option::ControlledOption;
+use controlled_option::Niche;
+use enumset::EnumSetType;
+use smallvec::SmallVec;
+
+use crate::arena::Deque;
+use crate::arena::DequeArena;
+use crate::arena::Handle;
+use crate::graph::Edge;
+use crate::graph::Node;
+use crate::graph::NodeID;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::paths::PathResolutionError;
+use crate::utils::cmp_option;
+use crate::utils::equals_option;
+
+//-------------------------------------------------------------------------------------------------
+// Displaying stuff
+
+/// This trait only exists because:
+///
+///   - we need `Display` implementations that dereference arena handles from our `StackGraph` and
+///     `PartialPaths` bags o' crap,
+///   - many of our arena-managed types can handles to _other_ arena-managed data, which we need to
+///     recursively display as part of displaying the "outer" instance, and
+///   - in particular, we sometimes need `&mut` access to the `PartialPaths` arenas.
+///
+/// The borrow checker is not very happy with us having all of these constraints at the same time —
+/// in particular, the last one.
+///
+/// This trait gets around the problem by breaking up the display operation into two steps:
+///
+///   - First, each data instance has a chance to "prepare" itself with `&mut` access to whatever
+///     arenas it needs.  (Anything containing a `Deque`, for instance, uses this step to ensure
+///     that our copy of the deque is pointed in the right direction, since reversing requires
+///     `&mut` access to the arena.)
+///
+///   - Once everything has been prepared, we return a value that implements `Display`, and
+///     contains _non-mutable_ references to the arena.  Because our arena references are
+///     non-mutable, we don't run into any problems with the borrow checker while recursively
+///     displaying the contents of the data instance.
+trait DisplayWithPartialPaths {
+    fn prepare(&mut self, _graph: &StackGraph, _partials: &mut PartialPaths) {}
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result;
+}
+
+/// Prepares and returns a `Display` implementation for a type `D` that implements
+/// `DisplayWithPartialPaths`.  We only require `&mut` access to the `PartialPath` arenas while
+/// creating the `Display` instance; the `Display` instance itself will only retain shared access
+/// to the arenas.
+fn display_with<'a, D>(
+    mut value: D,
+    graph: &'a StackGraph,
+    partials: &'a mut PartialPaths,
+) -> impl Display + 'a
+where
+    D: DisplayWithPartialPaths + 'a,
+{
+    value.prepare(graph, partials);
+    DisplayWithPartialPathsWrapper {
+        value,
+        graph,
+        partials,
+    }
+}
+
+/// Returns a `Display` implementation that you can use inside of your `display_with` method to
+/// display any recursive fields.  This assumes that the recursive fields have already been
+/// prepared.
+fn display_prepared<'a, D>(
+    value: D,
+    graph: &'a StackGraph,
+    partials: &'a PartialPaths,
+) -> impl Display + 'a
+where
+    D: DisplayWithPartialPaths + 'a,
+{
+    DisplayWithPartialPathsWrapper {
+        value,
+        graph,
+        partials,
+    }
+}
+
+#[doc(hidden)]
+struct DisplayWithPartialPathsWrapper<'a, D> {
+    value: D,
+    graph: &'a StackGraph,
+    partials: &'a PartialPaths,
+}
+
+impl<'a, D> Display for DisplayWithPartialPathsWrapper<'a, D>
+where
+    D: DisplayWithPartialPaths,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.value.display_with(self.graph, self.partials, f)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Symbol stack variables
+
+/// Represents an unknown list of scoped symbols.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Niche, Ord, PartialEq, PartialOrd)]
+pub struct SymbolStackVariable(#[niche] NonZeroU32);
+
+impl SymbolStackVariable {
+    pub fn new(variable: u32) -> Option<SymbolStackVariable> {
+        NonZeroU32::new(variable).map(SymbolStackVariable)
+    }
+
+    /// Creates a new symbol stack variable.  This constructor is used when creating a new, empty
+    /// partial path, since there aren't any other variables that we need to be fresher than.
+    pub(crate) fn initial() -> SymbolStackVariable {
+        SymbolStackVariable(unsafe { NonZeroU32::new_unchecked(1) })
+    }
+
+    /// Applies an offset to this variable.
+    ///
+    /// When concatenating partial paths, we have to ensure that the left- and right-hand sides
+    /// have non-overlapping sets of variables.  To do this, we find the maximum value of any
+    /// variable on the left-hand side, and add this “offset” to the values of all of the variables
+    /// on the right-hand side.
+    pub fn with_offset(self, symbol_variable_offset: u32) -> SymbolStackVariable {
+        let offset_value = self.0.get() + symbol_variable_offset;
+        SymbolStackVariable(unsafe { NonZeroU32::new_unchecked(offset_value) })
+    }
+
+    pub(crate) fn as_u32(self) -> u32 {
+        self.0.get()
+    }
+
+    fn as_usize(self) -> usize {
+        self.0.get() as usize
+    }
+}
+
+impl Display for SymbolStackVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "%{}", self.0.get())
+    }
+}
+
+impl From<NonZeroU32> for SymbolStackVariable {
+    fn from(value: NonZeroU32) -> SymbolStackVariable {
+        SymbolStackVariable(value)
+    }
+}
+
+impl Into<u32> for SymbolStackVariable {
+    fn into(self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u32> for SymbolStackVariable {
+    type Error = ();
+    fn try_from(value: u32) -> Result<SymbolStackVariable, ()> {
+        let value = NonZeroU32::new(value).ok_or(())?;
+        Ok(SymbolStackVariable(value))
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Scope stack variables
+
+/// Represents an unknown list of exported scopes.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Niche, Ord, PartialEq, PartialOrd)]
+pub struct ScopeStackVariable(#[niche] NonZeroU32);
+
+impl ScopeStackVariable {
+    pub fn new(variable: u32) -> Option<ScopeStackVariable> {
+        NonZeroU32::new(variable).map(ScopeStackVariable)
+    }
+
+    /// Creates a new scope stack variable.  This constructor is used when creating a new, empty
+    /// partial path, since there aren't any other variables that we need to be fresher than.
+    fn initial() -> ScopeStackVariable {
+        ScopeStackVariable(unsafe { NonZeroU32::new_unchecked(1) })
+    }
+
+    /// Creates a new scope stack variable that is fresher than all other variables in a partial
+    /// path.  (You must calculate the maximum variable number already in use.)
+    fn fresher_than(max_used: u32) -> ScopeStackVariable {
+        ScopeStackVariable(unsafe { NonZeroU32::new_unchecked(max_used + 1) })
+    }
+
+    /// Applies an offset to this variable.
+    ///
+    /// When concatenating partial paths, we have to ensure that the left- and right-hand sides
+    /// have non-overlapping sets of variables.  To do this, we find the maximum value of any
+    /// variable on the left-hand side, and add this “offset” to the values of all of the variables
+    /// on the right-hand side.
+    pub fn with_offset(self, scope_variable_offset: u32) -> ScopeStackVariable {
+        let offset_value = self.0.get() + scope_variable_offset;
+        ScopeStackVariable(unsafe { NonZeroU32::new_unchecked(offset_value) })
+    }
+
+    pub(crate) fn as_u32(self) -> u32 {
+        self.0.get()
+    }
+
+    fn as_usize(self) -> usize {
+        self.0.get() as usize
+    }
+}
+
+impl Display for ScopeStackVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "${}", self.0.get())
+    }
+}
+
+impl From<NonZeroU32> for ScopeStackVariable {
+    fn from(value: NonZeroU32) -> ScopeStackVariable {
+        ScopeStackVariable(value)
+    }
+}
+
+impl Into<u32> for ScopeStackVariable {
+    fn into(self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u32> for ScopeStackVariable {
+    type Error = ();
+    fn try_from(value: u32) -> Result<ScopeStackVariable, ()> {
+        let value = NonZeroU32::new(value).ok_or(())?;
+        Ok(ScopeStackVariable(value))
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial symbol stacks
+
+/// A symbol with an unknown, but possibly empty, list of exported scopes attached to it.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PartialScopedSymbol {
+    pub symbol: Handle<Symbol>,
+    // Note that not having an attached scope list is _different_ than having an empty attached
+    // scope list.
+    pub scopes: ControlledOption<PartialScopeStack>,
+}
+
+impl PartialScopedSymbol {
+    /// Applies an offset to this scoped symbol.
+    ///
+    /// When concatenating partial paths, we have to ensure that the left- and right-hand sides
+    /// have non-overlapping sets of variables.  To do this, we find the maximum value of any
+    /// variable on the left-hand side, and add this “offset” to the values of all of the variables
+    /// on the right-hand side.
+    pub fn with_offset(mut self, scope_variable_offset: u32) -> PartialScopedSymbol {
+        let scopes = self
+            .scopes
+            .into_option()
+            .map(|stack| stack.with_offset(scope_variable_offset));
+        self.scopes = ControlledOption::from_option(scopes);
+        self
+    }
+
+    /// Matches this precondition symbol against another, unifying its contents with an existing
+    /// set of bindings.
+    pub fn unify(
+        &mut self,
+        partials: &mut PartialPaths,
+        rhs: PartialScopedSymbol,
+        scope_bindings: &mut PartialScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        if self.symbol != rhs.symbol {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        match (self.scopes.into_option(), rhs.scopes.into_option()) {
+            (Some(lhs), Some(rhs)) => {
+                let unified = lhs.unify(partials, rhs, scope_bindings)?;
+                self.scopes = ControlledOption::some(unified);
+            }
+            (None, None) => {}
+            _ => return Err(PathResolutionError::SymbolStackUnsatisfied),
+        }
+        Ok(())
+    }
+
+    /// Returns whether two partial scoped symbols "match".  The symbols must be identical, and any
+    /// attached scopes must also match.
+    pub fn matches(self, partials: &mut PartialPaths, postcondition: PartialScopedSymbol) -> bool {
+        if self.symbol != postcondition.symbol {
+            return false;
+        }
+
+        // If one side has an attached scope but the other doesn't, then the scoped symbols don't
+        // match.
+        if self.scopes.is_none() != postcondition.scopes.is_none() {
+            return false;
+        }
+
+        // Otherwise, if both sides have an attached scope, they have to be compatible.
+        if let Some(precondition_scopes) = self.scopes.into_option() {
+            if let Some(postcondition_scopes) = postcondition.scopes.into_option() {
+                return precondition_scopes.matches(partials, postcondition_scopes);
+            }
+        }
+
+        true
+    }
+
+    /// Applies a set of bindings to this partial scoped symbol, producing a new scoped symbol.
+    pub fn apply_partial_bindings(
+        mut self,
+        partials: &mut PartialPaths,
+        scope_bindings: &PartialScopeStackBindings,
+    ) -> Result<PartialScopedSymbol, PathResolutionError> {
+        let scopes = match self.scopes.into_option() {
+            Some(scopes) => Some(scopes.apply_partial_bindings(partials, scope_bindings)?),
+            None => None,
+        };
+        self.scopes = scopes.into();
+        Ok(self)
+    }
+
+    pub fn equals(&self, partials: &mut PartialPaths, other: &PartialScopedSymbol) -> bool {
+        self.symbol == other.symbol
+            && equals_option(
+                self.scopes.into_option(),
+                other.scopes.into_option(),
+                |a, b| a.equals(partials, b),
+            )
+    }
+
+    pub fn cmp(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        other: &PartialScopedSymbol,
+    ) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+            .then_with(|| graph[self.symbol].cmp(&graph[other.symbol]))
+            .then_with(|| {
+                cmp_option(
+                    self.scopes.into_option(),
+                    other.scopes.into_option(),
+                    |a, b| a.cmp(partials, b),
+                )
+            })
+    }
+
+    pub fn display<'a>(
+        self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+impl DisplayWithPartialPaths for PartialScopedSymbol {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        if let Some(mut scopes) = self.scopes.into_option() {
+            scopes.prepare(graph, partials);
+            self.scopes = scopes.into();
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        if let Some(scopes) = self.scopes.into_option() {
+            write!(
+                f,
+                "{}/({})",
+                self.symbol.display(graph),
+                display_prepared(scopes, graph, partials)
+            )
+        } else {
+            write!(f, "{}", self.symbol.display(graph))
+        }
+    }
+}
+
+/// A pattern that might match against a symbol stack.  Consists of a (possibly empty) list of
+/// partial scoped symbols, along with an optional symbol stack variable.
+#[repr(C)]
+#[derive(Clone, Copy, Niche)]
+pub struct PartialSymbolStack {
+    #[niche]
+    symbols: Deque<PartialScopedSymbol>,
+    length: u32,
+    variable: ControlledOption<SymbolStackVariable>,
+}
+
+impl PartialSymbolStack {
+    /// Returns whether this partial symbol stack can match the empty symbol stack.
+    #[inline(always)]
+    pub fn can_match_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
+    /// Returns whether this partial symbol stack can _only_ match the empty symbol stack.
+    #[inline(always)]
+    pub fn can_only_match_empty(&self) -> bool {
+        self.symbols.is_empty() && self.variable.is_none()
+    }
+
+    /// Returns whether this partial symbol stack contains any symbols.
+    #[inline(always)]
+    pub fn contains_symbols(&self) -> bool {
+        !self.symbols.is_empty()
+    }
+
+    /// Returns whether this partial symbol stack has a symbol stack variable.
+    #[inline(always)]
+    pub fn has_variable(&self) -> bool {
+        self.variable.is_some()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Returns an empty partial symbol stack.
+    pub fn empty() -> PartialSymbolStack {
+        PartialSymbolStack {
+            symbols: Deque::empty(),
+            length: 0,
+            variable: ControlledOption::none(),
+        }
+    }
+
+    /// Returns a partial symbol stack containing only a symbol stack variable.
+    pub fn from_variable(variable: SymbolStackVariable) -> PartialSymbolStack {
+        PartialSymbolStack {
+            symbols: Deque::empty(),
+            length: 0,
+            variable: ControlledOption::some(variable),
+        }
+    }
+
+    /// Returns whether this partial symbol stack is iterable in both directions without needing
+    /// mutable access to the arena.
+    pub fn have_reversal(&self, partials: &PartialPaths) -> bool {
+        self.symbols.have_reversal(&partials.partial_symbol_stacks)
+    }
+
+    /// Applies an offset to this partial symbol stack.
+    ///
+    /// When concatenating partial paths, we have to ensure that the left- and right-hand sides
+    /// have non-overlapping sets of variables.  To do this, we find the maximum value of any
+    /// variable on the left-hand side, and add this “offset” to the values of all of the variables
+    /// on the right-hand side.
+    pub fn with_offset(
+        mut self,
+        partials: &mut PartialPaths,
+        symbol_variable_offset: u32,
+        scope_variable_offset: u32,
+    ) -> PartialSymbolStack {
+        let mut result = match self.variable.into_option() {
+            Some(variable) => Self::from_variable(variable.with_offset(symbol_variable_offset)),
+            None => Self::empty(),
+        };
+        while let Some(symbol) = self.pop_front(partials) {
+            result.push_back(partials, symbol.with_offset(scope_variable_offset));
+        }
+        result
+    }
+
+    fn prepend(&mut self, partials: &mut PartialPaths, mut head: Deque<PartialScopedSymbol>) {
+        while let Some(head) = head.pop_back(&mut partials.partial_symbol_stacks).copied() {
+            self.push_front(partials, head);
+        }
+    }
+
+    /// Pushes a new [`PartialScopedSymbol`][] onto the front of this partial symbol stack.
+    pub fn push_front(&mut self, partials: &mut PartialPaths, symbol: PartialScopedSymbol) {
+        self.length += 1;
+        self.symbols
+            .push_front(&mut partials.partial_symbol_stacks, symbol);
+    }
+
+    /// Pushes a new [`PartialScopedSymbol`][] onto the back of this partial symbol stack.
+    pub fn push_back(&mut self, partials: &mut PartialPaths, symbol: PartialScopedSymbol) {
+        self.length += 1;
+        self.symbols
+            .push_back(&mut partials.partial_symbol_stacks, symbol);
+    }
+
+    /// Removes and returns the [`PartialScopedSymbol`][] at the front of this partial symbol
+    /// stack.  If the stack is empty, returns `None`.
+    pub fn pop_front(&mut self, partials: &mut PartialPaths) -> Option<PartialScopedSymbol> {
+        let result = self
+            .symbols
+            .pop_front(&mut partials.partial_symbol_stacks)
+            .copied();
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result
+    }
+
+    /// Removes and returns the [`PartialScopedSymbol`][] at the back of this partial symbol stack.
+    /// If the stack is empty, returns `None`.
+    pub fn pop_back(&mut self, partials: &mut PartialPaths) -> Option<PartialScopedSymbol> {
+        let result = self
+            .symbols
+            .pop_back(&mut partials.partial_symbol_stacks)
+            .copied();
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result
+    }
+
+    pub fn display<'a>(
+        self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+
+    /// Returns whether two partial symbol stacks "match".  They must be the same length, and each
+    /// respective partial scoped symbol must match.
+    pub fn matches(mut self, partials: &mut PartialPaths, mut other: PartialSymbolStack) -> bool {
+        while let Some(self_element) = self.pop_front(partials) {
+            if let Some(other_element) = other.pop_front(partials) {
+                if !self_element.matches(partials, other_element) {
+                    return false;
+                }
+            } else {
+                // Stacks aren't the same length.
+                return false;
+            }
+        }
+        if other.contains_symbols() {
+            // Stacks aren't the same length.
+            return false;
+        }
+        self.variable.into_option() == other.variable.into_option()
+    }
+
+    /// Applies a set of bindings to this partial symbol stack, producing a new partial symbol
+    /// stack.
+    pub fn apply_partial_bindings(
+        mut self,
+        partials: &mut PartialPaths,
+        symbol_bindings: &PartialSymbolStackBindings,
+        scope_bindings: &PartialScopeStackBindings,
+    ) -> Result<PartialSymbolStack, PathResolutionError> {
+        // If this partial symbol stack ends in a variable, see if we have a binding for it.  If
+        // so, substitute that binding in.  If not, leave the variable as-is.
+        let mut result = match self.variable.into_option() {
+            Some(variable) => match symbol_bindings.get(variable) {
+                Some(bound) => bound,
+                None => PartialSymbolStack::from_variable(variable),
+            },
+            None => PartialSymbolStack::empty(),
+        };
+
+        // Then prepend all of the scoped symbols that appear at the beginning of this stack,
+        // applying the bindings to any attached scopes as well.
+        while let Some(partial_symbol) = self.pop_back(partials) {
+            let partial_symbol = partial_symbol.apply_partial_bindings(partials, scope_bindings)?;
+            result.push_front(partials, partial_symbol);
+        }
+        Ok(result)
+    }
+
+    /// Given two partial symbol stacks, returns the largest possible partial symbol stack such that
+    /// any symbol stack that satisfies the result also satisfies both inputs.  This takes into
+    /// account any existing variable assignments, and updates those variable assignments with
+    /// whatever constraints are necessary to produce a correct result.
+    ///
+    /// Note that this operation is commutative.  (Concatenating partial paths, defined in
+    /// [`PartialPath::concatenate`][], is not.)
+    pub fn unify(
+        self,
+        partials: &mut PartialPaths,
+        mut rhs: PartialSymbolStack,
+        symbol_bindings: &mut PartialSymbolStackBindings,
+        scope_bindings: &mut PartialScopeStackBindings,
+    ) -> Result<PartialSymbolStack, PathResolutionError> {
+        let mut lhs = self;
+
+        // First, look at the shortest common prefix of lhs and rhs, and verify that they match.
+        let mut head = Deque::empty();
+        while lhs.contains_symbols() && rhs.contains_symbols() {
+            let mut lhs_front = lhs.pop_front(partials).unwrap();
+            let rhs_front = rhs.pop_front(partials).unwrap();
+            lhs_front.unify(partials, rhs_front, scope_bindings)?;
+            head.push_back(&mut partials.partial_symbol_stacks, lhs_front);
+        }
+
+        // Now at most one stack still has symbols.  Zero, one, or both of them have variables.
+        // Let's do a case analysis on all of those possibilities.
+
+        // CASE 1:
+        // Both lhs and rhs have no more symbols.  The answer is always yes, and any variables that
+        // are present get bound.  (If both sides have variables, then one variable gets bound to
+        // the other, since both lhs and rhs will match _any other symbol stack_ at this point.  If
+        // only one side has a variable, then the variable gets bound to the empty stack.)
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            ()            => yes either
+        //  ()            () $2         => yes rhs, $2 => ()
+        //  () $1         ()            => yes lhs, $1 => ()
+        //  () $1         () $2         => yes lhs, $2 => $1
+        if !lhs.contains_symbols() && !rhs.contains_symbols() {
+            match (lhs.variable.into_option(), rhs.variable.into_option()) {
+                (None, None) => {
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+                (None, Some(var)) => {
+                    symbol_bindings.add(
+                        partials,
+                        var,
+                        PartialSymbolStack::empty(),
+                        scope_bindings,
+                    )?;
+                    rhs.prepend(partials, head);
+                    return Ok(rhs);
+                }
+                (Some(var), None) => {
+                    symbol_bindings.add(
+                        partials,
+                        var,
+                        PartialSymbolStack::empty(),
+                        scope_bindings,
+                    )?;
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+                (Some(lhs_var), Some(rhs_var)) => {
+                    symbol_bindings.add(
+                        partials,
+                        rhs_var,
+                        PartialSymbolStack::from_variable(lhs_var),
+                        scope_bindings,
+                    )?;
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+            }
+        }
+
+        // CASE 2:
+        // One of the stacks contains symbols and the other doesn't, and the “empty” stack doesn't
+        // have a variable.  Since there's no variable on the empty side to capture the remaining
+        // content on the non-empty side, the answer is always no.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            (stuff)       => NO
+        //  ()            (stuff) $2    => NO
+        //  (stuff)       ()            => NO
+        //  (stuff) $1    ()            => NO
+        if !lhs.contains_symbols() && lhs.variable.is_none() {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        if !rhs.contains_symbols() && rhs.variable.is_none() {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+
+        // CASE 3:
+        // One of the stacks contains symbols and the other doesn't, and the “empty” stack _does_
+        // have a variable.  If both sides have the same variable, the answer is NO. Otherwise,
+        // the answer is YES, and the “empty” side's variable needs to capture the entirety of the
+        // non-empty side.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  (...) $1      (...) $1      => no
+        //  () $1         (stuff)       => yes rhs,  $1 => rhs
+        //  () $1         (stuff) $2    => yes rhs,  $1 => rhs
+        //  (stuff)       () $2         => yes lhs,  $2 => lhs
+        //  (stuff) $1    () $2         => yes lhs,  $2 => lhs
+        match (lhs.variable.into_option(), rhs.variable.into_option()) {
+            (Some(v1), Some(v2)) if v1 == v2 => {
+                return Err(PathResolutionError::ScopeStackUnsatisfied)
+            }
+            _ => {}
+        }
+        if lhs.contains_symbols() {
+            let rhs_variable = rhs.variable.into_option().unwrap();
+            symbol_bindings.add(partials, rhs_variable, lhs, scope_bindings)?;
+            lhs.prepend(partials, head);
+            return Ok(lhs);
+        }
+        if rhs.contains_symbols() {
+            let lhs_variable = lhs.variable.into_option().unwrap();
+            symbol_bindings.add(partials, lhs_variable, rhs, scope_bindings)?;
+            rhs.prepend(partials, head);
+            return Ok(rhs);
+        }
+
+        unreachable!();
+    }
+
+    pub fn equals(mut self, partials: &mut PartialPaths, mut other: PartialSymbolStack) -> bool {
+        while let Some(self_symbol) = self.pop_front(partials) {
+            if let Some(other_symbol) = other.pop_front(partials) {
+                if !self_symbol.equals(partials, &other_symbol) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        if !other.symbols.is_empty() {
+            return false;
+        }
+        equals_option(
+            self.variable.into_option(),
+            other.variable.into_option(),
+            |a, b| a == b,
+        )
+    }
+
+    pub fn cmp(
+        mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        mut other: PartialSymbolStack,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        while let Some(self_symbol) = self.pop_front(partials) {
+            if let Some(other_symbol) = other.pop_front(partials) {
+                match self_symbol.cmp(graph, partials, &other_symbol) {
+                    Ordering::Equal => continue,
+                    result @ _ => return result,
+                }
+            } else {
+                return Ordering::Greater;
+            }
+        }
+        if !other.symbols.is_empty() {
+            return Ordering::Less;
+        }
+        cmp_option(
+            self.variable.into_option(),
+            other.variable.into_option(),
+            |a, b| a.cmp(&b),
+        )
+    }
+
+    /// Returns an iterator over the contents of this partial symbol stack.
+    pub fn iter<'a>(
+        &self,
+        partials: &'a mut PartialPaths,
+    ) -> impl Iterator<Item = PartialScopedSymbol> + 'a {
+        self.symbols
+            .iter(&mut partials.partial_symbol_stacks)
+            .copied()
+    }
+
+    /// Returns an iterator over the contents of this partial symbol stack, with no guarantee
+    /// about the ordering of the elements.
+    pub fn iter_unordered<'a>(
+        &self,
+        partials: &'a PartialPaths,
+    ) -> impl Iterator<Item = PartialScopedSymbol> + 'a {
+        self.symbols
+            .iter_unordered(&partials.partial_symbol_stacks)
+            .copied()
+    }
+
+    pub fn variable(&self) -> Option<SymbolStackVariable> {
+        self.variable.clone().into_option()
+    }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.symbols
+            .ensure_backwards(&mut partials.partial_symbol_stacks);
+        self.symbols
+            .ensure_forwards(&mut partials.partial_symbol_stacks);
+    }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.symbols
+            .ensure_forwards(&mut partials.partial_symbol_stacks);
+    }
+
+    /// Returns the largest value of any symbol stack variable in this partial symbol stack.
+    pub fn largest_symbol_stack_variable(&self) -> u32 {
+        self.variable
+            .into_option()
+            .map(SymbolStackVariable::as_u32)
+            .unwrap_or(0)
+    }
+
+    /// Returns the largest value of any scope stack variable in this partial symbol stack.
+    pub fn largest_scope_stack_variable(&self, partials: &PartialPaths) -> u32 {
+        // We don't have to check the postconditions, because it's not valid for a postcondition to
+        // refer to a variable that doesn't exist in the precondition.
+        self.iter_unordered(partials)
+            .filter_map(|symbol| symbol.scopes.into_option())
+            .filter_map(|scopes| scopes.variable.into_option())
+            .map(ScopeStackVariable::as_u32)
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+impl DisplayWithPartialPaths for PartialSymbolStack {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        // Ensure that our deque is pointed forwards while we still have a mutable reference to the
+        // arena.
+        self.symbols
+            .ensure_forwards(&mut partials.partial_symbol_stacks);
+        // And then prepare each symbol in the stack.
+        let mut symbols = self.symbols;
+        while let Some(mut symbol) = symbols
+            .pop_front(&mut partials.partial_symbol_stacks)
+            .copied()
+        {
+            symbol.prepare(graph, partials);
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        for symbol in self.symbols.iter_reused(&partials.partial_symbol_stacks) {
+            symbol.display_with(graph, partials, f)?;
+        }
+        if let Some(variable) = self.variable.into_option() {
+            if self.symbols.is_empty() {
+                write!(f, "{}", variable)?;
+            } else {
+                write!(f, ",{}", variable)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial scope stacks
+
+/// A pattern that might match against a scope stack.  Consists of a (possibly empty) list of
+/// exported scopes, along with an optional scope stack variable.
+#[repr(C)]
+#[derive(Clone, Copy, Niche)]
+pub struct PartialScopeStack {
+    #[niche]
+    scopes: Deque<Handle<Node>>,
+    length: u32,
+    variable: ControlledOption<ScopeStackVariable>,
+}
+
+impl PartialScopeStack {
+    /// Returns whether this partial scope stack can match the empty scope stack.
+    #[inline(always)]
+    pub fn can_match_empty(&self) -> bool {
+        self.scopes.is_empty()
+    }
+
+    /// Returns whether this partial scope stack can _only_ match the empty scope stack.
+    #[inline(always)]
+    pub fn can_only_match_empty(&self) -> bool {
+        self.scopes.is_empty() && self.variable.is_none()
+    }
+
+    /// Returns whether this partial scope stack contains any scopes.
+    #[inline(always)]
+    pub fn contains_scopes(&self) -> bool {
+        !self.scopes.is_empty()
+    }
+
+    /// Returns whether this partial scope stack has a scope stack variable.
+    #[inline(always)]
+    pub fn has_variable(&self) -> bool {
+        self.variable.is_some()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Returns an empty partial scope stack.
+    pub fn empty() -> PartialScopeStack {
+        PartialScopeStack {
+            scopes: Deque::empty(),
+            length: 0,
+            variable: ControlledOption::none(),
+        }
+    }
+
+    /// Returns a partial scope stack containing only a scope stack variable.
+    pub fn from_variable(variable: ScopeStackVariable) -> PartialScopeStack {
+        PartialScopeStack {
+            scopes: Deque::empty(),
+            length: 0,
+            variable: ControlledOption::some(variable),
+        }
+    }
+
+    /// Returns whether this partial scope stack is iterable in both directions without needing
+    /// mutable access to the arena.
+    pub fn have_reversal(&self, partials: &PartialPaths) -> bool {
+        self.scopes.have_reversal(&partials.partial_scope_stacks)
+    }
+
+    /// Applies an offset to this partial scope stack.
+    ///
+    /// When concatenating partial paths, we have to ensure that the left- and right-hand sides
+    /// have non-overlapping sets of variables.  To do this, we find the maximum value of any
+    /// variable on the left-hand side, and add this “offset” to the values of all of the variables
+    /// on the right-hand side.
+    pub fn with_offset(mut self, scope_variable_offset: u32) -> PartialScopeStack {
+        match self.variable.into_option() {
+            Some(variable) => {
+                self.variable = ControlledOption::some(variable.with_offset(scope_variable_offset));
+            }
+            None => {}
+        };
+        self
+    }
+
+    /// Returns whether two partial scope stacks match exactly the same set of scope stacks.
+    pub fn matches(mut self, partials: &mut PartialPaths, mut other: PartialScopeStack) -> bool {
+        while let Some(self_element) = self.pop_front(partials) {
+            if let Some(other_element) = other.pop_front(partials) {
+                if self_element != other_element {
+                    return false;
+                }
+            } else {
+                // Stacks aren't the same length.
+                return false;
+            }
+        }
+        if other.contains_scopes() {
+            // Stacks aren't the same length.
+            return false;
+        }
+        self.variable.into_option() == other.variable.into_option()
+    }
+
+    /// Applies a set of partial scope stack bindings to this partial scope stack, producing a new
+    /// partial scope stack.
+    pub fn apply_partial_bindings(
+        mut self,
+        partials: &mut PartialPaths,
+        scope_bindings: &PartialScopeStackBindings,
+    ) -> Result<PartialScopeStack, PathResolutionError> {
+        // If this partial scope stack ends in a variable, see if we have a binding for it.  If so,
+        // substitute that binding in.  If not, leave the variable as-is.
+        let mut result = match self.variable.into_option() {
+            Some(variable) => match scope_bindings.get(variable) {
+                Some(bound) => bound,
+                None => PartialScopeStack::from_variable(variable),
+            },
+            None => PartialScopeStack::empty(),
+        };
+
+        // Then prepend all of the scopes that appear at the beginning of this stack.
+        while let Some(scope) = self.pop_back(partials) {
+            result.push_front(partials, scope);
+        }
+        Ok(result)
+    }
+
+    /// Given two partial scope stacks, returns the largest possible partial scope stack such that
+    /// any scope stack that satisfies the result also satisfies both inputs.  This takes into
+    /// account any existing variable assignments, and updates those variable assignments with
+    /// whatever constraints are necessary to produce a correct result.
+    ///
+    /// Note that this operation is commutative.  (Concatenating partial paths, defined in
+    /// [`PartialPath::concatenate`][], is not.)
+    pub fn unify(
+        self,
+        partials: &mut PartialPaths,
+        mut rhs: PartialScopeStack,
+        bindings: &mut PartialScopeStackBindings,
+    ) -> Result<PartialScopeStack, PathResolutionError> {
+        let mut lhs = self;
+        let original_rhs = rhs;
+
+        // First, look at the shortest common prefix of lhs and rhs, and verify that they match.
+        while lhs.contains_scopes() && rhs.contains_scopes() {
+            let lhs_front = lhs.pop_front(partials).unwrap();
+            let rhs_front = rhs.pop_front(partials).unwrap();
+            if lhs_front != rhs_front {
+                return Err(PathResolutionError::ScopeStackUnsatisfied);
+            }
+        }
+
+        // Now at most one stack still has scopes.  Zero, one, or both of them have variables.
+        // Let's do a case analysis on all of those possibilities.
+
+        // CASE 1:
+        // Both lhs and rhs have no more scopes.  The answer is always yes, and any variables that
+        // are present get bound.  (If both sides have variables, then one variable gets bound to
+        // the other, since both lhs and rhs will match _any other scope stack_ at this point.  If
+        // only one side has a variable, then the variable gets bound to the empty stack.)
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            ()            => yes either
+        //  ()            () $2         => yes rhs, $2 => ()
+        //  () $1         ()            => yes lhs, $1 => ()
+        //  () $1         () $2         => yes lhs, $2 => $1
+        if !lhs.contains_scopes() && !rhs.contains_scopes() {
+            match (lhs.variable.into_option(), rhs.variable.into_option()) {
+                (None, None) => return Ok(self),
+                (None, Some(var)) => {
+                    bindings.add(partials, var, PartialScopeStack::empty())?;
+                    return Ok(original_rhs);
+                }
+                (Some(var), None) => {
+                    bindings.add(partials, var, PartialScopeStack::empty())?;
+                    return Ok(self);
+                }
+                (Some(lhs_var), Some(rhs_var)) => {
+                    bindings.add(partials, rhs_var, PartialScopeStack::from_variable(lhs_var))?;
+                    return Ok(self);
+                }
+            }
+        }
+
+        // CASE 2:
+        // One of the stacks contains scopes and the other doesn't, and the “empty” stack doesn't
+        // have a variable.  Since there's no variable on the empty side to capture the remaining
+        // content on the non-empty side, the answer is always no.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            (stuff)       => NO
+        //  ()            (stuff) $2    => NO
+        //  (stuff)       ()            => NO
+        //  (stuff) $1    ()            => NO
+        if !lhs.contains_scopes() && lhs.variable.is_none() {
+            return Err(PathResolutionError::ScopeStackUnsatisfied);
+        }
+        if !rhs.contains_scopes() && rhs.variable.is_none() {
+            return Err(PathResolutionError::ScopeStackUnsatisfied);
+        }
+
+        // CASE 3:
+        // One of the stacks contains scopes and the other doesn't, and the “empty” stack _does_
+        // have a variable.  If both sides have the same variable, the answer is NO. Otherwise,
+        // the answer is YES, and the “empty” side's variable needs to capture the entirety of the
+        // non-empty side.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  (...) $1      (...) $1      => no
+        //  () $1         (stuff)       => yes rhs,  $1 => rhs
+        //  () $1         (stuff) $2    => yes rhs,  $1 => rhs
+        //  (stuff)       () $2         => yes lhs,  $2 => lhs
+        //  (stuff) $1    () $2         => yes lhs,  $2 => lhs
+        match (lhs.variable.into_option(), rhs.variable.into_option()) {
+            (Some(v1), Some(v2)) if v1 == v2 => {
+                return Err(PathResolutionError::ScopeStackUnsatisfied)
+            }
+            _ => {}
+        }
+        if lhs.contains_scopes() {
+            let rhs_variable = rhs.variable.into_option().unwrap();
+            bindings.add(partials, rhs_variable, lhs)?;
+            return Ok(self);
+        }
+        if rhs.contains_scopes() {
+            let lhs_variable = lhs.variable.into_option().unwrap();
+            bindings.add(partials, lhs_variable, rhs)?;
+            return Ok(original_rhs);
+        }
+
+        unreachable!();
+    }
+
+    /// Pushes a new [`Node`][] onto the front of this partial scope stack.  The node must be an
+    /// _exported scope node_.
+    ///
+    /// [`Node`]: ../graph/enum.Node.html
+    pub fn push_front(&mut self, partials: &mut PartialPaths, node: Handle<Node>) {
+        self.length += 1;
+        self.scopes
+            .push_front(&mut partials.partial_scope_stacks, node);
+    }
+
+    /// Pushes a new [`Node`][] onto the back of this partial scope stack.  The node must be an
+    /// _exported scope node_.
+    ///
+    /// [`Node`]: ../graph/enum.Node.html
+    pub fn push_back(&mut self, partials: &mut PartialPaths, node: Handle<Node>) {
+        self.length += 1;
+        self.scopes
+            .push_back(&mut partials.partial_scope_stacks, node);
+    }
+
+    /// Removes and returns the [`Node`][] at the front of this partial scope stack.  If the stack
+    /// does not contain any exported scope nodes, returns `None`.
+    pub fn pop_front(&mut self, partials: &mut PartialPaths) -> Option<Handle<Node>> {
+        let result = self
+            .scopes
+            .pop_front(&mut partials.partial_scope_stacks)
+            .copied();
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result
+    }
+
+    /// Removes and returns the [`Node`][] at the back of this partial scope stack.  If the stack
+    /// does not contain any exported scope nodes, returns `None`.
+    pub fn pop_back(&mut self, partials: &mut PartialPaths) -> Option<Handle<Node>> {
+        let result = self
+            .scopes
+            .pop_back(&mut partials.partial_scope_stacks)
+            .copied();
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result
+    }
+
+    /// Returns the scope stack variable at the end of this partial scope stack.  If the stack does
+    /// not contain a scope stack variable, returns `None`.
+    pub fn variable(&self) -> Option<ScopeStackVariable> {
+        self.variable.into_option()
+    }
+
+    pub fn equals(self, partials: &mut PartialPaths, other: PartialScopeStack) -> bool {
+        self.scopes
+            .equals_with(&mut partials.partial_scope_stacks, other.scopes, |a, b| {
+                *a == *b
+            })
+            && equals_option(
+                self.variable.into_option(),
+                other.variable.into_option(),
+                |a, b| a == b,
+            )
+    }
+
+    pub fn cmp(self, partials: &mut PartialPaths, other: PartialScopeStack) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+            .then_with(|| {
+                self.scopes
+                    .cmp_with(&mut partials.partial_scope_stacks, other.scopes, |a, b| {
+                        a.cmp(b)
+                    })
+            })
+            .then_with(|| {
+                cmp_option(
+                    self.variable.into_option(),
+                    other.variable.into_option(),
+                    |a, b| a.cmp(&b),
+                )
+            })
+    }
+
+    /// Returns an iterator over the scopes in this partial scope stack.
+    pub fn iter_scopes<'a>(
+        &self,
+        partials: &'a mut PartialPaths,
+    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+        self.scopes
+            .iter(&mut partials.partial_scope_stacks)
+            .copied()
+    }
+
+    /// Returns an iterator over the contents of this partial scope stack, with no guarantee
+    /// about the ordering of the elements.
+    pub fn iter_unordered<'a>(
+        &self,
+        partials: &'a PartialPaths,
+    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+        self.scopes
+            .iter_unordered(&partials.partial_scope_stacks)
+            .copied()
+    }
+
+    pub fn display<'a>(
+        self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.scopes
+            .ensure_backwards(&mut partials.partial_scope_stacks);
+        self.scopes
+            .ensure_forwards(&mut partials.partial_scope_stacks);
+    }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.scopes
+            .ensure_forwards(&mut partials.partial_scope_stacks);
+    }
+
+    /// Returns the largest value of any scope stack variable in this partial scope stack.
+    pub fn largest_scope_stack_variable(&self) -> u32 {
+        self.variable
+            .into_option()
+            .map(ScopeStackVariable::as_u32)
+            .unwrap_or(0)
+    }
+}
+
+impl DisplayWithPartialPaths for PartialScopeStack {
+    fn prepare(&mut self, _graph: &StackGraph, partials: &mut PartialPaths) {
+        self.scopes
+            .ensure_forwards(&mut partials.partial_scope_stacks);
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        let mut first = true;
+        for scope in self.scopes.iter_reused(&partials.partial_scope_stacks) {
+            if first {
+                first = false;
+            } else {
+                write!(f, ",")?;
+            }
+            write!(f, "{:#}", scope.display(graph))?;
+        }
+        if let Some(variable) = self.variable.into_option() {
+            if self.scopes.is_empty() {
+                write!(f, "{}", variable)?;
+            } else {
+                write!(f, ",{}", variable)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial symbol bindings
+
+pub struct PartialSymbolStackBindings {
+    bindings: SmallVec<[Option<PartialSymbolStack>; 4]>,
+}
+
+impl PartialSymbolStackBindings {
+    /// Creates a new, empty set of partial symbol stack bindings.
+    pub fn new() -> PartialSymbolStackBindings {
+        PartialSymbolStackBindings {
+            bindings: SmallVec::new(),
+        }
+    }
+
+    /// Returns the partial symbol stack that a particular symbol stack variable matched.  Returns an
+    /// error if that variable didn't match anything.
+    pub fn get(&self, variable: SymbolStackVariable) -> Option<PartialSymbolStack> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            return None;
+        }
+        self.bindings[index - 1]
+    }
+
+    /// Adds a new binding from a symbol stack variable to the partial symbol stack that it
+    /// matched.  Returns an error if you try to bind a particular variable more than once.
+    pub fn add(
+        &mut self,
+        partials: &mut PartialPaths,
+        variable: SymbolStackVariable,
+        mut symbols: PartialSymbolStack,
+        scope_bindings: &mut PartialScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            self.bindings.resize_with(index, || None);
+        }
+        if let Some(old_binding) = self.bindings[index - 1] {
+            symbols = symbols.unify(partials, old_binding, self, scope_bindings)?;
+        }
+        self.bindings[index - 1] = Some(symbols);
+        Ok(())
+    }
+
+    pub fn display<'a>(
+        &'a mut self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+impl<'a> DisplayWithPartialPaths for &'a mut PartialSymbolStackBindings {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        for binding in &mut self.bindings {
+            if let Some(binding) = binding.as_mut() {
+                binding.prepare(graph, partials);
+            }
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let mut first = true;
+        for (idx, binding) in self.bindings.iter().enumerate() {
+            if let Some(binding) = binding.as_ref() {
+                if first {
+                    first = false;
+                } else {
+                    write!(f, ", ")?;
+                }
+                write!(
+                    f,
+                    "%{} => <{}>",
+                    idx + 1,
+                    display_prepared(*binding, graph, partials)
+                )?;
+            }
+        }
+        write!(f, "}}")
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial scope bindings
+
+pub struct PartialScopeStackBindings {
+    bindings: SmallVec<[Option<PartialScopeStack>; 4]>,
+}
+
+impl PartialScopeStackBindings {
+    /// Creates a new, empty set of partial scope stack bindings.
+    pub fn new() -> PartialScopeStackBindings {
+        PartialScopeStackBindings {
+            bindings: SmallVec::new(),
+        }
+    }
+
+    /// Returns the partial scope stack that a particular scope stack variable matched.  Returns an error
+    /// if that variable didn't match anything.
+    pub fn get(&self, variable: ScopeStackVariable) -> Option<PartialScopeStack> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            return None;
+        }
+        self.bindings[index - 1]
+    }
+
+    /// Adds a new binding from a scope stack variable to the partial scope stack that it matched.  Returns
+    /// an error if you try to bind a particular variable more than once.
+    pub fn add(
+        &mut self,
+        partials: &mut PartialPaths,
+        variable: ScopeStackVariable,
+        mut scopes: PartialScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            self.bindings.resize_with(index, || None);
+        }
+        if let Some(old_binding) = self.bindings[index - 1] {
+            scopes = scopes.unify(partials, old_binding, self)?;
+        }
+        self.bindings[index - 1] = Some(scopes);
+        Ok(())
+    }
+
+    pub fn display<'a>(
+        &'a mut self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+impl<'a> DisplayWithPartialPaths for &'a mut PartialScopeStackBindings {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        for binding in &mut self.bindings {
+            if let Some(binding) = binding.as_mut() {
+                binding.prepare(graph, partials);
+            }
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let mut first = true;
+        for (idx, binding) in self.bindings.iter().enumerate() {
+            if let Some(binding) = binding.as_ref() {
+                if first {
+                    first = false;
+                } else {
+                    write!(f, ", ")?;
+                }
+                write!(
+                    f,
+                    "${} => ({})",
+                    idx + 1,
+                    display_prepared(*binding, graph, partials)
+                )?;
+            }
+        }
+        write!(f, "}}")
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Edge lists
+
+#[repr(C)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PartialPathEdge {
+    pub source_node_id: NodeID,
+    pub precedence: i32,
+}
+
+impl PartialPathEdge {
+    /// Returns whether one edge shadows another.  Note that shadowing is not commutative — if path
+    /// A shadows path B, the reverse is not true.
+    pub fn shadows(self, other: PartialPathEdge) -> bool {
+        self.source_node_id == other.source_node_id && self.precedence > other.precedence
+    }
+
+    pub fn display<'a>(
+        self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+impl DisplayWithPartialPaths for PartialPathEdge {
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        _partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match graph.node_for_id(self.source_node_id) {
+            Some(node) => write!(f, "{:#}", node.display(graph))?,
+            None => write!(f, "[missing]")?,
+        }
+        if self.precedence != 0 {
+            write!(f, "({})", self.precedence)?;
+        }
+        Ok(())
+    }
+}
+
+/// The edges in a path keep track of precedence information so that we can correctly handle
+/// shadowed definitions.
+#[repr(C)]
+#[derive(Clone, Copy, Niche)]
+pub struct PartialPathEdgeList {
+    #[niche]
+    edges: Deque<PartialPathEdge>,
+    length: u32,
+}
+
+impl PartialPathEdgeList {
+    /// Returns whether this edge list is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Returns whether this edge list is iterable in both directions without needing mutable
+    /// access to the arena.
+    pub fn have_reversal(&self, partials: &PartialPaths) -> bool {
+        self.edges.have_reversal(&partials.partial_path_edges)
+    }
+
+    /// Returns an empty edge list.
+    pub fn empty() -> PartialPathEdgeList {
+        PartialPathEdgeList {
+            edges: Deque::empty(),
+            length: 0,
+        }
+    }
+
+    /// Pushes a new edge onto the front of this edge list.
+    pub fn push_front(&mut self, partials: &mut PartialPaths, edge: PartialPathEdge) {
+        self.length += 1;
+        self.edges
+            .push_front(&mut partials.partial_path_edges, edge);
+    }
+
+    /// Pushes a new edge onto the back of this edge list.
+    pub fn push_back(&mut self, partials: &mut PartialPaths, edge: PartialPathEdge) {
+        self.length += 1;
+        self.edges.push_back(&mut partials.partial_path_edges, edge);
+    }
+
+    /// Removes and returns the edge at the front of this edge list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_front(&mut self, partials: &mut PartialPaths) -> Option<PartialPathEdge> {
+        let result = self.edges.pop_front(&mut partials.partial_path_edges);
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result.copied()
+    }
+
+    /// Removes and returns the edge at the back of this edge list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_back(&mut self, partials: &mut PartialPaths) -> Option<PartialPathEdge> {
+        let result = self.edges.pop_back(&mut partials.partial_path_edges);
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result.copied()
+    }
+
+    pub fn display<'a>(
+        self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+
+    /// Returns whether one edge list shadows another.  Note that shadowing is not commutative — if
+    /// path A shadows path B, the reverse is not true.
+    pub fn shadows(mut self, partials: &mut PartialPaths, mut other: PartialPathEdgeList) -> bool {
+        while let Some(self_edge) = self.pop_front(partials) {
+            if let Some(other_edge) = other.pop_front(partials) {
+                if self_edge.source_node_id != other_edge.source_node_id {
+                    return false;
+                } else if self_edge.shadows(other_edge) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+        false
+    }
+
+    pub fn equals(mut self, partials: &mut PartialPaths, mut other: PartialPathEdgeList) -> bool {
+        while let Some(self_edge) = self.pop_front(partials) {
+            if let Some(other_edge) = other.pop_front(partials) {
+                if self_edge != other_edge {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        other.edges.is_empty()
+    }
+
+    pub fn cmp(
+        mut self,
+        partials: &mut PartialPaths,
+        mut other: PartialPathEdgeList,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        while let Some(self_edge) = self.pop_front(partials) {
+            if let Some(other_edge) = other.pop_front(partials) {
+                match self_edge.cmp(&other_edge) {
+                    Ordering::Equal => continue,
+                    result @ _ => return result,
+                }
+            } else {
+                return Ordering::Greater;
+            }
+        }
+        if other.edges.is_empty() {
+            Ordering::Equal
+        } else {
+            Ordering::Less
+        }
+    }
+
+    /// Returns an iterator over the contents of this edge list.
+    pub fn iter<'a>(
+        &self,
+        partials: &'a mut PartialPaths,
+    ) -> impl Iterator<Item = PartialPathEdge> + 'a {
+        self.edges.iter(&mut partials.partial_path_edges).copied()
+    }
+
+    /// Returns an iterator over the contents of this edge list, with no guarantee about the
+    /// ordering of the elements.
+    pub fn iter_unordered<'a>(
+        &self,
+        partials: &'a PartialPaths,
+    ) -> impl Iterator<Item = PartialPathEdge> + 'a {
+        self.edges
+            .iter_unordered(&partials.partial_path_edges)
+            .copied()
+    }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.edges
+            .ensure_backwards(&mut partials.partial_path_edges);
+        self.edges.ensure_forwards(&mut partials.partial_path_edges);
+    }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.edges.ensure_forwards(&mut partials.partial_path_edges);
+    }
+}
+
+impl DisplayWithPartialPaths for PartialPathEdgeList {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        self.edges.ensure_forwards(&mut partials.partial_path_edges);
+        let mut edges = self.edges;
+        while let Some(mut edge) = edges.pop_front(&mut partials.partial_path_edges).copied() {
+            edge.prepare(graph, partials);
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        for edge in self.edges.iter_reused(&partials.partial_path_edges) {
+            edge.display_with(graph, partials, f)?;
+        }
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial paths
+
+/// A portion of a name-binding path.
+///
+/// Partial paths can be computed _incrementally_, in which case all of the edges in the partial
+/// path belong to a single file.  At query time, we can efficiently concatenate partial paths to
+/// yield a name-binding path.
+///
+/// Paths describe the contents of the symbol stack and scope stack at the end of the path.
+/// Partial paths, on the other hand, have _preconditions_ and _postconditions_ for each stack.
+/// The precondition describes what the stack must look like for us to be able to concatenate this
+/// partial path onto the end of a path.  The postcondition describes what the resulting stack
+/// looks like after doing so.
+///
+/// The preconditions can contain _scope stack variables_, which describe parts of the scope stack
+/// (or parts of a scope symbol's attached scope list) whose contents we don't care about.  The
+/// postconditions can _also_ refer to those variables, and describe how those variable parts of
+/// the input scope stacks are carried through unmodified into the resulting scope stack.
+#[repr(C)]
+#[derive(Clone)]
+pub struct PartialPath {
+    pub start_node: Handle<Node>,
+    pub end_node: Handle<Node>,
+    pub symbol_stack_precondition: PartialSymbolStack,
+    pub symbol_stack_postcondition: PartialSymbolStack,
+    pub scope_stack_precondition: PartialScopeStack,
+    pub scope_stack_postcondition: PartialScopeStack,
+    pub edges: PartialPathEdgeList,
+}
+
+impl PartialPath {
+    /// Creates a new empty partial path starting at a stack graph node.
+    pub fn from_node(
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        node: Handle<Node>,
+    ) -> PartialPath {
+        let initial_symbol_stack = SymbolStackVariable::initial();
+        let initial_scope_stack = ScopeStackVariable::initial();
+        let mut symbol_stack_precondition = PartialSymbolStack::from_variable(initial_symbol_stack);
+        let mut symbol_stack_postcondition =
+            PartialSymbolStack::from_variable(initial_symbol_stack);
+        let mut scope_stack_precondition = PartialScopeStack::from_variable(initial_scope_stack);
+        let mut scope_stack_postcondition = PartialScopeStack::from_variable(initial_scope_stack);
+
+        graph[node]
+            .append_to_partial_stacks(
+                graph,
+                partials,
+                &mut symbol_stack_precondition,
+                &mut scope_stack_precondition,
+                &mut symbol_stack_postcondition,
+                &mut scope_stack_postcondition,
+            )
+            .expect("lifting single nodes to partial paths should not fail");
+
+        PartialPath {
+            start_node: node,
+            end_node: node,
+            symbol_stack_precondition,
+            symbol_stack_postcondition,
+            scope_stack_precondition,
+            scope_stack_postcondition,
+            edges: PartialPathEdgeList::empty(),
+        }
+    }
+
+    /// Returns whether one path shadows another.  Note that shadowing is not commutative — if path
+    /// A shadows path B, the reverse is not true.
+    pub fn shadows(&self, partials: &mut PartialPaths, other: &PartialPath) -> bool {
+        self.edges.shadows(partials, other.edges)
+    }
+
+    pub fn equals(&self, partials: &mut PartialPaths, other: &PartialPath) -> bool {
+        self.start_node == other.start_node
+            && self.end_node == other.end_node
+            && self
+                .symbol_stack_precondition
+                .equals(partials, other.symbol_stack_precondition)
+            && self
+                .symbol_stack_postcondition
+                .equals(partials, other.symbol_stack_postcondition)
+            && self
+                .scope_stack_precondition
+                .equals(partials, other.scope_stack_precondition)
+            && self
+                .scope_stack_postcondition
+                .equals(partials, other.scope_stack_postcondition)
+    }
+
+    pub fn cmp(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        other: &PartialPath,
+    ) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+            .then_with(|| self.start_node.cmp(&other.start_node))
+            .then_with(|| self.end_node.cmp(&other.end_node))
+            .then_with(|| {
+                self.symbol_stack_precondition
+                    .cmp(graph, partials, other.symbol_stack_precondition)
+            })
+            .then_with(|| {
+                self.symbol_stack_postcondition.cmp(
+                    graph,
+                    partials,
+                    other.symbol_stack_postcondition,
+                )
+            })
+            .then_with(|| {
+                self.scope_stack_precondition
+                    .cmp(partials, other.scope_stack_precondition)
+            })
+            .then_with(|| {
+                self.scope_stack_postcondition
+                    .cmp(partials, other.scope_stack_postcondition)
+            })
+    }
+
+    /// Returns whether a partial path represents the start of a name binding from a reference to a
+    /// definition.
+    pub fn starts_at_reference(&self, graph: &StackGraph) -> bool {
+        graph[self.start_node].is_reference()
+            && self.symbol_stack_precondition.can_match_empty()
+            && self.scope_stack_precondition.can_match_empty()
+    }
+
+    /// Returns whether a partial path represents the end of a name binding from a reference to a
+    /// definition.
+    pub fn ends_at_definition(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_definition() && self.symbol_stack_postcondition.can_match_empty()
+    }
+
+    /// A _complete_ partial path represents a full name binding that resolves a reference to a
+    /// definition.
+    pub fn is_complete(&self, graph: &StackGraph) -> bool {
+        self.starts_at_reference(graph) && self.ends_at_definition(graph)
+    }
+
+    pub fn starts_at_endpoint(&self, graph: &StackGraph) -> bool {
+        graph[self.start_node].is_endpoint()
+    }
+
+    pub fn ends_at_endpoint(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_endpoint()
+    }
+
+    pub fn ends_in_jump(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_jump_to()
+    }
+
+    /// Returns whether a partial path is cyclic---that is, it starts and ends at the same node,
+    /// and its postcondition is compatible with its precondition.  If the path is cyclic, a
+    /// tuple is returned indicating whether cycle requires strengthening the pre- or postcondition.
+    pub fn is_cyclic(&self, graph: &StackGraph, partials: &mut PartialPaths) -> Option<Cyclicity> {
+        // StackGraph ensures that there are no nodes with duplicate IDs, so we can do a simple
+        // comparison of node handles here.
+        if self.start_node != self.end_node {
+            return None;
+        }
+
+        let lhs = self;
+        let mut rhs = self.clone();
+        rhs.ensure_no_overlapping_variables(partials, lhs);
+
+        let join = match Self::compute_join(graph, partials, lhs, &rhs) {
+            Ok(join) => join,
+            Err(_) => return None,
+        };
+
+        if lhs
+            .symbol_stack_precondition
+            .variable
+            .into_option()
+            .map_or(false, |v| join.symbol_bindings.get(v).iter().len() > 0)
+            || lhs
+                .scope_stack_precondition
+                .variable
+                .into_option()
+                .map_or(false, |v| join.scope_bindings.get(v).iter().len() > 0)
+        {
+            Some(Cyclicity::StrengthensPrecondition)
+        } else if rhs
+            .symbol_stack_postcondition
+            .variable
+            .into_option()
+            .map_or(false, |v| join.symbol_bindings.get(v).iter().len() > 0)
+            || rhs
+                .scope_stack_postcondition
+                .variable
+                .into_option()
+                .map_or(false, |v| join.scope_bindings.get(v).iter().len() > 0)
+        {
+            Some(Cyclicity::StrengthensPostcondition)
+        } else {
+            Some(Cyclicity::Free)
+        }
+    }
+
+    /// Ensures that the content of this partial path is available in both forwards and backwards
+    /// directions.
+    pub fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.symbol_stack_precondition
+            .ensure_both_directions(partials);
+        self.symbol_stack_postcondition
+            .ensure_both_directions(partials);
+        self.scope_stack_precondition
+            .ensure_both_directions(partials);
+        self.scope_stack_postcondition
+            .ensure_both_directions(partials);
+        self.edges.ensure_both_directions(partials);
+
+        let mut stack = self.symbol_stack_precondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_both_directions(partials);
+            }
+        }
+
+        let mut stack = self.symbol_stack_postcondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_both_directions(partials);
+            }
+        }
+    }
+
+    /// Ensures that the content of this partial path is in forwards direction.
+    pub fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.symbol_stack_precondition.ensure_forwards(partials);
+        self.symbol_stack_postcondition.ensure_forwards(partials);
+        self.scope_stack_precondition.ensure_forwards(partials);
+        self.scope_stack_postcondition.ensure_forwards(partials);
+        self.edges.ensure_forwards(partials);
+
+        let mut stack = self.symbol_stack_precondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_forwards(partials);
+            }
+        }
+
+        let mut stack = self.symbol_stack_postcondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_forwards(partials);
+            }
+        }
+    }
+
+    /// Returns the largest value of any symbol stack variable in this partial path.
+    pub fn largest_symbol_stack_variable(&self) -> u32 {
+        // We don't have to check the postconditions, because it's not valid for a postcondition to
+        // refer to a variable that doesn't exist in the precondition.
+        self.symbol_stack_precondition
+            .largest_symbol_stack_variable()
+    }
+
+    /// Returns the largest value of any scope stack variable in this partial path.
+    pub fn largest_scope_stack_variable(&self, partials: &PartialPaths) -> u32 {
+        Self::largest_scope_stack_variable_for_partial_stacks(
+            partials,
+            &self.symbol_stack_precondition,
+            &self.scope_stack_precondition,
+        )
+    }
+
+    fn largest_scope_stack_variable_for_partial_stacks(
+        partials: &PartialPaths,
+        symbol_stack_precondition: &PartialSymbolStack,
+        scope_stack_precondition: &PartialScopeStack,
+    ) -> u32 {
+        // We don't have to check the postconditions, because it's not valid for a postcondition to
+        // refer to a variable that doesn't exist in the precondition.
+        std::cmp::max(
+            symbol_stack_precondition.largest_scope_stack_variable(partials),
+            scope_stack_precondition.largest_scope_stack_variable(),
+        )
+    }
+
+    /// Returns a fresh scope stack variable that is not already used anywhere in this partial
+    /// path.
+    pub fn fresh_scope_stack_variable(&self, partials: &PartialPaths) -> ScopeStackVariable {
+        Self::fresh_scope_stack_variable_for_partial_stack(
+            partials,
+            &self.symbol_stack_precondition,
+            &self.scope_stack_precondition,
+        )
+    }
+
+    fn fresh_scope_stack_variable_for_partial_stack(
+        partials: &PartialPaths,
+        symbol_stack_precondition: &PartialSymbolStack,
+        scope_stack_precondition: &PartialScopeStack,
+    ) -> ScopeStackVariable {
+        ScopeStackVariable::fresher_than(Self::largest_scope_stack_variable_for_partial_stacks(
+            partials,
+            symbol_stack_precondition,
+            scope_stack_precondition,
+        ))
+    }
+
+    pub fn display<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+#[derive(Debug, EnumSetType)]
+pub enum Cyclicity {
+    /// The path can be freely concatenated to itself.
+    Free,
+    /// Concatenating the path to itself strengthens the precondition---symbols are eliminated from the stack.
+    StrengthensPrecondition,
+    /// Concatenating the path to itself strengthens the postcondition---symbols are introduced on the stack.
+    StrengthensPostcondition,
+}
+
+impl<'a> DisplayWithPartialPaths for &'a PartialPath {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        self.symbol_stack_precondition
+            .clone()
+            .prepare(graph, partials);
+        self.symbol_stack_postcondition
+            .clone()
+            .prepare(graph, partials);
+        self.scope_stack_precondition
+            .clone()
+            .prepare(graph, partials);
+        self.scope_stack_postcondition
+            .clone()
+            .prepare(graph, partials);
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "<{}> ({}) {} -> {} <{}> ({})",
+            display_prepared(self.symbol_stack_precondition, graph, partials),
+            display_prepared(self.scope_stack_precondition, graph, partials),
+            self.start_node.display(graph),
+            self.end_node.display(graph),
+            display_prepared(self.symbol_stack_postcondition, graph, partials),
+            display_prepared(self.scope_stack_postcondition, graph, partials),
+        )
+    }
+}
+
+impl PartialPath {
+    /// Modifies this partial path so that it has no symbol or scope stack variables in common with
+    /// another partial path.
+    pub fn ensure_no_overlapping_variables(
+        &mut self,
+        partials: &mut PartialPaths,
+        other: &PartialPath,
+    ) {
+        let symbol_variable_offset = other.largest_symbol_stack_variable();
+        let scope_variable_offset = other.largest_scope_stack_variable(partials);
+        self.symbol_stack_precondition = self.symbol_stack_precondition.with_offset(
+            partials,
+            symbol_variable_offset,
+            scope_variable_offset,
+        );
+        self.symbol_stack_postcondition = self.symbol_stack_postcondition.with_offset(
+            partials,
+            symbol_variable_offset,
+            scope_variable_offset,
+        );
+        self.scope_stack_precondition = self
+            .scope_stack_precondition
+            .with_offset(scope_variable_offset);
+        self.scope_stack_postcondition = self
+            .scope_stack_postcondition
+            .with_offset(scope_variable_offset);
+    }
+
+    /// Replaces stack variables in the precondition with empty stacks.
+    pub fn eliminate_precondition_stack_variables(&mut self, partials: &mut PartialPaths) {
+        let mut symbol_bindings = PartialSymbolStackBindings::new();
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        if let Some(symbol_variable) = self.symbol_stack_precondition.variable() {
+            symbol_bindings
+                .add(
+                    partials,
+                    symbol_variable,
+                    PartialSymbolStack::empty(),
+                    &mut scope_bindings,
+                )
+                .unwrap();
+        }
+        if let Some(scope_variable) = self.scope_stack_precondition.variable() {
+            scope_bindings
+                .add(partials, scope_variable, PartialScopeStack::empty())
+                .unwrap();
+        }
+
+        self.symbol_stack_precondition = self
+            .symbol_stack_precondition
+            .apply_partial_bindings(partials, &symbol_bindings, &scope_bindings)
+            .unwrap();
+        self.scope_stack_precondition = self
+            .scope_stack_precondition
+            .apply_partial_bindings(partials, &scope_bindings)
+            .unwrap();
+
+        self.symbol_stack_postcondition = self
+            .symbol_stack_postcondition
+            .apply_partial_bindings(partials, &symbol_bindings, &scope_bindings)
+            .unwrap();
+        self.scope_stack_postcondition = self
+            .scope_stack_postcondition
+            .apply_partial_bindings(partials, &scope_bindings)
+            .unwrap();
+    }
+
+    /// Attempts to append an edge to the end of a partial path.  If the edge is not a valid
+    /// extension of this partial path, we return an error describing why.
+    pub fn append(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        edge: Edge,
+    ) -> Result<(), PathResolutionError> {
+        if edge.source != self.end_node {
+            return Err(PathResolutionError::IncorrectSourceNode);
+        }
+
+        graph[edge.sink].append_to_partial_stacks(
+            graph,
+            partials,
+            &mut self.symbol_stack_precondition,
+            &mut self.scope_stack_precondition,
+            &mut self.symbol_stack_postcondition,
+            &mut self.scope_stack_postcondition,
+        )?;
+
+        self.end_node = edge.sink;
+        self.edges.push_back(
+            partials,
+            PartialPathEdge {
+                source_node_id: graph[edge.source].id(),
+                precedence: edge.precedence,
+            },
+        );
+
+        self.resolve_from_postcondition(graph, partials)?;
+
+        Ok(())
+    }
+
+    /// Attempts to resolve any _jump to scope_ node at the end of a partial path from the postcondition
+    /// scope stack.  If the partial path does not end in a _jump to scope_ node, we do nothing.  If it
+    /// does, and we cannot resolve it, then we return an error describing why.
+    pub fn resolve_from_postcondition(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+    ) -> Result<(), PathResolutionError> {
+        if !graph[self.end_node].is_jump_to() {
+            return Ok(());
+        }
+        if self.scope_stack_postcondition.can_only_match_empty() {
+            return Err(PathResolutionError::EmptyScopeStack);
+        }
+        if !self.scope_stack_postcondition.contains_scopes() {
+            return Ok(());
+        }
+        let top_scope = self.scope_stack_postcondition.pop_front(partials).unwrap();
+        self.edges.push_back(
+            partials,
+            PartialPathEdge {
+                source_node_id: graph[self.end_node].id(),
+                precedence: 0,
+            },
+        );
+        self.end_node = top_scope;
+        Ok(())
+    }
+
+    /// Resolve any _jump to scope_ node at the end of a partial path to the given node, updating the
+    /// precondition to include the given node.  If the partial path does not end in a _jump to scope_
+    /// node, we do nothing.  If it does, and we cannot resolve it, then we return an error describing
+    /// why.
+    pub fn resolve_to_node(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        node: Handle<Node>,
+    ) -> Result<(), PathResolutionError> {
+        if !graph[self.end_node].is_jump_to() {
+            return Ok(());
+        }
+
+        let scope_variable = match self.scope_stack_postcondition.variable() {
+            Some(scope_variable) => scope_variable,
+            None => return Err(PathResolutionError::ScopeStackUnsatisfied),
+        };
+        let mut scope_stack = PartialScopeStack::from_variable(scope_variable);
+        scope_stack.push_front(partials, node);
+
+        let symbol_bindings = PartialSymbolStackBindings::new();
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        scope_bindings
+            .add(partials, scope_variable, scope_stack)
+            .unwrap();
+
+        self.symbol_stack_precondition = self
+            .symbol_stack_precondition
+            .apply_partial_bindings(partials, &symbol_bindings, &scope_bindings)
+            .unwrap();
+        self.scope_stack_precondition = self
+            .scope_stack_precondition
+            .apply_partial_bindings(partials, &scope_bindings)
+            .unwrap();
+
+        self.end_node = node;
+
+        Ok(())
+    }
+}
+
+impl Node {
+    /// Update the given partial path pre- and postconditions with the effect of
+    /// appending this node to that partial path.
+    pub(crate) fn append_to_partial_stacks(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        symbol_stack_precondition: &mut PartialSymbolStack,
+        scope_stack_precondition: &mut PartialScopeStack,
+        symbol_stack_postcondition: &mut PartialSymbolStack,
+        scope_stack_postcondition: &mut PartialScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        match self {
+            Self::DropScopes(_) => {
+                *scope_stack_postcondition = PartialScopeStack::empty();
+            }
+            Self::JumpTo(_) => {}
+            Self::PopScopedSymbol(sink) => {
+                // Ideally we want to pop sink's scoped symbol off from top of the symbol stack
+                // postcondition.
+                if let Some(top) = symbol_stack_postcondition.pop_front(partials) {
+                    if top.symbol != sink.symbol {
+                        return Err(PathResolutionError::IncorrectPoppedSymbol);
+                    }
+                    let new_scope_stack = match top.scopes.into_option() {
+                        Some(scopes) => scopes,
+                        None => return Err(PathResolutionError::MissingAttachedScopeList),
+                    };
+                    *scope_stack_postcondition = new_scope_stack;
+                } else if symbol_stack_postcondition.has_variable() {
+                    // If the symbol stack postcondition is empty but has a variable, then we can update
+                    // the _precondition_ to indicate that the symbol stack needs to contain this scoped
+                    // symbol in order to successfully use this partial path.
+                    let scope_stack_variable =
+                        PartialPath::fresh_scope_stack_variable_for_partial_stack(
+                            partials,
+                            symbol_stack_precondition,
+                            scope_stack_precondition,
+                        );
+                    let precondition_symbol = PartialScopedSymbol {
+                        symbol: sink.symbol,
+                        scopes: ControlledOption::some(PartialScopeStack::from_variable(
+                            scope_stack_variable,
+                        )),
+                    };
+                    // We simply push to the precondition. The official procedure here
+                    // is to bind the postcondition symbol stack variable to the symbol
+                    // and a fresh variable, and apply that. However, because the variable
+                    // can only be bound in the precondition symbol stack, this amounts to
+                    // pushing the symbol there directly.
+                    symbol_stack_precondition.push_back(partials, precondition_symbol);
+                    *scope_stack_postcondition =
+                        PartialScopeStack::from_variable(scope_stack_variable);
+                } else {
+                    // The symbol stack postcondition is empty and has no variable, so we cannot
+                    // perform the operation.
+                    return Err(PathResolutionError::SymbolStackUnsatisfied);
+                }
+            }
+            Self::PopSymbol(sink) => {
+                // Ideally we want to pop sink's symbol off from top of the symbol stack postcondition.
+                if let Some(top) = symbol_stack_postcondition.pop_front(partials) {
+                    if top.symbol != sink.symbol {
+                        return Err(PathResolutionError::IncorrectPoppedSymbol);
+                    }
+                    if top.scopes.is_some() {
+                        return Err(PathResolutionError::UnexpectedAttachedScopeList);
+                    }
+                } else if symbol_stack_postcondition.has_variable() {
+                    // If the symbol stack postcondition is empty but has a variable, then we can update
+                    // the _precondition_ to indicate that the symbol stack needs to contain this symbol
+                    // in order to successfully use this partial path.
+                    let precondition_symbol = PartialScopedSymbol {
+                        symbol: sink.symbol,
+                        scopes: ControlledOption::none(),
+                    };
+                    // We simply push to the precondition. The official procedure here
+                    // is to bind the postcondition symbol stack variable to the symbol
+                    // and a fresh variable, and apply that. However, because the variable
+                    // can only be bound in the precondition symbol stack, this amounts to
+                    // pushing the symbol there directly.
+                    symbol_stack_precondition.push_back(partials, precondition_symbol);
+                } else {
+                    // The symbol stack postcondition is empty and has no variable, so we cannot
+                    // perform the operation.
+                    return Err(PathResolutionError::SymbolStackUnsatisfied);
+                }
+            }
+            Self::PushScopedSymbol(sink) => {
+                // The symbol stack postcondition is our representation of the path's symbol stack.
+                // Pushing the scoped symbol onto our postcondition indicates that using this partial
+                // path would push the scoped symbol onto the path's symbol stack.
+                let sink_symbol = sink.symbol;
+                let sink_scope = graph
+                    .node_for_id(sink.scope)
+                    .ok_or(PathResolutionError::UnknownAttachedScope)?;
+                let mut attached_scopes = scope_stack_postcondition.clone();
+                attached_scopes.push_front(partials, sink_scope);
+                let postcondition_symbol = PartialScopedSymbol {
+                    symbol: sink_symbol,
+                    scopes: ControlledOption::some(attached_scopes),
+                };
+                symbol_stack_postcondition.push_front(partials, postcondition_symbol);
+            }
+            Self::PushSymbol(sink) => {
+                // The symbol stack postcondition is our representation of the path's symbol stack.
+                // Pushing the symbol onto our postcondition indicates that using this partial path
+                // would push the symbol onto the path's symbol stack.
+                let sink_symbol = sink.symbol;
+                let postcondition_symbol = PartialScopedSymbol {
+                    symbol: sink_symbol,
+                    scopes: ControlledOption::none(),
+                };
+                symbol_stack_postcondition.push_front(partials, postcondition_symbol);
+            }
+            Self::Root(_) => {}
+            Self::Scope(_) => {}
+        }
+        Ok(())
+    }
+
+    /// Ensure the given closed precondition stacks are half-open for this end node.
+    ///
+    /// Partial paths have closed (cf. a closed interval) pre- and postconditions, which means
+    /// the start node is reflected in the precondition, and the end node is reflected in the
+    /// postcondition. For example, a path starting with a pop node, has a precondition starting
+    /// with the popped symbol. Similarly, a ending with a push node, has a postcondition ending
+    /// with the pushed symbol.
+    ///
+    /// When concatenating two partial paths, their closed pre- and postconditions are not compatible,
+    /// because the effect of the join node (i.e., the node shared between the two paths) is present
+    /// in both the right and the left path. If two paths join at a push node, the right postcondition
+    /// contains the pushed symbol, while the left precondition does not contain it, behaving as if the
+    /// symbol was pushed twice. Similarly, when joining at a pop node, the right precondition contains
+    /// the popped symbol, while the right postcondition will not anymore, because it was already popped.
+    /// Unifying closed pre- and postconditions can result in incorrect concatenation results.
+    ///
+    /// We can make pre- and postconditions compatible again by making them half-open (cf. open intervals,
+    /// but half because we only undo the effect of some node types). A precondition is half-open if it
+    /// does not reflect the effect if a start pop node, Similarly, a postcondition is half-open if it
+    /// does not reflect the effect of an end push node. Unifying half-open pre- and postconditions results
+    /// in the correct behavior for path concatenation.
+    fn halfopen_closed_partial_precondition(
+        &self,
+        partials: &mut PartialPaths,
+        symbol_stack: &mut PartialSymbolStack,
+        scope_stack: &mut PartialScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        match self {
+            Node::DropScopes(_) => {}
+            Node::JumpTo(_) => {}
+            Node::PopScopedSymbol(node) => {
+                let symbol = symbol_stack
+                    .pop_front(partials)
+                    .ok_or(PathResolutionError::EmptySymbolStack)?;
+                if symbol.symbol != node.symbol {
+                    return Err(PathResolutionError::IncorrectPoppedSymbol);
+                }
+                *scope_stack = symbol.scopes.into_option().unwrap();
+            }
+            Node::PopSymbol(node) => {
+                let symbol = symbol_stack
+                    .pop_front(partials)
+                    .ok_or(PathResolutionError::EmptySymbolStack)?;
+                if symbol.symbol != node.symbol {
+                    return Err(PathResolutionError::IncorrectPoppedSymbol);
+                }
+            }
+            Node::PushScopedSymbol(_) => {}
+            Node::PushSymbol(_) => {}
+            Node::Root(_) => {}
+            Node::Scope(_) => {}
+        };
+        Ok(())
+    }
+
+    /// Ensure the given closed postcondition stacks are half-open for this start node.
+    ///
+    /// Partial paths have closed (cf. a closed interval) pre- and postconditions, which means
+    /// the start node is reflected in the precondition, and the end node is reflected in the
+    /// postcondition. For example, a path starting with a pop node, has a precondition starting
+    /// with the popped symbol. Similarly, a ending with a push node, has a postcondition ending
+    /// with the pushed symbol.
+    ///
+    /// When concatenating two partial paths, their closed pre- and postconditions are not compatible,
+    /// because the effect of the join node (i.e., the node shared between the two paths) is present
+    /// in both the right and the left path. If two paths join at a push node, the right postcondition
+    /// contains the pushed symbol, while the left precondition does not contain it, behaving as if the
+    /// symbol was pushed twice. Similarly, when joining at a pop node, the right precondition contains
+    /// the popped symbol, while the right postcondition will not anymore, because it was already popped.
+    /// Unifying closed pre- and postconditions can result in incorrect concatenation results.
+    ///
+    /// We can make pre- and postconditions compatible again by making them half-open (cf. open intervals,
+    /// but half because we only undo the effect of some node types). A precondition is half-open if it
+    /// does not reflect the effect if a start pop node, Similarly, a postcondition is half-open if it
+    /// does not reflect the effect of an end push node. Unifying half-open pre- and postconditions results
+    /// in the correct behavior for path concatenation.
+    fn halfopen_closed_partial_postcondition(
+        &self,
+        partials: &mut PartialPaths,
+        symbol_stack: &mut PartialSymbolStack,
+        _scope_stack: &mut PartialScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        match self {
+            Self::DropScopes(_) => {}
+            Self::JumpTo(_) => {}
+            Self::PopScopedSymbol(_) => {}
+            Self::PopSymbol(_) => {}
+            Self::PushScopedSymbol(node) => {
+                let symbol = symbol_stack
+                    .pop_front(partials)
+                    .ok_or(PathResolutionError::EmptySymbolStack)?;
+                if symbol.symbol != node.symbol {
+                    return Err(PathResolutionError::IncorrectPoppedSymbol);
+                }
+            }
+            Self::PushSymbol(node) => {
+                let symbol = symbol_stack
+                    .pop_front(partials)
+                    .ok_or(PathResolutionError::EmptySymbolStack)?;
+                if symbol.symbol != node.symbol {
+                    return Err(PathResolutionError::IncorrectPoppedSymbol);
+                }
+            }
+            Self::Root(_) => {}
+            Self::Scope(_) => {}
+        };
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Extending partial paths with partial paths
+
+impl PartialPath {
+    /// Attempts to append a partial path to this one.  If the postcondition of the “left” partial path
+    /// is not compatible with the precondition of the “right” path, we return an error describing why.
+    ///
+    /// If the left- and right-hand partial paths have any symbol or scope stack variables in
+    /// common, then we ensure that the variables bind to the same values on both sides.  It's your
+    /// responsibility to update the two partial paths so that they have no variables in common, if
+    /// that's needed for your use case.
+    #[cfg_attr(not(feature = "copious-debugging"), allow(unused_variables))]
+    pub fn concatenate(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        rhs: &PartialPath,
+    ) -> Result<(), PathResolutionError> {
+        let lhs = self;
+
+        #[cfg_attr(not(feature = "copious-debugging"), allow(unused_mut))]
+        let mut join = Self::compute_join(graph, partials, lhs, rhs)?;
+        #[cfg(feature = "copious-debugging")]
+        {
+            let unified_symbol_stack = join
+                .unified_symbol_stack
+                .display(graph, partials)
+                .to_string();
+            let unified_scope_stack = join
+                .unified_scope_stack
+                .display(graph, partials)
+                .to_string();
+            let symbol_bindings = join.symbol_bindings.display(graph, partials).to_string();
+            let scope_bindings = join.scope_bindings.display(graph, partials).to_string();
+            copious_debugging!(
+                "       via <{}> ({}) {} {}",
+                unified_symbol_stack,
+                unified_scope_stack,
+                symbol_bindings,
+                scope_bindings,
+            );
+        }
+
+        lhs.symbol_stack_precondition = lhs.symbol_stack_precondition.apply_partial_bindings(
+            partials,
+            &join.symbol_bindings,
+            &join.scope_bindings,
+        )?;
+        lhs.symbol_stack_postcondition = rhs.symbol_stack_postcondition.apply_partial_bindings(
+            partials,
+            &join.symbol_bindings,
+            &join.scope_bindings,
+        )?;
+
+        lhs.scope_stack_precondition = lhs
+            .scope_stack_precondition
+            .apply_partial_bindings(partials, &join.scope_bindings)?;
+        lhs.scope_stack_postcondition = rhs
+            .scope_stack_postcondition
+            .apply_partial_bindings(partials, &join.scope_bindings)?;
+
+        let mut edges = rhs.edges;
+        while let Some(edge) = edges.pop_front(partials) {
+            lhs.edges.push_back(partials, edge);
+        }
+        lhs.end_node = rhs.end_node;
+
+        lhs.resolve_from_postcondition(graph, partials)?;
+
+        Ok(())
+    }
+
+    /// Compute the bindings to join to partial paths. It is the caller's responsibility
+    /// to ensure non-overlapping variables, if that is required.
+    fn compute_join(
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        lhs: &PartialPath,
+        rhs: &PartialPath,
+    ) -> Result<Join, PathResolutionError> {
+        if lhs.end_node != rhs.start_node {
+            return Err(PathResolutionError::IncorrectSourceNode);
+        }
+
+        // Ensure the right post- and left precondition are half-open, so we can unify them.
+        let mut lhs_symbol_stack_postcondition = lhs.symbol_stack_postcondition;
+        let mut lhs_scope_stack_postcondition = lhs.scope_stack_postcondition;
+        let mut rhs_symbol_stack_precondition = rhs.symbol_stack_precondition;
+        let mut rhs_scope_stack_precondition = rhs.scope_stack_precondition;
+        graph[lhs.end_node]
+            .halfopen_closed_partial_postcondition(
+                partials,
+                &mut lhs_symbol_stack_postcondition,
+                &mut lhs_scope_stack_postcondition,
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to halfopen postcondition of {}: {:?}",
+                    lhs.display(graph, partials),
+                    e
+                );
+            });
+        graph[rhs.start_node]
+            .halfopen_closed_partial_precondition(
+                partials,
+                &mut rhs_symbol_stack_precondition,
+                &mut rhs_scope_stack_precondition,
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to halfopen postcondition of {}: {:?}",
+                    rhs.display(graph, partials),
+                    e
+                );
+            });
+
+        let mut symbol_bindings = PartialSymbolStackBindings::new();
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        let unified_symbol_stack = lhs_symbol_stack_postcondition.unify(
+            partials,
+            rhs_symbol_stack_precondition,
+            &mut symbol_bindings,
+            &mut scope_bindings,
+        )?;
+        let unified_scope_stack = lhs_scope_stack_postcondition.unify(
+            partials,
+            rhs_scope_stack_precondition,
+            &mut scope_bindings,
+        )?;
+
+        Ok(Join {
+            unified_symbol_stack,
+            unified_scope_stack,
+            symbol_bindings,
+            scope_bindings,
+        })
+    }
+}
+
+struct Join {
+    #[cfg_attr(not(feature = "copious-debugging"), allow(dead_code))]
+    pub unified_symbol_stack: PartialSymbolStack,
+    #[cfg_attr(not(feature = "copious-debugging"), allow(dead_code))]
+    pub unified_scope_stack: PartialScopeStack,
+    pub symbol_bindings: PartialSymbolStackBindings,
+    pub scope_bindings: PartialScopeStackBindings,
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial path resolution state
+
+/// Manages the state of a collection of partial paths built up as part of the partial-path-finding
+/// algorithm or path-stitching algorithm.
+pub struct PartialPaths {
+    pub(crate) partial_symbol_stacks: DequeArena<PartialScopedSymbol>,
+    pub(crate) partial_scope_stacks: DequeArena<Handle<Node>>,
+    pub(crate) partial_path_edges: DequeArena<PartialPathEdge>,
+}
+
+impl PartialPaths {
+    pub fn new() -> PartialPaths {
+        PartialPaths {
+            partial_symbol_stacks: Deque::new_arena(),
+            partial_scope_stacks: Deque::new_arena(),
+            partial_path_edges: Deque::new_arena(),
+        }
+    }
+
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
+    pub(crate) fn clear(&mut self) {
+        self.partial_symbol_stacks.clear();
+        self.partial_scope_stacks.clear();
+        self.partial_path_edges.clear();
+    }
+}

--- a/crates/metaslang/stack_graphs/src/paths.rs
+++ b/crates/metaslang/stack_graphs/src/paths.rs
@@ -1,0 +1,96 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Paths represent name bindings in a source language.
+//!
+//! With the set of rules we have for constructing stack graphs, bindings between references and
+//! definitions are represented by paths within the graph.  Each edge in the path must leave the
+//! symbol and scopes stacks in a valid state — otherwise we have violated some name binding rule
+//! in the source language.  The symbol and scope stacks must be empty at the beginning and end of
+//! the path.  The reference's _push symbol_ node "seeds" the symbol stack with the first thing
+//! that we want to look for, and once we (hopefully) reach the definition that reference refers
+//! to, its pop node will remove that symbol from the symbol stack, leaving both stacks empty.
+
+use std::collections::VecDeque;
+
+/// Errors that can occur during the path resolution process.
+#[derive(Debug)]
+pub enum PathResolutionError {
+    /// The path is cyclic, and the cycle is disallowed.
+    DisallowedCycle,
+    /// The path contains a _jump to scope_ node, but there are no scopes on the scope stack to
+    /// jump to.
+    EmptyScopeStack,
+    /// The path contains a _pop symbol_ or _pop scoped symbol_ node, but there are no symbols on
+    /// the symbol stack to pop off.
+    EmptySymbolStack,
+    /// The partial path contains multiple references to a scope stack variable, and those
+    /// references can't unify on a single scope stack.
+    IncompatibleScopeStackVariables,
+    /// The partial path contains multiple references to a symbol stack variable, and those
+    /// references can't unify on a single symbol stack.
+    IncompatibleSymbolStackVariables,
+    /// The partial path contains edges from multiple files.
+    IncorrectFile,
+    /// The path contains a _pop symbol_ or _pop scoped symbol_ node, but the symbol at the top of
+    /// the symbol stack does not match.
+    IncorrectPoppedSymbol,
+    /// The path contains an edge whose source node does not match the sink node of the preceding
+    /// edge.
+    IncorrectSourceNode,
+    /// The path contains a _pop scoped symbol_ node, but the symbol at the top of the symbol stack
+    /// does not have an attached scope list to pop off.
+    MissingAttachedScopeList,
+    /// The path's scope stack does not satisfy the partial path's scope stack precondition.
+    ScopeStackUnsatisfied,
+    /// The path's symbol stack does not satisfy the partial path's symbol stack precondition.
+    SymbolStackUnsatisfied,
+    /// The partial path's postcondition references a symbol stack variable that isn't present in
+    /// the precondition.
+    UnboundSymbolStackVariable,
+    /// The partial path's postcondition references a scope stack variable that isn't present in
+    /// the precondition.
+    UnboundScopeStackVariable,
+    /// The path contains a _pop symbol_ node, but the symbol at the top of the symbol stack has an
+    /// attached scope list that we weren't expecting.
+    UnexpectedAttachedScopeList,
+    /// A _push scoped symbol_ node referes to an exported scope node that doesn't exist.
+    UnknownAttachedScope,
+}
+
+/// A collection that can be used to receive the results of the [`Path::extend`][] method.
+///
+/// Note: There's an [open issue][std-extend] to add these methods to std's `Extend` trait.  If
+/// that gets merged, we can drop this trait and use the std one instead.
+///
+/// [std-extend]: https://github.com/rust-lang/rust/issues/72631
+pub trait Extend<T> {
+    /// Reserve space for `additional` elements in the collection.
+    fn reserve(&mut self, additional: usize);
+    /// Add a new element to the collection.
+    fn push(&mut self, item: T);
+}
+
+impl<T> Extend<T> for Vec<T> {
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+
+    fn push(&mut self, item: T) {
+        self.push(item);
+    }
+}
+
+impl<T> Extend<T> for VecDeque<T> {
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+
+    fn push(&mut self, item: T) {
+        self.push_back(item);
+    }
+}

--- a/crates/metaslang/stack_graphs/src/serde/filter.rs
+++ b/crates/metaslang/stack_graphs/src/serde/filter.rs
@@ -1,0 +1,177 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use itertools::Itertools;
+
+use crate::arena::Handle;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+
+pub trait Filter {
+    /// Return whether elements for the given file must be included.
+    fn include_file(&self, graph: &StackGraph, file: &Handle<File>) -> bool;
+
+    /// Return whether the given node must be included.
+    /// Nodes of excluded files are always excluded.
+    fn include_node(&self, graph: &StackGraph, node: &Handle<Node>) -> bool;
+
+    /// Return whether the given edge must be included.
+    /// Edges via excluded nodes are always excluded.
+    fn include_edge(&self, graph: &StackGraph, source: &Handle<Node>, sink: &Handle<Node>) -> bool;
+
+    /// Return whether the given path must be included.
+    /// Paths via excluded nodes or edges are always excluded.
+    fn include_partial_path(
+        &self,
+        graph: &StackGraph,
+        paths: &PartialPaths,
+        path: &PartialPath,
+    ) -> bool;
+}
+
+impl<F> Filter for F
+where
+    F: Fn(&StackGraph, &Handle<File>) -> bool,
+{
+    fn include_file(&self, graph: &StackGraph, file: &Handle<File>) -> bool {
+        self(graph, file)
+    }
+
+    fn include_node(&self, _graph: &StackGraph, _node: &Handle<Node>) -> bool {
+        true
+    }
+
+    fn include_edge(
+        &self,
+        _graph: &StackGraph,
+        _source: &Handle<Node>,
+        _sink: &Handle<Node>,
+    ) -> bool {
+        true
+    }
+
+    fn include_partial_path(
+        &self,
+        _graph: &StackGraph,
+        _paths: &PartialPaths,
+        _path: &PartialPath,
+    ) -> bool {
+        true
+    }
+}
+
+// Filter implementation that includes everything.
+pub struct NoFilter;
+
+impl Filter for NoFilter {
+    fn include_file(&self, _graph: &StackGraph, _file: &Handle<File>) -> bool {
+        true
+    }
+
+    fn include_node(&self, _graph: &StackGraph, _node: &Handle<Node>) -> bool {
+        true
+    }
+
+    fn include_edge(
+        &self,
+        _graph: &StackGraph,
+        _source: &Handle<Node>,
+        _sink: &Handle<Node>,
+    ) -> bool {
+        true
+    }
+
+    fn include_partial_path(
+        &self,
+        _graph: &StackGraph,
+        _paths: &PartialPaths,
+        _path: &PartialPath,
+    ) -> bool {
+        true
+    }
+}
+
+/// Filter implementation that includes a single file.
+pub struct FileFilter(pub Handle<File>);
+
+impl Filter for FileFilter {
+    fn include_file(&self, _graph: &StackGraph, file: &Handle<File>) -> bool {
+        *file == self.0
+    }
+
+    fn include_node(&self, _graph: &StackGraph, _node: &Handle<Node>) -> bool {
+        true
+    }
+
+    fn include_edge(
+        &self,
+        _graph: &StackGraph,
+        _source: &Handle<Node>,
+        _sink: &Handle<Node>,
+    ) -> bool {
+        true
+    }
+
+    fn include_partial_path(
+        &self,
+        _graph: &StackGraph,
+        _paths: &PartialPaths,
+        _path: &PartialPath,
+    ) -> bool {
+        true
+    }
+}
+
+/// Filter implementation that enforces all implications of another filter.
+/// For example, that nodes frome excluded files are not included, etc.
+pub(crate) struct ImplicationFilter<'a>(pub &'a dyn Filter);
+
+impl Filter for ImplicationFilter<'_> {
+    fn include_file(&self, graph: &StackGraph, file: &Handle<File>) -> bool {
+        self.0.include_file(graph, file)
+    }
+
+    fn include_node(&self, graph: &StackGraph, node: &Handle<Node>) -> bool {
+        graph[*node]
+            .id()
+            .file()
+            .map_or(true, |f| self.include_file(graph, &f))
+            && self.0.include_node(graph, node)
+    }
+
+    fn include_edge(&self, graph: &StackGraph, source: &Handle<Node>, sink: &Handle<Node>) -> bool {
+        self.include_node(graph, source)
+            && self.include_node(graph, sink)
+            && self.0.include_edge(graph, source, sink)
+    }
+
+    fn include_partial_path(
+        &self,
+        graph: &StackGraph,
+        paths: &PartialPaths,
+        path: &PartialPath,
+    ) -> bool {
+        let super_ok = self.0.include_partial_path(graph, paths, path);
+        if !super_ok {
+            return false;
+        }
+        let all_included_edges = path
+            .edges
+            .iter_unordered(paths)
+            .map(|e| graph.node_for_id(e.source_node_id).unwrap())
+            .chain(std::iter::once(path.end_node))
+            .tuple_windows()
+            .all(|(source, sink)| self.include_edge(graph, &source, &sink));
+        if !all_included_edges {
+            return false;
+        }
+        true
+    }
+}

--- a/crates/metaslang/stack_graphs/src/serde/graph.rs
+++ b/crates/metaslang/stack_graphs/src/serde/graph.rs
@@ -1,0 +1,599 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use thiserror::Error;
+
+use crate::arena::Handle;
+
+use super::Filter;
+use super::ImplicationFilter;
+use super::NoFilter;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct StackGraph {
+    pub files: Files,
+    pub nodes: Nodes,
+    pub edges: Edges,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum Error {
+    #[error("failed to load file `{0}`")]
+    FileNotFound(String),
+    #[error("duplicate file `{0}`")]
+    FileAlreadyPresent(String),
+    #[error("node `{0}` is an invalid node")]
+    InvalidGlobalNodeID(u32),
+    #[error("variable `{0}` is an invalid stack variable")]
+    InvalidStackVariable(u32),
+    #[error("failed to locate node `{0}` in graph")]
+    NodeNotFound(NodeID),
+}
+
+impl StackGraph {
+    pub fn from_graph<'a>(graph: &crate::graph::StackGraph) -> Self {
+        Self::from_graph_filter(graph, &NoFilter)
+    }
+
+    pub fn from_graph_filter<'a>(graph: &crate::graph::StackGraph, filter: &'a dyn Filter) -> Self {
+        let filter = ImplicationFilter(filter);
+        let files = graph.filter_files(&filter);
+        let nodes = graph.filter_nodes(&filter);
+        let edges = graph.filter_edges(&filter);
+        Self {
+            files,
+            nodes,
+            edges,
+        }
+    }
+
+    pub fn load_into(&self, graph: &mut crate::graph::StackGraph) -> Result<(), Error> {
+        self.load_files(graph)?;
+        self.load_nodes(graph)?;
+        self.load_edges(graph)?;
+        Ok(())
+    }
+
+    fn load_files(&self, graph: &mut crate::graph::StackGraph) -> Result<(), Error> {
+        for file in self.files.data.iter() {
+            graph
+                .add_file(&file)
+                .map_err(|_| Error::FileAlreadyPresent(file.to_owned()))?;
+        }
+
+        Ok(())
+    }
+
+    fn load_nodes(&self, graph: &mut crate::graph::StackGraph) -> Result<(), Error> {
+        for node in &self.nodes.data {
+            let handle = match node {
+                Node::DropScopes { id, .. } => {
+                    let node_id = id.to_node_id(graph)?;
+                    graph.add_drop_scopes_node(node_id)
+                }
+                Node::PopScopedSymbol {
+                    id,
+                    symbol,
+                    is_definition,
+                    ..
+                } => {
+                    let node_id = id.to_node_id(graph)?;
+                    let symbol_handle = graph.add_symbol(&symbol);
+                    graph.add_pop_scoped_symbol_node(node_id, symbol_handle, *is_definition)
+                }
+                Node::PopSymbol {
+                    id,
+                    symbol,
+                    is_definition,
+                    ..
+                } => {
+                    let node_id = id.to_node_id(graph)?;
+                    let symbol_handle = graph.add_symbol(&symbol);
+                    graph.add_pop_symbol_node(node_id, symbol_handle, *is_definition)
+                }
+                Node::PushScopedSymbol {
+                    id,
+                    symbol,
+                    scope,
+                    is_reference,
+                    ..
+                } => {
+                    let node_id = id.to_node_id(graph)?;
+                    let scope_id = scope.to_node_id(graph)?;
+                    let symbol_handle = graph.add_symbol(&symbol);
+                    graph.add_push_scoped_symbol_node(
+                        node_id,
+                        symbol_handle,
+                        scope_id,
+                        *is_reference,
+                    )
+                }
+                Node::PushSymbol {
+                    id,
+                    symbol,
+                    is_reference,
+                    ..
+                } => {
+                    let node_id = id.to_node_id(graph)?;
+                    let symbol_handle = graph.add_symbol(&symbol);
+                    graph.add_push_symbol_node(node_id, symbol_handle, *is_reference)
+                }
+                Node::Scope {
+                    id, is_exported, ..
+                } => {
+                    let node_id = id.to_node_id(graph)?;
+                    graph.add_scope_node(node_id, *is_exported)
+                }
+                Node::JumpToScope { .. } | Node::Root { .. } => None,
+            };
+
+            if let Some(handle) = handle {
+                // load source-info of each node
+                if let Some(source_info) = node.source_info() {
+                    *graph.source_info_mut(handle) = crate::graph::SourceInfo {
+                        span: source_info.span.clone(),
+                        syntax_type: source_info
+                            .syntax_type
+                            .as_ref()
+                            .map(|st| graph.add_string(&st))
+                            .into(),
+                        ..Default::default()
+                    };
+                }
+
+                // load debug-info of each node
+                if let Some(debug_info) = node.debug_info() {
+                    *graph.node_debug_info_mut(handle) = debug_info.data.iter().fold(
+                        crate::graph::DebugInfo::default(),
+                        |mut info, entry| {
+                            let key = graph.add_string(&entry.key);
+                            let value = graph.add_string(&entry.value);
+                            info.add(key, value);
+                            info
+                        },
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn load_edges(&self, graph: &mut crate::graph::StackGraph) -> Result<(), Error> {
+        // load edges into stack-graph
+        for Edge {
+            source,
+            sink,
+            precedence,
+            debug_info,
+        } in &self.edges.data
+        {
+            let source_id = source.to_node_id(graph)?;
+            let sink_id = sink.to_node_id(graph)?;
+
+            let source_handle = graph
+                .node_for_id(source_id)
+                .ok_or(Error::InvalidGlobalNodeID(source.local_id))?;
+            let sink_handle = graph
+                .node_for_id(sink_id)
+                .ok_or(Error::InvalidGlobalNodeID(sink.local_id))?;
+
+            graph.add_edge(source_handle, sink_handle, *precedence);
+
+            // load debug-info of each node
+            if let Some(debug_info) = debug_info {
+                *graph.edge_debug_info_mut(source_handle, sink_handle) = debug_info
+                    .data
+                    .iter()
+                    .fold(crate::graph::DebugInfo::default(), |mut info, entry| {
+                        let key = graph.add_string(&entry.key);
+                        let value = graph.add_string(&entry.value);
+                        info.add(key, value);
+                        info
+                    });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct Files {
+    pub data: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct Nodes {
+    pub data: Vec<Node>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+    serde(tag = "type", rename_all = "snake_case"),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub enum Node {
+    DropScopes {
+        id: NodeID,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    JumpToScope {
+        id: NodeID,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    PopScopedSymbol {
+        id: NodeID,
+        symbol: String,
+        is_definition: bool,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    PopSymbol {
+        id: NodeID,
+        symbol: String,
+        is_definition: bool,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    PushScopedSymbol {
+        id: NodeID,
+        symbol: String,
+        scope: NodeID,
+        is_reference: bool,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    PushSymbol {
+        id: NodeID,
+        symbol: String,
+        is_reference: bool,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    Root {
+        id: NodeID,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+
+    Scope {
+        id: NodeID,
+        is_exported: bool,
+        source_info: Option<SourceInfo>,
+        debug_info: Option<DebugInfo>,
+    },
+}
+
+impl Node {
+    fn source_info(&self) -> Option<&SourceInfo> {
+        match self {
+            Self::DropScopes { source_info, .. } => source_info,
+            Self::JumpToScope { source_info, .. } => source_info,
+            Self::PopScopedSymbol { source_info, .. } => source_info,
+            Self::PopSymbol { source_info, .. } => source_info,
+            Self::PushScopedSymbol { source_info, .. } => source_info,
+            Self::PushSymbol { source_info, .. } => source_info,
+            Self::Root { source_info, .. } => source_info,
+            Self::Scope { source_info, .. } => source_info,
+        }
+        .as_ref()
+    }
+
+    fn debug_info(&self) -> Option<&DebugInfo> {
+        match self {
+            Self::DropScopes { debug_info, .. } => debug_info,
+            Self::JumpToScope { debug_info, .. } => debug_info,
+            Self::PopScopedSymbol { debug_info, .. } => debug_info,
+            Self::PopSymbol { debug_info, .. } => debug_info,
+            Self::PushScopedSymbol { debug_info, .. } => debug_info,
+            Self::PushSymbol { debug_info, .. } => debug_info,
+            Self::Root { debug_info, .. } => debug_info,
+            Self::Scope { debug_info, .. } => debug_info,
+        }
+        .as_ref()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct SourceInfo {
+    pub span: lsp_positions::Span,
+    pub syntax_type: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct DebugInfo {
+    pub data: Vec<DebugEntry>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct DebugEntry {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct NodeID {
+    pub file: Option<String>,
+    pub local_id: u32,
+}
+
+impl NodeID {
+    pub fn from_node_id(graph: &crate::graph::StackGraph, value: crate::graph::NodeID) -> Self {
+        Self {
+            file: value.file().map(|f| graph[f].to_string()),
+            local_id: value.local_id(),
+        }
+    }
+
+    pub fn to_node_id(
+        &self,
+        graph: &crate::graph::StackGraph,
+    ) -> Result<crate::graph::NodeID, Error> {
+        if let Some(file) = &self.file {
+            let file = graph
+                .get_file(file)
+                .ok_or_else(|| Error::FileNotFound(file.clone()))?;
+            Ok(crate::graph::NodeID::new_in_file(file, self.local_id))
+        } else if self.local_id == crate::graph::JUMP_TO_NODE_ID {
+            Ok(crate::graph::NodeID::jump_to())
+        } else if self.local_id == crate::graph::ROOT_NODE_ID {
+            Ok(crate::graph::NodeID::root())
+        } else {
+            Err(Error::InvalidGlobalNodeID(self.local_id))
+        }
+    }
+
+    pub fn from_node(graph: &crate::graph::StackGraph, handle: Handle<crate::graph::Node>) -> Self {
+        Self::from_node_id(graph, graph[handle].id())
+    }
+
+    pub fn to_node(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+    ) -> Result<Handle<crate::graph::Node>, Error> {
+        let value = self.to_node_id(graph)?;
+        Ok(graph
+            .node_for_id(value)
+            .ok_or_else(|| Error::NodeNotFound(self.clone()))?)
+    }
+}
+
+impl std::fmt::Display for NodeID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(file) = &self.file {
+            write!(f, "{}:", file)?;
+        }
+        write!(f, "{}", self.local_id)
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct Edges {
+    pub data: Vec<Edge>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct Edge {
+    pub source: NodeID,
+    pub sink: NodeID,
+    pub precedence: i32,
+    pub debug_info: Option<DebugInfo>,
+}
+
+impl crate::graph::StackGraph {
+    pub fn to_serializable(&self) -> StackGraph {
+        self.to_serializable_filter(&NoFilter)
+    }
+
+    pub fn to_serializable_filter<'a>(&self, f: &'a dyn Filter) -> StackGraph {
+        crate::serde::StackGraph::from_graph_filter(self, f)
+    }
+
+    fn filter_files<'a>(&self, filter: &'a dyn Filter) -> Files {
+        Files {
+            data: self
+                .iter_files()
+                .filter(|f| filter.include_file(self, f))
+                .map(|f| self[f].name().to_owned())
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    fn filter_node<'a>(&self, _filter: &'a dyn Filter, id: crate::graph::NodeID) -> NodeID {
+        let file = id.file().map(|idx| self[idx].name().to_owned());
+        let local_id = id.local_id();
+        NodeID { file, local_id }
+    }
+
+    fn filter_source_info<'a>(
+        &self,
+        _filter: &'a dyn Filter,
+        handle: Handle<crate::graph::Node>,
+    ) -> Option<SourceInfo> {
+        self.source_info(handle).map(|info| SourceInfo {
+            span: info.span.clone(),
+            syntax_type: info.syntax_type.into_option().map(|ty| self[ty].to_owned()),
+        })
+    }
+
+    fn filter_node_debug_info<'a>(
+        &self,
+        _filter: &'a dyn Filter,
+        handle: Handle<crate::graph::Node>,
+    ) -> Option<DebugInfo> {
+        self.node_debug_info(handle).map(|info| DebugInfo {
+            data: info
+                .iter()
+                .map(|entry| DebugEntry {
+                    key: self[entry.key].to_owned(),
+                    value: self[entry.value].to_owned(),
+                })
+                .collect(),
+        })
+    }
+
+    fn filter_nodes<'a>(&self, filter: &'a dyn Filter) -> Nodes {
+        Nodes {
+            data: self
+                .iter_nodes()
+                .filter(|n| filter.include_node(self, &n))
+                .map(|handle| {
+                    let node = &self[handle];
+                    let id = self.filter_node(filter, node.id());
+                    let source_info = self.filter_source_info(filter, handle);
+                    let debug_info = self.filter_node_debug_info(filter, handle);
+
+                    match node {
+                        crate::graph::Node::DropScopes(_node) => Node::DropScopes {
+                            id,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::JumpTo(_node) => Node::JumpToScope {
+                            id,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::PopScopedSymbol(node) => Node::PopScopedSymbol {
+                            id,
+                            symbol: self[node.symbol].to_owned(),
+                            is_definition: node.is_definition,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::PopSymbol(node) => Node::PopSymbol {
+                            id,
+                            symbol: self[node.symbol].to_owned(),
+                            is_definition: node.is_definition,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::PushScopedSymbol(node) => Node::PushScopedSymbol {
+                            id,
+                            symbol: self[node.symbol].to_owned(),
+                            scope: self.filter_node(filter, node.scope),
+                            is_reference: node.is_reference,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::PushSymbol(node) => Node::PushSymbol {
+                            id,
+                            symbol: self[node.symbol].to_owned(),
+                            is_reference: node.is_reference,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::Root(_node) => Node::Root {
+                            id,
+                            source_info,
+                            debug_info,
+                        },
+                        crate::graph::Node::Scope(node) => Node::Scope {
+                            id,
+                            is_exported: node.is_exported,
+                            source_info,
+                            debug_info,
+                        },
+                    }
+                })
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    fn filter_edges<'a>(&self, filter: &'a dyn Filter) -> Edges {
+        Edges {
+            data: self
+                .iter_nodes()
+                .map(|source| {
+                    self.outgoing_edges(source)
+                        .filter(|e| filter.include_edge(self, &e.source, &e.sink))
+                        .map(|e| Edge {
+                            source: self.filter_node(filter, self[e.source].id()),
+                            sink: self.filter_node(filter, self[e.sink].id()),
+                            precedence: e.precedence,
+                            debug_info: self.filter_edge_debug_info(filter, e.source, e.sink),
+                        })
+                })
+                .flatten()
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    fn filter_edge_debug_info<'a>(
+        &self,
+        _filter: &'a dyn Filter,
+        source_handle: Handle<crate::graph::Node>,
+        sink_handle: Handle<crate::graph::Node>,
+    ) -> Option<DebugInfo> {
+        self.edge_debug_info(source_handle, sink_handle)
+            .map(|info| DebugInfo {
+                data: info
+                    .iter()
+                    .map(|entry| DebugEntry {
+                        key: self[entry.key].to_owned(),
+                        value: self[entry.value].to_owned(),
+                    })
+                    .collect(),
+            })
+    }
+}

--- a/crates/metaslang/stack_graphs/src/serde/mod.rs
+++ b/crates/metaslang/stack_graphs/src/serde/mod.rs
@@ -1,0 +1,16 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+mod filter;
+mod graph;
+mod partial;
+mod stitching;
+
+pub use filter::*;
+pub use graph::*;
+pub use partial::*;
+pub use stitching::*;

--- a/crates/metaslang/stack_graphs/src/serde/partial.rs
+++ b/crates/metaslang/stack_graphs/src/serde/partial.rs
@@ -1,0 +1,340 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use crate::partial::PartialPaths;
+
+use super::Error;
+use super::NodeID;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialPath {
+    pub(crate) start_node: NodeID,
+    pub(crate) end_node: NodeID,
+    pub(crate) symbol_stack_precondition: PartialSymbolStack,
+    pub(crate) symbol_stack_postcondition: PartialSymbolStack,
+    pub(crate) scope_stack_precondition: PartialScopeStack,
+    pub(crate) scope_stack_postcondition: PartialScopeStack,
+    pub(crate) edges: PartialPathEdgeList,
+}
+
+impl PartialPath {
+    pub fn from_partial_path(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::partial::PartialPath,
+    ) -> Self {
+        Self {
+            start_node: NodeID::from_node(graph, value.start_node),
+            end_node: NodeID::from_node(graph, value.end_node),
+            symbol_stack_precondition: PartialSymbolStack::from_partial_symbol_stack(
+                graph,
+                partials,
+                &value.symbol_stack_precondition,
+            ),
+            symbol_stack_postcondition: PartialSymbolStack::from_partial_symbol_stack(
+                graph,
+                partials,
+                &value.symbol_stack_postcondition,
+            ),
+            scope_stack_precondition: PartialScopeStack::from_partial_scope_stack(
+                graph,
+                partials,
+                &value.scope_stack_precondition,
+            ),
+            scope_stack_postcondition: PartialScopeStack::from_partial_scope_stack(
+                graph,
+                partials,
+                &value.scope_stack_postcondition,
+            ),
+            edges: PartialPathEdgeList::from_partial_path_edge_list(graph, partials, &value.edges),
+        }
+    }
+
+    pub fn to_partial_path(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+    ) -> Result<crate::partial::PartialPath, Error> {
+        Ok(crate::partial::PartialPath {
+            start_node: self.start_node.to_node(graph)?,
+            end_node: self.end_node.to_node(graph)?,
+            symbol_stack_precondition: self
+                .symbol_stack_precondition
+                .to_partial_symbol_stack(graph, partials)?,
+            symbol_stack_postcondition: self
+                .symbol_stack_postcondition
+                .to_partial_symbol_stack(graph, partials)?,
+            scope_stack_precondition: self
+                .scope_stack_precondition
+                .to_partial_scope_stack(graph, partials)?,
+            scope_stack_postcondition: self
+                .scope_stack_postcondition
+                .to_partial_scope_stack(graph, partials)?,
+            edges: self.edges.to_partial_path_edge_list(graph, partials)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialScopeStack {
+    pub(crate) scopes: Vec<NodeID>,
+    variable: Option<ScopeStackVariable>,
+}
+
+impl PartialScopeStack {
+    pub fn from_partial_scope_stack(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::partial::PartialScopeStack,
+    ) -> Self {
+        let mut value = *value;
+        let mut scopes = Vec::new();
+        while let Some(scope) = value.pop_front(partials) {
+            scopes.push(NodeID::from_node(graph, scope));
+        }
+        Self {
+            scopes,
+            variable: value
+                .variable()
+                .map(|v| ScopeStackVariable::from_scope_stack_variable(v)),
+        }
+    }
+
+    pub fn to_partial_scope_stack(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+    ) -> Result<crate::partial::PartialScopeStack, Error> {
+        let mut value = match &self.variable {
+            Some(variable) => crate::partial::PartialScopeStack::from_variable(
+                variable.to_scope_stack_variable()?,
+            ),
+            None => crate::partial::PartialScopeStack::empty(),
+        };
+        for scope in &self.scopes {
+            let scope = scope.to_node(graph)?;
+            value.push_back(partials, scope);
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct ScopeStackVariable(u32);
+
+impl ScopeStackVariable {
+    pub fn from_scope_stack_variable(value: crate::partial::ScopeStackVariable) -> Self {
+        Self(value.as_u32())
+    }
+
+    pub fn to_scope_stack_variable(&self) -> Result<crate::partial::ScopeStackVariable, Error> {
+        crate::partial::ScopeStackVariable::new(self.0)
+            .ok_or_else(|| Error::InvalidStackVariable(self.0))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialSymbolStack {
+    pub(crate) symbols: Vec<PartialScopedSymbol>,
+    variable: Option<SymbolStackVariable>,
+}
+
+impl PartialSymbolStack {
+    pub fn from_partial_symbol_stack(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::partial::PartialSymbolStack,
+    ) -> Self {
+        let mut value = *value;
+        let mut symbols = Vec::new();
+        while let Some(symbol) = value.pop_front(partials) {
+            symbols.push(PartialScopedSymbol::from_partial_scoped_symbol(
+                graph, partials, &symbol,
+            ));
+        }
+        Self {
+            symbols,
+            variable: value
+                .variable()
+                .map(|v| SymbolStackVariable::from_symbol_stack_variable(v)),
+        }
+    }
+
+    pub fn to_partial_symbol_stack(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+    ) -> Result<crate::partial::PartialSymbolStack, Error> {
+        let mut value = match &self.variable {
+            Some(variable) => crate::partial::PartialSymbolStack::from_variable(
+                variable.to_symbol_stack_variable()?,
+            ),
+            None => crate::partial::PartialSymbolStack::empty(),
+        };
+        for symbol in &self.symbols {
+            let symbol = symbol.to_partial_scoped_symbol(graph, partials)?;
+            value.push_back(partials, symbol);
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct SymbolStackVariable(u32);
+
+impl SymbolStackVariable {
+    pub fn from_symbol_stack_variable(value: crate::partial::SymbolStackVariable) -> Self {
+        Self(value.as_u32())
+    }
+
+    pub fn to_symbol_stack_variable(&self) -> Result<crate::partial::SymbolStackVariable, Error> {
+        crate::partial::SymbolStackVariable::new(self.0)
+            .ok_or_else(|| Error::InvalidStackVariable(self.0))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    serde_with::skip_serializing_none, // must come before derive
+    derive(serde::Deserialize, serde::Serialize),
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialScopedSymbol {
+    symbol: String,
+    pub(crate) scopes: Option<PartialScopeStack>,
+}
+
+impl PartialScopedSymbol {
+    pub fn from_partial_scoped_symbol(
+        graph: &crate::graph::StackGraph,
+        partials: &mut crate::partial::PartialPaths,
+        value: &crate::partial::PartialScopedSymbol,
+    ) -> Self {
+        Self {
+            symbol: graph[value.symbol].to_string(),
+            scopes: value.scopes.into_option().map(|scopes| {
+                PartialScopeStack::from_partial_scope_stack(graph, partials, &scopes)
+            }),
+        }
+    }
+
+    pub fn to_partial_scoped_symbol(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut crate::partial::PartialPaths,
+    ) -> Result<crate::partial::PartialScopedSymbol, Error> {
+        Ok(crate::partial::PartialScopedSymbol {
+            symbol: graph.add_symbol(&self.symbol),
+            scopes: self
+                .scopes
+                .as_ref()
+                .map(|scopes| scopes.to_partial_scope_stack(graph, partials))
+                .transpose()?
+                .into(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialPathEdgeList {
+    pub(crate) edges: Vec<PartialPathEdge>,
+}
+
+impl PartialPathEdgeList {
+    pub fn from_partial_path_edge_list(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::partial::PartialPathEdgeList,
+    ) -> Self {
+        let mut value = *value;
+        let mut edges = Vec::new();
+        while let Some(edge) = value.pop_front(partials) {
+            edges.push(PartialPathEdge::from_partial_path_edge(
+                graph, partials, &edge,
+            ));
+        }
+        Self { edges }
+    }
+
+    pub fn to_partial_path_edge_list(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+    ) -> Result<crate::partial::PartialPathEdgeList, Error> {
+        let mut value = crate::partial::PartialPathEdgeList::empty();
+        for edge in &self.edges {
+            let edge = edge.to_partial_path_edge(graph, partials)?;
+            value.push_back(partials, edge);
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct PartialPathEdge {
+    pub(crate) source: NodeID,
+    precedence: i32,
+}
+
+impl PartialPathEdge {
+    pub fn from_partial_path_edge(
+        graph: &crate::graph::StackGraph,
+        _partials: &mut PartialPaths,
+        value: &crate::partial::PartialPathEdge,
+    ) -> Self {
+        Self {
+            source: NodeID::from_node_id(graph, value.source_node_id),
+            precedence: value.precedence,
+        }
+    }
+
+    pub fn to_partial_path_edge(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        _partials: &mut PartialPaths,
+    ) -> Result<crate::partial::PartialPathEdge, Error> {
+        Ok(crate::partial::PartialPathEdge {
+            source_node_id: self.source.to_node_id(graph)?,
+            precedence: self.precedence,
+        })
+    }
+}

--- a/crates/metaslang/stack_graphs/src/serde/stitching.rs
+++ b/crates/metaslang/stack_graphs/src/serde/stitching.rs
@@ -1,0 +1,82 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use crate::graph::StackGraph;
+use crate::partial::PartialPaths;
+
+use super::Error;
+use super::Filter;
+use super::ImplicationFilter;
+use super::NoFilter;
+use super::PartialPath;
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
+pub struct Database {
+    paths: Vec<PartialPath>,
+}
+
+impl Database {
+    pub fn from_database(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::stitching::Database,
+    ) -> Self {
+        Self::from_database_filter(graph, partials, value, &NoFilter)
+    }
+
+    pub fn from_database_filter(
+        graph: &crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &crate::stitching::Database,
+        filter: &dyn Filter,
+    ) -> Self {
+        let filter = ImplicationFilter(filter);
+        let mut paths = Vec::new();
+        for path in value.iter_partial_paths() {
+            let path = &value[path];
+            if !filter.include_partial_path(graph, partials, path) {
+                continue;
+            }
+            let path = PartialPath::from_partial_path(graph, partials, &path);
+            paths.push(path);
+        }
+        Self { paths }
+    }
+
+    pub fn load_into(
+        &self,
+        graph: &mut crate::graph::StackGraph,
+        partials: &mut PartialPaths,
+        value: &mut crate::stitching::Database,
+    ) -> Result<(), Error> {
+        for path in &self.paths {
+            let path = path.to_partial_path(graph, partials)?;
+            value.add_partial_path(graph, partials, path);
+        }
+        Ok(())
+    }
+}
+
+impl crate::stitching::Database {
+    pub fn to_serializable(&self, graph: &StackGraph, partials: &mut PartialPaths) -> Database {
+        Database::from_database(graph, partials, self)
+    }
+
+    pub fn to_serializable_filter(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        filter: &dyn Filter,
+    ) -> Database {
+        Database::from_database_filter(graph, partials, self, filter)
+    }
+}

--- a/crates/metaslang/stack_graphs/src/stats.rs
+++ b/crates/metaslang/stack_graphs/src/stats.rs
@@ -1,0 +1,106 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use itertools::Itertools;
+
+/// Frequency distribution maintains the frequency of T values.
+#[derive(Clone, Debug, Default)]
+pub struct FrequencyDistribution<T>
+where
+    T: Eq + Hash,
+{
+    values: HashMap<T, usize>,
+    total: usize,
+}
+
+impl<T: Eq + Hash> FrequencyDistribution<T> {
+    pub fn record(&mut self, value: T) {
+        *self.values.entry(value).or_default() += 1;
+        self.total += 1;
+    }
+
+    // The number of recorded values.
+    pub fn count(&self) -> usize {
+        return self.total;
+    }
+
+    // The number of unique recorded values.
+    pub fn unique(&self) -> usize {
+        return self.values.len();
+    }
+
+    pub fn frequencies(&self) -> FrequencyDistribution<usize> {
+        let mut fs = FrequencyDistribution::default();
+        for count in self.values.values() {
+            fs.record(*count);
+        }
+        fs
+    }
+}
+
+impl<T: Eq + Hash + Ord> FrequencyDistribution<T> {
+    pub fn quantiles(&self, q: usize) -> Vec<&T> {
+        if q == 0 || self.total == 0 {
+            return vec![];
+        }
+
+        let mut it = self.values.iter().sorted_by_key(|e| e.0);
+        let mut total_count = 0;
+        let mut last_value;
+        let mut result = Vec::new();
+
+        if let Some((value, count)) = it.next() {
+            total_count += count;
+            last_value = value;
+        } else {
+            return vec![];
+        }
+        result.push(last_value);
+
+        for k in 1..=q {
+            let limit = ((self.total as f64 * k as f64) / q as f64).round() as usize;
+            while total_count < limit {
+                if let Some((value, count)) = it.next() {
+                    total_count += count;
+                    last_value = value;
+                } else {
+                    break;
+                }
+            }
+            result.push(last_value);
+        }
+
+        result
+    }
+}
+
+impl<T> std::ops::AddAssign<Self> for FrequencyDistribution<T>
+where
+    T: Eq + Hash,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        for (value, count) in rhs.values {
+            *self.values.entry(value).or_default() += count;
+        }
+        self.total += rhs.total;
+    }
+}
+
+impl<T> std::ops::AddAssign<&Self> for FrequencyDistribution<T>
+where
+    T: Eq + Hash + Clone,
+{
+    fn add_assign(&mut self, rhs: &Self) {
+        for (value, count) in &rhs.values {
+            *self.values.entry(value.clone()).or_default() += count;
+        }
+        self.total += rhs.total;
+    }
+}

--- a/crates/metaslang/stack_graphs/src/stitching.rs
+++ b/crates/metaslang/stack_graphs/src/stitching.rs
@@ -1,0 +1,1417 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Partial paths can be "stitched together" to produce name-binding paths.
+//!
+//! The "path stitching" algorithm defined in this module is how we take a collection of [partial
+//! paths][] and use them to build up name-binding paths.  Our conjecture is that by building paths
+//! this way, we can precompute a useful amount of work at _index time_ (when we construct the
+//! partial paths), to reduce the amount of work that needs to be done at _query time_ (when those
+//! partial paths are stitched together into paths).
+//!
+//! Complicating this story is that for large codebases (especially those with many upstream and
+//! downstream dependencies), there is a _very_ large set of partial paths available to us.  We
+//! want to be able to load those in _lazily_, during the execution of the path-stitching
+//! algorithm.
+//!
+//! The [`Database`][] and [`PathStitcher`][] types provide this functionality.  `Database`
+//! manages a collection of partial paths that have been loaded into this process from some
+//! external data store.  `PathStitcher` implements the path-stitching algorithm in _phases_.
+//! During each phase, we will process a set of (possibly incomplete) paths, looking in the
+//! `Database` for the set of partial paths that are compatible with those paths.  It is your
+//! responsibility to make sure that the database contains all of possible extensions of the paths
+//! that we're going to process in that phase.  For the first phase, you already know which
+//! paths you're starting the search from, and must make sure that the database starts out
+//! containing the possible extensions of those "seed" paths.  For subsequent phases, you get to
+//! see which paths will be processed in the _next_ phase as part of handling the _current_ phase.
+//! This gives you the opporunity to load additional partial paths into the `Database` before
+//! allowing the next phase to proceed.
+//!
+//! [partial paths]: ../partial/index.html
+//! [`Database`]: struct.Database.html
+//! [`PathStitcher`]: struct.PathStitcher.html
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+#[cfg(feature = "copious-debugging")]
+use std::fmt::Display;
+
+use itertools::izip;
+use itertools::Itertools;
+
+use crate::arena::Arena;
+use crate::arena::Handle;
+use crate::arena::HandleSet;
+use crate::arena::List;
+use crate::arena::ListArena;
+use crate::arena::ListCell;
+use crate::arena::SupplementalArena;
+use crate::cycles::Appendables;
+use crate::cycles::AppendingCycleDetector;
+use crate::cycles::SimilarPathDetector;
+use crate::cycles::SimilarPathStats;
+use crate::graph::Degree;
+use crate::graph::Edge;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::partial::Cyclicity;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::partial::PartialSymbolStack;
+use crate::paths::Extend;
+use crate::paths::PathResolutionError;
+use crate::stats::FrequencyDistribution;
+use crate::CancellationError;
+use crate::CancellationFlag;
+
+//-------------------------------------------------------------------------------------------------
+// Appendable
+
+/// Something that can be appended to a partial path.
+pub trait Appendable {
+    /// Append this appendable to the given path. Resolving jump nodes and renaming unused_variables
+    /// is part of the responsibility of this method.
+    fn append_to(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: &mut PartialPath,
+    ) -> Result<(), PathResolutionError>;
+
+    /// Return the start node.
+    fn start_node(&self) -> Handle<Node>;
+
+    /// Return the end node.
+    fn end_node(&self) -> Handle<Node>;
+
+    /// Return a Display implementation.
+    fn display<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> Box<dyn std::fmt::Display + 'a>;
+}
+
+impl Appendable for Edge {
+    fn append_to(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: &mut PartialPath,
+    ) -> Result<(), PathResolutionError> {
+        path.resolve_to_node(graph, partials, self.source)?;
+        path.append(graph, partials, *self)
+    }
+
+    fn start_node(&self) -> Handle<Node> {
+        self.source
+    }
+
+    fn end_node(&self) -> Handle<Node> {
+        self.sink
+    }
+
+    fn display<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+        _partials: &'a mut PartialPaths,
+    ) -> Box<dyn std::fmt::Display + 'a> {
+        Box::new(format!(
+            "{} -> {}",
+            self.source.display(graph),
+            self.sink.display(graph)
+        ))
+    }
+}
+
+impl Appendable for PartialPath {
+    fn append_to(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: &mut PartialPath,
+    ) -> Result<(), PathResolutionError> {
+        path.resolve_to_node(graph, partials, self.start_node)?;
+        path.ensure_no_overlapping_variables(partials, self);
+        path.concatenate(graph, partials, self)?;
+        Ok(())
+    }
+
+    fn start_node(&self) -> Handle<Node> {
+        self.start_node
+    }
+
+    fn end_node(&self) -> Handle<Node> {
+        self.end_node
+    }
+
+    fn display<'a>(
+        &'a self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> Box<dyn std::fmt::Display + 'a> {
+        Box::new(self.display(graph, partials))
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// ToAppendable
+
+/// A trait to be implemented on types such as [`Database`][] that allow converting handles
+/// to appendables.
+///
+/// It is very similar to the [`std::ops::Index`] trait, but returns a reference instead
+/// of a value, such that an efficient identifity implementation is possible, that doesn't
+/// require cloning values.
+pub trait ToAppendable<H, A>
+where
+    A: Appendable,
+{
+    fn get_appendable<'a>(&'a self, handle: &'a H) -> &'a A;
+}
+
+//-------------------------------------------------------------------------------------------------
+// Candidates
+
+/// A trait to support finding candidates for partial path extension. The candidates are represented
+/// by handles `H`, which are mapped to appendables `A` using the database `Db`. Loading errors are
+/// reported as values of the `Err` type.
+pub trait ForwardCandidates<H, A, Db, Err>
+where
+    A: Appendable,
+    Db: ToAppendable<H, A>,
+{
+    /// Load possible forward candidates for the given partial path into this candidates instance.
+    /// Must be called before [`get_forward_candidates`] to allow lazy-loading implementations.
+    fn load_forward_candidates(
+        &mut self,
+        _path: &PartialPath,
+        _cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<(), Err> {
+        Ok(())
+    }
+
+    /// Get forward candidates for extending the given partial path and add them to the provided
+    /// result instance. If this instance loads data lazily, this only considers previously loaded
+    /// data.
+    fn get_forward_candidates<R>(&mut self, path: &PartialPath, result: &mut R)
+    where
+        R: std::iter::Extend<H>;
+
+    /// Get the number of available candidates that share the given path's end node.
+    fn get_joining_candidate_degree(&self, path: &PartialPath) -> Degree;
+
+    /// Get the graph, partial path arena, and database backing this candidates instance.
+    fn get_graph_partials_and_db(&mut self) -> (&StackGraph, &mut PartialPaths, &Db);
+}
+
+//-------------------------------------------------------------------------------------------------
+// FileEdges
+
+/// Acts as a database of the edges in the graph.
+pub struct GraphEdgeCandidates<'a> {
+    graph: &'a StackGraph,
+    partials: &'a mut PartialPaths,
+    file: Option<Handle<File>>,
+    edges: GraphEdges,
+}
+
+impl<'a> GraphEdgeCandidates<'a> {
+    pub fn new(
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+        file: Option<Handle<File>>,
+    ) -> Self {
+        Self {
+            graph,
+            partials,
+            file,
+            edges: GraphEdges,
+        }
+    }
+}
+
+impl ForwardCandidates<Edge, Edge, GraphEdges, CancellationError> for GraphEdgeCandidates<'_> {
+    fn get_forward_candidates<R>(&mut self, path: &PartialPath, result: &mut R)
+    where
+        R: std::iter::Extend<Edge>,
+    {
+        result.extend(self.graph.outgoing_edges(path.end_node).filter(|e| {
+            self.file
+                .map_or(true, |file| self.graph[e.sink].is_in_file(file))
+        }));
+    }
+
+    fn get_joining_candidate_degree(&self, path: &PartialPath) -> Degree {
+        self.graph.incoming_edge_degree(path.end_node)
+    }
+
+    fn get_graph_partials_and_db(&mut self) -> (&StackGraph, &mut PartialPaths, &GraphEdges) {
+        (self.graph, self.partials, &self.edges)
+    }
+}
+
+/// A dummy type to act as the "database" for graph edges. Its [`ToAppendable`] implementation
+/// is the identity on edges.
+pub struct GraphEdges;
+
+impl ToAppendable<Edge, Edge> for GraphEdges {
+    fn get_appendable<'a>(&'a self, edge: &'a Edge) -> &'a Edge {
+        edge
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Databases
+
+/// Contains a "database" of partial paths.
+///
+/// This type is meant to be a lazily loaded "view" into a proper storage layer.  During the
+/// path-stitching algorithm, we repeatedly try to extend a currently incomplete path with any
+/// partial paths that are compatible with it.  For large codebases, or projects with a large
+/// number of dependencies, it can be prohibitive to load in _all_ of the partial paths up-front.
+/// We've written the path-stitching algorithm so that you have a chance to only load in the
+/// partial paths that are actually needed, placing them into a `Database` instance as they're
+/// needed.
+pub struct Database {
+    pub(crate) partial_paths: Arena<PartialPath>,
+    pub(crate) local_nodes: HandleSet<Node>,
+    symbol_stack_keys: ListArena<Handle<Symbol>>,
+    symbol_stack_key_cache: HashMap<SymbolStackCacheKey, SymbolStackKeyHandle>,
+    paths_by_start_node: SupplementalArena<Node, Vec<Handle<PartialPath>>>,
+    root_paths_by_precondition_prefix:
+        SupplementalArena<SymbolStackKeyCell, Vec<Handle<PartialPath>>>,
+    root_paths_by_precondition_with_variable:
+        SupplementalArena<SymbolStackKeyCell, Vec<Handle<PartialPath>>>,
+    root_paths_by_precondition_without_variable:
+        SupplementalArena<SymbolStackKeyCell, Vec<Handle<PartialPath>>>,
+    incoming_paths: SupplementalArena<Node, Degree>,
+}
+
+impl Database {
+    /// Creates a new, empty database.
+    pub fn new() -> Database {
+        Database {
+            partial_paths: Arena::new(),
+            local_nodes: HandleSet::new(),
+            symbol_stack_keys: List::new_arena(),
+            symbol_stack_key_cache: HashMap::new(),
+            paths_by_start_node: SupplementalArena::new(),
+            root_paths_by_precondition_prefix: SupplementalArena::new(),
+            root_paths_by_precondition_with_variable: SupplementalArena::new(),
+            root_paths_by_precondition_without_variable: SupplementalArena::new(),
+            incoming_paths: SupplementalArena::new(),
+        }
+    }
+
+    /// Clear the database.  After this, all previous handles into the database are
+    /// invalid.
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
+    pub(crate) fn clear(&mut self) {
+        self.partial_paths.clear();
+        self.local_nodes.clear();
+        self.symbol_stack_keys.clear();
+        self.symbol_stack_key_cache.clear();
+        self.paths_by_start_node.clear();
+        self.root_paths_by_precondition_prefix.clear();
+        self.root_paths_by_precondition_with_variable.clear();
+        self.root_paths_by_precondition_without_variable.clear();
+        self.incoming_paths.clear();
+    }
+
+    /// Adds a partial path to this database.  We do not deduplicate partial paths in any way; it's
+    /// your responsibility to only add each partial path once.
+    pub fn add_partial_path(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: PartialPath,
+    ) -> Handle<PartialPath> {
+        let start_node = path.start_node;
+        let end_node = path.end_node;
+        copious_debugging!(
+            "    Add {} path to database {}",
+            if graph[start_node].is_root() {
+                "root"
+            } else {
+                "node"
+            },
+            path.display(graph, partials)
+        );
+        let symbol_stack_precondition = path.symbol_stack_precondition;
+        let handle = self.partial_paths.add(path);
+
+        // If the partial path starts at the root node, index it by its symbol stack precondition.
+        if graph[start_node].is_root() {
+            // The join node is root, so there's no need to use half-open symbol stacks here, as we
+            // do for [`PartialPath::concatenate`][].
+            let mut key = SymbolStackKey::from_partial_symbol_stack(
+                partials,
+                self,
+                symbol_stack_precondition,
+            );
+            if !key.is_empty() {
+                match symbol_stack_precondition.has_variable() {
+                    true => self.root_paths_by_precondition_with_variable[key.back_handle()]
+                        .push(handle),
+                    false => self.root_paths_by_precondition_without_variable[key.back_handle()]
+                        .push(handle),
+                }
+            }
+            while key.pop_back(self).is_some() && !key.is_empty() {
+                self.root_paths_by_precondition_prefix[key.back_handle()].push(handle);
+            }
+        } else {
+            // Otherwise index it by its source node.
+            self.paths_by_start_node[start_node].push(handle);
+        }
+
+        self.incoming_paths[end_node] += Degree::One;
+        handle
+    }
+
+    /// Find all partial paths in this database that start at the given path's end node.
+    /// If the end node is the root node, returns paths with a symbol stack precondition
+    /// that are compatible with the path's symbol stack post condition.
+    pub fn find_candidate_partial_paths<R>(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: &PartialPath,
+        result: &mut R,
+    ) where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        if graph[path.end_node].is_root() {
+            // The join node is root, so there's no need to use half-open symbol stacks here, as we
+            // do for [`PartialPath::concatenate`][].
+            self.find_candidate_partial_paths_from_root(
+                graph,
+                partials,
+                Some(path.symbol_stack_postcondition),
+                result,
+            );
+        } else {
+            self.find_candidate_partial_paths_from_node(graph, partials, path.end_node, result);
+        }
+    }
+
+    /// Find all partial paths in this database that start at the root node, and have a symbol
+    /// stack precondition that is compatible with a given symbol stack.
+    #[cfg_attr(not(feature = "copious-debugging"), allow(unused_variables))]
+    pub fn find_candidate_partial_paths_from_root<R>(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        symbol_stack: Option<PartialSymbolStack>,
+        result: &mut R,
+    ) where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        // If the path currently ends at the root node, then we need to look up partial paths whose
+        // symbol stack precondition is compatible with the path.
+        match symbol_stack {
+            Some(symbol_stack) => {
+                let mut key =
+                    SymbolStackKey::from_partial_symbol_stack(partials, self, symbol_stack);
+                copious_debugging!(
+                    "      Search for symbol stack <{}>",
+                    key.display(graph, self)
+                );
+                // paths that have exactly this symbol stack
+                if let Some(paths) = self
+                    .root_paths_by_precondition_without_variable
+                    .get(key.back_handle())
+                {
+                    #[cfg(feature = "copious-debugging")]
+                    {
+                        for path in paths {
+                            copious_debugging!(
+                                "        Found path with exact stack {}",
+                                self[*path].display(graph, partials)
+                            );
+                        }
+                    }
+                    result.extend(paths.iter().copied());
+                }
+                // paths that have an extension of this symbol stack
+                if symbol_stack.has_variable() {
+                    if let Some(paths) = self
+                        .root_paths_by_precondition_prefix
+                        .get(key.back_handle())
+                    {
+                        #[cfg(feature = "copious-debugging")]
+                        {
+                            for path in paths {
+                                copious_debugging!(
+                                    "        Found path with smaller stack {}",
+                                    self[*path].display(graph, partials)
+                                );
+                            }
+                        }
+                        result.extend(paths.iter().copied());
+                    }
+                }
+                loop {
+                    // paths that have a prefix of this symbol stack
+                    if let Some(paths) = self
+                        .root_paths_by_precondition_with_variable
+                        .get(key.back_handle())
+                    {
+                        #[cfg(feature = "copious-debugging")]
+                        {
+                            for path in paths {
+                                copious_debugging!(
+                                    "        Found path with smaller stack {}",
+                                    self[*path].display(graph, partials)
+                                );
+                            }
+                        }
+                        result.extend(paths.iter().copied());
+                    }
+                    if key.pop_back(self).is_none() {
+                        break;
+                    }
+                }
+            }
+            None => {
+                copious_debugging!("      Search for all root paths");
+                for (_, paths) in self
+                    .root_paths_by_precondition_with_variable
+                    .iter()
+                    .chain(self.root_paths_by_precondition_without_variable.iter())
+                {
+                    #[cfg(feature = "copious-debugging")]
+                    {
+                        for path in paths {
+                            copious_debugging!(
+                                "        Found path {}",
+                                self[*path].display(graph, partials)
+                            );
+                        }
+                    }
+                    result.extend(paths.iter().copied());
+                }
+            }
+        }
+    }
+
+    /// Find all partial paths in the database that start at the given node.  We don't filter the
+    /// results any further than that, since we have to check each partial path for compatibility
+    /// as we try to append it to the current incomplete path anyway, and non-root nodes will
+    /// typically have a small number of outgoing edges.
+    #[cfg_attr(not(feature = "copious-debugging"), allow(unused_variables))]
+    pub fn find_candidate_partial_paths_from_node<R>(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        start_node: Handle<Node>,
+        result: &mut R,
+    ) where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        copious_debugging!("      Search for start node {}", start_node.display(graph));
+        // Return all of the partial paths that start at the requested node.
+        if let Some(paths) = self.paths_by_start_node.get(start_node) {
+            #[cfg(feature = "copious-debugging")]
+            {
+                for path in paths {
+                    copious_debugging!(
+                        "        Found path {}",
+                        self[*path].display(graph, partials)
+                    );
+                }
+            }
+            result.extend(paths.iter().copied());
+        }
+    }
+
+    /// Returns the number of paths in this database that share the given end node.
+    pub fn get_incoming_path_degree(&self, end_node: Handle<Node>) -> Degree {
+        self.incoming_paths[end_node]
+    }
+
+    /// Determines which nodes in the stack graph are “local”, taking into account the partial
+    /// paths in this database.
+    ///
+    /// A local node has no partial path that connects it to the root node in either direction.
+    /// That means that it cannot participate in any paths that leave the file.
+    ///
+    /// This method is meant to be used at index time, to calculate the set of nodes that are local
+    /// after having just calculated the set of partial paths for the file.
+    pub fn find_local_nodes(&mut self) {
+        // Assume that any node that is the start or end of a partial path is local to this file
+        // until we see a path connecting the root node to it (in either direction).
+        self.local_nodes.clear();
+        for handle in self.iter_partial_paths() {
+            self.local_nodes.add(self[handle].start_node);
+            self.local_nodes.add(self[handle].end_node);
+        }
+
+        // The root node and jump-to-scope node are the most obvious non-local nodes.
+        let mut nonlocal_start_nodes = HandleSet::new();
+        let mut nonlocal_end_nodes = HandleSet::new();
+        self.local_nodes.remove(StackGraph::root_node());
+        nonlocal_start_nodes.add(StackGraph::root_node());
+        nonlocal_end_nodes.add(StackGraph::root_node());
+        self.local_nodes.remove(StackGraph::jump_to_node());
+        nonlocal_start_nodes.add(StackGraph::jump_to_node());
+        nonlocal_end_nodes.add(StackGraph::jump_to_node());
+
+        // Other nodes are non-local if we see any partial path that connects it to another
+        // non-local node.  Repeat until we reach a fixed point.
+        let mut keep_checking = true;
+        while keep_checking {
+            keep_checking = false;
+            for handle in self.iter_partial_paths() {
+                let start_node = self[handle].start_node;
+                let end_node = self[handle].end_node;
+
+                // First check forwards paths, where non-localness propagates from the start node
+                // of each path.
+                let start_node_is_nonlocal = nonlocal_start_nodes.contains(start_node);
+                let end_node_is_nonlocal = nonlocal_start_nodes.contains(end_node);
+                if start_node_is_nonlocal && !end_node_is_nonlocal {
+                    keep_checking = true;
+                    nonlocal_start_nodes.add(end_node);
+                    self.local_nodes.remove(end_node);
+                }
+
+                // Then check reverse paths, where non-localness propagates from the end node of
+                // each path.
+                let start_node_is_nonlocal = nonlocal_end_nodes.contains(start_node);
+                let end_node_is_nonlocal = nonlocal_end_nodes.contains(end_node);
+                if !start_node_is_nonlocal && end_node_is_nonlocal {
+                    keep_checking = true;
+                    nonlocal_end_nodes.add(start_node);
+                    self.local_nodes.remove(start_node);
+                }
+            }
+        }
+    }
+
+    /// Marks that a stack graph node is local.
+    ///
+    /// This method is meant to be used at query time.  You will have precalculated the set of
+    /// local nodes for a file at index time; at query time, you will load this information from
+    /// your storage layer and use this method to update our internal view of which nodes are
+    /// local.
+    pub fn mark_local_node(&mut self, node: Handle<Node>) {
+        self.local_nodes.add(node);
+    }
+
+    /// Returns whether a node is local according to the partial paths in this database.  You must
+    /// have already called [`find_local_nodes`][] or [`mark_local_node`][], depending on whether
+    /// it is index time or query time.
+    pub fn node_is_local(&self, node: Handle<Node>) -> bool {
+        self.local_nodes.contains(node)
+    }
+
+    /// Returns an iterator over all of the handles of all of the partial paths in this database.
+    /// (Note that because we're only returning _handles_, this iterator does not retain a
+    /// reference to the `Database`.)
+    pub fn iter_partial_paths(&self) -> impl Iterator<Item = Handle<PartialPath>> {
+        self.partial_paths.iter_handles()
+    }
+
+    pub fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        for path in self.partial_paths.iter_handles() {
+            self.partial_paths
+                .get_mut(path)
+                .ensure_both_directions(partials);
+        }
+    }
+
+    pub fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        for path in self.partial_paths.iter_handles() {
+            self.partial_paths.get_mut(path).ensure_forwards(partials);
+        }
+    }
+}
+
+impl std::ops::Index<Handle<PartialPath>> for Database {
+    type Output = PartialPath;
+    #[inline(always)]
+    fn index(&self, handle: Handle<PartialPath>) -> &PartialPath {
+        self.partial_paths.get(handle)
+    }
+}
+
+impl ToAppendable<Handle<PartialPath>, PartialPath> for Database {
+    fn get_appendable<'a>(&'a self, handle: &'a Handle<PartialPath>) -> &'a PartialPath {
+        &self[*handle]
+    }
+}
+
+pub struct DatabaseCandidates<'a> {
+    graph: &'a StackGraph,
+    partials: &'a mut PartialPaths,
+    database: &'a mut Database,
+}
+
+impl<'a> DatabaseCandidates<'a> {
+    pub fn new(
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+        database: &'a mut Database,
+    ) -> Self {
+        Self {
+            graph,
+            partials,
+            database,
+        }
+    }
+}
+
+impl ForwardCandidates<Handle<PartialPath>, PartialPath, Database, CancellationError>
+    for DatabaseCandidates<'_>
+{
+    fn get_forward_candidates<R>(&mut self, path: &PartialPath, result: &mut R)
+    where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        self.database
+            .find_candidate_partial_paths(self.graph, self.partials, path, result);
+    }
+
+    fn get_joining_candidate_degree(&self, path: &PartialPath) -> Degree {
+        self.database.get_incoming_path_degree(path.end_node)
+    }
+
+    fn get_graph_partials_and_db(&mut self) -> (&StackGraph, &mut PartialPaths, &Database) {
+        (self.graph, self.partials, self.database)
+    }
+}
+
+/// The key type that we use to find partial paths that start from the root node and have a
+/// particular symbol stack as their precondition.
+#[derive(Clone, Copy)]
+pub struct SymbolStackKey {
+    // Note: the symbols are stored in reverse order, with the "front" of the List being the "back"
+    // of the symbol stack.  That lets us easily get a handle to the back of the symbol stack, and
+    // also lets us easily pops items off the back of key, which we need to do to search for all
+    // prefixes of a particular symbol stack down in `find_candidate_partial_paths_from_root`.
+    symbols: List<Handle<Symbol>>,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct SymbolStackCacheKey {
+    head: Handle<Symbol>,
+    tail: SymbolStackKeyHandle,
+}
+
+type SymbolStackKeyCell = ListCell<Handle<Symbol>>;
+type SymbolStackKeyHandle = Handle<SymbolStackKeyCell>;
+
+impl SymbolStackKey {
+    /// Returns an empty symbol stack key.
+    fn empty() -> SymbolStackKey {
+        SymbolStackKey {
+            symbols: List::empty(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
+    /// Pushes a new symbol onto the back of this symbol stack key.
+    fn push_back(&mut self, db: &mut Database, symbol: Handle<Symbol>) {
+        let cache_key = SymbolStackCacheKey {
+            head: symbol,
+            tail: self.back_handle(),
+        };
+        if let Some(handle) = db.symbol_stack_key_cache.get(&cache_key) {
+            self.symbols = List::from_handle(*handle);
+            return;
+        }
+        // push_front because we store the key's symbols in reverse order.
+        self.symbols.push_front(&mut db.symbol_stack_keys, symbol);
+        let handle = self.back_handle();
+        db.symbol_stack_key_cache.insert(cache_key, handle);
+    }
+
+    /// Pops a symbol from the back of this symbol stack key.
+    fn pop_back(&mut self, db: &Database) -> Option<Handle<Symbol>> {
+        // pop_front because we store the key's symbols in reverse order.
+        self.symbols.pop_front(&db.symbol_stack_keys).copied()
+    }
+
+    /// Extracts a new symbol stack key from a partial symbol stack.
+    pub fn from_partial_symbol_stack(
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        mut stack: PartialSymbolStack,
+    ) -> SymbolStackKey {
+        let mut result = SymbolStackKey::empty();
+        while let Some(symbol) = stack.pop_front(partials) {
+            result.push_back(db, symbol.symbol);
+        }
+        result
+    }
+
+    /// Returns a handle to the back of the symbol stack key.
+    fn back_handle(self) -> SymbolStackKeyHandle {
+        // Because the symbols are stored in reverse order, the handle to the "front" of the list
+        // is a handle to the "back" of the key.
+        self.symbols.handle()
+    }
+
+    #[cfg(feature = "copious-debugging")]
+    fn display<'a>(self, graph: &'a StackGraph, db: &'a Database) -> impl Display + 'a {
+        DisplaySymbolStackKey(self, graph, db)
+    }
+}
+
+#[cfg(feature = "copious-debugging")]
+struct DisplaySymbolStackKey<'a>(SymbolStackKey, &'a StackGraph, &'a Database);
+
+#[cfg(feature = "copious-debugging")]
+impl<'a> Display for DisplaySymbolStackKey<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Use a recursive function to print the contents of the key out in reverse order.
+        fn display_one(
+            mut key: SymbolStackKey,
+            graph: &StackGraph,
+            db: &Database,
+            f: &mut std::fmt::Formatter,
+        ) -> std::fmt::Result {
+            let last = match key.pop_back(db) {
+                Some(last) => last,
+                None => return Ok(()),
+            };
+            display_one(key, graph, db, f)?;
+            last.display(graph).fmt(f)
+        }
+        display_one(self.0, self.1, self.2, f)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Stitching partial paths together
+
+/// Implements a phased forward partial path stitching algorithm.
+///
+/// Our overall goal is to start with a set of _seed_ partial paths, and to repeatedly extend each
+/// partial path by concatenating another, compatible partial path onto the end of it.  (If there
+/// are multiple compatible partial paths, we concatenate each of them separately, resulting in
+/// more than one extension for the current path.)
+///
+/// We perform this processing in _phases_.  At the start of each phase, we have a _current set_ of
+/// partial paths that need to be processed.  As we extend those partial paths, we add the
+/// extensions to the set of partial paths to process in the _next_ phase.  Phases are processed
+/// one at a time, each time you invoke the [`process_next_phase`][] method.
+///
+/// [`process_next_phase`]: #method.process_next_phase
+///
+/// After each phase has completed, you can use the [`previous_phase_partial_paths`][] method to
+/// retrieve all of the partial paths that were discovered during that phase.  That gives you a
+/// chance to add to the `Database` all of the other partial paths that we might need to extend
+/// those partial paths with before invoking the next phase.
+///
+/// [`previous_phase_partial_paths`]: #method.previous_phase_partial_paths
+///
+/// If you don't care about this phasing nonsense, you can instead preload your `Database` with all
+/// possible partial paths, and run the forward partial path stitching algorithm all the way to
+/// completion, using the [`find_all_complete_partial_paths`][] method.
+///
+/// [`find_all_complete_partial_paths`]: #method.find_all_complete_partial_paths
+pub struct ForwardPartialPathStitcher<H> {
+    candidates: Vec<H>,
+    extensions: Vec<(PartialPath, AppendingCycleDetector<H>)>,
+    queue: VecDeque<(PartialPath, AppendingCycleDetector<H>, bool)>,
+    // tracks the number of initial paths in the queue because we do not want call
+    // extend_until on those
+    initial_paths_in_queue: usize,
+    // next_iteration is a tuple of queues instead of an queue of tuples so that the path queue
+    // can be cheaply exposed through the C API as a continuous memory block
+    next_iteration: (
+        VecDeque<PartialPath>,
+        VecDeque<AppendingCycleDetector<H>>,
+        VecDeque<bool>,
+    ),
+    appended_paths: Appendables<H>,
+    similar_path_detector: Option<SimilarPathDetector<PartialPath>>,
+    check_only_join_nodes: bool,
+    max_work_per_phase: usize,
+    initial_paths: usize,
+    stats: Option<Stats>,
+    #[cfg(feature = "copious-debugging")]
+    phase_number: usize,
+}
+
+impl<H> ForwardPartialPathStitcher<H> {
+    /// Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
+    /// paths. If the sticher is used to find complete paths, it is the responsibility of the caller
+    /// to ensure precondition variables are eliminated by calling [`PartialPath::eliminate_precondition_stack_variables`][].
+    pub fn from_partial_paths<I>(
+        _graph: &StackGraph,
+        _partials: &mut PartialPaths,
+        initial_partial_paths: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = PartialPath>,
+    {
+        let mut appended_paths = Appendables::new();
+        let next_iteration: (VecDeque<_>, VecDeque<_>, VecDeque<_>) = initial_partial_paths
+            .into_iter()
+            .map(|p| {
+                let c = AppendingCycleDetector::from(&mut appended_paths, p.clone().into());
+                (p, c, false)
+            })
+            .multiunzip();
+        let initial_paths = next_iteration.0.len();
+        Self {
+            candidates: Vec::new(),
+            extensions: Vec::new(),
+            queue: VecDeque::new(),
+            initial_paths_in_queue: initial_paths,
+            next_iteration,
+            appended_paths,
+            // By default, all paths are checked for similarity
+            similar_path_detector: Some(SimilarPathDetector::new()),
+            // By default, all nodes are checked for cycles and (if enabled) similarity
+            check_only_join_nodes: false,
+            // By default, there's no artificial bound on the amount of work done per phase
+            max_work_per_phase: usize::MAX,
+            initial_paths,
+            stats: None,
+            #[cfg(feature = "copious-debugging")]
+            phase_number: 1,
+        }
+    }
+
+    /// Sets whether similar path detection should be enabled during path stitching. Paths are similar
+    /// if start and end node, and pre- and postconditions are the same. The presence of similar paths
+    /// can lead to exponential blow up during path stitching. Similar path detection is enabled by
+    /// default.
+    pub fn set_similar_path_detection(&mut self, detect_similar_paths: bool) {
+        if !detect_similar_paths {
+            self.similar_path_detector = None;
+        } else if self.similar_path_detector.is_none() {
+            let mut similar_path_detector = SimilarPathDetector::new();
+            similar_path_detector.set_collect_stats(self.stats.is_some());
+            self.similar_path_detector = Some(similar_path_detector);
+        }
+    }
+
+    /// Sets whether all nodes are checked for cycles and (if enabled) similar paths, or only nodes with multiple
+    /// incoming candidates. Checking only join nodes is **unsafe** unless the database of candidates is stable
+    /// between all stitching phases. If paths are added to the database from one phase to another, for example if
+    /// paths are dynamically loaded from storage, setting this to true is incorrect and might lead to non-termination!
+    pub fn set_check_only_join_nodes(&mut self, check_only_join_nodes: bool) {
+        self.check_only_join_nodes = check_only_join_nodes;
+    }
+
+    /// Sets the maximum amount of work that can be performed during each phase of the algorithm.
+    /// By bounding our work this way, you can ensure that it's not possible for our CPU-bound
+    /// algorithm to starve any worker threads or processes that you might be using.  If you don't
+    /// call this method, then we allow ourselves to process all of the extensions of all of the
+    /// paths found in the previous phase, with no additional bound.
+    pub fn set_max_work_per_phase(&mut self, max_work_per_phase: usize) {
+        self.max_work_per_phase = max_work_per_phase;
+    }
+
+    /// Sets whether to collect statistics during stitching.
+    pub fn set_collect_stats(&mut self, collect_stats: bool) {
+        if !collect_stats {
+            self.stats = None;
+        } else if self.stats.is_none() {
+            let mut stats = Stats::default();
+            stats.initial_paths.record(self.initial_paths);
+            self.stats = Some(stats);
+        }
+        if let Some(similar_path_detector) = &mut self.similar_path_detector {
+            similar_path_detector.set_collect_stats(collect_stats);
+        }
+    }
+
+    pub fn into_stats(mut self) -> Stats {
+        if let (Some(stats), Some(similar_path_detector)) =
+            (&mut self.stats, self.similar_path_detector)
+        {
+            stats.similar_paths_stats = similar_path_detector.stats();
+        }
+        self.stats.unwrap_or_default()
+    }
+}
+
+impl<H: Clone> ForwardPartialPathStitcher<H> {
+    /// Returns an iterator of all of the (possibly incomplete) partial paths that were encountered
+    /// during the most recent phase of the algorithm.
+    pub fn previous_phase_partial_paths(&self) -> impl Iterator<Item = &PartialPath> + '_ {
+        self.next_iteration.0.iter()
+    }
+
+    /// Returns a slice of all of the (possibly incomplete) partial paths that were encountered
+    /// during the most recent phase of the algorithm.
+    pub fn previous_phase_partial_paths_slice(&mut self) -> &[PartialPath] {
+        self.next_iteration.0.make_contiguous();
+        self.next_iteration.0.as_slices().0
+    }
+
+    /// Returns a mutable slice of all of the (possibly incomplete) partial paths that were
+    /// encountered during the most recent phase of the algorithm.
+    pub fn previous_phase_partial_paths_slice_mut(&mut self) -> &mut [PartialPath] {
+        self.next_iteration.0.make_contiguous();
+        self.next_iteration.0.as_mut_slices().0
+    }
+
+    /// Attempts to extend one partial path as part of the algorithm.  When calling this function,
+    /// you are responsible for ensuring that `db` already contains all of the possible appendables
+    /// that we might want to extend `partial_path` with.
+    fn extend<A, Db, C, Err>(
+        &mut self,
+        candidates: &mut C,
+        partial_path: &PartialPath,
+        cycle_detector: AppendingCycleDetector<H>,
+        has_split: bool,
+    ) -> usize
+    where
+        A: Appendable,
+        Db: ToAppendable<H, A>,
+        C: ForwardCandidates<H, A, Db, Err>,
+    {
+        let check_cycle = !self.check_only_join_nodes
+            || partial_path.start_node == partial_path.end_node
+            || candidates.get_joining_candidate_degree(partial_path) == Degree::Multiple;
+
+        let (graph, partials, db) = candidates.get_graph_partials_and_db();
+        copious_debugging!("    Extend {}", partial_path.display(graph, partials));
+
+        if check_cycle {
+            // Check is path is cyclic, in which case we do not extend it. We only do this if the start and end nodes are the same,
+            // or the current end node has multiple incoming edges. If neither of these hold, the path cannot end in a cycle.
+            let has_precondition_variables = partial_path.symbol_stack_precondition.has_variable()
+                || partial_path.scope_stack_precondition.has_variable();
+            let cycles = cycle_detector
+                .is_cyclic(graph, partials, db, &mut self.appended_paths)
+                .expect("cyclic test failed when stitching partial paths");
+            let cyclic = match has_precondition_variables {
+                // If the precondition has no variables, we allow cycles that strengthen the
+                // precondition, because we know they cannot strengthen the precondition of
+                // the overall path.
+                false => !cycles
+                    .into_iter()
+                    .all(|c| c == Cyclicity::StrengthensPrecondition),
+                // If the precondition has variables, do not allow any cycles, not even those
+                // that strengthen the precondition. This is more strict than necessary. Better
+                // might be to disallow precondition strengthening cycles only if they would
+                // strengthen the overall path precondition.
+                true => !cycles.is_empty(),
+            };
+            if cyclic {
+                copious_debugging!("      is discontinued: cyclic");
+                return 0;
+            }
+        }
+
+        // find candidates to append
+        self.candidates.clear();
+        candidates.get_forward_candidates(partial_path, &mut self.candidates);
+        let (graph, partials, db) = candidates.get_graph_partials_and_db();
+
+        // try to extend path with candidates
+        let candidate_count = self.candidates.len();
+        self.extensions.clear();
+        self.extensions.reserve(candidate_count);
+        for candidate in &self.candidates {
+            let appendable = db.get_appendable(candidate);
+            copious_debugging!("      with {}", appendable.display(graph, partials));
+
+            let mut new_partial_path = partial_path.clone();
+            let mut new_cycle_detector = cycle_detector.clone();
+            // If there are errors concatenating these partial paths, or resolving the resulting
+            // partial path, just skip the extension — it's not a fatal error.
+            #[cfg_attr(not(feature = "copious-debugging"), allow(unused_variables))]
+            {
+                if let Err(err) = appendable.append_to(graph, partials, &mut new_partial_path) {
+                    copious_debugging!("        is invalid: {:?}", err);
+                    continue;
+                }
+            }
+            new_cycle_detector.append(&mut self.appended_paths, candidate.clone());
+            copious_debugging!("        is {}", new_partial_path.display(graph, partials));
+            self.extensions.push((new_partial_path, new_cycle_detector));
+        }
+
+        let extension_count = self.extensions.len();
+        let new_has_split = has_split || self.extensions.len() > 1;
+        self.next_iteration.0.reserve(extension_count);
+        self.next_iteration.1.reserve(extension_count);
+        self.next_iteration.2.reserve(extension_count);
+        for (new_partial_path, new_cycle_detector) in self.extensions.drain(..) {
+            let check_similar_path = new_has_split
+                && (!self.check_only_join_nodes
+                    || candidates.get_joining_candidate_degree(&new_partial_path)
+                        == Degree::Multiple);
+            let (graph, partials, _) = candidates.get_graph_partials_and_db();
+            if check_similar_path {
+                if let Some(similar_path_detector) = &mut self.similar_path_detector {
+                    if similar_path_detector.add_path(
+                        graph,
+                        partials,
+                        &new_partial_path,
+                        |ps, left, right| {
+                            if !left.equals(ps, right) {
+                                None
+                            } else {
+                                if left.shadows(ps, right) {
+                                    Some(Ordering::Less)
+                                } else if right.shadows(ps, left) {
+                                    Some(Ordering::Greater)
+                                } else {
+                                    Some(Ordering::Equal)
+                                }
+                            }
+                        },
+                    ) {
+                        copious_debugging!(
+                            " extension {}",
+                            new_partial_path.display(graph, partials)
+                        );
+                        copious_debugging!("        is rejected: too many similar");
+                        continue;
+                    }
+                }
+            }
+
+            self.next_iteration.0.push(new_partial_path);
+            self.next_iteration.1.push(new_cycle_detector);
+            self.next_iteration.2.push(new_has_split);
+        }
+
+        if let Some(stats) = &mut self.stats {
+            let (graph, _, _) = candidates.get_graph_partials_and_db();
+            let end_node = &graph[partial_path.end_node];
+            if end_node.is_root() {
+                stats.candidates_per_root_path.record(candidate_count);
+                stats.extensions_per_root_path.record(extension_count);
+                stats.root_visits += 1;
+            } else {
+                stats.candidates_per_node_path.record(candidate_count);
+                stats.extensions_per_node_path.record(extension_count);
+                stats.node_visits.record(end_node.id());
+            }
+            if extension_count == 0 {
+                stats.terminal_path_lengh.record(partial_path.edges.len());
+            }
+        }
+        candidate_count
+    }
+
+    /// Returns whether the algorithm has completed.
+    pub fn is_complete(&self) -> bool {
+        self.queue.is_empty() && self.next_iteration.0.is_empty()
+    }
+
+    /// Runs the next phase of the algorithm.  We will have built up a set of incomplete partial
+    /// paths during the _previous_ phase.  Before calling this function, you must ensure that `db`
+    /// contains all of the possible appendables that we might want to extend any of those
+    /// candidate partial paths with.
+    ///
+    /// After this method returns, you can use [`previous_phase_partial_paths`][] to retrieve a
+    /// list of the (possibly incomplete) partial paths that were encountered during this phase.
+    ///
+    /// The `extend_while` closure is used to control whether the extended paths are further extended
+    /// or not. It is not called on the initial paths.
+    ///
+    /// [`previous_phase_partial_paths`]: #method.previous_phase_partial_paths
+    pub fn process_next_phase<A, Db, C, E, Err>(&mut self, candidates: &mut C, extend_while: E)
+    where
+        A: Appendable,
+        Db: ToAppendable<H, A>,
+        C: ForwardCandidates<H, A, Db, Err>,
+        E: Fn(&StackGraph, &mut PartialPaths, &PartialPath) -> bool,
+    {
+        copious_debugging!("==> Start phase {}", self.phase_number);
+        self.queue.extend(izip!(
+            self.next_iteration.0.drain(..),
+            self.next_iteration.1.drain(..),
+            self.next_iteration.2.drain(..),
+        ));
+        if let Some(stats) = &mut self.stats {
+            stats.queued_paths_per_phase.record(self.queue.len());
+        }
+        let mut work_performed = 0;
+        while let Some((partial_path, cycle_detector, has_split)) = self.queue.pop_front() {
+            let (graph, partials, _) = candidates.get_graph_partials_and_db();
+            copious_debugging!(
+                "--> Candidate partial path {}",
+                partial_path.display(graph, partials)
+            );
+            if self.initial_paths_in_queue > 0 {
+                self.initial_paths_in_queue -= 1;
+            } else if !extend_while(graph, partials, &partial_path) {
+                copious_debugging!(
+                    "    Do not extend {}",
+                    partial_path.display(graph, partials)
+                );
+                continue;
+            }
+            work_performed += self.extend(candidates, &partial_path, cycle_detector, has_split);
+            if work_performed >= self.max_work_per_phase {
+                break;
+            }
+        }
+        if let Some(stats) = &mut self.stats {
+            stats.processed_paths_per_phase.record(work_performed);
+        }
+
+        #[cfg(feature = "copious-debugging")]
+        {
+            if let Some(similar_path_detector) = &self.similar_path_detector {
+                copious_debugging!(
+                    "    Max similar path bucket size: {}",
+                    similar_path_detector.max_bucket_size()
+                );
+            }
+            copious_debugging!("==> End phase {}", self.phase_number);
+            self.phase_number += 1;
+        }
+    }
+}
+
+impl ForwardPartialPathStitcher<Edge> {
+    /// Finds a minimal set of partial paths in a file, calling the `visit` closure for each one.
+    ///
+    /// This function ensures that the set of visited partial paths
+    ///  (a) is minimal, no path can be constructed by stitching other paths in the set, and
+    ///  (b) covers all complete paths, from references to definitions, when used for path stitching
+    ///
+    /// This function will not return until all reachable partial paths have been processed, so
+    /// your database must already contain all partial paths that might be needed.  If you have a
+    /// very large stack graph stored in some other storage system, and want more control over
+    /// lazily loading only the necessary pieces, then you should code up your own loop that calls
+    /// [`process_next_phase`][] manually.
+    ///
+    /// Caveat: Edges between nodes of different files are not used. Hence the returned set of partial
+    /// paths will not cover paths going through those edges.
+    ///
+    /// [`process_next_phase`]: #method.process_next_phase
+    pub fn find_minimal_partial_path_set_in_file<F>(
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        file: Handle<File>,
+        config: StitcherConfig,
+        cancellation_flag: &dyn CancellationFlag,
+        mut visit: F,
+    ) -> Result<Stats, CancellationError>
+    where
+        F: FnMut(&StackGraph, &mut PartialPaths, &PartialPath),
+    {
+        fn as_complete_as_necessary(graph: &StackGraph, path: &PartialPath) -> bool {
+            path.starts_at_endpoint(graph)
+                && (path.ends_at_endpoint(graph) || path.ends_in_jump(graph))
+        }
+
+        let initial_paths = graph
+            .nodes_for_file(file)
+            .chain(std::iter::once(StackGraph::root_node()))
+            .filter(|node| graph[*node].is_endpoint())
+            .map(|node| PartialPath::from_node(graph, partials, node))
+            .collect::<Vec<_>>();
+        let mut stitcher =
+            ForwardPartialPathStitcher::from_partial_paths(graph, partials, initial_paths);
+        config.apply(&mut stitcher);
+        stitcher.set_check_only_join_nodes(true);
+
+        let mut accepted_path_length = FrequencyDistribution::default();
+        while !stitcher.is_complete() {
+            cancellation_flag.check("finding complete partial paths")?;
+            stitcher.process_next_phase(
+                &mut GraphEdgeCandidates::new(graph, partials, Some(file)),
+                |g, _ps, p| !as_complete_as_necessary(g, p),
+            );
+            for path in stitcher.previous_phase_partial_paths() {
+                if as_complete_as_necessary(graph, path) {
+                    accepted_path_length.record(path.edges.len());
+                    visit(graph, partials, path);
+                }
+            }
+        }
+
+        Ok(Stats {
+            accepted_path_length,
+            ..stitcher.into_stats()
+        })
+    }
+}
+
+impl<H: Clone> ForwardPartialPathStitcher<H> {
+    /// Finds all complete partial paths that are reachable from a set of starting nodes,
+    /// building them up by stitching together partial paths from this database, and calling
+    /// the `visit` closure on each one.
+    ///
+    /// This function will not return until all reachable partial paths have been processed, so
+    /// your database must already contain all partial paths that might be needed.  If you have a
+    /// very large stack graph stored in some other storage system, and want more control over
+    /// lazily loading only the necessary pieces, then you should code up your own loop that calls
+    /// [`process_next_phase`][] manually.
+    ///
+    /// [`process_next_phase`]: #method.process_next_phase
+    pub fn find_all_complete_partial_paths<I, F, A, Db, C, Err>(
+        candidates: &mut C,
+        starting_nodes: I,
+        config: StitcherConfig,
+        cancellation_flag: &dyn CancellationFlag,
+        mut visit: F,
+    ) -> Result<Stats, Err>
+    where
+        I: IntoIterator<Item = Handle<Node>>,
+        A: Appendable,
+        Db: ToAppendable<H, A>,
+        C: ForwardCandidates<H, A, Db, Err>,
+        F: FnMut(&StackGraph, &mut PartialPaths, &PartialPath),
+        Err: std::convert::From<CancellationError>,
+    {
+        let (graph, partials, _) = candidates.get_graph_partials_and_db();
+        let initial_paths = starting_nodes
+            .into_iter()
+            .filter(|n| graph[*n].is_reference())
+            .map(|n| {
+                let mut p = PartialPath::from_node(graph, partials, n);
+                p.eliminate_precondition_stack_variables(partials);
+                p
+            })
+            .collect::<Vec<_>>();
+        let mut stitcher =
+            ForwardPartialPathStitcher::from_partial_paths(graph, partials, initial_paths);
+        config.apply(&mut stitcher);
+        stitcher.set_check_only_join_nodes(true);
+
+        let mut accepted_path_length = FrequencyDistribution::default();
+        while !stitcher.is_complete() {
+            cancellation_flag.check("finding complete partial paths")?;
+            for path in stitcher.previous_phase_partial_paths() {
+                candidates.load_forward_candidates(path, cancellation_flag)?;
+            }
+            stitcher.process_next_phase(candidates, |_, _, _| true);
+            let (graph, partials, _) = candidates.get_graph_partials_and_db();
+            for path in stitcher.previous_phase_partial_paths() {
+                if path.is_complete(graph) {
+                    accepted_path_length.record(path.edges.len());
+                    visit(graph, partials, path);
+                }
+            }
+        }
+
+        Ok(Stats {
+            accepted_path_length,
+            ..stitcher.into_stats()
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Stats {
+    /// The distribution of the number of initial paths
+    pub initial_paths: FrequencyDistribution<usize>,
+    /// The distribution of the number of queued paths per stitching phase
+    pub queued_paths_per_phase: FrequencyDistribution<usize>,
+    /// The distribution of the number of processed paths per stitching phase
+    pub processed_paths_per_phase: FrequencyDistribution<usize>,
+    /// The distribution of the length of accepted paths
+    pub accepted_path_length: FrequencyDistribution<usize>,
+    /// The distribution of the maximal length of paths (when they cannot be extended more)
+    pub terminal_path_lengh: FrequencyDistribution<usize>,
+    /// The distribution of the number of candidates for paths ending in a regular node
+    pub candidates_per_node_path: FrequencyDistribution<usize>,
+    /// The distribution of the number of candidates for paths ending in the root node
+    pub candidates_per_root_path: FrequencyDistribution<usize>,
+    /// The distribution of the number of extensions (accepted candidates) for paths ending in a regular node
+    pub extensions_per_node_path: FrequencyDistribution<usize>,
+    /// The distribution of the number of extensions (accepted candidates) for paths ending in the root node
+    pub extensions_per_root_path: FrequencyDistribution<usize>,
+    /// The number of times the root node is visited
+    pub root_visits: usize,
+    /// The distribution of the number of times a regular node is visited
+    pub node_visits: FrequencyDistribution<crate::graph::NodeID>,
+    /// The distribution of the number of similar paths between node pairs.
+    pub similar_paths_stats: SimilarPathStats,
+}
+
+impl std::ops::AddAssign<Self> for Stats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.initial_paths += rhs.initial_paths;
+        self.queued_paths_per_phase += rhs.queued_paths_per_phase;
+        self.processed_paths_per_phase += rhs.processed_paths_per_phase;
+        self.accepted_path_length += rhs.accepted_path_length;
+        self.terminal_path_lengh += rhs.terminal_path_lengh;
+        self.candidates_per_node_path += rhs.candidates_per_node_path;
+        self.candidates_per_root_path += rhs.candidates_per_root_path;
+        self.extensions_per_node_path += rhs.extensions_per_node_path;
+        self.extensions_per_root_path += rhs.extensions_per_root_path;
+        self.root_visits += rhs.root_visits;
+        self.node_visits += rhs.node_visits;
+        self.similar_paths_stats += rhs.similar_paths_stats;
+    }
+}
+
+impl std::ops::AddAssign<&Self> for Stats {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.initial_paths += &rhs.initial_paths;
+        self.processed_paths_per_phase += &rhs.processed_paths_per_phase;
+        self.accepted_path_length += &rhs.accepted_path_length;
+        self.terminal_path_lengh += &rhs.terminal_path_lengh;
+        self.candidates_per_node_path += &rhs.candidates_per_node_path;
+        self.candidates_per_root_path += &rhs.candidates_per_root_path;
+        self.extensions_per_node_path += &rhs.extensions_per_node_path;
+        self.extensions_per_root_path += &rhs.extensions_per_root_path;
+        self.root_visits += rhs.root_visits;
+        self.node_visits += &rhs.node_visits;
+        self.similar_paths_stats += &rhs.similar_paths_stats;
+    }
+}
+
+/// Configuration for partial path stitchers.
+#[derive(Clone, Copy, Debug)]
+pub struct StitcherConfig {
+    /// Enables similar path detection during path stitching.
+    detect_similar_paths: bool,
+    /// Collect statistics about path stitching.
+    collect_stats: bool,
+}
+
+impl StitcherConfig {
+    pub fn detect_similar_paths(&self) -> bool {
+        self.detect_similar_paths
+    }
+
+    pub fn with_detect_similar_paths(mut self, detect_similar_paths: bool) -> Self {
+        self.detect_similar_paths = detect_similar_paths;
+        self
+    }
+
+    pub fn collect_stats(&self) -> bool {
+        self.collect_stats
+    }
+
+    pub fn with_collect_stats(mut self, collect_stats: bool) -> Self {
+        self.collect_stats = collect_stats;
+        self
+    }
+}
+
+impl StitcherConfig {
+    fn apply<H>(&self, stitcher: &mut ForwardPartialPathStitcher<H>) {
+        stitcher.set_similar_path_detection(self.detect_similar_paths);
+        stitcher.set_collect_stats(self.collect_stats);
+    }
+}
+
+impl Default for StitcherConfig {
+    fn default() -> Self {
+        Self {
+            detect_similar_paths: true,
+            collect_stats: false,
+        }
+    }
+}

--- a/crates/metaslang/stack_graphs/src/storage.rs
+++ b/crates/metaslang/stack_graphs/src/storage.rs
@@ -1,0 +1,871 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use bincode::error::DecodeError;
+use bincode::error::EncodeError;
+use itertools::Itertools;
+use rusqlite::functions::FunctionFlags;
+use rusqlite::types::ValueRef;
+use rusqlite::Connection;
+use rusqlite::OptionalExtension;
+use rusqlite::Params;
+use rusqlite::Statement;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+use thiserror::Error;
+
+use crate::arena::Handle;
+use crate::graph::Degree;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::partial::PartialSymbolStack;
+use crate::serde;
+use crate::serde::FileFilter;
+use crate::stitching::Database;
+use crate::stitching::ForwardCandidates;
+use crate::CancellationError;
+use crate::CancellationFlag;
+
+const VERSION: usize = 6;
+
+const SCHEMA: &str = r#"
+        CREATE TABLE metadata (
+            version INTEGER NOT NULL
+        ) STRICT;
+        CREATE TABLE graphs (
+            file   TEXT PRIMARY KEY,
+            tag    TEXT NOT NULL,
+            error  TEXT,
+            value  BLOB NOT NULL
+        ) STRICT;
+        CREATE TABLE file_paths (
+            file     TEXT NOT NULL,
+            local_id INTEGER NOT NULL,
+            value    BLOB NOT NULL,
+            FOREIGN KEY(file) REFERENCES graphs(file)
+        ) STRICT;
+        CREATE TABLE root_paths (
+            file         TEXT NOT NULL,
+            symbol_stack TEXT NOT NULL,
+            value        BLOB NOT NULL,
+            FOREIGN KEY(file) REFERENCES graphs(file)
+        ) STRICT;
+    "#;
+
+const INDEXES: &str = r#"
+        CREATE INDEX IF NOT EXISTS idx_graphs_file ON graphs(file);
+        CREATE INDEX IF NOT EXISTS idx_file_paths_local_id ON file_paths(file, local_id);
+        CREATE INDEX IF NOT EXISTS idx_root_paths_symbol_stack ON root_paths(symbol_stack);
+    "#;
+
+const PRAGMAS: &str = r#"
+        PRAGMA journal_mode = WAL;
+        PRAGMA foreign_keys = false;
+        PRAGMA secure_delete = false;
+    "#;
+
+pub static BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard();
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("cancelled at {0}")]
+    Cancelled(&'static str),
+    #[error("unsupported database version {0}")]
+    IncorrectVersion(usize),
+    #[error("database does not exist {0}")]
+    MissingDatabase(String),
+    #[error(transparent)]
+    Rusqlite(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Serde(#[from] serde::Error),
+    #[error(transparent)]
+    SerializeFail(#[from] EncodeError),
+    #[error(transparent)]
+    DeserializeFail(#[from] DecodeError),
+}
+
+pub type Result<T> = std::result::Result<T, StorageError>;
+
+impl From<CancellationError> for StorageError {
+    fn from(value: CancellationError) -> Self {
+        Self::Cancelled(value.0)
+    }
+}
+
+/// The status of a file in the database.
+pub enum FileStatus {
+    Missing,
+    Indexed,
+    Error(String),
+}
+
+impl<'a> From<ValueRef<'a>> for FileStatus {
+    fn from(value: ValueRef<'a>) -> Self {
+        match value {
+            ValueRef::Null => Self::Indexed,
+            ValueRef::Text(error) => Self::Error(
+                std::str::from_utf8(error)
+                    .expect("invalid error encoding in database")
+                    .to_string(),
+            ),
+            _ => panic!("invalid value type in database"),
+        }
+    }
+}
+
+/// A file entry in the database.
+pub struct FileEntry {
+    pub path: PathBuf,
+    pub tag: String,
+    pub status: FileStatus,
+}
+
+/// An iterator over a query returning rows with (path,tag,error) tuples.
+pub struct Files<'a, P: Params>(Statement<'a>, P);
+
+impl<'a, P: Params + Clone> Files<'a, P> {
+    pub fn try_iter<'b>(&'b mut self) -> Result<impl Iterator<Item = Result<FileEntry>> + 'b> {
+        let entries = self.0.query_map(self.1.clone(), |r| {
+            Ok(FileEntry {
+                path: PathBuf::from(r.get::<_, String>(0)?),
+                tag: r.get::<_, String>(1)?,
+                status: r.get_ref(2)?.into(),
+            })
+        })?;
+        let entries = entries.map(|r| -> Result<FileEntry> { Ok(r?) });
+        Ok(entries)
+    }
+}
+
+/// Writer to store stack graphs and partial paths in a SQLite database.
+pub struct SQLiteWriter {
+    conn: Connection,
+}
+
+impl SQLiteWriter {
+    /// Open an in-memory database.
+    pub fn open_in_memory() -> Result<Self> {
+        let mut conn = Connection::open_in_memory()?;
+        Self::init(&mut conn)?;
+        init_indexes(&mut conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Open a file database.  If the file does not exist, it is automatically created.
+    /// An error is returned if the database version is not supported.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let is_new = !path.as_ref().exists();
+        let mut conn = Connection::open(path)?;
+        set_pragmas_and_functions(&conn)?;
+        if is_new {
+            Self::init(&mut conn)?;
+        } else {
+            check_version(&conn)?;
+        }
+        init_indexes(&mut conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Create database tables and write metadata.
+    fn init(conn: &mut Connection) -> Result<()> {
+        let tx = conn.transaction()?;
+        tx.execute_batch(SCHEMA)?;
+        tx.execute("INSERT INTO metadata (version) VALUES (?)", [VERSION])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Clean all data from the database.
+    pub fn clean_all(&mut self) -> Result<usize> {
+        let tx = self.conn.transaction()?;
+        let count = Self::clean_all_inner(&tx)?;
+        tx.commit()?;
+        Ok(count)
+    }
+
+    /// Clean all data from the database.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn clean_all_inner(conn: &Connection) -> Result<usize> {
+        {
+            let mut stmt = conn.prepare_cached("DELETE FROM file_paths")?;
+            stmt.execute([])?;
+        }
+        {
+            let mut stmt = conn.prepare_cached("DELETE FROM root_paths")?;
+            stmt.execute([])?;
+        }
+        let count = {
+            let mut stmt = conn.prepare_cached("DELETE FROM graphs")?;
+            stmt.execute([])?
+        };
+        Ok(count)
+    }
+
+    /// Clean file data from the database.  If recursive is true, data for all descendants of
+    /// that file is cleaned.
+    pub fn clean_file(&mut self, file: &Path) -> Result<usize> {
+        let tx = self.conn.transaction()?;
+        let count = Self::clean_file_inner(&tx, file)?;
+        tx.commit()?;
+        Ok(count)
+    }
+
+    /// Clean file data from the database.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn clean_file_inner(conn: &Connection, file: &Path) -> Result<usize> {
+        let file = file.to_string_lossy();
+        {
+            let mut stmt = conn.prepare_cached("DELETE FROM file_paths WHERE file=?")?;
+            stmt.execute([&file])?;
+        }
+        {
+            let mut stmt = conn.prepare_cached("DELETE FROM root_paths WHERE file=?")?;
+            stmt.execute([&file])?;
+        }
+        let count = {
+            let mut stmt = conn.prepare_cached("DELETE FROM graphs WHERE file=?")?;
+            stmt.execute([&file])?
+        };
+        Ok(count)
+    }
+
+    /// Clean file or directory data from the database.  Data for all decendants of the given path
+    /// is cleaned.
+    pub fn clean_file_or_directory(&mut self, file_or_directory: &Path) -> Result<usize> {
+        let tx = self.conn.transaction()?;
+        let count = Self::clean_file_or_directory_inner(&tx, file_or_directory)?;
+        tx.commit()?;
+        Ok(count)
+    }
+
+    /// Clean file or directory data from the database.  Data for all decendants of the given path
+    /// is cleaned.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn clean_file_or_directory_inner(conn: &Connection, file_or_directory: &Path) -> Result<usize> {
+        let file_or_directory = file_or_directory.to_string_lossy();
+        {
+            let mut stmt =
+                conn.prepare_cached("DELETE FROM file_paths WHERE path_descendant_of(file, ?)")?;
+            stmt.execute([&file_or_directory])?;
+        }
+        {
+            let mut stmt =
+                conn.prepare_cached("DELETE FROM root_paths WHERE path_descendant_of(file, ?)")?;
+            stmt.execute([&file_or_directory])?;
+        }
+        let count = {
+            let mut stmt =
+                conn.prepare_cached("DELETE FROM graphs WHERE path_descendant_of(file, ?)")?;
+            stmt.execute([&file_or_directory])?
+        };
+        Ok(count)
+    }
+
+    /// Store an error, indicating that indexing this file failed.
+    pub fn store_error_for_file(&mut self, file: &Path, tag: &str, error: &str) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        Self::store_error_for_file_inner(&tx, file, tag, error)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Store an error, indicating that indexing this file failed.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn store_error_for_file_inner(
+        conn: &Connection,
+        file: &Path,
+        tag: &str,
+        error: &str,
+    ) -> Result<()> {
+        copious_debugging!("--> Store error for {}", file.display());
+        let mut stmt = conn
+            .prepare_cached("INSERT INTO graphs (file, tag, error, value) VALUES (?, ?, ?, ?)")?;
+        let graph = crate::serde::StackGraph::default();
+        let serialized = bincode::encode_to_vec(&graph, BINCODE_CONFIG)?;
+        stmt.execute((&file.to_string_lossy(), tag, error, serialized))?;
+        Ok(())
+    }
+
+    /// Store the result of a successful file index.
+    pub fn store_result_for_file<'a, IP>(
+        &mut self,
+        graph: &StackGraph,
+        file: Handle<File>,
+        tag: &str,
+        partials: &mut PartialPaths,
+        paths: IP,
+    ) -> Result<()>
+    where
+        IP: IntoIterator<Item = &'a PartialPath>,
+    {
+        let path = Path::new(graph[file].name());
+        let tx = self.conn.transaction()?;
+        Self::clean_file_inner(&tx, path)?;
+        Self::store_graph_for_file_inner(&tx, graph, file, tag)?;
+        Self::store_partial_paths_for_file_inner(&tx, graph, file, partials, paths)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Store the file graph.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn store_graph_for_file_inner(
+        conn: &Connection,
+        graph: &StackGraph,
+        file: Handle<File>,
+        tag: &str,
+    ) -> Result<()> {
+        let file_str = graph[file].name();
+        copious_debugging!("--> Store graph for {}", file_str);
+        let mut stmt =
+            conn.prepare_cached("INSERT INTO graphs (file, tag, value) VALUES (?, ?, ?)")?;
+        let graph = serde::StackGraph::from_graph_filter(graph, &FileFilter(file));
+        let serialized = bincode::encode_to_vec(&graph, BINCODE_CONFIG)?;
+        stmt.execute((file_str, tag, &serialized))?;
+        Ok(())
+    }
+
+    /// Store the file partial paths.
+    ///
+    /// This is an inner method, which does not wrap individual SQL statements in a transaction.
+    fn store_partial_paths_for_file_inner<'a, IP>(
+        conn: &Connection,
+        graph: &StackGraph,
+        file: Handle<File>,
+        partials: &mut PartialPaths,
+        paths: IP,
+    ) -> Result<()>
+    where
+        IP: IntoIterator<Item = &'a PartialPath>,
+    {
+        let file_str = graph[file].name();
+        let mut node_stmt =
+            conn.prepare_cached("INSERT INTO file_paths (file, local_id, value) VALUES (?, ?, ?)")?;
+        let mut root_stmt = conn.prepare_cached(
+            "INSERT INTO root_paths (file, symbol_stack, value) VALUES (?, ?, ?)",
+        )?;
+        #[cfg_attr(not(feature = "copious-debugging"), allow(unused))]
+        let mut node_path_count = 0usize;
+        #[cfg_attr(not(feature = "copious-debugging"), allow(unused))]
+        let mut root_path_count = 0usize;
+        for path in paths {
+            copious_debugging!(
+                "--> Add {} partial path {}",
+                file_str,
+                path.display(graph, partials)
+            );
+            let start_node = graph[path.start_node].id();
+            if start_node.is_root() {
+                copious_debugging!(
+                    " * Add as root path with symbol stack {}",
+                    path.symbol_stack_precondition.display(graph, partials),
+                );
+                let symbol_stack = path.symbol_stack_precondition.storage_key(graph, partials);
+                let path = serde::PartialPath::from_partial_path(graph, partials, path);
+                let serialized = bincode::encode_to_vec(&path, BINCODE_CONFIG)?;
+                root_stmt.execute((file_str, symbol_stack, serialized))?;
+                root_path_count += 1;
+            } else if start_node.is_in_file(file) {
+                copious_debugging!(
+                    " * Add as node path from node {}",
+                    path.start_node.display(graph),
+                );
+                let path = serde::PartialPath::from_partial_path(graph, partials, path);
+                let serialized = bincode::encode_to_vec(&path, BINCODE_CONFIG)?;
+                node_stmt.execute((file_str, path.start_node.local_id, serialized))?;
+                node_path_count += 1;
+            } else {
+                panic!(
+                    "added path {} must start in given file {} or at root",
+                    path.display(graph, partials),
+                    graph[file].name()
+                );
+            }
+            copious_debugging!(
+                " * Added {} node paths and {} root paths",
+                node_path_count,
+                root_path_count,
+            );
+        }
+        Ok(())
+    }
+
+    /// Get the file's status in the database. If a tag is provided, it must match or the file
+    /// is reported missing.
+    pub fn status_for_file(&mut self, file: &str, tag: Option<&str>) -> Result<FileStatus> {
+        status_for_file(&self.conn, file, tag)
+    }
+
+    /// Convert this writer into a reader for the same database.
+    pub fn into_reader(self) -> SQLiteReader {
+        SQLiteReader {
+            conn: self.conn,
+            loaded_graphs: HashSet::new(),
+            loaded_node_paths: HashSet::new(),
+            loaded_root_paths: HashSet::new(),
+            graph: StackGraph::new(),
+            partials: PartialPaths::new(),
+            db: Database::new(),
+            stats: Stats::default(),
+        }
+    }
+}
+
+/// Reader to load stack graphs and partial paths from a SQLite database.
+pub struct SQLiteReader {
+    conn: Connection,
+    loaded_graphs: HashSet<String>,
+    loaded_node_paths: HashSet<Handle<Node>>,
+    loaded_root_paths: HashSet<String>,
+    graph: StackGraph,
+    partials: PartialPaths,
+    db: Database,
+    stats: Stats,
+}
+
+impl SQLiteReader {
+    /// Open a file database.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        if !path.as_ref().exists() {
+            return Err(StorageError::MissingDatabase(
+                path.as_ref().to_string_lossy().to_string(),
+            ));
+        }
+        let mut conn = Connection::open(path)?;
+        set_pragmas_and_functions(&conn)?;
+        check_version(&conn)?;
+        init_indexes(&mut conn)?;
+        Ok(Self {
+            conn,
+            loaded_graphs: HashSet::new(),
+            loaded_node_paths: HashSet::new(),
+            loaded_root_paths: HashSet::new(),
+            graph: StackGraph::new(),
+            partials: PartialPaths::new(),
+            db: Database::new(),
+            stats: Stats::default(),
+        })
+    }
+
+    /// Clear all data that has been loaded into this reader instance.
+    /// After this call, all existing handles from this reader are invalid.
+    pub fn clear(&mut self) {
+        self.loaded_graphs.clear();
+        self.graph = StackGraph::new();
+
+        self.loaded_node_paths.clear();
+        self.loaded_root_paths.clear();
+        self.partials.clear();
+        self.db.clear();
+
+        self.stats.clear();
+    }
+
+    /// Clear path data that has been loaded into this reader instance.
+    /// After this call, all node handles remain valid, but all path data
+    /// is invalid.
+    pub fn clear_paths(&mut self) {
+        self.loaded_node_paths.clear();
+        self.loaded_root_paths.clear();
+        self.partials.clear();
+        self.db.clear();
+
+        self.stats.clear_paths();
+    }
+
+    /// Get the file's status in the database. If a tag is provided, it must match or the file
+    /// is reported missing.
+    pub fn status_for_file<T: AsRef<str>>(
+        &mut self,
+        file: &str,
+        tag: Option<T>,
+    ) -> Result<FileStatus> {
+        status_for_file(&self.conn, file, tag)
+    }
+
+    /// Returns a [`Files`][] value that can be used to iterate over all files in the database.
+    pub fn list_all<'a>(&'a mut self) -> Result<Files<'a, ()>> {
+        self.conn
+            .prepare("SELECT file, tag, error FROM graphs")
+            .map(|stmt| Files(stmt, ()))
+            .map_err(|e| e.into())
+    }
+
+    /// Returns a [`Files`][] value that can be used to iterate over all descendants of a
+    /// file or directory in the database.
+    pub fn list_file_or_directory<'a>(
+        &'a self,
+        file_or_directory: &Path,
+    ) -> Result<Files<'a, [String; 1]>> {
+        Self::list_file_or_directory_inner(&self.conn, file_or_directory)
+    }
+
+    fn list_file_or_directory_inner<'a>(
+        conn: &'a Connection,
+        file_or_directory: &Path,
+    ) -> Result<Files<'a, [String; 1]>> {
+        let file_or_directory = file_or_directory.to_string_lossy().to_string();
+        conn.prepare("SELECT file, tag, error FROM graphs WHERE path_descendant_of(file, ?)")
+            .map(|stmt| Files(stmt, [file_or_directory]))
+            .map_err(|e| e.into())
+    }
+
+    /// Ensure the graph for the given file is loaded.
+    pub fn load_graph_for_file(&mut self, file: &str) -> Result<Handle<File>> {
+        Self::load_graph_for_file_inner(
+            file,
+            &mut self.graph,
+            &mut self.loaded_graphs,
+            &self.conn,
+            &mut self.stats,
+        )
+    }
+
+    fn load_graph_for_file_inner(
+        file: &str,
+        graph: &mut StackGraph,
+        loaded_graphs: &mut HashSet<String>,
+        conn: &Connection,
+        stats: &mut Stats,
+    ) -> Result<Handle<File>> {
+        copious_debugging!("--> Load graph for {}", file);
+        if !loaded_graphs.insert(file.to_string()) {
+            copious_debugging!(" * Already loaded");
+            stats.file_cached += 1;
+            return Ok(graph.get_file(file).expect("loaded file to exist"));
+        }
+        copious_debugging!(" * Load from database");
+        stats.file_loads += 1;
+        let mut stmt = conn.prepare_cached("SELECT value FROM graphs WHERE file = ?")?;
+        let value = stmt.query_row([file], |row| row.get::<_, Vec<u8>>(0))?;
+        let (file_graph, _): (serde::StackGraph, usize) =
+            bincode::decode_from_slice(&value, BINCODE_CONFIG)?;
+        file_graph.load_into(graph)?;
+        Ok(graph.get_file(file).expect("loaded file to exist"))
+    }
+
+    pub fn load_graphs_for_file_or_directory(
+        &mut self,
+        file_or_directory: &Path,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<()> {
+        for file in Self::list_file_or_directory_inner(&self.conn, file_or_directory)?.try_iter()? {
+            cancellation_flag.check("loading graphs")?;
+            let file = file?;
+            Self::load_graph_for_file_inner(
+                &file.path.to_string_lossy(),
+                &mut self.graph,
+                &mut self.loaded_graphs,
+                &self.conn,
+                &mut self.stats,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Ensure the paths starting a the given node are loaded.
+    fn load_paths_for_node(
+        &mut self,
+        node: Handle<Node>,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<()> {
+        copious_debugging!(" * Load extensions from node {}", node.display(&self.graph));
+        if !self.loaded_node_paths.insert(node) {
+            copious_debugging!("   > Already loaded");
+            self.stats.node_path_cached += 1;
+            return Ok(());
+        }
+        self.stats.node_path_loads += 1;
+        let id = self.graph[node].id();
+        let file = id.file().expect("file node required");
+        let file = self.graph[file].name();
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT file,value from file_paths WHERE file = ? AND local_id = ?")?;
+        let paths = stmt.query_map((file, id.local_id()), |row| {
+            let file = row.get::<_, String>(0)?;
+            let value = row.get::<_, Vec<u8>>(1)?;
+            Ok((file, value))
+        })?;
+        #[cfg_attr(not(feature = "copious-debugging"), allow(unused))]
+        let mut count = 0usize;
+        for path in paths {
+            cancellation_flag.check("loading node paths")?;
+            let (file, value) = path?;
+            Self::load_graph_for_file_inner(
+                &file,
+                &mut self.graph,
+                &mut self.loaded_graphs,
+                &self.conn,
+                &mut self.stats,
+            )?;
+            let (path, _): (serde::PartialPath, usize) =
+                bincode::decode_from_slice(&value, BINCODE_CONFIG)?;
+            let path = path.to_partial_path(&mut self.graph, &mut self.partials)?;
+            copious_debugging!(
+                "   > Loaded {}",
+                path.display(&self.graph, &mut self.partials)
+            );
+            self.db
+                .add_partial_path(&self.graph, &mut self.partials, path);
+            count += 1;
+        }
+        copious_debugging!("   > Loaded {}", count);
+        Ok(())
+    }
+
+    /// Ensure the paths starting at the root and matching the given symbol stack are loaded.
+    fn load_paths_for_root(
+        &mut self,
+        symbol_stack: PartialSymbolStack,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<()> {
+        copious_debugging!(
+            " * Load extensions from root with symbol stack {}",
+            symbol_stack.display(&self.graph, &mut self.partials)
+        );
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT file,value from root_paths WHERE symbol_stack LIKE ? ESCAPE ?",
+        )?;
+        let (symbol_stack_patterns, escape) =
+            symbol_stack.storage_key_patterns(&self.graph, &mut self.partials);
+        for symbol_stack in symbol_stack_patterns {
+            copious_debugging!(
+                " * Load extensions from root with prefix symbol stack {}",
+                symbol_stack
+            );
+            if !self.loaded_root_paths.insert(symbol_stack.clone()) {
+                copious_debugging!("   > Already loaded");
+                self.stats.root_path_cached += 1;
+                continue;
+            }
+            self.stats.root_path_loads += 1;
+            let paths = stmt.query_map([symbol_stack, escape.clone()], |row| {
+                let file = row.get::<_, String>(0)?;
+                let value = row.get::<_, Vec<u8>>(1)?;
+                Ok((file, value))
+            })?;
+            #[cfg_attr(not(feature = "copious-debugging"), allow(unused))]
+            let mut count = 0usize;
+            for path in paths {
+                cancellation_flag.check("loading root paths")?;
+                let (file, value) = path?;
+                Self::load_graph_for_file_inner(
+                    &file,
+                    &mut self.graph,
+                    &mut self.loaded_graphs,
+                    &self.conn,
+                    &mut self.stats,
+                )?;
+                let (path, _): (serde::PartialPath, usize) =
+                    bincode::decode_from_slice(&value, BINCODE_CONFIG)?;
+                let path = path.to_partial_path(&mut self.graph, &mut self.partials)?;
+                copious_debugging!(
+                    "   > Loaded {}",
+                    path.display(&self.graph, &mut self.partials)
+                );
+                self.db
+                    .add_partial_path(&self.graph, &mut self.partials, path);
+                count += 1;
+            }
+            copious_debugging!("   > Loaded {}", count);
+        }
+        Ok(())
+    }
+
+    /// Ensure all possible extensions for the given partial path are loaded.
+    pub fn load_partial_path_extensions(
+        &mut self,
+        path: &PartialPath,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<()> {
+        copious_debugging!(
+            "--> Load extensions for {}",
+            path.display(&self.graph, &mut self.partials)
+        );
+        let end_node = self.graph[path.end_node].id();
+        if self.graph[path.end_node].file().is_some() {
+            self.load_paths_for_node(path.end_node, cancellation_flag)?;
+        } else if end_node.is_root() {
+            self.load_paths_for_root(path.symbol_stack_postcondition, cancellation_flag)?;
+        }
+        Ok(())
+    }
+
+    /// Get the stack graph, partial paths arena, and path database for the currently loaded data.
+    pub fn get(&mut self) -> (&mut StackGraph, &mut PartialPaths, &mut Database) {
+        (&mut self.graph, &mut self.partials, &mut self.db)
+    }
+
+    /// Return stats about this database reader.
+    pub fn stats(&self) -> Stats {
+        self.stats.clone()
+    }
+}
+
+// Methods for computing keys and patterns for a symbol stack. The format of a storage key is:
+//
+//     has-var GS ( symbol (US symbol)* )?
+//
+// where has-var is "V" if the symbol stack has a variable, "X" otherwise.
+impl PartialSymbolStack {
+    /// Returns a string representation of this symbol stack for indexing in the database.
+    fn storage_key(self, graph: &StackGraph, partials: &mut PartialPaths) -> String {
+        let mut key = String::new();
+        match self.has_variable() {
+            true => key += "V\u{241E}",
+            false => key += "X\u{241E}",
+        }
+        key += &self
+            .iter(partials)
+            .map(|s| &graph[s.symbol])
+            .join("\u{241F}");
+        key
+    }
+
+    /// Returns string representations for all prefixes of this symbol stack for querying the
+    /// index in the database.
+    fn storage_key_patterns(
+        mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+    ) -> (Vec<String>, String) {
+        let mut key_patterns = Vec::new();
+        let mut symbols = String::new();
+        while let Some(symbol) = self.pop_front(partials) {
+            if !symbols.is_empty() {
+                symbols += "\u{241F}";
+            }
+            let symbol = graph[symbol.symbol]
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+                .to_string();
+            symbols += &symbol;
+            // patterns for paths matching a prefix of this stack
+            key_patterns.push("V\u{241E}".to_string() + &symbols);
+        }
+        // pattern for paths matching exactly this stack
+        key_patterns.push("X\u{241E}".to_string() + &symbols);
+        if self.has_variable() {
+            // patterns for paths for which this stack is a prefix
+            key_patterns.push("_\u{241E}".to_string() + &symbols + "\u{241F}%");
+        }
+        (key_patterns, "\\".to_string())
+    }
+}
+
+impl ForwardCandidates<Handle<PartialPath>, PartialPath, Database, StorageError> for SQLiteReader {
+    fn load_forward_candidates(
+        &mut self,
+        path: &PartialPath,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> std::result::Result<(), StorageError> {
+        self.load_partial_path_extensions(path, cancellation_flag)
+    }
+
+    fn get_forward_candidates<R>(&mut self, path: &PartialPath, result: &mut R)
+    where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        self.db
+            .find_candidate_partial_paths(&self.graph, &mut self.partials, path, result);
+    }
+
+    fn get_joining_candidate_degree(&self, path: &PartialPath) -> Degree {
+        self.db.get_incoming_path_degree(path.end_node)
+    }
+
+    fn get_graph_partials_and_db(&mut self) -> (&StackGraph, &mut PartialPaths, &Database) {
+        (&self.graph, &mut self.partials, &self.db)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Stats {
+    pub file_loads: usize,
+    pub file_cached: usize,
+    pub root_path_loads: usize,
+    pub root_path_cached: usize,
+    pub node_path_loads: usize,
+    pub node_path_cached: usize,
+}
+
+impl Stats {
+    fn clear(&mut self) {
+        *self = Stats::default();
+    }
+
+    fn clear_paths(&mut self) {
+        *self = Stats {
+            file_loads: self.file_loads,
+            file_cached: self.file_cached,
+            ..Stats::default()
+        }
+    }
+}
+
+/// Check if the database has the version supported by this library version.
+fn check_version(conn: &Connection) -> Result<()> {
+    let version = conn.query_row("SELECT version FROM metadata", [], |r| r.get::<_, usize>(0))?;
+    if version != VERSION {
+        return Err(StorageError::IncorrectVersion(version));
+    }
+    Ok(())
+}
+
+fn set_pragmas_and_functions(conn: &Connection) -> Result<()> {
+    conn.execute_batch(PRAGMAS)?;
+    conn.create_scalar_function(
+        "path_descendant_of",
+        2,
+        FunctionFlags::SQLITE_DETERMINISTIC | FunctionFlags::SQLITE_UTF8,
+        move |ctx| {
+            assert_eq!(ctx.len(), 2, "called with unexpected number of arguments");
+            let path = PathBuf::from(ctx.get::<String>(0)?);
+            let parent = PathBuf::from(ctx.get::<String>(1)?);
+            let result = path.starts_with(&parent);
+            Ok(result)
+        },
+    )?;
+    Ok(())
+}
+
+fn init_indexes(conn: &mut Connection) -> Result<()> {
+    let tx = conn.transaction()?;
+    tx.execute_batch(INDEXES)?;
+    tx.commit()?;
+    Ok(())
+}
+
+fn status_for_file<T: AsRef<str>>(
+    conn: &Connection,
+    file: &str,
+    tag: Option<T>,
+) -> Result<FileStatus> {
+    let result = if let Some(tag) = tag {
+        let mut stmt =
+            conn.prepare_cached("SELECT error FROM graphs WHERE file = ? AND tag = ?")?;
+        stmt.query_row([file, tag.as_ref()], |r| r.get_ref(0).map(FileStatus::from))
+            .optional()?
+            .unwrap_or(FileStatus::Missing)
+    } else {
+        let mut stmt = conn.prepare_cached("SELECT status FROM graphs WHERE file = ?")?;
+        stmt.query_row([file], |r| r.get_ref(0).map(FileStatus::from))
+            .optional()?
+            .unwrap_or(FileStatus::Missing)
+    };
+    Ok(result)
+}

--- a/crates/metaslang/stack_graphs/src/utils.rs
+++ b/crates/metaslang/stack_graphs/src/utils.rs
@@ -1,0 +1,39 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+pub(crate) fn equals_option<A, B, F>(a: Option<A>, b: Option<B>, mut eq: F) -> bool
+where
+    F: FnMut(A, B) -> bool,
+{
+    match a {
+        Some(a) => match b {
+            Some(b) => eq(a, b),
+            None => false,
+        },
+        None => match b {
+            Some(_) => false,
+            None => true,
+        },
+    }
+}
+
+pub(crate) fn cmp_option<T, F>(a: Option<T>, b: Option<T>, mut cmp: F) -> std::cmp::Ordering
+where
+    F: FnMut(T, T) -> std::cmp::Ordering,
+{
+    use std::cmp::Ordering;
+    match a {
+        Some(a) => match b {
+            Some(b) => cmp(a, b),
+            None => Ordering::Greater,
+        },
+        None => match b {
+            Some(_) => Ordering::Less,
+            None => Ordering::Equal,
+        },
+    }
+}

--- a/crates/metaslang/stack_graphs/src/visualization.rs
+++ b/crates/metaslang/stack_graphs/src/visualization.rs
@@ -1,0 +1,129 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use serde_json::Error;
+
+use crate::arena::Handle;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::serde::Filter;
+use crate::stitching::Database;
+
+static CSS: &'static str = include_str!("visualization/visualization.css");
+static D3: &'static str = include_str!("visualization/d3.min.js");
+static D3_DAG: &'static str = include_str!("visualization/d3-dag.min.js");
+static JS: &'static str = include_str!("visualization/visualization.js");
+
+static PKG: &'static str = env!("CARGO_PKG_NAME");
+static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+//-----------------------------------------------------------------------------
+// StackGraph
+
+impl StackGraph {
+    pub fn to_html_string(
+        &self,
+        title: &str,
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        filter: &dyn Filter,
+    ) -> Result<String, Error> {
+        let filter = VisualizationFilter(filter);
+        let graph = serde_json::to_string(&self.to_serializable_filter(&filter))?;
+        let paths = serde_json::to_string(&db.to_serializable_filter(self, partials, &filter))?;
+        let html = format!(
+            r#"
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+<meta charset="utf-8">
+<title>{title}</title>
+
+<!-- <link href="visualization.css" type="text/css" rel="stylesheet"></link> -->
+<style>
+{CSS}
+</style>
+
+<!-- <script type="text/javascript" src="d3.v7.min.js"></script> -->
+<script type="text/javascript">
+{D3}
+</script>
+
+<!-- <script type="text/javascript" src="d3-dag.v0.10.0.min.js"></script> -->
+<script type="text/javascript">
+{D3_DAG}
+</script>
+
+<!-- <script type="text/javascript" src="visualization.js"></script> -->
+<script charset="utf-8">
+{JS}
+</script>
+
+<script type="text/javascript">
+  let graph = {graph};
+  let paths = {paths};
+</script>
+
+<style>
+  html, body, #container {{
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+  }}
+</style>
+
+</head>
+
+<body>
+  <div id="container">
+  </div>
+  <script type="text/javascript">
+    const container = d3.select("\#container");
+    new StackGraph(container, graph, paths, {{ version: "{PKG} {VERSION}" }});
+  </script>
+</body>
+
+</html>
+"#
+        );
+        Ok(html)
+    }
+}
+
+struct VisualizationFilter<'a>(&'a dyn Filter);
+
+impl Filter for VisualizationFilter<'_> {
+    fn include_file(&self, graph: &StackGraph, file: &Handle<File>) -> bool {
+        self.0.include_file(graph, file)
+    }
+
+    fn include_node(&self, graph: &StackGraph, node: &Handle<Node>) -> bool {
+        self.0.include_node(graph, node)
+    }
+
+    fn include_edge(&self, graph: &StackGraph, source: &Handle<Node>, sink: &Handle<Node>) -> bool {
+        self.0.include_edge(graph, source, sink)
+    }
+
+    fn include_partial_path(
+        &self,
+        graph: &StackGraph,
+        paths: &PartialPaths,
+        path: &PartialPath,
+    ) -> bool {
+        self.0.include_partial_path(graph, paths, path)
+            && !path.edges.is_empty()
+            && path.starts_at_reference(graph)
+            && (path.ends_at_definition(graph) || path.ends_in_jump(graph))
+    }
+}


### PR DESCRIPTION
This copies the `stack-graphs` crate, starting at the following commit:

- https://github.com/NomicFoundation/stack-graphs/tree/2f261d481644ccf898ac77968f6f5720262e8603

Subsequent PRs will update it with our fork changes to preserve history.

Note: the following files were skipped/not copied over from the original project, as they are not used in the fork:

- cbindgen infra: `include/stack-graphs.h` and `cbindgen.toml`
- visualization disabled feature: `src/visualization/*.{js,css}`
- integration tests: `tests/it/**`