### PR TITLE
[stack-graphs] add `{save,restore}_checkpoint` to `PartialPaths` to rewind the arena allocator pointers

### DIFF
--- a/crates/metaslang/stack_graphs/src/arena.rs
+++ b/crates/metaslang/stack_graphs/src/arena.rs
@@ -188,6 +188,11 @@ impl<T> Arena<T> {
         self.items.truncate(1);
     }
 
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
+    pub(crate) fn truncate(&mut self, new_len: usize) {
+        self.items.truncate(new_len);
+    }
+
     /// Adds a new instance to this arena, returning a stable handle to it.
     ///
     /// Note that we do not deduplicate instances of `T` in any way.  If you add two instances that

--- a/crates/metaslang/stack_graphs/src/partial.rs
+++ b/crates/metaslang/stack_graphs/src/partial.rs
@@ -2631,4 +2631,30 @@ impl PartialPaths {
         self.partial_scope_stacks.clear();
         self.partial_path_edges.clear();
     }
+
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
+    pub fn save_checkpoint(&self) -> PartialPathsCheckpoint {
+        PartialPathsCheckpoint {
+            partial_symbol_stacks_len: self.partial_symbol_stacks.len(),
+            partial_scope_stacks_len: self.partial_scope_stacks.len(),
+            partial_path_edges_len: self.partial_path_edges.len(),
+        }
+    }
+
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
+    pub fn restore_checkpoint(&mut self, checkpoint: PartialPathsCheckpoint) {
+        self.partial_symbol_stacks
+            .truncate(checkpoint.partial_symbol_stacks_len);
+        self.partial_scope_stacks
+            .truncate(checkpoint.partial_scope_stacks_len);
+        self.partial_path_edges
+            .truncate(checkpoint.partial_path_edges_len);
+    }
+}
+
+// __NOMIC_FOUNDATION_FORK__ (added this struct)
+pub struct PartialPathsCheckpoint {
+    partial_symbol_stacks_len: usize,
+    partial_scope_stacks_len: usize,
+    partial_path_edges_len: usize,
 }


### PR DESCRIPTION
Copied over from our fork: https://github.com/NomicFoundation/stack-graphs/pull/2