### PR TITLE
replace `stack-graphs` fork with workspace `metaslang_stack_graphs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,7 +2223,8 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "lsp-positions"
 version = "0.3.4"
-source = "git+https://github.com/NomicFoundation/stack-graphs?branch=nomic#9631ed9c7de4443525491745d46557dc16a7355c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562e6bd1c8366ac1cbe8a37057f530c40101eb8f4e98ce005be641c99d7331c8"
 dependencies = [
  "memchr",
  "unicode-segmentation",
@@ -2267,8 +2268,8 @@ version = "1.3.0"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
+ "metaslang_stack_graphs",
  "semver 1.0.26",
- "stack-graphs",
  "thiserror 2.0.12",
 ]
 
@@ -2296,6 +2297,22 @@ dependencies = [
  "string-interner",
  "strum 0.26.3",
  "strum_macros 0.26.4",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "metaslang_stack_graphs"
+version = "1.3.0"
+dependencies = [
+ "bitvec",
+ "controlled-option",
+ "either",
+ "enumset",
+ "fxhash",
+ "itertools 0.13.0",
+ "libc",
+ "lsp-positions",
+ "smallvec",
  "thiserror 2.0.12",
 ]
 
@@ -3890,23 +3907,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stack-graphs"
-version = "0.14.1"
-source = "git+https://github.com/NomicFoundation/stack-graphs?branch=nomic#9631ed9c7de4443525491745d46557dc16a7355c"
-dependencies = [
- "bitvec",
- "controlled-option",
- "either",
- "enumset",
- "fxhash",
- "itertools 0.10.5",
- "libc",
- "lsp-positions",
- "smallvec",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/metaslang/bindings",
     "crates/metaslang/cst",
     "crates/metaslang/graph_builder",
+    "crates/metaslang/stack_graphs",
 
     "crates/solidity/inputs/language",
 
@@ -72,8 +73,9 @@ language_v2_macros = { path = "crates/language-v2/macros", version = "1.3.0" }
 language_v2_tests = { path = "crates/language-v2/tests", version = "1.3.0" }
 
 metaslang_bindings = { path = "crates/metaslang/bindings", version = "1.3.0" }
-metaslang_graph_builder = { path = "crates/metaslang/graph_builder", version = "1.3.0" }
 metaslang_cst = { path = "crates/metaslang/cst", version = "1.3.0" }
+metaslang_graph_builder = { path = "crates/metaslang/graph_builder", version = "1.3.0" }
+metaslang_stack_graphs = { path = "crates/metaslang/stack_graphs", version = "1.3.0" }
 
 solidity_language = { path = "crates/solidity/inputs/language", version = "1.3.0" }
 
@@ -100,13 +102,18 @@ ariadne = { version = "0.2.0" }
 # Currently 'bencher' backend API is under development/unstable.
 # They recommend always running with the latest CLI version from 'main' until it is stabilized.
 bencher_cli = { git = "https://github.com/bencherdev/bencher", branch = "main" }
+bitvec = { version = "1.0.1" }
 cargo-edit = { version = "0.12.3" }
 cargo-nextest = { version = "0.9.72" }
 clap = { version = "4.5.40", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5.54" }
 console = { version = "0.15.11" }
+controlled-option = { version = "0.4.1" }
 derive-new = { version = "0.6.0" }
+either = { version = "1.6.0" }
+enumset = { version = "1.1.0" }
 env_logger = { version = "0.11.6" }
+fxhash = { version = "0.2.0" }
 iai-callgrind = { version = "0.12.3" }
 iai-callgrind-runner = { version = "0.12.3" }
 ignore = { version = "0.4.23" }
@@ -115,7 +122,9 @@ indicatif = { version = "0.17.12", features = ["in_memory"] }
 indoc = { version = "2.0.6" }
 Inflector = { version = "0.11.4" }
 itertools = { version = "0.13.0" }
+libc = { version = "0.2.0" }
 log = { version = "0.4.27" }
+lsp-positions = { version = "0.3.0" } 
 markdown = { version = "0.3.0" }
 nom = { version = "7.1.3" }
 num-format = { version = "0.4.4" }
@@ -133,7 +142,6 @@ serde_json = { version = "1.0.140", features = ["preserve_order"] }
 similar-asserts = { version = "1.7.0" }
 smallvec = { version = "1.15.0", features = ["union"] }
 solar = { version = "0.1.3", package = "solar-compiler" }
-stack-graphs = { git = "https://github.com/NomicFoundation/stack-graphs", branch = "nomic" }
 streaming-iterator = { version = "0.1.9" }
 string-interner = { version = "0.17.0", features = [
     "std",

--- a/crates/infra/cli/src/toolchains/public_api/mod.rs
+++ b/crates/infra/cli/src/toolchains/public_api/mod.rs
@@ -11,6 +11,7 @@ pub enum UserFacingCrate {
     // Sorted by dependency order (from dependencies to dependents):
     metaslang_cst,
     metaslang_graph_builder,
+    metaslang_stack_graphs,
     metaslang_bindings,
     slang_solidity,
     slang_solidity_cli,
@@ -51,6 +52,7 @@ fn has_library_target(crate_name: UserFacingCrate) -> bool {
     match crate_name {
         UserFacingCrate::metaslang_cst => true,
         UserFacingCrate::metaslang_graph_builder => true,
+        UserFacingCrate::metaslang_stack_graphs => true,
         UserFacingCrate::metaslang_bindings => true,
         UserFacingCrate::slang_solidity => true,
         UserFacingCrate::slang_solidity_cli => false,

--- a/crates/metaslang/bindings/Cargo.toml
+++ b/crates/metaslang/bindings/Cargo.toml
@@ -21,8 +21,8 @@ categories = ["compilers", "parsing", "parser-implementations"]
 [dependencies]
 metaslang_cst = { workspace = true }
 metaslang_graph_builder = { workspace = true }
+metaslang_stack_graphs = { workspace = true }
 semver = { workspace = true }
-stack-graphs = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/metaslang/bindings/src/builder/loader/cancellation.rs
+++ b/crates/metaslang/bindings/src/builder/loader/cancellation.rs
@@ -25,9 +25,10 @@ pub trait CancellationFlag: Sync {
 #[error("Cancelled at \"{0}\"")]
 pub struct CancellationError(pub &'static str);
 
-impl stack_graphs::CancellationFlag for &dyn CancellationFlag {
-    fn check(&self, at: &'static str) -> Result<(), stack_graphs::CancellationError> {
-        CancellationFlag::check(*self, at).map_err(|err| stack_graphs::CancellationError(err.0))
+impl metaslang_stack_graphs::CancellationFlag for &dyn CancellationFlag {
+    fn check(&self, at: &'static str) -> Result<(), metaslang_stack_graphs::CancellationError> {
+        CancellationFlag::check(*self, at)
+            .map_err(|err| metaslang_stack_graphs::CancellationError(err.0))
     }
 }
 

--- a/crates/metaslang/bindings/src/builder/loader/mod.rs
+++ b/crates/metaslang/bindings/src/builder/loader/mod.rs
@@ -289,8 +289,8 @@ use metaslang_graph_builder::ast::File as GraphBuilderFile;
 use metaslang_graph_builder::functions::Functions;
 use metaslang_graph_builder::graph::{Edge, Graph, GraphNode, GraphNodeRef, Value};
 use metaslang_graph_builder::{ExecutionConfig, ExecutionError, Variables};
-use stack_graphs::arena::Handle;
-use stack_graphs::graph::{File, Node, NodeID, StackGraph};
+use metaslang_stack_graphs::arena::Handle;
+use metaslang_stack_graphs::graph::{File, Node, NodeID, StackGraph};
 use thiserror::Error;
 
 use crate::builder::{DefinitionBindingInfo, ReferenceBindingInfo};
@@ -547,8 +547,8 @@ pub enum BuildError {
     InvalidParent(GraphNodeRef),
 }
 
-impl From<stack_graphs::CancellationError> for BuildError {
-    fn from(value: stack_graphs::CancellationError) -> Self {
+impl From<metaslang_stack_graphs::CancellationError> for BuildError {
+    fn from(value: metaslang_stack_graphs::CancellationError) -> Self {
         Self::Cancelled(value.0)
     }
 }
@@ -564,7 +564,7 @@ impl From<ExecutionError> for BuildError {
 
 impl<KT: KindTypes + 'static> Loader<'_, KT> {
     fn load(&mut self, cancellation_flag: &dyn CancellationFlag) -> Result<(), BuildError> {
-        let cancellation_flag: &dyn stack_graphs::CancellationFlag = &cancellation_flag;
+        let cancellation_flag: &dyn metaslang_stack_graphs::CancellationFlag = &cancellation_flag;
 
         // By default graph ids are used for stack graph local_ids. A remapping is computed
         // for local_ids that already exist in the graph---all other graph ids are mapped to

--- a/crates/metaslang/bindings/src/builder/mod.rs
+++ b/crates/metaslang/bindings/src/builder/mod.rs
@@ -10,11 +10,12 @@ use metaslang_cst::kinds::KindTypes;
 use metaslang_cst::nodes::NodeId;
 use metaslang_graph_builder::ast::File;
 use metaslang_graph_builder::functions::Functions;
+use metaslang_stack_graphs::graph::{NodeID as GraphNodeId, StackGraph};
 use semver::Version;
-use stack_graphs::graph::{NodeID as GraphNodeId, StackGraph};
 
-pub type GraphHandle = stack_graphs::arena::Handle<stack_graphs::graph::Node>;
-pub(crate) type FileHandle = stack_graphs::arena::Handle<stack_graphs::graph::File>;
+pub type GraphHandle = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>;
+pub(crate) type FileHandle =
+    metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>;
 
 pub use crate::graph::BindingGraph;
 

--- a/crates/metaslang/bindings/src/graph/resolver.rs
+++ b/crates/metaslang/bindings/src/graph/resolver.rs
@@ -2,13 +2,13 @@ use std::collections::{HashMap, HashSet};
 use std::iter::once;
 
 use metaslang_cst::kinds::KindTypes;
-use stack_graphs::arena::Handle;
-use stack_graphs::graph::{Degree, Edge, StackGraph};
-use stack_graphs::partial::{PartialPath, PartialPaths};
-use stack_graphs::stitching::{
+use metaslang_stack_graphs::arena::Handle;
+use metaslang_stack_graphs::graph::{Degree, Edge, StackGraph};
+use metaslang_stack_graphs::partial::{PartialPath, PartialPaths};
+use metaslang_stack_graphs::stitching::{
     Database, ForwardCandidates, ForwardPartialPathStitcher, StitcherConfig, ToAppendable,
 };
-use stack_graphs::{CancellationError, NoCancellation};
+use metaslang_stack_graphs::{CancellationError, NoCancellation};
 
 use crate::builder::{ExtendedStackGraph, GraphHandle};
 

--- a/crates/metaslang/stack_graphs/.rustfmt.toml
+++ b/crates/metaslang/stack_graphs/.rustfmt.toml
@@ -1,0 +1,1 @@
+ignore = ["src/"] # __NOMIC_FOUNDATION_FORK__ (disable formatting to minimize changes to the fork)

--- a/crates/metaslang/stack_graphs/Cargo.toml
+++ b/crates/metaslang/stack_graphs/Cargo.toml
@@ -1,50 +1,56 @@
 [package]
-name = "stack-graphs"
-version = "0.14.1"
-description = "Name binding for arbitrary programming languages"
-homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs"
-repository = "https://github.com/github/stack-graphs/"
-readme = "README.md"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish = true
+
+name = "metaslang_stack_graphs"
+description = "Stack graphs utilities used in Slang"
+homepage = "https://nomicfoundation.github.io/slang/"
+repository = "https://github.com/NomicFoundation/slang/"
 authors = [
-  "GitHub <opensource+stack-graphs@github.com>",
-  "Douglas Creager <dcreager@dcreager.net>"
+  "Slang Team <slang@nomic.foundation>",
+  "Nomic Foundation <packages@nomic.foundation>",
 ]
-edition = "2018"
 
-[features]
-bincode = ["dep:bincode", "lsp-positions/bincode"]
-copious-debugging = []
-serde = ["dep:serde", "serde_with", "lsp-positions/serde"]
-storage = ["bincode", "rusqlite"]
-visualization = ["serde", "serde_json"]
+readme = "README.md"
+license = "MIT"
+keywords = ["stack-graphs"]
+categories = ["compilers"]
 
-[lib]
-# All of our tests are in the tests/it "integration" test executable.
-test = false
+# __NOMIC_FOUNDATION_FORK__ (disable optional features not used in Slang)
+# [features]
+# bincode = ["dep:bincode", "lsp-positions/bincode"]
+# copious-debugging = []
+# serde = ["dep:serde", "serde_with", "lsp-positions/serde"]
+# storage = ["bincode", "rusqlite"]
+# visualization = ["serde", "serde_json"]
 
 [dependencies]
-bincode = { version = "2.0.0-rc.3", optional = true }
-bitvec = "1.0.1"
-controlled-option = "0.4.1"
-either = "1.6"
-enumset = "1.1"
-fxhash = "0.2"
-itertools = "0.10.2"
-libc = "0.2"
-lsp-positions = { version = "0.3", path = "../lsp-positions" } # explicit version is required to be able to publish crate
-rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
-serde_with = { version = "3.1", optional = true }
-smallvec = { version = "1.6", features = ["union"] }
-thiserror = { version = "1.0" }
+bitvec = { workspace = true }
+controlled-option = { workspace = true }
+either = { workspace = true }
+enumset = { workspace = true }
+fxhash = { workspace = true }
+itertools = { workspace = true }
+libc = { workspace = true }
+lsp-positions = { workspace = true }
+smallvec = { workspace = true, features = ["union"] }
+thiserror = { workspace = true }
 
-[dev-dependencies]
-assert-json-diff = "2"
-maplit = "1.0"
-pretty_assertions = "0.7"
-serde_json = { version = "1.0" }
+# __NOMIC_FOUNDATION_FORK__ (disable optional dependencies not used in Slang)
+# [dependencies]
+# bincode = { version = "2.0.0-rc.3", optional = true }
+# rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
+# serde = { version = "1.0", optional = true, features = ["derive"] }
+# serde_json = { version = "1.0", optional = true }
+# serde_with = { version = "3.1", optional = true }
 
-[package.metadata.docs.rs]
-all-features = true
+[lints.rust]
+unexpected_cfgs = "allow" # __NOMIC_FOUNDATION_FORK__ (disable warning about non-existing features, disabled above)
+
+[lints.rustdoc]
+all = "allow" # __NOMIC_FOUNDATION_FORK__ (disable lints to minimize changes to the fork)
+
+[lints.clippy]
+all = "allow" # __NOMIC_FOUNDATION_FORK__ (disable lints to minimize changes to the fork)

--- a/crates/metaslang/stack_graphs/LICENSE
+++ b/crates/metaslang/stack_graphs/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 stack-graphs authors
+Copyright (c) 2025 Nomic Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/metaslang/stack_graphs/README.md
+++ b/crates/metaslang/stack_graphs/README.md
@@ -1,0 +1,5 @@
+# metaslang_stack_graphs
+
+A fork of [stack-graphs](https://crates.io/crates/stack-graphs),
+used as an internal dependency of [slang_solidity](https://crates.io/crates/slang_solidity).
+Please see the [NomicFoundation/slang](https://github.com/NomicFoundation/slang/) project for more information.

--- a/crates/metaslang/stack_graphs/generated/public_api.txt
+++ b/crates/metaslang/stack_graphs/generated/public_api.txt
@@ -1,0 +1,1770 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+pub mod metaslang_stack_graphs
+pub mod metaslang_stack_graphs::arena
+pub struct metaslang_stack_graphs::arena::Arena<T>
+impl<T> metaslang_stack_graphs::arena::Arena<T>
+pub fn metaslang_stack_graphs::arena::Arena<T>::add(&mut self, item: T) -> metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Arena<T>::clear(&mut self)
+pub fn metaslang_stack_graphs::arena::Arena<T>::get(&self, handle: metaslang_stack_graphs::arena::Handle<T>) -> &T
+pub fn metaslang_stack_graphs::arena::Arena<T>::get_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<T>) -> &mut T
+pub fn metaslang_stack_graphs::arena::Arena<T>::iter_handles(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<T>>
+pub fn metaslang_stack_graphs::arena::Arena<T>::len(&self) -> usize
+pub fn metaslang_stack_graphs::arena::Arena<T>::new() -> metaslang_stack_graphs::arena::Arena<T>
+impl<T> core::ops::drop::Drop for metaslang_stack_graphs::arena::Arena<T>
+pub fn metaslang_stack_graphs::arena::Arena<T>::drop(&mut self)
+#[repr(C)] pub struct metaslang_stack_graphs::arena::Deque<T>
+impl<T> metaslang_stack_graphs::arena::Deque<T> where T: core::clone::Clone + core::cmp::Eq
+pub fn metaslang_stack_graphs::arena::Deque<T>::equals(self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, other: metaslang_stack_graphs::arena::Deque<T>) -> bool
+impl<T> metaslang_stack_graphs::arena::Deque<T> where T: core::clone::Clone + core::cmp::Ord
+pub fn metaslang_stack_graphs::arena::Deque<T>::cmp(self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, other: metaslang_stack_graphs::arena::Deque<T>) -> core::cmp::Ordering
+impl<T> metaslang_stack_graphs::arena::Deque<T> where T: core::clone::Clone
+pub fn metaslang_stack_graphs::arena::Deque<T>::cmp_with<F>(self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, other: metaslang_stack_graphs::arena::Deque<T>, cmp: F) -> core::cmp::Ordering where F: core::ops::function::FnMut(&T, &T) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::arena::Deque<T>::equals_with<F>(self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, other: metaslang_stack_graphs::arena::Deque<T>, eq: F) -> bool where F: core::ops::function::FnMut(&T, &T) -> bool
+impl<T> metaslang_stack_graphs::arena::Deque<T> where T: core::clone::Clone
+pub fn metaslang_stack_graphs::arena::Deque<T>::ensure_backwards(&mut self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>)
+pub fn metaslang_stack_graphs::arena::Deque<T>::ensure_forwards(&mut self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>)
+pub fn metaslang_stack_graphs::arena::Deque<T>::iter<'a>(&self, arena: &'a mut metaslang_stack_graphs::arena::DequeArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::Deque<T>::iter_reversed<'a>(&self, arena: &'a mut metaslang_stack_graphs::arena::DequeArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::Deque<T>::pop_back<'a>(&mut self, arena: &'a mut metaslang_stack_graphs::arena::DequeArena<T>) -> core::option::Option<&'a T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::pop_front<'a>(&mut self, arena: &'a mut metaslang_stack_graphs::arena::DequeArena<T>) -> core::option::Option<&'a T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::push_back(&mut self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, element: T)
+pub fn metaslang_stack_graphs::arena::Deque<T>::push_front(&mut self, arena: &mut metaslang_stack_graphs::arena::DequeArena<T>, element: T)
+impl<T> metaslang_stack_graphs::arena::Deque<T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::empty() -> metaslang_stack_graphs::arena::Deque<T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::have_reversal(&self, arena: &metaslang_stack_graphs::arena::DequeArena<T>) -> bool
+pub fn metaslang_stack_graphs::arena::Deque<T>::is_empty(&self) -> bool
+pub fn metaslang_stack_graphs::arena::Deque<T>::iter_unordered<'a>(&self, arena: &'a metaslang_stack_graphs::arena::DequeArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::Deque<T>::new_arena() -> metaslang_stack_graphs::arena::DequeArena<T>
+impl<T> metaslang_stack_graphs::arena::Deque<T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::iter_reused<'a>(&self, arena: &'a metaslang_stack_graphs::arena::DequeArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::Deque<T>::iter_reversed_reused<'a>(&self, arena: &'a metaslang_stack_graphs::arena::DequeArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+impl<T> controlled_option::Niche for metaslang_stack_graphs::arena::Deque<T> where metaslang_stack_graphs::arena::ReversibleList<T>: controlled_option::Niche
+pub type metaslang_stack_graphs::arena::Deque<T>::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::arena::Deque<T>>
+pub fn metaslang_stack_graphs::arena::Deque<T>::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::arena::Deque<T>::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::arena::Deque<T>::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::arena::Deque<T>::none() -> Self::Output
+impl<T> core::clone::Clone for metaslang_stack_graphs::arena::Deque<T>
+pub fn metaslang_stack_graphs::arena::Deque<T>::clone(&self) -> metaslang_stack_graphs::arena::Deque<T>
+impl<T> core::marker::Copy for metaslang_stack_graphs::arena::Deque<T>
+#[repr(transparent)] pub struct metaslang_stack_graphs::arena::Handle<T>
+impl metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>
+pub fn metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>::display(self, graph: &metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + '_
+impl metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>
+pub fn metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>::display(self, graph: &metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + '_
+impl metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>::display(self, graph: &metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + '_
+impl metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+pub fn metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>::display(self, graph: &metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + '_
+impl<T> metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::as_u32(self) -> u32
+pub fn metaslang_stack_graphs::arena::Handle<T>::as_usize(self) -> usize
+impl core::convert::Into<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>> for metaslang_stack_graphs::c::sg_file_handle
+pub fn metaslang_stack_graphs::c::sg_file_handle::into(self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>
+impl core::convert::Into<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> for metaslang_stack_graphs::c::sg_node_handle
+pub fn metaslang_stack_graphs::c::sg_node_handle::into(self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = metaslang_stack_graphs::graph::File
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> &metaslang_stack_graphs::graph::File
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = str
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>) -> &str
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &metaslang_stack_graphs::graph::Node
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = str
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>) -> &str
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>> for metaslang_stack_graphs::stitching::Database
+pub type metaslang_stack_graphs::stitching::Database::Output = metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::stitching::Database::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &metaslang_stack_graphs::partial::PartialPath
+impl core::ops::index::IndexMut<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> for metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::index_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &mut metaslang_stack_graphs::graph::Node
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::get_appendable<'a>(&'a self, handle: &'a metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &'a metaslang_stack_graphs::partial::PartialPath
+impl<H, T> core::ops::index::Index<metaslang_stack_graphs::arena::Handle<H>> for metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub type metaslang_stack_graphs::arena::SupplementalArena<H, T>::Output = T
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::index(&self, handle: metaslang_stack_graphs::arena::Handle<H>) -> &T
+impl<H, T> core::ops::index::IndexMut<metaslang_stack_graphs::arena::Handle<H>> for metaslang_stack_graphs::arena::SupplementalArena<H, T> where T: core::default::Default
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::index_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<H>) -> &mut T
+impl<T> controlled_option::Niche for metaslang_stack_graphs::arena::Handle<T>
+pub type metaslang_stack_graphs::arena::Handle<T>::Output = u32
+pub fn metaslang_stack_graphs::arena::Handle<T>::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::arena::Handle<T>::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::arena::Handle<T>::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::arena::Handle<T>::none() -> Self::Output
+impl<T> core::clone::Clone for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::clone(&self) -> metaslang_stack_graphs::arena::Handle<T>
+impl<T> core::cmp::Eq for metaslang_stack_graphs::arena::Handle<T>
+impl<T> core::cmp::Ord for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::cmp(&self, other: &Self) -> core::cmp::Ordering
+impl<T> core::cmp::PartialEq for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::eq(&self, other: &Self) -> bool
+impl<T> core::cmp::PartialOrd for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl<T> core::fmt::Debug for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::hash::Hash for metaslang_stack_graphs::arena::Handle<T>
+pub fn metaslang_stack_graphs::arena::Handle<T>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+impl<T> core::marker::Copy for metaslang_stack_graphs::arena::Handle<T>
+impl<T> core::marker::Send for metaslang_stack_graphs::arena::Handle<T>
+impl<T> core::marker::Sync for metaslang_stack_graphs::arena::Handle<T>
+#[repr(C)] pub struct metaslang_stack_graphs::arena::HandleSet<T>
+impl<T> metaslang_stack_graphs::arena::HandleSet<T>
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::add(&mut self, handle: metaslang_stack_graphs::arena::Handle<T>)
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::clear(&mut self)
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::contains(&self, handle: metaslang_stack_graphs::arena::Handle<T>) -> bool
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<T>> + '_
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::new() -> metaslang_stack_graphs::arena::HandleSet<T>
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::remove(&mut self, handle: metaslang_stack_graphs::arena::Handle<T>)
+impl<T> core::default::Default for metaslang_stack_graphs::arena::HandleSet<T>
+pub fn metaslang_stack_graphs::arena::HandleSet<T>::default() -> metaslang_stack_graphs::arena::HandleSet<T>
+#[repr(C)] pub struct metaslang_stack_graphs::arena::List<T>
+impl<T> metaslang_stack_graphs::arena::List<T> where T: core::cmp::Eq
+pub fn metaslang_stack_graphs::arena::List<T>::equals(self, arena: &metaslang_stack_graphs::arena::ListArena<T>, other: metaslang_stack_graphs::arena::List<T>) -> bool
+impl<T> metaslang_stack_graphs::arena::List<T> where T: core::cmp::Ord
+pub fn metaslang_stack_graphs::arena::List<T>::cmp(self, arena: &metaslang_stack_graphs::arena::ListArena<T>, other: metaslang_stack_graphs::arena::List<T>) -> core::cmp::Ordering
+impl<T> metaslang_stack_graphs::arena::List<T>
+pub fn metaslang_stack_graphs::arena::List<T>::cmp_with<F>(self, arena: &metaslang_stack_graphs::arena::ListArena<T>, other: metaslang_stack_graphs::arena::List<T>, cmp: F) -> core::cmp::Ordering where F: core::ops::function::FnMut(&T, &T) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::arena::List<T>::equals_with<F>(self, arena: &metaslang_stack_graphs::arena::ListArena<T>, other: metaslang_stack_graphs::arena::List<T>, eq: F) -> bool where F: core::ops::function::FnMut(&T, &T) -> bool
+impl<T> metaslang_stack_graphs::arena::List<T>
+pub fn metaslang_stack_graphs::arena::List<T>::empty() -> metaslang_stack_graphs::arena::List<T>
+pub fn metaslang_stack_graphs::arena::List<T>::from_handle(handle: metaslang_stack_graphs::arena::Handle<ListCell<T>>) -> metaslang_stack_graphs::arena::List<T>
+pub fn metaslang_stack_graphs::arena::List<T>::handle(&self) -> metaslang_stack_graphs::arena::Handle<ListCell<T>>
+pub fn metaslang_stack_graphs::arena::List<T>::is_empty(&self) -> bool
+pub fn metaslang_stack_graphs::arena::List<T>::iter<'a>(self, arena: &'a metaslang_stack_graphs::arena::ListArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::List<T>::new_arena() -> metaslang_stack_graphs::arena::ListArena<T>
+pub fn metaslang_stack_graphs::arena::List<T>::pop_front<'a>(&mut self, arena: &'a metaslang_stack_graphs::arena::ListArena<T>) -> core::option::Option<&'a T>
+pub fn metaslang_stack_graphs::arena::List<T>::push_front(&mut self, arena: &mut metaslang_stack_graphs::arena::ListArena<T>, head: T)
+impl<T> controlled_option::Niche for metaslang_stack_graphs::arena::List<T> where metaslang_stack_graphs::arena::Handle<ListCell<T>>: controlled_option::Niche
+pub type metaslang_stack_graphs::arena::List<T>::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::arena::List<T>>
+pub fn metaslang_stack_graphs::arena::List<T>::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::arena::List<T>::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::arena::List<T>::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::arena::List<T>::none() -> Self::Output
+impl<T> core::clone::Clone for metaslang_stack_graphs::arena::List<T>
+pub fn metaslang_stack_graphs::arena::List<T>::clone(&self) -> metaslang_stack_graphs::arena::List<T>
+impl<T> core::marker::Copy for metaslang_stack_graphs::arena::List<T>
+#[repr(C)] pub struct metaslang_stack_graphs::arena::ReversibleList<T>
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T> where T: core::clone::Clone
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::ensure_reversal_available(&mut self, arena: &mut metaslang_stack_graphs::arena::ReversibleListArena<T>)
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::reverse(&mut self, arena: &mut metaslang_stack_graphs::arena::ReversibleListArena<T>)
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T> where T: core::cmp::Eq
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::equals(self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>, other: metaslang_stack_graphs::arena::ReversibleList<T>) -> bool
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T> where T: core::cmp::Ord
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::cmp(self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>, other: metaslang_stack_graphs::arena::ReversibleList<T>) -> core::cmp::Ordering
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::cmp_with<F>(self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>, other: metaslang_stack_graphs::arena::ReversibleList<T>, cmp: F) -> core::cmp::Ordering where F: core::ops::function::FnMut(&T, &T) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::equals_with<F>(self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>, other: metaslang_stack_graphs::arena::ReversibleList<T>, eq: F) -> bool where F: core::ops::function::FnMut(&T, &T) -> bool
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::empty() -> metaslang_stack_graphs::arena::ReversibleList<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::have_reversal(&self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>) -> bool
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::is_empty(&self) -> bool
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::iter<'a>(self, arena: &'a metaslang_stack_graphs::arena::ReversibleListArena<T>) -> impl core::iter::traits::iterator::Iterator<Item = &'a T> + 'a
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::new_arena() -> metaslang_stack_graphs::arena::ReversibleListArena<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::pop_front<'a>(&mut self, arena: &'a metaslang_stack_graphs::arena::ReversibleListArena<T>) -> core::option::Option<&'a T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::push_front(&mut self, arena: &mut metaslang_stack_graphs::arena::ReversibleListArena<T>, head: T)
+impl<T> metaslang_stack_graphs::arena::ReversibleList<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::reverse_reused(&mut self, arena: &metaslang_stack_graphs::arena::ReversibleListArena<T>) -> core::result::Result<(), ()>
+impl<T> controlled_option::Niche for metaslang_stack_graphs::arena::ReversibleList<T> where metaslang_stack_graphs::arena::Handle<ReversibleListCell<T>>: controlled_option::Niche
+pub type metaslang_stack_graphs::arena::ReversibleList<T>::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::arena::ReversibleList<T>>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::none() -> Self::Output
+impl<T> core::clone::Clone for metaslang_stack_graphs::arena::ReversibleList<T>
+pub fn metaslang_stack_graphs::arena::ReversibleList<T>::clone(&self) -> metaslang_stack_graphs::arena::ReversibleList<T>
+impl<T> core::marker::Copy for metaslang_stack_graphs::arena::ReversibleList<T>
+pub struct metaslang_stack_graphs::arena::SupplementalArena<H, T>
+impl<H, T> metaslang_stack_graphs::arena::SupplementalArena<H, T> where T: core::default::Default
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::get_mut_or_default(&mut self, handle: metaslang_stack_graphs::arena::Handle<H>) -> &mut T
+impl<H, T> metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::clear(&mut self)
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::get(&self, handle: metaslang_stack_graphs::arena::Handle<H>) -> core::option::Option<&T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::get_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<H>) -> core::option::Option<&mut T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::len(&self) -> usize
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::new() -> metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::with_capacity(arena: &metaslang_stack_graphs::arena::Arena<H>) -> metaslang_stack_graphs::arena::SupplementalArena<H, T>
+impl<H, T> core::default::Default for metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::default() -> metaslang_stack_graphs::arena::SupplementalArena<H, T>
+impl<H, T> core::ops::drop::Drop for metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::drop(&mut self)
+impl<H, T> core::ops::index::Index<metaslang_stack_graphs::arena::Handle<H>> for metaslang_stack_graphs::arena::SupplementalArena<H, T>
+pub type metaslang_stack_graphs::arena::SupplementalArena<H, T>::Output = T
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::index(&self, handle: metaslang_stack_graphs::arena::Handle<H>) -> &T
+impl<H, T> core::ops::index::IndexMut<metaslang_stack_graphs::arena::Handle<H>> for metaslang_stack_graphs::arena::SupplementalArena<H, T> where T: core::default::Default
+pub fn metaslang_stack_graphs::arena::SupplementalArena<H, T>::index_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<H>) -> &mut T
+pub type metaslang_stack_graphs::arena::DequeArena<T> = metaslang_stack_graphs::arena::ReversibleListArena<T>
+pub type metaslang_stack_graphs::arena::ListArena<T> = metaslang_stack_graphs::arena::Arena<ListCell<T>>
+pub type metaslang_stack_graphs::arena::ReversibleListArena<T> = metaslang_stack_graphs::arena::Arena<ReversibleListCell<T>>
+pub mod metaslang_stack_graphs::assert
+pub enum metaslang_stack_graphs::assert::Assertion
+pub metaslang_stack_graphs::assert::Assertion::Defined
+pub metaslang_stack_graphs::assert::Assertion::Defined::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::Assertion::Defined::targets: alloc::vec::Vec<metaslang_stack_graphs::assert::AssertionTarget>
+pub metaslang_stack_graphs::assert::Assertion::Defines
+pub metaslang_stack_graphs::assert::Assertion::Defines::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::Assertion::Defines::symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+pub metaslang_stack_graphs::assert::Assertion::Refers
+pub metaslang_stack_graphs::assert::Assertion::Refers::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::Assertion::Refers::symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+impl metaslang_stack_graphs::assert::Assertion
+pub fn metaslang_stack_graphs::assert::Assertion::run(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, db: &mut metaslang_stack_graphs::stitching::Database, stitcher_config: metaslang_stack_graphs::stitching::StitcherConfig, cancellation_flag: &dyn metaslang_stack_graphs::CancellationFlag) -> core::result::Result<(), metaslang_stack_graphs::assert::AssertionError>
+impl core::clone::Clone for metaslang_stack_graphs::assert::Assertion
+pub fn metaslang_stack_graphs::assert::Assertion::clone(&self) -> metaslang_stack_graphs::assert::Assertion
+impl core::fmt::Debug for metaslang_stack_graphs::assert::Assertion
+pub fn metaslang_stack_graphs::assert::Assertion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum metaslang_stack_graphs::assert::AssertionError
+pub metaslang_stack_graphs::assert::AssertionError::Cancelled(metaslang_stack_graphs::CancellationError)
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectDefinitions
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectDefinitions::missing_symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectDefinitions::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectDefinitions::unexpected_symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectReferences
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectReferences::missing_symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectReferences::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectReferences::unexpected_symbols: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectlyDefined
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectlyDefined::missing_targets: alloc::vec::Vec<metaslang_stack_graphs::assert::AssertionTarget>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectlyDefined::references: alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectlyDefined::source: metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::AssertionError::IncorrectlyDefined::unexpected_paths: alloc::vec::Vec<metaslang_stack_graphs::partial::PartialPath>
+pub metaslang_stack_graphs::assert::AssertionError::NoReferences
+pub metaslang_stack_graphs::assert::AssertionError::NoReferences::source: metaslang_stack_graphs::assert::AssertionSource
+impl core::clone::Clone for metaslang_stack_graphs::assert::AssertionError
+pub fn metaslang_stack_graphs::assert::AssertionError::clone(&self) -> metaslang_stack_graphs::assert::AssertionError
+impl core::convert::From<metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::assert::AssertionError
+pub fn metaslang_stack_graphs::assert::AssertionError::from(value: metaslang_stack_graphs::CancellationError) -> Self
+pub struct metaslang_stack_graphs::assert::AssertionSource
+pub metaslang_stack_graphs::assert::AssertionSource::file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>
+pub metaslang_stack_graphs::assert::AssertionSource::position: lsp_positions::Position
+impl metaslang_stack_graphs::assert::AssertionSource
+pub fn metaslang_stack_graphs::assert::AssertionSource::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::assert::AssertionSource::iter_definitions<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> + 'a
+pub fn metaslang_stack_graphs::assert::AssertionSource::iter_references<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> + 'a
+impl core::clone::Clone for metaslang_stack_graphs::assert::AssertionSource
+pub fn metaslang_stack_graphs::assert::AssertionSource::clone(&self) -> metaslang_stack_graphs::assert::AssertionSource
+impl core::fmt::Debug for metaslang_stack_graphs::assert::AssertionSource
+pub fn metaslang_stack_graphs::assert::AssertionSource::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct metaslang_stack_graphs::assert::AssertionTarget
+pub metaslang_stack_graphs::assert::AssertionTarget::file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>
+pub metaslang_stack_graphs::assert::AssertionTarget::line: usize
+impl metaslang_stack_graphs::assert::AssertionTarget
+pub fn metaslang_stack_graphs::assert::AssertionTarget::matches_node(&self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+impl core::clone::Clone for metaslang_stack_graphs::assert::AssertionTarget
+pub fn metaslang_stack_graphs::assert::AssertionTarget::clone(&self) -> metaslang_stack_graphs::assert::AssertionTarget
+impl core::cmp::Eq for metaslang_stack_graphs::assert::AssertionTarget
+impl core::cmp::PartialEq for metaslang_stack_graphs::assert::AssertionTarget
+pub fn metaslang_stack_graphs::assert::AssertionTarget::eq(&self, other: &metaslang_stack_graphs::assert::AssertionTarget) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::assert::AssertionTarget
+pub fn metaslang_stack_graphs::assert::AssertionTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for metaslang_stack_graphs::assert::AssertionTarget
+pub fn metaslang_stack_graphs::assert::AssertionTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::assert::AssertionTarget
+pub mod metaslang_stack_graphs::c
+#[repr(C)] pub enum metaslang_stack_graphs::c::sg_deque_direction
+pub metaslang_stack_graphs::c::sg_deque_direction::SG_DEQUE_BACKWARDS
+pub metaslang_stack_graphs::c::sg_deque_direction::SG_DEQUE_FORWARDS
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_deque_direction
+pub fn metaslang_stack_graphs::c::sg_deque_direction::clone(&self) -> metaslang_stack_graphs::c::sg_deque_direction
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_deque_direction
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_deque_direction
+pub fn metaslang_stack_graphs::c::sg_deque_direction::eq(&self, other: &metaslang_stack_graphs::c::sg_deque_direction) -> bool
+impl core::default::Default for metaslang_stack_graphs::c::sg_deque_direction
+pub fn metaslang_stack_graphs::c::sg_deque_direction::default() -> metaslang_stack_graphs::c::sg_deque_direction
+impl core::fmt::Debug for metaslang_stack_graphs::c::sg_deque_direction
+pub fn metaslang_stack_graphs::c::sg_deque_direction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_deque_direction
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_deque_direction
+#[repr(C)] pub enum metaslang_stack_graphs::c::sg_node_kind
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_DROP_SCOPES
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_JUMP_TO
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_POP_SYMBOL
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_ROOT
+pub metaslang_stack_graphs::c::sg_node_kind::SG_NODE_KIND_SCOPE
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_node_kind
+pub fn metaslang_stack_graphs::c::sg_node_kind::clone(&self) -> metaslang_stack_graphs::c::sg_node_kind
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_node_kind
+#[repr(C)] pub enum metaslang_stack_graphs::c::sg_result
+pub metaslang_stack_graphs::c::sg_result::SG_RESULT_CANCELLED
+pub metaslang_stack_graphs::c::sg_result::SG_RESULT_SUCCESS
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_result
+pub fn metaslang_stack_graphs::c::sg_result::clone(&self) -> metaslang_stack_graphs::c::sg_result
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_result
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_result
+pub fn metaslang_stack_graphs::c::sg_result::eq(&self, other: &metaslang_stack_graphs::c::sg_result) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::c::sg_result
+pub fn metaslang_stack_graphs::c::sg_result::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_result
+impl<T> core::convert::From<core::result::Result<T, metaslang_stack_graphs::CancellationError>> for metaslang_stack_graphs::c::sg_result
+pub fn metaslang_stack_graphs::c::sg_result::from(result: core::result::Result<T, metaslang_stack_graphs::CancellationError>) -> Self
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_edge
+pub metaslang_stack_graphs::c::sg_edge::precedence: i32
+pub metaslang_stack_graphs::c::sg_edge::sink: metaslang_stack_graphs::c::sg_node_handle
+pub metaslang_stack_graphs::c::sg_edge::source: metaslang_stack_graphs::c::sg_node_handle
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_file
+pub metaslang_stack_graphs::c::sg_file::name: *const libc::primitives::c_char
+pub metaslang_stack_graphs::c::sg_file::name_len: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_files
+pub metaslang_stack_graphs::c::sg_files::count: usize
+pub metaslang_stack_graphs::c::sg_files::files: *const metaslang_stack_graphs::c::sg_file
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_forward_partial_path_stitcher
+pub metaslang_stack_graphs::c::sg_forward_partial_path_stitcher::is_complete: bool
+pub metaslang_stack_graphs::c::sg_forward_partial_path_stitcher::previous_phase_partial_paths: *const metaslang_stack_graphs::c::sg_partial_path
+pub metaslang_stack_graphs::c::sg_forward_partial_path_stitcher::previous_phase_partial_paths_length: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_node
+pub metaslang_stack_graphs::c::sg_node::id: metaslang_stack_graphs::c::sg_node_id
+pub metaslang_stack_graphs::c::sg_node::is_endpoint: bool
+pub metaslang_stack_graphs::c::sg_node::kind: metaslang_stack_graphs::c::sg_node_kind
+pub metaslang_stack_graphs::c::sg_node::scope: metaslang_stack_graphs::c::sg_node_id
+pub metaslang_stack_graphs::c::sg_node::symbol: metaslang_stack_graphs::c::sg_symbol_handle
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_node
+pub fn metaslang_stack_graphs::c::sg_node::clone(&self) -> metaslang_stack_graphs::c::sg_node
+impl core::convert::Into<metaslang_stack_graphs::graph::Node> for metaslang_stack_graphs::c::sg_node
+pub fn metaslang_stack_graphs::c::sg_node::into(self) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_node_handle_set
+pub metaslang_stack_graphs::c::sg_node_handle_set::elements: *const u32
+pub metaslang_stack_graphs::c::sg_node_handle_set::length: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_node_id
+pub metaslang_stack_graphs::c::sg_node_id::file: metaslang_stack_graphs::c::sg_file_handle
+pub metaslang_stack_graphs::c::sg_node_id::local_id: u32
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_node_id
+pub fn metaslang_stack_graphs::c::sg_node_id::clone(&self) -> metaslang_stack_graphs::c::sg_node_id
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_node_id
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_node_id
+pub fn metaslang_stack_graphs::c::sg_node_id::eq(&self, other: &metaslang_stack_graphs::c::sg_node_id) -> bool
+impl core::convert::Into<metaslang_stack_graphs::graph::NodeID> for metaslang_stack_graphs::c::sg_node_id
+pub fn metaslang_stack_graphs::c::sg_node_id::into(self) -> metaslang_stack_graphs::graph::NodeID
+impl core::default::Default for metaslang_stack_graphs::c::sg_node_id
+pub fn metaslang_stack_graphs::c::sg_node_id::default() -> metaslang_stack_graphs::c::sg_node_id
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_node_id
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_node_id
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_node_source_info
+pub metaslang_stack_graphs::c::sg_node_source_info::node: metaslang_stack_graphs::c::sg_node_handle
+pub metaslang_stack_graphs::c::sg_node_source_info::source_info: metaslang_stack_graphs::c::sg_source_info
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_node_source_info
+pub fn metaslang_stack_graphs::c::sg_node_source_info::clone(&self) -> metaslang_stack_graphs::c::sg_node_source_info
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_node_source_info
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_nodes
+pub metaslang_stack_graphs::c::sg_nodes::count: usize
+pub metaslang_stack_graphs::c::sg_nodes::nodes: *const metaslang_stack_graphs::c::sg_node
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_offset
+pub metaslang_stack_graphs::c::sg_offset::grapheme_offset: usize
+pub metaslang_stack_graphs::c::sg_offset::utf16_offset: usize
+pub metaslang_stack_graphs::c::sg_offset::utf8_offset: usize
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_offset
+pub fn metaslang_stack_graphs::c::sg_offset::clone(&self) -> metaslang_stack_graphs::c::sg_offset
+impl core::default::Default for metaslang_stack_graphs::c::sg_offset
+pub fn metaslang_stack_graphs::c::sg_offset::default() -> metaslang_stack_graphs::c::sg_offset
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_offset
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_path
+pub metaslang_stack_graphs::c::sg_partial_path::edges: metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub metaslang_stack_graphs::c::sg_partial_path::end_node: metaslang_stack_graphs::c::sg_node_handle
+pub metaslang_stack_graphs::c::sg_partial_path::scope_stack_postcondition: metaslang_stack_graphs::c::sg_partial_scope_stack
+pub metaslang_stack_graphs::c::sg_partial_path::scope_stack_precondition: metaslang_stack_graphs::c::sg_partial_scope_stack
+pub metaslang_stack_graphs::c::sg_partial_path::start_node: metaslang_stack_graphs::c::sg_node_handle
+pub metaslang_stack_graphs::c::sg_partial_path::symbol_stack_postcondition: metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub metaslang_stack_graphs::c::sg_partial_path::symbol_stack_precondition: metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_path
+pub fn metaslang_stack_graphs::c::sg_partial_path::clone(&self) -> metaslang_stack_graphs::c::sg_partial_path
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::c::sg_partial_path
+pub fn metaslang_stack_graphs::c::sg_partial_path::into(self) -> metaslang_stack_graphs::partial::PartialPath
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_path
+pub struct metaslang_stack_graphs::c::sg_partial_path_arena
+pub metaslang_stack_graphs::c::sg_partial_path_arena::inner: metaslang_stack_graphs::partial::PartialPaths
+pub struct metaslang_stack_graphs::c::sg_partial_path_database
+pub metaslang_stack_graphs::c::sg_partial_path_database::inner: metaslang_stack_graphs::stitching::Database
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_path_edge
+pub metaslang_stack_graphs::c::sg_partial_path_edge::precedence: i32
+pub metaslang_stack_graphs::c::sg_partial_path_edge::source_node_id: metaslang_stack_graphs::c::sg_node_id
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_path_edge
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge::clone(&self) -> metaslang_stack_graphs::c::sg_partial_path_edge
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_partial_path_edge
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_partial_path_edge
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge::eq(&self, other: &metaslang_stack_graphs::c::sg_partial_path_edge) -> bool
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialPathEdge> for metaslang_stack_graphs::c::sg_partial_path_edge
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge::into(self) -> metaslang_stack_graphs::partial::PartialPathEdge
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_path_edge
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_partial_path_edge
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list::cells: metaslang_stack_graphs::c::sg_partial_path_edge_list_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list::direction: metaslang_stack_graphs::c::sg_deque_direction
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list::length: u32
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge_list::clone(&self) -> metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge_list::eq(&self, other: &metaslang_stack_graphs::c::sg_partial_path_edge_list) -> bool
+impl core::convert::From<metaslang_stack_graphs::partial::PartialPathEdgeList> for metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge_list::from(edges: metaslang_stack_graphs::partial::PartialPathEdgeList) -> metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::default::Default for metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge_list::default() -> metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_partial_path_edge_list
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_path_edge_list_cell
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list_cell::head: metaslang_stack_graphs::c::sg_partial_path_edge
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list_cell::reversed: metaslang_stack_graphs::c::sg_partial_path_edge_list_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list_cell::tail: metaslang_stack_graphs::c::sg_partial_path_edge_list_cell_handle
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_path_edge_list_cells
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list_cells::cells: *const metaslang_stack_graphs::c::sg_partial_path_edge_list_cell
+pub metaslang_stack_graphs::c::sg_partial_path_edge_list_cells::count: usize
+pub struct metaslang_stack_graphs::c::sg_partial_path_list
+impl core::default::Default for metaslang_stack_graphs::c::sg_partial_path_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_list::default() -> metaslang_stack_graphs::c::sg_partial_path_list
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_paths
+pub metaslang_stack_graphs::c::sg_partial_paths::count: usize
+pub metaslang_stack_graphs::c::sg_partial_paths::paths: *const metaslang_stack_graphs::c::sg_partial_path
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_scope_stack
+pub metaslang_stack_graphs::c::sg_partial_scope_stack::cells: metaslang_stack_graphs::c::sg_partial_scope_stack_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_scope_stack::direction: metaslang_stack_graphs::c::sg_deque_direction
+pub metaslang_stack_graphs::c::sg_partial_scope_stack::length: u32
+pub metaslang_stack_graphs::c::sg_partial_scope_stack::variable: metaslang_stack_graphs::c::sg_scope_stack_variable
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_scope_stack
+pub fn metaslang_stack_graphs::c::sg_partial_scope_stack::clone(&self) -> metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_partial_scope_stack
+pub fn metaslang_stack_graphs::c::sg_partial_scope_stack::eq(&self, other: &metaslang_stack_graphs::c::sg_partial_scope_stack) -> bool
+impl core::convert::From<metaslang_stack_graphs::partial::PartialScopeStack> for metaslang_stack_graphs::c::sg_partial_scope_stack
+pub fn metaslang_stack_graphs::c::sg_partial_scope_stack::from(stack: metaslang_stack_graphs::partial::PartialScopeStack) -> metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::default::Default for metaslang_stack_graphs::c::sg_partial_scope_stack
+pub fn metaslang_stack_graphs::c::sg_partial_scope_stack::default() -> metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_partial_scope_stack
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_scope_stack_cell
+pub metaslang_stack_graphs::c::sg_partial_scope_stack_cell::head: metaslang_stack_graphs::c::sg_node_handle
+pub metaslang_stack_graphs::c::sg_partial_scope_stack_cell::reversed: metaslang_stack_graphs::c::sg_partial_scope_stack_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_scope_stack_cell::tail: metaslang_stack_graphs::c::sg_partial_scope_stack_cell_handle
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_scope_stack_cells
+pub metaslang_stack_graphs::c::sg_partial_scope_stack_cells::cells: *const metaslang_stack_graphs::c::sg_partial_scope_stack_cell
+pub metaslang_stack_graphs::c::sg_partial_scope_stack_cells::count: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub metaslang_stack_graphs::c::sg_partial_scoped_symbol::scopes: metaslang_stack_graphs::c::sg_partial_scope_stack
+pub metaslang_stack_graphs::c::sg_partial_scoped_symbol::symbol: metaslang_stack_graphs::c::sg_symbol_handle
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub fn metaslang_stack_graphs::c::sg_partial_scoped_symbol::clone(&self) -> metaslang_stack_graphs::c::sg_partial_scoped_symbol
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub fn metaslang_stack_graphs::c::sg_partial_scoped_symbol::eq(&self, other: &metaslang_stack_graphs::c::sg_partial_scoped_symbol) -> bool
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialScopedSymbol> for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub fn metaslang_stack_graphs::c::sg_partial_scoped_symbol::into(self) -> metaslang_stack_graphs::partial::PartialScopedSymbol
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack::cells: metaslang_stack_graphs::c::sg_partial_symbol_stack_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack::direction: metaslang_stack_graphs::c::sg_deque_direction
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack::length: u32
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack::variable: metaslang_stack_graphs::c::sg_symbol_stack_variable
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub fn metaslang_stack_graphs::c::sg_partial_symbol_stack::clone(&self) -> metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::cmp::Eq for metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::cmp::PartialEq for metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub fn metaslang_stack_graphs::c::sg_partial_symbol_stack::eq(&self, other: &metaslang_stack_graphs::c::sg_partial_symbol_stack) -> bool
+impl core::convert::From<metaslang_stack_graphs::partial::PartialSymbolStack> for metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub fn metaslang_stack_graphs::c::sg_partial_symbol_stack::from(stack: metaslang_stack_graphs::partial::PartialSymbolStack) -> metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::default::Default for metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub fn metaslang_stack_graphs::c::sg_partial_symbol_stack::default() -> metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::c::sg_partial_symbol_stack
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_symbol_stack_cell
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack_cell::head: metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack_cell::reversed: metaslang_stack_graphs::c::sg_partial_symbol_stack_cell_handle
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack_cell::tail: metaslang_stack_graphs::c::sg_partial_symbol_stack_cell_handle
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_partial_symbol_stack_cells
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack_cells::cells: *const metaslang_stack_graphs::c::sg_partial_symbol_stack_cell
+pub metaslang_stack_graphs::c::sg_partial_symbol_stack_cells::count: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_position
+pub metaslang_stack_graphs::c::sg_position::column: metaslang_stack_graphs::c::sg_offset
+pub metaslang_stack_graphs::c::sg_position::containing_line: metaslang_stack_graphs::c::sg_utf8_bounds
+pub metaslang_stack_graphs::c::sg_position::line: usize
+pub metaslang_stack_graphs::c::sg_position::trimmed_line: metaslang_stack_graphs::c::sg_utf8_bounds
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_position
+pub fn metaslang_stack_graphs::c::sg_position::clone(&self) -> metaslang_stack_graphs::c::sg_position
+impl core::default::Default for metaslang_stack_graphs::c::sg_position
+pub fn metaslang_stack_graphs::c::sg_position::default() -> metaslang_stack_graphs::c::sg_position
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_position
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_source_info
+pub metaslang_stack_graphs::c::sg_source_info::containing_line: metaslang_stack_graphs::c::sg_string_handle
+pub metaslang_stack_graphs::c::sg_source_info::definiens_span: metaslang_stack_graphs::c::sg_span
+pub metaslang_stack_graphs::c::sg_source_info::fully_qualified_name: metaslang_stack_graphs::c::sg_string_handle
+pub metaslang_stack_graphs::c::sg_source_info::span: metaslang_stack_graphs::c::sg_span
+pub metaslang_stack_graphs::c::sg_source_info::syntax_type: metaslang_stack_graphs::c::sg_string_handle
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_source_info
+pub fn metaslang_stack_graphs::c::sg_source_info::clone(&self) -> metaslang_stack_graphs::c::sg_source_info
+impl core::default::Default for metaslang_stack_graphs::c::sg_source_info
+pub fn metaslang_stack_graphs::c::sg_source_info::default() -> metaslang_stack_graphs::c::sg_source_info
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_source_info
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_source_infos
+pub metaslang_stack_graphs::c::sg_source_infos::count: usize
+pub metaslang_stack_graphs::c::sg_source_infos::infos: *const metaslang_stack_graphs::c::sg_source_info
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_span
+pub metaslang_stack_graphs::c::sg_span::end: metaslang_stack_graphs::c::sg_position
+pub metaslang_stack_graphs::c::sg_span::start: metaslang_stack_graphs::c::sg_position
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_span
+pub fn metaslang_stack_graphs::c::sg_span::clone(&self) -> metaslang_stack_graphs::c::sg_span
+impl core::default::Default for metaslang_stack_graphs::c::sg_span
+pub fn metaslang_stack_graphs::c::sg_span::default() -> metaslang_stack_graphs::c::sg_span
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_span
+pub struct metaslang_stack_graphs::c::sg_stack_graph
+pub metaslang_stack_graphs::c::sg_stack_graph::inner: metaslang_stack_graphs::graph::StackGraph
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_stitcher_config
+pub metaslang_stack_graphs::c::sg_stitcher_config::detect_similar_paths: bool
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_stitcher_config
+pub fn metaslang_stack_graphs::c::sg_stitcher_config::clone(&self) -> metaslang_stack_graphs::c::sg_stitcher_config
+impl core::convert::Into<metaslang_stack_graphs::stitching::StitcherConfig> for metaslang_stack_graphs::c::sg_stitcher_config
+pub fn metaslang_stack_graphs::c::sg_stitcher_config::into(self) -> metaslang_stack_graphs::stitching::StitcherConfig
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_stitcher_config
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_string
+pub metaslang_stack_graphs::c::sg_string::content: *const libc::primitives::c_char
+pub metaslang_stack_graphs::c::sg_string::length: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_strings
+pub metaslang_stack_graphs::c::sg_strings::count: usize
+pub metaslang_stack_graphs::c::sg_strings::strings: *const metaslang_stack_graphs::c::sg_string
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_symbol
+pub metaslang_stack_graphs::c::sg_symbol::symbol: *const libc::primitives::c_char
+pub metaslang_stack_graphs::c::sg_symbol::symbol_len: usize
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_symbols
+pub metaslang_stack_graphs::c::sg_symbols::count: usize
+pub metaslang_stack_graphs::c::sg_symbols::symbols: *const metaslang_stack_graphs::c::sg_symbol
+#[repr(C)] pub struct metaslang_stack_graphs::c::sg_utf8_bounds
+pub metaslang_stack_graphs::c::sg_utf8_bounds::end: usize
+pub metaslang_stack_graphs::c::sg_utf8_bounds::start: usize
+impl core::clone::Clone for metaslang_stack_graphs::c::sg_utf8_bounds
+pub fn metaslang_stack_graphs::c::sg_utf8_bounds::clone(&self) -> metaslang_stack_graphs::c::sg_utf8_bounds
+impl core::default::Default for metaslang_stack_graphs::c::sg_utf8_bounds
+pub fn metaslang_stack_graphs::c::sg_utf8_bounds::default() -> metaslang_stack_graphs::c::sg_utf8_bounds
+impl core::marker::Copy for metaslang_stack_graphs::c::sg_utf8_bounds
+pub const metaslang_stack_graphs::c::SG_JUMP_TO_NODE_HANDLE: metaslang_stack_graphs::c::sg_node_handle
+pub const metaslang_stack_graphs::c::SG_JUMP_TO_NODE_ID: u32
+pub const metaslang_stack_graphs::c::SG_LIST_EMPTY_HANDLE: u32
+pub const metaslang_stack_graphs::c::SG_NULL_HANDLE: u32
+pub const metaslang_stack_graphs::c::SG_ROOT_NODE_HANDLE: metaslang_stack_graphs::c::sg_node_handle
+pub const metaslang_stack_graphs::c::SG_ROOT_NODE_ID: u32
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_free(stitcher: *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_from_nodes(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, count: usize, starting_nodes: *const metaslang_stack_graphs::c::sg_node_handle) -> *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_from_partial_paths(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, count: usize, initial_partial_paths: *const metaslang_stack_graphs::c::sg_partial_path) -> *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_process_next_phase(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, db: *mut metaslang_stack_graphs::c::sg_partial_path_database, stitcher: *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher: *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher, max_work: usize)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_forward_partial_path_stitcher_set_similar_path_detection(stitcher: *mut metaslang_stack_graphs::c::sg_forward_partial_path_stitcher, detect_similar_paths: bool)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_add_partial_path_edge_lists(partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, count: usize, edges: *const metaslang_stack_graphs::c::sg_partial_path_edge, lengths: *const usize, out: *mut metaslang_stack_graphs::c::sg_partial_path_edge_list)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_add_partial_scope_stacks(partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, count: usize, scopes: *const metaslang_stack_graphs::c::sg_node_handle, lengths: *const usize, variables: *const metaslang_stack_graphs::c::sg_scope_stack_variable, out: *mut metaslang_stack_graphs::c::sg_partial_scope_stack)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_add_partial_symbol_stacks(partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, count: usize, symbols: *const metaslang_stack_graphs::c::sg_partial_scoped_symbol, lengths: *const usize, variables: *const metaslang_stack_graphs::c::sg_symbol_stack_variable, out: *mut metaslang_stack_graphs::c::sg_partial_symbol_stack)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_find_all_complete_paths(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, starting_node_count: usize, starting_nodes: *const metaslang_stack_graphs::c::sg_node_handle, path_list: *mut metaslang_stack_graphs::c::sg_partial_path_list, stitcher_config: *const metaslang_stack_graphs::c::sg_stitcher_config, cancellation_flag: *const usize) -> metaslang_stack_graphs::c::sg_result
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, file: metaslang_stack_graphs::c::sg_file_handle, partial_path_list: *mut metaslang_stack_graphs::c::sg_partial_path_list, stitcher_config: *const metaslang_stack_graphs::c::sg_stitcher_config, cancellation_flag: *const usize) -> metaslang_stack_graphs::c::sg_result
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_free(partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_new() -> *mut metaslang_stack_graphs::c::sg_partial_path_arena
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_partial_path_edge_list_cells(partials: *const metaslang_stack_graphs::c::sg_partial_path_arena) -> metaslang_stack_graphs::c::sg_partial_path_edge_list_cells
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_partial_scope_stack_cells(partials: *const metaslang_stack_graphs::c::sg_partial_path_arena) -> metaslang_stack_graphs::c::sg_partial_scope_stack_cells
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_arena_partial_symbol_stack_cells(partials: *const metaslang_stack_graphs::c::sg_partial_path_arena) -> metaslang_stack_graphs::c::sg_partial_symbol_stack_cells
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_add_partial_paths(graph: *const metaslang_stack_graphs::c::sg_stack_graph, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena, db: *mut metaslang_stack_graphs::c::sg_partial_path_database, count: usize, paths: *const metaslang_stack_graphs::c::sg_partial_path, out: *mut metaslang_stack_graphs::c::sg_partial_path_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_ensure_both_directions(db: *mut metaslang_stack_graphs::c::sg_partial_path_database, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_ensure_forwards(db: *mut metaslang_stack_graphs::c::sg_partial_path_database, partials: *mut metaslang_stack_graphs::c::sg_partial_path_arena)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_find_local_nodes(db: *mut metaslang_stack_graphs::c::sg_partial_path_database)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_free(db: *mut metaslang_stack_graphs::c::sg_partial_path_database)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_local_nodes(db: *const metaslang_stack_graphs::c::sg_partial_path_database) -> metaslang_stack_graphs::c::sg_node_handle_set
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_mark_local_nodes(db: *mut metaslang_stack_graphs::c::sg_partial_path_database, count: usize, nodes: *const metaslang_stack_graphs::c::sg_node_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_new() -> *mut metaslang_stack_graphs::c::sg_partial_path_database
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_database_partial_paths(db: *const metaslang_stack_graphs::c::sg_partial_path_database) -> metaslang_stack_graphs::c::sg_partial_paths
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_list_count(partial_path_list: *const metaslang_stack_graphs::c::sg_partial_path_list) -> usize
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_list_free(partial_path_list: *mut metaslang_stack_graphs::c::sg_partial_path_list)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_list_new() -> *mut metaslang_stack_graphs::c::sg_partial_path_list
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_partial_path_list_paths(partial_path_list: *const metaslang_stack_graphs::c::sg_partial_path_list) -> *const metaslang_stack_graphs::c::sg_partial_path
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_add_edges(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, edges: *const metaslang_stack_graphs::c::sg_edge)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_add_files(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, files: *const libc::primitives::c_char, lengths: *const usize, handles_out: *mut metaslang_stack_graphs::c::sg_file_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_add_source_infos(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, infos: *const metaslang_stack_graphs::c::sg_node_source_info)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_add_strings(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, strings: *const libc::primitives::c_char, lengths: *const usize, handles_out: *mut metaslang_stack_graphs::c::sg_string_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_add_symbols(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, symbols: *const libc::primitives::c_char, lengths: *const usize, handles_out: *mut metaslang_stack_graphs::c::sg_symbol_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_files(graph: *const metaslang_stack_graphs::c::sg_stack_graph) -> metaslang_stack_graphs::c::sg_files
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_free(graph: *mut metaslang_stack_graphs::c::sg_stack_graph)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_get_or_create_nodes(graph: *mut metaslang_stack_graphs::c::sg_stack_graph, count: usize, nodes: *const metaslang_stack_graphs::c::sg_node, handles_out: *mut metaslang_stack_graphs::c::sg_node_handle)
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_new() -> *mut metaslang_stack_graphs::c::sg_stack_graph
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_nodes(graph: *const metaslang_stack_graphs::c::sg_stack_graph) -> metaslang_stack_graphs::c::sg_nodes
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_source_infos(graph: *const metaslang_stack_graphs::c::sg_stack_graph) -> metaslang_stack_graphs::c::sg_source_infos
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_strings(graph: *const metaslang_stack_graphs::c::sg_stack_graph) -> metaslang_stack_graphs::c::sg_strings
+#[no_mangle] pub c fn metaslang_stack_graphs::c::sg_stack_graph_symbols(graph: *const metaslang_stack_graphs::c::sg_stack_graph) -> metaslang_stack_graphs::c::sg_symbols
+pub type metaslang_stack_graphs::c::sg_file_handle = u32
+pub type metaslang_stack_graphs::c::sg_node_handle = u32
+pub type metaslang_stack_graphs::c::sg_partial_path_edge_list_cell_handle = u32
+pub type metaslang_stack_graphs::c::sg_partial_path_handle = u32
+pub type metaslang_stack_graphs::c::sg_partial_scope_stack_cell_handle = u32
+pub type metaslang_stack_graphs::c::sg_partial_symbol_stack_cell_handle = u32
+pub type metaslang_stack_graphs::c::sg_scope_stack_variable = u32
+pub type metaslang_stack_graphs::c::sg_string_handle = u32
+pub type metaslang_stack_graphs::c::sg_symbol_handle = u32
+pub type metaslang_stack_graphs::c::sg_symbol_stack_variable = u32
+pub mod metaslang_stack_graphs::cycles
+pub struct metaslang_stack_graphs::cycles::Appendables<H>
+impl<H> metaslang_stack_graphs::cycles::Appendables<H>
+pub fn metaslang_stack_graphs::cycles::Appendables<H>::new() -> Self
+pub struct metaslang_stack_graphs::cycles::AppendingCycleDetector<H>
+impl<H> metaslang_stack_graphs::cycles::AppendingCycleDetector<H> where H: core::clone::Clone
+pub fn metaslang_stack_graphs::cycles::AppendingCycleDetector<H>::is_cyclic<'a, A, Db>(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, db: &'a Db, appendables: &mut metaslang_stack_graphs::cycles::Appendables<H>) -> core::result::Result<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>, metaslang_stack_graphs::paths::PathResolutionError> where A: metaslang_stack_graphs::stitching::Appendable + 'a, Db: metaslang_stack_graphs::stitching::ToAppendable<H, A>
+impl<H> metaslang_stack_graphs::cycles::AppendingCycleDetector<H>
+pub fn metaslang_stack_graphs::cycles::AppendingCycleDetector<H>::append(&mut self, appendables: &mut metaslang_stack_graphs::cycles::Appendables<H>, appendage: H)
+pub fn metaslang_stack_graphs::cycles::AppendingCycleDetector<H>::from(appendables: &mut metaslang_stack_graphs::cycles::Appendables<H>, path: metaslang_stack_graphs::partial::PartialPath) -> Self
+pub fn metaslang_stack_graphs::cycles::AppendingCycleDetector<H>::new() -> Self
+impl<H: core::clone::Clone> core::clone::Clone for metaslang_stack_graphs::cycles::AppendingCycleDetector<H>
+pub fn metaslang_stack_graphs::cycles::AppendingCycleDetector<H>::clone(&self) -> metaslang_stack_graphs::cycles::AppendingCycleDetector<H>
+pub struct metaslang_stack_graphs::cycles::SimilarPathDetector<P>
+impl<P> metaslang_stack_graphs::cycles::SimilarPathDetector<P> where P: HasPathKey
+pub fn metaslang_stack_graphs::cycles::SimilarPathDetector<P>::add_path<Cmp>(&mut self, _graph: &metaslang_stack_graphs::graph::StackGraph, arena: &mut <P as >::Arena, path: &P, cmp: Cmp) -> bool where Cmp: core::ops::function::Fn(&mut <P as >::Arena, &P, &P) -> core::option::Option<core::cmp::Ordering>
+pub fn metaslang_stack_graphs::cycles::SimilarPathDetector<P>::new() -> metaslang_stack_graphs::cycles::SimilarPathDetector<P>
+pub fn metaslang_stack_graphs::cycles::SimilarPathDetector<P>::set_collect_stats(&mut self, collect_stats: bool)
+pub fn metaslang_stack_graphs::cycles::SimilarPathDetector<P>::stats(&self) -> metaslang_stack_graphs::cycles::SimilarPathStats
+pub struct metaslang_stack_graphs::cycles::SimilarPathStats
+pub metaslang_stack_graphs::cycles::SimilarPathStats::similar_path_bucket_size: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::cycles::SimilarPathStats::similar_path_count: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+impl core::clone::Clone for metaslang_stack_graphs::cycles::SimilarPathStats
+pub fn metaslang_stack_graphs::cycles::SimilarPathStats::clone(&self) -> metaslang_stack_graphs::cycles::SimilarPathStats
+impl core::default::Default for metaslang_stack_graphs::cycles::SimilarPathStats
+pub fn metaslang_stack_graphs::cycles::SimilarPathStats::default() -> metaslang_stack_graphs::cycles::SimilarPathStats
+impl core::fmt::Debug for metaslang_stack_graphs::cycles::SimilarPathStats
+pub fn metaslang_stack_graphs::cycles::SimilarPathStats::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::arith::AddAssign for metaslang_stack_graphs::cycles::SimilarPathStats
+pub fn metaslang_stack_graphs::cycles::SimilarPathStats::add_assign(&mut self, rhs: Self)
+impl core::ops::arith::AddAssign<&metaslang_stack_graphs::cycles::SimilarPathStats> for metaslang_stack_graphs::cycles::SimilarPathStats
+pub fn metaslang_stack_graphs::cycles::SimilarPathStats::add_assign(&mut self, rhs: &Self)
+pub mod metaslang_stack_graphs::graph
+#[repr(u8)] pub enum metaslang_stack_graphs::graph::Degree
+pub metaslang_stack_graphs::graph::Degree::Multiple
+pub metaslang_stack_graphs::graph::Degree::One
+pub metaslang_stack_graphs::graph::Degree::Zero
+impl core::clone::Clone for metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::clone(&self) -> metaslang_stack_graphs::graph::Degree
+impl core::cmp::Eq for metaslang_stack_graphs::graph::Degree
+impl core::cmp::PartialEq for metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::eq(&self, other: &metaslang_stack_graphs::graph::Degree) -> bool
+impl core::default::Default for metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::default() -> Self
+impl core::fmt::Debug for metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for metaslang_stack_graphs::graph::Degree
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::graph::Degree
+impl core::ops::arith::Add for metaslang_stack_graphs::graph::Degree
+pub type metaslang_stack_graphs::graph::Degree::Output = metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::add(self, rhs: Self) -> Self::Output
+impl core::ops::arith::AddAssign for metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::Degree::add_assign(&mut self, rhs: Self)
+#[repr(C)] pub enum metaslang_stack_graphs::graph::Node
+pub metaslang_stack_graphs::graph::Node::DropScopes(metaslang_stack_graphs::graph::DropScopesNode)
+pub metaslang_stack_graphs::graph::Node::JumpTo(metaslang_stack_graphs::graph::JumpToNode)
+pub metaslang_stack_graphs::graph::Node::PopScopedSymbol(metaslang_stack_graphs::graph::PopScopedSymbolNode)
+pub metaslang_stack_graphs::graph::Node::PopSymbol(metaslang_stack_graphs::graph::PopSymbolNode)
+pub metaslang_stack_graphs::graph::Node::PushScopedSymbol(metaslang_stack_graphs::graph::PushScopedSymbolNode)
+pub metaslang_stack_graphs::graph::Node::PushSymbol(metaslang_stack_graphs::graph::PushSymbolNode)
+pub metaslang_stack_graphs::graph::Node::Root(metaslang_stack_graphs::graph::RootNode)
+pub metaslang_stack_graphs::graph::Node::Scope(metaslang_stack_graphs::graph::ScopeNode)
+impl metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::graph::Node::file(&self) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>
+pub fn metaslang_stack_graphs::graph::Node::id(&self) -> metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::Node::is_definition(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_endpoint(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_exported_scope(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_in_file(&self, file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_jump_to(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_reference(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::is_root(&self) -> bool
+pub fn metaslang_stack_graphs::graph::Node::scope(&self) -> core::option::Option<metaslang_stack_graphs::graph::NodeID>
+pub fn metaslang_stack_graphs::graph::Node::symbol(&self) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+impl core::convert::From<metaslang_stack_graphs::graph::DropScopesNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::DropScopesNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::JumpToNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::JumpToNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::PopScopedSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PopScopedSymbolNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::PopSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PopSymbolNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::PushScopedSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PushScopedSymbolNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::PushSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PushSymbolNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::RootNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::RootNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::From<metaslang_stack_graphs::graph::ScopeNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::ScopeNode) -> metaslang_stack_graphs::graph::Node
+impl core::convert::Into<metaslang_stack_graphs::graph::Node> for metaslang_stack_graphs::c::sg_node
+pub fn metaslang_stack_graphs::c::sg_node::into(self) -> metaslang_stack_graphs::graph::Node
+pub struct metaslang_stack_graphs::graph::DebugEntry
+pub metaslang_stack_graphs::graph::DebugEntry::key: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>
+pub metaslang_stack_graphs::graph::DebugEntry::value: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>
+pub struct metaslang_stack_graphs::graph::DebugInfo
+impl metaslang_stack_graphs::graph::DebugInfo
+pub fn metaslang_stack_graphs::graph::DebugInfo::add(&mut self, key: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>, value: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>)
+pub fn metaslang_stack_graphs::graph::DebugInfo::iter(&self) -> core::slice::iter::Iter<'_, metaslang_stack_graphs::graph::DebugEntry>
+impl core::default::Default for metaslang_stack_graphs::graph::DebugInfo
+pub fn metaslang_stack_graphs::graph::DebugInfo::default() -> metaslang_stack_graphs::graph::DebugInfo
+#[repr(C)] pub struct metaslang_stack_graphs::graph::DropScopesNode
+pub metaslang_stack_graphs::graph::DropScopesNode::id: metaslang_stack_graphs::graph::NodeID
+impl metaslang_stack_graphs::graph::DropScopesNode
+pub fn metaslang_stack_graphs::graph::DropScopesNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::DropScopesNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::DropScopesNode) -> metaslang_stack_graphs::graph::Node
+pub struct metaslang_stack_graphs::graph::Edge
+pub metaslang_stack_graphs::graph::Edge::precedence: i32
+pub metaslang_stack_graphs::graph::Edge::sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub metaslang_stack_graphs::graph::Edge::source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl core::clone::Clone for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::clone(&self) -> metaslang_stack_graphs::graph::Edge
+impl core::cmp::Eq for metaslang_stack_graphs::graph::Edge
+impl core::cmp::Ord for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::cmp(&self, other: &metaslang_stack_graphs::graph::Edge) -> core::cmp::Ordering
+impl core::cmp::PartialEq for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::eq(&self, other: &metaslang_stack_graphs::graph::Edge) -> bool
+impl core::cmp::PartialOrd for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::partial_cmp(&self, other: &metaslang_stack_graphs::graph::Edge) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for metaslang_stack_graphs::graph::Edge
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::graph::Edge
+impl metaslang_stack_graphs::stitching::Appendable for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::append_to(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &mut metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::graph::Edge::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, _partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> alloc::boxed::Box<(dyn core::fmt::Display + 'a)>
+pub fn metaslang_stack_graphs::graph::Edge::end_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::graph::Edge::start_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::stitching::GraphEdges, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::GraphEdges)
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge> for metaslang_stack_graphs::stitching::GraphEdges
+pub fn metaslang_stack_graphs::stitching::GraphEdges::get_appendable<'a>(&'a self, edge: &'a metaslang_stack_graphs::graph::Edge) -> &'a metaslang_stack_graphs::graph::Edge
+pub struct metaslang_stack_graphs::graph::File
+impl metaslang_stack_graphs::graph::File
+pub fn metaslang_stack_graphs::graph::File::name(&self) -> &str
+impl core::fmt::Display for metaslang_stack_graphs::graph::File
+pub fn metaslang_stack_graphs::graph::File::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+#[repr(C)] pub struct metaslang_stack_graphs::graph::InternedString
+impl core::cmp::PartialEq<&str> for metaslang_stack_graphs::graph::InternedString
+pub fn metaslang_stack_graphs::graph::InternedString::eq(&self, other: &&str) -> bool
+#[repr(C)] pub struct metaslang_stack_graphs::graph::JumpToNode
+impl core::convert::From<metaslang_stack_graphs::graph::JumpToNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::JumpToNode) -> metaslang_stack_graphs::graph::Node
+impl core::fmt::Display for metaslang_stack_graphs::graph::JumpToNode
+pub fn metaslang_stack_graphs::graph::JumpToNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+#[repr(C)] pub struct metaslang_stack_graphs::graph::NodeID
+impl metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::display(self, graph: &metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + '_
+impl metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::file(self) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>
+pub fn metaslang_stack_graphs::graph::NodeID::is_in_file(self, file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::graph::NodeID::is_jump_to(self) -> bool
+pub fn metaslang_stack_graphs::graph::NodeID::is_root(self) -> bool
+pub fn metaslang_stack_graphs::graph::NodeID::jump_to() -> metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::local_id(self) -> u32
+pub fn metaslang_stack_graphs::graph::NodeID::new_in_file(file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>, local_id: u32) -> metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::root() -> metaslang_stack_graphs::graph::NodeID
+impl core::clone::Clone for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::clone(&self) -> metaslang_stack_graphs::graph::NodeID
+impl core::cmp::Eq for metaslang_stack_graphs::graph::NodeID
+impl core::cmp::Ord for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::cmp(&self, other: &metaslang_stack_graphs::graph::NodeID) -> core::cmp::Ordering
+impl core::cmp::PartialEq for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::eq(&self, other: &metaslang_stack_graphs::graph::NodeID) -> bool
+impl core::cmp::PartialOrd for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::partial_cmp(&self, other: &metaslang_stack_graphs::graph::NodeID) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::Into<metaslang_stack_graphs::graph::NodeID> for metaslang_stack_graphs::c::sg_node_id
+pub fn metaslang_stack_graphs::c::sg_node_id::into(self) -> metaslang_stack_graphs::graph::NodeID
+impl core::default::Default for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::default() -> metaslang_stack_graphs::graph::NodeID
+impl core::fmt::Debug for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::NodeID::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for metaslang_stack_graphs::graph::NodeID
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::graph::NodeID
+#[repr(C)] pub struct metaslang_stack_graphs::graph::PopScopedSymbolNode
+pub metaslang_stack_graphs::graph::PopScopedSymbolNode::id: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::PopScopedSymbolNode::is_definition: bool
+pub metaslang_stack_graphs::graph::PopScopedSymbolNode::symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+impl metaslang_stack_graphs::graph::PopScopedSymbolNode
+pub fn metaslang_stack_graphs::graph::PopScopedSymbolNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::PopScopedSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PopScopedSymbolNode) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::PopSymbolNode
+pub metaslang_stack_graphs::graph::PopSymbolNode::id: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::PopSymbolNode::is_definition: bool
+pub metaslang_stack_graphs::graph::PopSymbolNode::symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+impl metaslang_stack_graphs::graph::PopSymbolNode
+pub fn metaslang_stack_graphs::graph::PopSymbolNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::PopSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PopSymbolNode) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::PushScopedSymbolNode
+pub metaslang_stack_graphs::graph::PushScopedSymbolNode::id: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::PushScopedSymbolNode::is_reference: bool
+pub metaslang_stack_graphs::graph::PushScopedSymbolNode::scope: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::PushScopedSymbolNode::symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+impl metaslang_stack_graphs::graph::PushScopedSymbolNode
+pub fn metaslang_stack_graphs::graph::PushScopedSymbolNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::PushScopedSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PushScopedSymbolNode) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::PushSymbolNode
+pub metaslang_stack_graphs::graph::PushSymbolNode::id: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::PushSymbolNode::is_reference: bool
+pub metaslang_stack_graphs::graph::PushSymbolNode::symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+impl metaslang_stack_graphs::graph::PushSymbolNode
+pub fn metaslang_stack_graphs::graph::PushSymbolNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::PushSymbolNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::PushSymbolNode) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::RootNode
+impl core::convert::From<metaslang_stack_graphs::graph::RootNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::RootNode) -> metaslang_stack_graphs::graph::Node
+impl core::fmt::Display for metaslang_stack_graphs::graph::RootNode
+pub fn metaslang_stack_graphs::graph::RootNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+#[repr(C)] pub struct metaslang_stack_graphs::graph::ScopeNode
+pub metaslang_stack_graphs::graph::ScopeNode::id: metaslang_stack_graphs::graph::NodeID
+pub metaslang_stack_graphs::graph::ScopeNode::is_exported: bool
+impl metaslang_stack_graphs::graph::ScopeNode
+pub fn metaslang_stack_graphs::graph::ScopeNode::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph) -> impl core::fmt::Display + 'a
+impl core::convert::From<metaslang_stack_graphs::graph::ScopeNode> for metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::Node::from(node: metaslang_stack_graphs::graph::ScopeNode) -> metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::SourceInfo
+pub metaslang_stack_graphs::graph::SourceInfo::containing_line: controlled_option::ControlledOption<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>>
+pub metaslang_stack_graphs::graph::SourceInfo::definiens_span: lsp_positions::Span
+pub metaslang_stack_graphs::graph::SourceInfo::fully_qualified_name: controlled_option::ControlledOption<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>>
+pub metaslang_stack_graphs::graph::SourceInfo::span: lsp_positions::Span
+pub metaslang_stack_graphs::graph::SourceInfo::syntax_type: controlled_option::ControlledOption<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>>
+impl core::default::Default for metaslang_stack_graphs::graph::SourceInfo
+pub fn metaslang_stack_graphs::graph::SourceInfo::default() -> metaslang_stack_graphs::graph::SourceInfo
+pub struct metaslang_stack_graphs::graph::StackGraph
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_drop_scopes_node(&mut self, id: metaslang_stack_graphs::graph::NodeID) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_edge(&mut self, source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, precedence: i32)
+pub fn metaslang_stack_graphs::graph::StackGraph::incoming_edge_degree(&self, sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::graph::StackGraph::outgoing_edges(&self, source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::graph::Edge> + '_
+pub fn metaslang_stack_graphs::graph::StackGraph::set_edge_precedence(&mut self, source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, precedence: i32)
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_file<S: core::convert::AsRef<str> + ?core::marker::Sized>(&mut self, name: &S) -> core::result::Result<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>, metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>
+pub fn metaslang_stack_graphs::graph::StackGraph::get_file<S: core::convert::AsRef<str> + ?core::marker::Sized>(&self, name: &S) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>
+pub fn metaslang_stack_graphs::graph::StackGraph::get_or_create_file<S: core::convert::AsRef<str> + ?core::marker::Sized>(&mut self, name: &S) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_from_graph(&mut self, other: &metaslang_stack_graphs::graph::StackGraph) -> core::result::Result<alloc::vec::Vec<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>, metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>
+pub fn metaslang_stack_graphs::graph::StackGraph::new() -> metaslang_stack_graphs::graph::StackGraph
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_pop_scoped_symbol_node(&mut self, id: metaslang_stack_graphs::graph::NodeID, symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>, is_definition: bool) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_pop_symbol_node(&mut self, id: metaslang_stack_graphs::graph::NodeID, symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>, is_definition: bool) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_push_scoped_symbol_node(&mut self, id: metaslang_stack_graphs::graph::NodeID, symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>, scope: metaslang_stack_graphs::graph::NodeID, is_reference: bool) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_push_symbol_node(&mut self, id: metaslang_stack_graphs::graph::NodeID, symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>, is_reference: bool) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_scope_node(&mut self, id: metaslang_stack_graphs::graph::NodeID, is_exported: bool) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_string<S: core::convert::AsRef<str> + ?core::marker::Sized>(&mut self, string: &S) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>
+pub fn metaslang_stack_graphs::graph::StackGraph::iter_strings(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::add_symbol<S: core::convert::AsRef<str> + ?core::marker::Sized>(&mut self, symbol: &S) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+pub fn metaslang_stack_graphs::graph::StackGraph::iter_symbols(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::edge_debug_info(&self, source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> core::option::Option<&metaslang_stack_graphs::graph::DebugInfo>
+pub fn metaslang_stack_graphs::graph::StackGraph::edge_debug_info_mut(&mut self, source: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, sink: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &mut metaslang_stack_graphs::graph::DebugInfo
+pub fn metaslang_stack_graphs::graph::StackGraph::node_debug_info(&self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> core::option::Option<&metaslang_stack_graphs::graph::DebugInfo>
+pub fn metaslang_stack_graphs::graph::StackGraph::node_debug_info_mut(&mut self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &mut metaslang_stack_graphs::graph::DebugInfo
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::iter_files(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>> + '_
+pub fn metaslang_stack_graphs::graph::StackGraph::nodes_for_file(&self, file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> + '_
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::iter_nodes(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+pub fn metaslang_stack_graphs::graph::StackGraph::jump_to_node() -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::graph::StackGraph::new_node_id(&mut self, file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> metaslang_stack_graphs::graph::NodeID
+pub fn metaslang_stack_graphs::graph::StackGraph::node_for_id(&self, id: metaslang_stack_graphs::graph::NodeID) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+pub fn metaslang_stack_graphs::graph::StackGraph::root_node() -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::source_info(&self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> core::option::Option<&metaslang_stack_graphs::graph::SourceInfo>
+pub fn metaslang_stack_graphs::graph::StackGraph::source_info_mut(&mut self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &mut metaslang_stack_graphs::graph::SourceInfo
+impl metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::to_serializable(&self) -> metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::to_serializable_filter<'a>(&self, f: &'a dyn metaslang_stack_graphs::serde::Filter) -> metaslang_stack_graphs::serde::StackGraph
+impl core::default::Default for metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::default() -> metaslang_stack_graphs::graph::StackGraph
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = metaslang_stack_graphs::graph::File
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> &metaslang_stack_graphs::graph::File
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = str
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::InternedString>) -> &str
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = metaslang_stack_graphs::graph::Node
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &metaslang_stack_graphs::graph::Node
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>> for metaslang_stack_graphs::graph::StackGraph
+pub type metaslang_stack_graphs::graph::StackGraph::Output = str
+pub fn metaslang_stack_graphs::graph::StackGraph::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>) -> &str
+impl core::ops::index::IndexMut<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> for metaslang_stack_graphs::graph::StackGraph
+pub fn metaslang_stack_graphs::graph::StackGraph::index_mut(&mut self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> &mut metaslang_stack_graphs::graph::Node
+#[repr(C)] pub struct metaslang_stack_graphs::graph::Symbol
+impl metaslang_stack_graphs::graph::Symbol
+pub fn metaslang_stack_graphs::graph::Symbol::as_str(&self) -> &str
+impl core::cmp::PartialEq<&str> for metaslang_stack_graphs::graph::Symbol
+pub fn metaslang_stack_graphs::graph::Symbol::eq(&self, other: &&str) -> bool
+pub mod metaslang_stack_graphs::partial
+pub enum metaslang_stack_graphs::partial::Cyclicity
+pub metaslang_stack_graphs::partial::Cyclicity::Free
+pub metaslang_stack_graphs::partial::Cyclicity::StrengthensPostcondition
+pub metaslang_stack_graphs::partial::Cyclicity::StrengthensPrecondition
+impl core::clone::Clone for metaslang_stack_graphs::partial::Cyclicity
+pub fn metaslang_stack_graphs::partial::Cyclicity::clone(&self) -> Self
+impl core::cmp::Eq for metaslang_stack_graphs::partial::Cyclicity
+impl core::cmp::PartialEq for metaslang_stack_graphs::partial::Cyclicity
+pub fn metaslang_stack_graphs::partial::Cyclicity::eq(&self, other: &Self) -> bool
+impl core::cmp::PartialEq<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>> for metaslang_stack_graphs::partial::Cyclicity
+pub fn metaslang_stack_graphs::partial::Cyclicity::eq(&self, other: &enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::partial::Cyclicity
+pub fn metaslang_stack_graphs::partial::Cyclicity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for metaslang_stack_graphs::partial::Cyclicity
+impl core::ops::bit::Not for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::Output = enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::Cyclicity::not(self) -> Self::Output
+impl enumset::traits::EnumSetType for metaslang_stack_graphs::partial::Cyclicity
+impl enumset::traits::EnumSetTypePrivate for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::ConstHelper = __EnumSetConstHelper
+pub type metaslang_stack_graphs::partial::Cyclicity::Repr = u8
+pub const metaslang_stack_graphs::partial::Cyclicity::ALL_BITS: Self::Repr
+pub const metaslang_stack_graphs::partial::Cyclicity::BIT_WIDTH: u32
+pub const metaslang_stack_graphs::partial::Cyclicity::CONST_HELPER_INSTANCE: __EnumSetConstHelper
+pub const metaslang_stack_graphs::partial::Cyclicity::VARIANT_COUNT: u32
+pub unsafe fn metaslang_stack_graphs::partial::Cyclicity::enum_from_u32(val: u32) -> Self
+pub fn metaslang_stack_graphs::partial::Cyclicity::enum_into_u32(self) -> u32
+impl<O: core::convert::Into<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>>> core::ops::arith::Sub<O> for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::Output = enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::Cyclicity::sub(self, other: O) -> Self::Output
+impl<O: core::convert::Into<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>>> core::ops::bit::BitAnd<O> for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::Output = enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::Cyclicity::bitand(self, other: O) -> Self::Output
+impl<O: core::convert::Into<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>>> core::ops::bit::BitOr<O> for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::Output = enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::Cyclicity::bitor(self, other: O) -> Self::Output
+impl<O: core::convert::Into<enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>>> core::ops::bit::BitXor<O> for metaslang_stack_graphs::partial::Cyclicity
+pub type metaslang_stack_graphs::partial::Cyclicity::Output = enumset::set::EnumSet<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::Cyclicity::bitxor(self, other: O) -> Self::Output
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialPath
+pub metaslang_stack_graphs::partial::PartialPath::edges: metaslang_stack_graphs::partial::PartialPathEdgeList
+pub metaslang_stack_graphs::partial::PartialPath::end_node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub metaslang_stack_graphs::partial::PartialPath::scope_stack_postcondition: metaslang_stack_graphs::partial::PartialScopeStack
+pub metaslang_stack_graphs::partial::PartialPath::scope_stack_precondition: metaslang_stack_graphs::partial::PartialScopeStack
+pub metaslang_stack_graphs::partial::PartialPath::start_node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub metaslang_stack_graphs::partial::PartialPath::symbol_stack_postcondition: metaslang_stack_graphs::partial::PartialSymbolStack
+pub metaslang_stack_graphs::partial::PartialPath::symbol_stack_precondition: metaslang_stack_graphs::partial::PartialSymbolStack
+impl metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::append(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, edge: metaslang_stack_graphs::graph::Edge) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialPath::eliminate_precondition_stack_variables(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths)
+pub fn metaslang_stack_graphs::partial::PartialPath::ensure_no_overlapping_variables(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialPath)
+pub fn metaslang_stack_graphs::partial::PartialPath::resolve_from_postcondition(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialPath::resolve_to_node(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+impl metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::cmp(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialPath) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::partial::PartialPath::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialPath::ends_at_definition(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::ends_at_endpoint(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::ends_in_jump(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::ensure_both_directions(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths)
+pub fn metaslang_stack_graphs::partial::PartialPath::ensure_forwards(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths)
+pub fn metaslang_stack_graphs::partial::PartialPath::equals(&self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialPath) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::fresh_scope_stack_variable(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::PartialPath::from_node(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::is_complete(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::is_cyclic(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::partial::Cyclicity>
+pub fn metaslang_stack_graphs::partial::PartialPath::largest_scope_stack_variable(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> u32
+pub fn metaslang_stack_graphs::partial::PartialPath::largest_symbol_stack_variable(&self) -> u32
+pub fn metaslang_stack_graphs::partial::PartialPath::shadows(&self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialPath) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::starts_at_endpoint(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPath::starts_at_reference(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> bool
+impl metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::concatenate(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, rhs: &metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::clone(&self) -> metaslang_stack_graphs::partial::PartialPath
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::c::sg_partial_path
+pub fn metaslang_stack_graphs::c::sg_partial_path::into(self) -> metaslang_stack_graphs::partial::PartialPath
+impl metaslang_stack_graphs::stitching::Appendable for metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::append_to(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &mut metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialPath::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> alloc::boxed::Box<(dyn core::fmt::Display + 'a)>
+pub fn metaslang_stack_graphs::partial::PartialPath::end_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::partial::PartialPath::start_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::get_appendable<'a>(&'a self, handle: &'a metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &'a metaslang_stack_graphs::partial::PartialPath
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialPathEdge
+pub metaslang_stack_graphs::partial::PartialPathEdge::precedence: i32
+pub metaslang_stack_graphs::partial::PartialPathEdge::source_node_id: metaslang_stack_graphs::graph::NodeID
+impl metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::display<'a>(self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::shadows(self, other: metaslang_stack_graphs::partial::PartialPathEdge) -> bool
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::clone(&self) -> metaslang_stack_graphs::partial::PartialPathEdge
+impl core::cmp::Eq for metaslang_stack_graphs::partial::PartialPathEdge
+impl core::cmp::Ord for metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::cmp(&self, other: &metaslang_stack_graphs::partial::PartialPathEdge) -> core::cmp::Ordering
+impl core::cmp::PartialEq for metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::eq(&self, other: &metaslang_stack_graphs::partial::PartialPathEdge) -> bool
+impl core::cmp::PartialOrd for metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::partial_cmp(&self, other: &metaslang_stack_graphs::partial::PartialPathEdge) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialPathEdge> for metaslang_stack_graphs::c::sg_partial_path_edge
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge::into(self) -> metaslang_stack_graphs::partial::PartialPathEdge
+impl core::hash::Hash for metaslang_stack_graphs::partial::PartialPathEdge
+pub fn metaslang_stack_graphs::partial::PartialPathEdge::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for metaslang_stack_graphs::partial::PartialPathEdge
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::partial::PartialPathEdge
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialPathEdgeList
+impl metaslang_stack_graphs::partial::PartialPathEdgeList
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::cmp(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialPathEdgeList) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::display<'a>(self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::empty() -> metaslang_stack_graphs::partial::PartialPathEdgeList
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::equals(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialPathEdgeList) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::have_reversal(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::is_empty(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::iter<'a>(&self, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::partial::PartialPathEdge> + 'a
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::iter_unordered<'a>(&self, partials: &'a metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::partial::PartialPathEdge> + 'a
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::len(&self) -> usize
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::pop_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::partial::PartialPathEdge>
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::pop_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::partial::PartialPathEdge>
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::push_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, edge: metaslang_stack_graphs::partial::PartialPathEdge)
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::push_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, edge: metaslang_stack_graphs::partial::PartialPathEdge)
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::shadows(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialPathEdgeList) -> bool
+impl controlled_option::Niche for metaslang_stack_graphs::partial::PartialPathEdgeList where metaslang_stack_graphs::arena::Deque<metaslang_stack_graphs::partial::PartialPathEdge>: controlled_option::Niche
+pub type metaslang_stack_graphs::partial::PartialPathEdgeList::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::partial::PartialPathEdgeList>
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::none() -> Self::Output
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialPathEdgeList
+pub fn metaslang_stack_graphs::partial::PartialPathEdgeList::clone(&self) -> metaslang_stack_graphs::partial::PartialPathEdgeList
+impl core::convert::From<metaslang_stack_graphs::partial::PartialPathEdgeList> for metaslang_stack_graphs::c::sg_partial_path_edge_list
+pub fn metaslang_stack_graphs::c::sg_partial_path_edge_list::from(edges: metaslang_stack_graphs::partial::PartialPathEdgeList) -> metaslang_stack_graphs::c::sg_partial_path_edge_list
+impl core::marker::Copy for metaslang_stack_graphs::partial::PartialPathEdgeList
+pub struct metaslang_stack_graphs::partial::PartialPaths
+impl metaslang_stack_graphs::partial::PartialPaths
+pub fn metaslang_stack_graphs::partial::PartialPaths::new() -> metaslang_stack_graphs::partial::PartialPaths
+pub fn metaslang_stack_graphs::partial::PartialPaths::restore_checkpoint(&mut self, checkpoint: metaslang_stack_graphs::partial::PartialPathsCheckpoint)
+pub fn metaslang_stack_graphs::partial::PartialPaths::save_checkpoint(&self) -> metaslang_stack_graphs::partial::PartialPathsCheckpoint
+pub struct metaslang_stack_graphs::partial::PartialPathsCheckpoint
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialScopeStack
+impl metaslang_stack_graphs::partial::PartialScopeStack
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::apply_partial_bindings(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, scope_bindings: &metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<metaslang_stack_graphs::partial::PartialScopeStack, metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::can_match_empty(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::can_only_match_empty(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::cmp(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialScopeStack) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::contains_scopes(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::display<'a>(self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::empty() -> metaslang_stack_graphs::partial::PartialScopeStack
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::equals(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialScopeStack) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::from_variable(variable: metaslang_stack_graphs::partial::ScopeStackVariable) -> metaslang_stack_graphs::partial::PartialScopeStack
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::has_variable(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::have_reversal(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::iter_scopes<'a>(&self, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> + 'a
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::iter_unordered<'a>(&self, partials: &'a metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>> + 'a
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::largest_scope_stack_variable(&self) -> u32
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::len(&self) -> usize
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::matches(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialScopeStack) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::pop_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::pop_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::push_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>)
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::push_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>)
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::unify(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, rhs: metaslang_stack_graphs::partial::PartialScopeStack, bindings: &mut metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<metaslang_stack_graphs::partial::PartialScopeStack, metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::variable(&self) -> core::option::Option<metaslang_stack_graphs::partial::ScopeStackVariable>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::with_offset(self, scope_variable_offset: u32) -> metaslang_stack_graphs::partial::PartialScopeStack
+impl controlled_option::Niche for metaslang_stack_graphs::partial::PartialScopeStack where metaslang_stack_graphs::arena::Deque<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>: controlled_option::Niche
+pub type metaslang_stack_graphs::partial::PartialScopeStack::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::partial::PartialScopeStack>
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::none() -> Self::Output
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialScopeStack
+pub fn metaslang_stack_graphs::partial::PartialScopeStack::clone(&self) -> metaslang_stack_graphs::partial::PartialScopeStack
+impl core::convert::From<metaslang_stack_graphs::partial::PartialScopeStack> for metaslang_stack_graphs::c::sg_partial_scope_stack
+pub fn metaslang_stack_graphs::c::sg_partial_scope_stack::from(stack: metaslang_stack_graphs::partial::PartialScopeStack) -> metaslang_stack_graphs::c::sg_partial_scope_stack
+impl core::marker::Copy for metaslang_stack_graphs::partial::PartialScopeStack
+pub struct metaslang_stack_graphs::partial::PartialScopeStackBindings
+impl metaslang_stack_graphs::partial::PartialScopeStackBindings
+pub fn metaslang_stack_graphs::partial::PartialScopeStackBindings::add(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, variable: metaslang_stack_graphs::partial::ScopeStackVariable, scopes: metaslang_stack_graphs::partial::PartialScopeStack) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialScopeStackBindings::display<'a>(&'a mut self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialScopeStackBindings::get(&self, variable: metaslang_stack_graphs::partial::ScopeStackVariable) -> core::option::Option<metaslang_stack_graphs::partial::PartialScopeStack>
+pub fn metaslang_stack_graphs::partial::PartialScopeStackBindings::new() -> metaslang_stack_graphs::partial::PartialScopeStackBindings
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialScopedSymbol
+pub metaslang_stack_graphs::partial::PartialScopedSymbol::scopes: controlled_option::ControlledOption<metaslang_stack_graphs::partial::PartialScopeStack>
+pub metaslang_stack_graphs::partial::PartialScopedSymbol::symbol: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Symbol>
+impl metaslang_stack_graphs::partial::PartialScopedSymbol
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::apply_partial_bindings(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, scope_bindings: &metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<metaslang_stack_graphs::partial::PartialScopedSymbol, metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::cmp(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialScopedSymbol) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::display<'a>(self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::equals(&self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: &metaslang_stack_graphs::partial::PartialScopedSymbol) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::matches(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, postcondition: metaslang_stack_graphs::partial::PartialScopedSymbol) -> bool
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::unify(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, rhs: metaslang_stack_graphs::partial::PartialScopedSymbol, scope_bindings: &mut metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::with_offset(self, scope_variable_offset: u32) -> metaslang_stack_graphs::partial::PartialScopedSymbol
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialScopedSymbol
+pub fn metaslang_stack_graphs::partial::PartialScopedSymbol::clone(&self) -> metaslang_stack_graphs::partial::PartialScopedSymbol
+impl core::convert::Into<metaslang_stack_graphs::partial::PartialScopedSymbol> for metaslang_stack_graphs::c::sg_partial_scoped_symbol
+pub fn metaslang_stack_graphs::c::sg_partial_scoped_symbol::into(self) -> metaslang_stack_graphs::partial::PartialScopedSymbol
+impl core::marker::Copy for metaslang_stack_graphs::partial::PartialScopedSymbol
+#[repr(C)] pub struct metaslang_stack_graphs::partial::PartialSymbolStack
+impl metaslang_stack_graphs::partial::PartialSymbolStack
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::apply_partial_bindings(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, symbol_bindings: &metaslang_stack_graphs::partial::PartialSymbolStackBindings, scope_bindings: &metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<metaslang_stack_graphs::partial::PartialSymbolStack, metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::can_match_empty(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::can_only_match_empty(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::cmp(self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialSymbolStack) -> core::cmp::Ordering
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::contains_symbols(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::display<'a>(self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::empty() -> metaslang_stack_graphs::partial::PartialSymbolStack
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::equals(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialSymbolStack) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::from_variable(variable: metaslang_stack_graphs::partial::SymbolStackVariable) -> metaslang_stack_graphs::partial::PartialSymbolStack
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::has_variable(&self) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::have_reversal(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::iter<'a>(&self, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::partial::PartialScopedSymbol> + 'a
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::iter_unordered<'a>(&self, partials: &'a metaslang_stack_graphs::partial::PartialPaths) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::partial::PartialScopedSymbol> + 'a
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::largest_scope_stack_variable(&self, partials: &metaslang_stack_graphs::partial::PartialPaths) -> u32
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::largest_symbol_stack_variable(&self) -> u32
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::len(&self) -> usize
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::matches(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, other: metaslang_stack_graphs::partial::PartialSymbolStack) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::pop_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::partial::PartialScopedSymbol>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::pop_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::option::Option<metaslang_stack_graphs::partial::PartialScopedSymbol>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::push_back(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, symbol: metaslang_stack_graphs::partial::PartialScopedSymbol)
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::push_front(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, symbol: metaslang_stack_graphs::partial::PartialScopedSymbol)
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::unify(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, rhs: metaslang_stack_graphs::partial::PartialSymbolStack, symbol_bindings: &mut metaslang_stack_graphs::partial::PartialSymbolStackBindings, scope_bindings: &mut metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<metaslang_stack_graphs::partial::PartialSymbolStack, metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::variable(&self) -> core::option::Option<metaslang_stack_graphs::partial::SymbolStackVariable>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::with_offset(self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, symbol_variable_offset: u32, scope_variable_offset: u32) -> metaslang_stack_graphs::partial::PartialSymbolStack
+impl controlled_option::Niche for metaslang_stack_graphs::partial::PartialSymbolStack where metaslang_stack_graphs::arena::Deque<metaslang_stack_graphs::partial::PartialScopedSymbol>: controlled_option::Niche
+pub type metaslang_stack_graphs::partial::PartialSymbolStack::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::partial::PartialSymbolStack>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::none() -> Self::Output
+impl core::clone::Clone for metaslang_stack_graphs::partial::PartialSymbolStack
+pub fn metaslang_stack_graphs::partial::PartialSymbolStack::clone(&self) -> metaslang_stack_graphs::partial::PartialSymbolStack
+impl core::convert::From<metaslang_stack_graphs::partial::PartialSymbolStack> for metaslang_stack_graphs::c::sg_partial_symbol_stack
+pub fn metaslang_stack_graphs::c::sg_partial_symbol_stack::from(stack: metaslang_stack_graphs::partial::PartialSymbolStack) -> metaslang_stack_graphs::c::sg_partial_symbol_stack
+impl core::marker::Copy for metaslang_stack_graphs::partial::PartialSymbolStack
+pub struct metaslang_stack_graphs::partial::PartialSymbolStackBindings
+impl metaslang_stack_graphs::partial::PartialSymbolStackBindings
+pub fn metaslang_stack_graphs::partial::PartialSymbolStackBindings::add(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths, variable: metaslang_stack_graphs::partial::SymbolStackVariable, symbols: metaslang_stack_graphs::partial::PartialSymbolStack, scope_bindings: &mut metaslang_stack_graphs::partial::PartialScopeStackBindings) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStackBindings::display<'a>(&'a mut self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> impl core::fmt::Display + 'a
+pub fn metaslang_stack_graphs::partial::PartialSymbolStackBindings::get(&self, variable: metaslang_stack_graphs::partial::SymbolStackVariable) -> core::option::Option<metaslang_stack_graphs::partial::PartialSymbolStack>
+pub fn metaslang_stack_graphs::partial::PartialSymbolStackBindings::new() -> metaslang_stack_graphs::partial::PartialSymbolStackBindings
+#[repr(transparent)] pub struct metaslang_stack_graphs::partial::ScopeStackVariable(_)
+impl metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::new(variable: u32) -> core::option::Option<metaslang_stack_graphs::partial::ScopeStackVariable>
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::with_offset(self, scope_variable_offset: u32) -> metaslang_stack_graphs::partial::ScopeStackVariable
+impl controlled_option::Niche for metaslang_stack_graphs::partial::ScopeStackVariable where core::num::nonzero::NonZeroU32: controlled_option::Niche
+pub type metaslang_stack_graphs::partial::ScopeStackVariable::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::partial::ScopeStackVariable>
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::none() -> Self::Output
+impl core::clone::Clone for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::clone(&self) -> metaslang_stack_graphs::partial::ScopeStackVariable
+impl core::cmp::Eq for metaslang_stack_graphs::partial::ScopeStackVariable
+impl core::cmp::Ord for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::cmp(&self, other: &metaslang_stack_graphs::partial::ScopeStackVariable) -> core::cmp::Ordering
+impl core::cmp::PartialEq for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::eq(&self, other: &metaslang_stack_graphs::partial::ScopeStackVariable) -> bool
+impl core::cmp::PartialOrd for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::partial_cmp(&self, other: &metaslang_stack_graphs::partial::ScopeStackVariable) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<core::num::nonzero::NonZero<u32>> for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::from(value: core::num::nonzero::NonZeroU32) -> metaslang_stack_graphs::partial::ScopeStackVariable
+impl core::convert::Into<u32> for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::into(self) -> u32
+impl core::convert::TryFrom<u32> for metaslang_stack_graphs::partial::ScopeStackVariable
+pub type metaslang_stack_graphs::partial::ScopeStackVariable::Error = ()
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::try_from(value: u32) -> core::result::Result<metaslang_stack_graphs::partial::ScopeStackVariable, ()>
+impl core::fmt::Debug for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for metaslang_stack_graphs::partial::ScopeStackVariable
+pub fn metaslang_stack_graphs::partial::ScopeStackVariable::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for metaslang_stack_graphs::partial::ScopeStackVariable
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::partial::ScopeStackVariable
+#[repr(transparent)] pub struct metaslang_stack_graphs::partial::SymbolStackVariable(_)
+impl metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::new(variable: u32) -> core::option::Option<metaslang_stack_graphs::partial::SymbolStackVariable>
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::with_offset(self, symbol_variable_offset: u32) -> metaslang_stack_graphs::partial::SymbolStackVariable
+impl controlled_option::Niche for metaslang_stack_graphs::partial::SymbolStackVariable where core::num::nonzero::NonZeroU32: controlled_option::Niche
+pub type metaslang_stack_graphs::partial::SymbolStackVariable::Output = core::mem::maybe_uninit::MaybeUninit<metaslang_stack_graphs::partial::SymbolStackVariable>
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::from_some(value: Self::Output) -> Self
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::into_some(value: Self) -> Self::Output
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::is_none(value: &Self::Output) -> bool
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::none() -> Self::Output
+impl core::clone::Clone for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::clone(&self) -> metaslang_stack_graphs::partial::SymbolStackVariable
+impl core::cmp::Eq for metaslang_stack_graphs::partial::SymbolStackVariable
+impl core::cmp::Ord for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::cmp(&self, other: &metaslang_stack_graphs::partial::SymbolStackVariable) -> core::cmp::Ordering
+impl core::cmp::PartialEq for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::eq(&self, other: &metaslang_stack_graphs::partial::SymbolStackVariable) -> bool
+impl core::cmp::PartialOrd for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::partial_cmp(&self, other: &metaslang_stack_graphs::partial::SymbolStackVariable) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<core::num::nonzero::NonZero<u32>> for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::from(value: core::num::nonzero::NonZeroU32) -> metaslang_stack_graphs::partial::SymbolStackVariable
+impl core::convert::Into<u32> for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::into(self) -> u32
+impl core::convert::TryFrom<u32> for metaslang_stack_graphs::partial::SymbolStackVariable
+pub type metaslang_stack_graphs::partial::SymbolStackVariable::Error = ()
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::try_from(value: u32) -> core::result::Result<metaslang_stack_graphs::partial::SymbolStackVariable, ()>
+impl core::fmt::Debug for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for metaslang_stack_graphs::partial::SymbolStackVariable
+pub fn metaslang_stack_graphs::partial::SymbolStackVariable::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for metaslang_stack_graphs::partial::SymbolStackVariable
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::partial::SymbolStackVariable
+pub mod metaslang_stack_graphs::paths
+pub enum metaslang_stack_graphs::paths::PathResolutionError
+pub metaslang_stack_graphs::paths::PathResolutionError::DisallowedCycle
+pub metaslang_stack_graphs::paths::PathResolutionError::EmptyScopeStack
+pub metaslang_stack_graphs::paths::PathResolutionError::EmptySymbolStack
+pub metaslang_stack_graphs::paths::PathResolutionError::IncompatibleScopeStackVariables
+pub metaslang_stack_graphs::paths::PathResolutionError::IncompatibleSymbolStackVariables
+pub metaslang_stack_graphs::paths::PathResolutionError::IncorrectFile
+pub metaslang_stack_graphs::paths::PathResolutionError::IncorrectPoppedSymbol
+pub metaslang_stack_graphs::paths::PathResolutionError::IncorrectSourceNode
+pub metaslang_stack_graphs::paths::PathResolutionError::MissingAttachedScopeList
+pub metaslang_stack_graphs::paths::PathResolutionError::ScopeStackUnsatisfied
+pub metaslang_stack_graphs::paths::PathResolutionError::SymbolStackUnsatisfied
+pub metaslang_stack_graphs::paths::PathResolutionError::UnboundScopeStackVariable
+pub metaslang_stack_graphs::paths::PathResolutionError::UnboundSymbolStackVariable
+pub metaslang_stack_graphs::paths::PathResolutionError::UnexpectedAttachedScopeList
+pub metaslang_stack_graphs::paths::PathResolutionError::UnknownAttachedScope
+impl core::fmt::Debug for metaslang_stack_graphs::paths::PathResolutionError
+pub fn metaslang_stack_graphs::paths::PathResolutionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub trait metaslang_stack_graphs::paths::Extend<T>
+pub fn metaslang_stack_graphs::paths::Extend::push(&mut self, item: T)
+pub fn metaslang_stack_graphs::paths::Extend::reserve(&mut self, additional: usize)
+impl<T> metaslang_stack_graphs::paths::Extend<T> for alloc::collections::vec_deque::VecDeque<T>
+pub fn alloc::collections::vec_deque::VecDeque<T>::push(&mut self, item: T)
+pub fn alloc::collections::vec_deque::VecDeque<T>::reserve(&mut self, additional: usize)
+impl<T> metaslang_stack_graphs::paths::Extend<T> for alloc::vec::Vec<T>
+pub fn alloc::vec::Vec<T>::push(&mut self, item: T)
+pub fn alloc::vec::Vec<T>::reserve(&mut self, additional: usize)
+pub mod metaslang_stack_graphs::serde
+pub enum metaslang_stack_graphs::serde::Error
+pub metaslang_stack_graphs::serde::Error::FileAlreadyPresent(alloc::string::String)
+pub metaslang_stack_graphs::serde::Error::FileNotFound(alloc::string::String)
+pub metaslang_stack_graphs::serde::Error::InvalidGlobalNodeID(u32)
+pub metaslang_stack_graphs::serde::Error::InvalidStackVariable(u32)
+pub metaslang_stack_graphs::serde::Error::NodeNotFound(metaslang_stack_graphs::serde::NodeID)
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Error
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Error
+pub fn metaslang_stack_graphs::serde::Error::eq(&self, other: &metaslang_stack_graphs::serde::Error) -> bool
+impl core::error::Error for metaslang_stack_graphs::serde::Error
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Error
+pub fn metaslang_stack_graphs::serde::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for metaslang_stack_graphs::serde::Error
+pub fn metaslang_stack_graphs::serde::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Error
+pub enum metaslang_stack_graphs::serde::Node
+pub metaslang_stack_graphs::serde::Node::DropScopes
+pub metaslang_stack_graphs::serde::Node::DropScopes::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::DropScopes::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::DropScopes::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::JumpToScope
+pub metaslang_stack_graphs::serde::Node::JumpToScope::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::JumpToScope::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::JumpToScope::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol::is_definition: bool
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::PopScopedSymbol::symbol: alloc::string::String
+pub metaslang_stack_graphs::serde::Node::PopSymbol
+pub metaslang_stack_graphs::serde::Node::PopSymbol::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::PopSymbol::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::PopSymbol::is_definition: bool
+pub metaslang_stack_graphs::serde::Node::PopSymbol::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::PopSymbol::symbol: alloc::string::String
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::is_reference: bool
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::scope: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::PushScopedSymbol::symbol: alloc::string::String
+pub metaslang_stack_graphs::serde::Node::PushSymbol
+pub metaslang_stack_graphs::serde::Node::PushSymbol::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::PushSymbol::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::PushSymbol::is_reference: bool
+pub metaslang_stack_graphs::serde::Node::PushSymbol::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::PushSymbol::symbol: alloc::string::String
+pub metaslang_stack_graphs::serde::Node::Root
+pub metaslang_stack_graphs::serde::Node::Root::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::Root::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::Root::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+pub metaslang_stack_graphs::serde::Node::Scope
+pub metaslang_stack_graphs::serde::Node::Scope::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Node::Scope::id: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Node::Scope::is_exported: bool
+pub metaslang_stack_graphs::serde::Node::Scope::source_info: core::option::Option<metaslang_stack_graphs::serde::SourceInfo>
+impl core::clone::Clone for metaslang_stack_graphs::serde::Node
+pub fn metaslang_stack_graphs::serde::Node::clone(&self) -> metaslang_stack_graphs::serde::Node
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Node
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Node
+pub fn metaslang_stack_graphs::serde::Node::eq(&self, other: &metaslang_stack_graphs::serde::Node) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Node
+pub fn metaslang_stack_graphs::serde::Node::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Node
+pub struct metaslang_stack_graphs::serde::Database
+impl metaslang_stack_graphs::serde::Database
+pub fn metaslang_stack_graphs::serde::Database::from_database(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::stitching::Database) -> Self
+pub fn metaslang_stack_graphs::serde::Database::from_database_filter(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::stitching::Database, filter: &dyn metaslang_stack_graphs::serde::Filter) -> Self
+pub fn metaslang_stack_graphs::serde::Database::load_into(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &mut metaslang_stack_graphs::stitching::Database) -> core::result::Result<(), metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::Database
+pub fn metaslang_stack_graphs::serde::Database::clone(&self) -> metaslang_stack_graphs::serde::Database
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Database
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Database
+pub fn metaslang_stack_graphs::serde::Database::eq(&self, other: &metaslang_stack_graphs::serde::Database) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Database
+pub fn metaslang_stack_graphs::serde::Database::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Database
+pub struct metaslang_stack_graphs::serde::DebugEntry
+pub metaslang_stack_graphs::serde::DebugEntry::key: alloc::string::String
+pub metaslang_stack_graphs::serde::DebugEntry::value: alloc::string::String
+impl core::clone::Clone for metaslang_stack_graphs::serde::DebugEntry
+pub fn metaslang_stack_graphs::serde::DebugEntry::clone(&self) -> metaslang_stack_graphs::serde::DebugEntry
+impl core::cmp::Eq for metaslang_stack_graphs::serde::DebugEntry
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::DebugEntry
+pub fn metaslang_stack_graphs::serde::DebugEntry::eq(&self, other: &metaslang_stack_graphs::serde::DebugEntry) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::DebugEntry
+pub fn metaslang_stack_graphs::serde::DebugEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::DebugEntry
+pub struct metaslang_stack_graphs::serde::DebugInfo
+pub metaslang_stack_graphs::serde::DebugInfo::data: alloc::vec::Vec<metaslang_stack_graphs::serde::DebugEntry>
+impl core::clone::Clone for metaslang_stack_graphs::serde::DebugInfo
+pub fn metaslang_stack_graphs::serde::DebugInfo::clone(&self) -> metaslang_stack_graphs::serde::DebugInfo
+impl core::cmp::Eq for metaslang_stack_graphs::serde::DebugInfo
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::DebugInfo
+pub fn metaslang_stack_graphs::serde::DebugInfo::eq(&self, other: &metaslang_stack_graphs::serde::DebugInfo) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::DebugInfo
+pub fn metaslang_stack_graphs::serde::DebugInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::DebugInfo
+pub struct metaslang_stack_graphs::serde::Edge
+pub metaslang_stack_graphs::serde::Edge::debug_info: core::option::Option<metaslang_stack_graphs::serde::DebugInfo>
+pub metaslang_stack_graphs::serde::Edge::precedence: i32
+pub metaslang_stack_graphs::serde::Edge::sink: metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::Edge::source: metaslang_stack_graphs::serde::NodeID
+impl core::clone::Clone for metaslang_stack_graphs::serde::Edge
+pub fn metaslang_stack_graphs::serde::Edge::clone(&self) -> metaslang_stack_graphs::serde::Edge
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Edge
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Edge
+pub fn metaslang_stack_graphs::serde::Edge::eq(&self, other: &metaslang_stack_graphs::serde::Edge) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Edge
+pub fn metaslang_stack_graphs::serde::Edge::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Edge
+pub struct metaslang_stack_graphs::serde::Edges
+pub metaslang_stack_graphs::serde::Edges::data: alloc::vec::Vec<metaslang_stack_graphs::serde::Edge>
+impl core::clone::Clone for metaslang_stack_graphs::serde::Edges
+pub fn metaslang_stack_graphs::serde::Edges::clone(&self) -> metaslang_stack_graphs::serde::Edges
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Edges
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Edges
+pub fn metaslang_stack_graphs::serde::Edges::eq(&self, other: &metaslang_stack_graphs::serde::Edges) -> bool
+impl core::default::Default for metaslang_stack_graphs::serde::Edges
+pub fn metaslang_stack_graphs::serde::Edges::default() -> metaslang_stack_graphs::serde::Edges
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Edges
+pub fn metaslang_stack_graphs::serde::Edges::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Edges
+pub struct metaslang_stack_graphs::serde::FileFilter(pub metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>)
+impl metaslang_stack_graphs::serde::Filter for metaslang_stack_graphs::serde::FileFilter
+pub fn metaslang_stack_graphs::serde::FileFilter::include_edge(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, _sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_file(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_node(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_partial_path(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _paths: &metaslang_stack_graphs::partial::PartialPaths, _path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+pub struct metaslang_stack_graphs::serde::Files
+pub metaslang_stack_graphs::serde::Files::data: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for metaslang_stack_graphs::serde::Files
+pub fn metaslang_stack_graphs::serde::Files::clone(&self) -> metaslang_stack_graphs::serde::Files
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Files
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Files
+pub fn metaslang_stack_graphs::serde::Files::eq(&self, other: &metaslang_stack_graphs::serde::Files) -> bool
+impl core::default::Default for metaslang_stack_graphs::serde::Files
+pub fn metaslang_stack_graphs::serde::Files::default() -> metaslang_stack_graphs::serde::Files
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Files
+pub fn metaslang_stack_graphs::serde::Files::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Files
+pub struct metaslang_stack_graphs::serde::NoFilter
+impl metaslang_stack_graphs::serde::Filter for metaslang_stack_graphs::serde::NoFilter
+pub fn metaslang_stack_graphs::serde::NoFilter::include_edge(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, _sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_file(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_node(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_partial_path(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _paths: &metaslang_stack_graphs::partial::PartialPaths, _path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+pub struct metaslang_stack_graphs::serde::NodeID
+pub metaslang_stack_graphs::serde::NodeID::file: core::option::Option<alloc::string::String>
+pub metaslang_stack_graphs::serde::NodeID::local_id: u32
+impl metaslang_stack_graphs::serde::NodeID
+pub fn metaslang_stack_graphs::serde::NodeID::from_node(graph: &metaslang_stack_graphs::graph::StackGraph, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> Self
+pub fn metaslang_stack_graphs::serde::NodeID::from_node_id(graph: &metaslang_stack_graphs::graph::StackGraph, value: metaslang_stack_graphs::graph::NodeID) -> Self
+pub fn metaslang_stack_graphs::serde::NodeID::to_node(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph) -> core::result::Result<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, metaslang_stack_graphs::serde::Error>
+pub fn metaslang_stack_graphs::serde::NodeID::to_node_id(&self, graph: &metaslang_stack_graphs::graph::StackGraph) -> core::result::Result<metaslang_stack_graphs::graph::NodeID, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::NodeID
+pub fn metaslang_stack_graphs::serde::NodeID::clone(&self) -> metaslang_stack_graphs::serde::NodeID
+impl core::cmp::Eq for metaslang_stack_graphs::serde::NodeID
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::NodeID
+pub fn metaslang_stack_graphs::serde::NodeID::eq(&self, other: &metaslang_stack_graphs::serde::NodeID) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::NodeID
+pub fn metaslang_stack_graphs::serde::NodeID::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for metaslang_stack_graphs::serde::NodeID
+pub fn metaslang_stack_graphs::serde::NodeID::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::NodeID
+pub struct metaslang_stack_graphs::serde::Nodes
+pub metaslang_stack_graphs::serde::Nodes::data: alloc::vec::Vec<metaslang_stack_graphs::serde::Node>
+impl core::clone::Clone for metaslang_stack_graphs::serde::Nodes
+pub fn metaslang_stack_graphs::serde::Nodes::clone(&self) -> metaslang_stack_graphs::serde::Nodes
+impl core::cmp::Eq for metaslang_stack_graphs::serde::Nodes
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::Nodes
+pub fn metaslang_stack_graphs::serde::Nodes::eq(&self, other: &metaslang_stack_graphs::serde::Nodes) -> bool
+impl core::default::Default for metaslang_stack_graphs::serde::Nodes
+pub fn metaslang_stack_graphs::serde::Nodes::default() -> metaslang_stack_graphs::serde::Nodes
+impl core::fmt::Debug for metaslang_stack_graphs::serde::Nodes
+pub fn metaslang_stack_graphs::serde::Nodes::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::Nodes
+pub struct metaslang_stack_graphs::serde::PartialPath
+impl metaslang_stack_graphs::serde::PartialPath
+pub fn metaslang_stack_graphs::serde::PartialPath::from_partial_path(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialPath) -> Self
+pub fn metaslang_stack_graphs::serde::PartialPath::to_partial_path(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialPath
+pub fn metaslang_stack_graphs::serde::PartialPath::clone(&self) -> metaslang_stack_graphs::serde::PartialPath
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialPath
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialPath
+pub fn metaslang_stack_graphs::serde::PartialPath::eq(&self, other: &metaslang_stack_graphs::serde::PartialPath) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialPath
+pub fn metaslang_stack_graphs::serde::PartialPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialPath
+pub struct metaslang_stack_graphs::serde::PartialPathEdge
+impl metaslang_stack_graphs::serde::PartialPathEdge
+pub fn metaslang_stack_graphs::serde::PartialPathEdge::from_partial_path_edge(graph: &metaslang_stack_graphs::graph::StackGraph, _partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialPathEdge) -> Self
+pub fn metaslang_stack_graphs::serde::PartialPathEdge::to_partial_path_edge(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, _partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialPathEdge, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialPathEdge
+pub fn metaslang_stack_graphs::serde::PartialPathEdge::clone(&self) -> metaslang_stack_graphs::serde::PartialPathEdge
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialPathEdge
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialPathEdge
+pub fn metaslang_stack_graphs::serde::PartialPathEdge::eq(&self, other: &metaslang_stack_graphs::serde::PartialPathEdge) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialPathEdge
+pub fn metaslang_stack_graphs::serde::PartialPathEdge::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialPathEdge
+pub struct metaslang_stack_graphs::serde::PartialPathEdgeList
+impl metaslang_stack_graphs::serde::PartialPathEdgeList
+pub fn metaslang_stack_graphs::serde::PartialPathEdgeList::from_partial_path_edge_list(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialPathEdgeList) -> Self
+pub fn metaslang_stack_graphs::serde::PartialPathEdgeList::to_partial_path_edge_list(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialPathEdgeList, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialPathEdgeList
+pub fn metaslang_stack_graphs::serde::PartialPathEdgeList::clone(&self) -> metaslang_stack_graphs::serde::PartialPathEdgeList
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialPathEdgeList
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialPathEdgeList
+pub fn metaslang_stack_graphs::serde::PartialPathEdgeList::eq(&self, other: &metaslang_stack_graphs::serde::PartialPathEdgeList) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialPathEdgeList
+pub fn metaslang_stack_graphs::serde::PartialPathEdgeList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialPathEdgeList
+pub struct metaslang_stack_graphs::serde::PartialScopeStack
+impl metaslang_stack_graphs::serde::PartialScopeStack
+pub fn metaslang_stack_graphs::serde::PartialScopeStack::from_partial_scope_stack(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialScopeStack) -> Self
+pub fn metaslang_stack_graphs::serde::PartialScopeStack::to_partial_scope_stack(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialScopeStack, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialScopeStack
+pub fn metaslang_stack_graphs::serde::PartialScopeStack::clone(&self) -> metaslang_stack_graphs::serde::PartialScopeStack
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialScopeStack
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialScopeStack
+pub fn metaslang_stack_graphs::serde::PartialScopeStack::eq(&self, other: &metaslang_stack_graphs::serde::PartialScopeStack) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialScopeStack
+pub fn metaslang_stack_graphs::serde::PartialScopeStack::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialScopeStack
+pub struct metaslang_stack_graphs::serde::PartialScopedSymbol
+impl metaslang_stack_graphs::serde::PartialScopedSymbol
+pub fn metaslang_stack_graphs::serde::PartialScopedSymbol::from_partial_scoped_symbol(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialScopedSymbol) -> Self
+pub fn metaslang_stack_graphs::serde::PartialScopedSymbol::to_partial_scoped_symbol(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialScopedSymbol, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialScopedSymbol
+pub fn metaslang_stack_graphs::serde::PartialScopedSymbol::clone(&self) -> metaslang_stack_graphs::serde::PartialScopedSymbol
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialScopedSymbol
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialScopedSymbol
+pub fn metaslang_stack_graphs::serde::PartialScopedSymbol::eq(&self, other: &metaslang_stack_graphs::serde::PartialScopedSymbol) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialScopedSymbol
+pub fn metaslang_stack_graphs::serde::PartialScopedSymbol::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialScopedSymbol
+pub struct metaslang_stack_graphs::serde::PartialSymbolStack
+impl metaslang_stack_graphs::serde::PartialSymbolStack
+pub fn metaslang_stack_graphs::serde::PartialSymbolStack::from_partial_symbol_stack(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, value: &metaslang_stack_graphs::partial::PartialSymbolStack) -> Self
+pub fn metaslang_stack_graphs::serde::PartialSymbolStack::to_partial_symbol_stack(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> core::result::Result<metaslang_stack_graphs::partial::PartialSymbolStack, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::PartialSymbolStack
+pub fn metaslang_stack_graphs::serde::PartialSymbolStack::clone(&self) -> metaslang_stack_graphs::serde::PartialSymbolStack
+impl core::cmp::Eq for metaslang_stack_graphs::serde::PartialSymbolStack
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::PartialSymbolStack
+pub fn metaslang_stack_graphs::serde::PartialSymbolStack::eq(&self, other: &metaslang_stack_graphs::serde::PartialSymbolStack) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::PartialSymbolStack
+pub fn metaslang_stack_graphs::serde::PartialSymbolStack::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::PartialSymbolStack
+pub struct metaslang_stack_graphs::serde::ScopeStackVariable(_)
+impl metaslang_stack_graphs::serde::ScopeStackVariable
+pub fn metaslang_stack_graphs::serde::ScopeStackVariable::from_scope_stack_variable(value: metaslang_stack_graphs::partial::ScopeStackVariable) -> Self
+pub fn metaslang_stack_graphs::serde::ScopeStackVariable::to_scope_stack_variable(&self) -> core::result::Result<metaslang_stack_graphs::partial::ScopeStackVariable, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::ScopeStackVariable
+pub fn metaslang_stack_graphs::serde::ScopeStackVariable::clone(&self) -> metaslang_stack_graphs::serde::ScopeStackVariable
+impl core::cmp::Eq for metaslang_stack_graphs::serde::ScopeStackVariable
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::ScopeStackVariable
+pub fn metaslang_stack_graphs::serde::ScopeStackVariable::eq(&self, other: &metaslang_stack_graphs::serde::ScopeStackVariable) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::ScopeStackVariable
+pub fn metaslang_stack_graphs::serde::ScopeStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::ScopeStackVariable
+pub struct metaslang_stack_graphs::serde::SourceInfo
+pub metaslang_stack_graphs::serde::SourceInfo::span: lsp_positions::Span
+pub metaslang_stack_graphs::serde::SourceInfo::syntax_type: core::option::Option<alloc::string::String>
+impl core::clone::Clone for metaslang_stack_graphs::serde::SourceInfo
+pub fn metaslang_stack_graphs::serde::SourceInfo::clone(&self) -> metaslang_stack_graphs::serde::SourceInfo
+impl core::cmp::Eq for metaslang_stack_graphs::serde::SourceInfo
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::SourceInfo
+pub fn metaslang_stack_graphs::serde::SourceInfo::eq(&self, other: &metaslang_stack_graphs::serde::SourceInfo) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::SourceInfo
+pub fn metaslang_stack_graphs::serde::SourceInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::SourceInfo
+pub struct metaslang_stack_graphs::serde::StackGraph
+pub metaslang_stack_graphs::serde::StackGraph::edges: metaslang_stack_graphs::serde::Edges
+pub metaslang_stack_graphs::serde::StackGraph::files: metaslang_stack_graphs::serde::Files
+pub metaslang_stack_graphs::serde::StackGraph::nodes: metaslang_stack_graphs::serde::Nodes
+impl metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::serde::StackGraph::from_graph<'a>(graph: &metaslang_stack_graphs::graph::StackGraph) -> Self
+pub fn metaslang_stack_graphs::serde::StackGraph::from_graph_filter<'a>(graph: &metaslang_stack_graphs::graph::StackGraph, filter: &'a dyn metaslang_stack_graphs::serde::Filter) -> Self
+pub fn metaslang_stack_graphs::serde::StackGraph::load_into(&self, graph: &mut metaslang_stack_graphs::graph::StackGraph) -> core::result::Result<(), metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::serde::StackGraph::clone(&self) -> metaslang_stack_graphs::serde::StackGraph
+impl core::cmp::Eq for metaslang_stack_graphs::serde::StackGraph
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::serde::StackGraph::eq(&self, other: &metaslang_stack_graphs::serde::StackGraph) -> bool
+impl core::default::Default for metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::serde::StackGraph::default() -> metaslang_stack_graphs::serde::StackGraph
+impl core::fmt::Debug for metaslang_stack_graphs::serde::StackGraph
+pub fn metaslang_stack_graphs::serde::StackGraph::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::StackGraph
+pub struct metaslang_stack_graphs::serde::SymbolStackVariable(_)
+impl metaslang_stack_graphs::serde::SymbolStackVariable
+pub fn metaslang_stack_graphs::serde::SymbolStackVariable::from_symbol_stack_variable(value: metaslang_stack_graphs::partial::SymbolStackVariable) -> Self
+pub fn metaslang_stack_graphs::serde::SymbolStackVariable::to_symbol_stack_variable(&self) -> core::result::Result<metaslang_stack_graphs::partial::SymbolStackVariable, metaslang_stack_graphs::serde::Error>
+impl core::clone::Clone for metaslang_stack_graphs::serde::SymbolStackVariable
+pub fn metaslang_stack_graphs::serde::SymbolStackVariable::clone(&self) -> metaslang_stack_graphs::serde::SymbolStackVariable
+impl core::cmp::Eq for metaslang_stack_graphs::serde::SymbolStackVariable
+impl core::cmp::PartialEq for metaslang_stack_graphs::serde::SymbolStackVariable
+pub fn metaslang_stack_graphs::serde::SymbolStackVariable::eq(&self, other: &metaslang_stack_graphs::serde::SymbolStackVariable) -> bool
+impl core::fmt::Debug for metaslang_stack_graphs::serde::SymbolStackVariable
+pub fn metaslang_stack_graphs::serde::SymbolStackVariable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for metaslang_stack_graphs::serde::SymbolStackVariable
+pub trait metaslang_stack_graphs::serde::Filter
+pub fn metaslang_stack_graphs::serde::Filter::include_edge(&self, graph: &metaslang_stack_graphs::graph::StackGraph, source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::Filter::include_file(&self, graph: &metaslang_stack_graphs::graph::StackGraph, file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::serde::Filter::include_node(&self, graph: &metaslang_stack_graphs::graph::StackGraph, node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::Filter::include_partial_path(&self, graph: &metaslang_stack_graphs::graph::StackGraph, paths: &metaslang_stack_graphs::partial::PartialPaths, path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+impl metaslang_stack_graphs::serde::Filter for metaslang_stack_graphs::serde::FileFilter
+pub fn metaslang_stack_graphs::serde::FileFilter::include_edge(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, _sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_file(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_node(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::FileFilter::include_partial_path(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _paths: &metaslang_stack_graphs::partial::PartialPaths, _path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+impl metaslang_stack_graphs::serde::Filter for metaslang_stack_graphs::serde::NoFilter
+pub fn metaslang_stack_graphs::serde::NoFilter::include_edge(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, _sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_file(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_node(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn metaslang_stack_graphs::serde::NoFilter::include_partial_path(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _paths: &metaslang_stack_graphs::partial::PartialPaths, _path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+impl<F> metaslang_stack_graphs::serde::Filter for F where F: core::ops::function::Fn(&metaslang_stack_graphs::graph::StackGraph, &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn F::include_edge(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _source: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, _sink: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn F::include_file(&self, graph: &metaslang_stack_graphs::graph::StackGraph, file: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>) -> bool
+pub fn F::include_node(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _node: &metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+pub fn F::include_partial_path(&self, _graph: &metaslang_stack_graphs::graph::StackGraph, _paths: &metaslang_stack_graphs::partial::PartialPaths, _path: &metaslang_stack_graphs::partial::PartialPath) -> bool
+pub mod metaslang_stack_graphs::stats
+pub struct metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash
+impl<T: core::cmp::Eq + core::hash::Hash + core::cmp::Ord> metaslang_stack_graphs::stats::FrequencyDistribution<T>
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::quantiles(&self, q: usize) -> alloc::vec::Vec<&T>
+impl<T: core::cmp::Eq + core::hash::Hash> metaslang_stack_graphs::stats::FrequencyDistribution<T>
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::count(&self) -> usize
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::frequencies(&self) -> metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::record(&mut self, value: T)
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::unique(&self) -> usize
+impl<T> core::clone::Clone for metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash + core::clone::Clone
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::clone(&self) -> metaslang_stack_graphs::stats::FrequencyDistribution<T>
+impl<T> core::default::Default for metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash + core::default::Default
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::default() -> metaslang_stack_graphs::stats::FrequencyDistribution<T>
+impl<T> core::fmt::Debug for metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash + core::fmt::Debug
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::ops::arith::AddAssign for metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::add_assign(&mut self, rhs: Self)
+impl<T> core::ops::arith::AddAssign<&metaslang_stack_graphs::stats::FrequencyDistribution<T>> for metaslang_stack_graphs::stats::FrequencyDistribution<T> where T: core::cmp::Eq + core::hash::Hash + core::clone::Clone
+pub fn metaslang_stack_graphs::stats::FrequencyDistribution<T>::add_assign(&mut self, rhs: &Self)
+pub mod metaslang_stack_graphs::stitching
+pub struct metaslang_stack_graphs::stitching::Database
+impl metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::add_partial_path(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>
+pub fn metaslang_stack_graphs::stitching::Database::ensure_both_directions(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths)
+pub fn metaslang_stack_graphs::stitching::Database::ensure_forwards(&mut self, partials: &mut metaslang_stack_graphs::partial::PartialPaths)
+pub fn metaslang_stack_graphs::stitching::Database::find_candidate_partial_paths<R>(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::Database::find_candidate_partial_paths_from_node<R>(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, start_node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::Database::find_candidate_partial_paths_from_root<R>(&mut self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, symbol_stack: core::option::Option<metaslang_stack_graphs::partial::PartialSymbolStack>, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::Database::find_local_nodes(&mut self)
+pub fn metaslang_stack_graphs::stitching::Database::get_incoming_path_degree(&self, end_node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::stitching::Database::iter_partial_paths(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::Database::mark_local_node(&mut self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>)
+pub fn metaslang_stack_graphs::stitching::Database::new() -> metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::node_is_local(&self, node: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>) -> bool
+impl metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::to_serializable(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths) -> metaslang_stack_graphs::serde::Database
+pub fn metaslang_stack_graphs::stitching::Database::to_serializable_filter(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, filter: &dyn metaslang_stack_graphs::serde::Filter) -> metaslang_stack_graphs::serde::Database
+impl core::ops::index::Index<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>> for metaslang_stack_graphs::stitching::Database
+pub type metaslang_stack_graphs::stitching::Database::Output = metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::stitching::Database::index(&self, handle: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &metaslang_stack_graphs::partial::PartialPath
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::get_appendable<'a>(&'a self, handle: &'a metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &'a metaslang_stack_graphs::partial::PartialPath
+pub struct metaslang_stack_graphs::stitching::DatabaseCandidates<'a>
+impl<'a> metaslang_stack_graphs::stitching::DatabaseCandidates<'a>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'a>::new(graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths, database: &'a mut metaslang_stack_graphs::stitching::Database) -> Self
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+pub struct metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>
+impl metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<metaslang_stack_graphs::graph::Edge>::find_minimal_partial_path_set_in_file<F>(graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, file: metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>, config: metaslang_stack_graphs::stitching::StitcherConfig, cancellation_flag: &dyn metaslang_stack_graphs::CancellationFlag, visit: F) -> core::result::Result<metaslang_stack_graphs::stitching::Stats, metaslang_stack_graphs::CancellationError> where F: core::ops::function::FnMut(&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::partial::PartialPath)
+impl<H: core::clone::Clone> metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::find_all_complete_partial_paths<I, F, A, Db, C, Err>(candidates: &mut C, starting_nodes: I, config: metaslang_stack_graphs::stitching::StitcherConfig, cancellation_flag: &dyn metaslang_stack_graphs::CancellationFlag, visit: F) -> core::result::Result<metaslang_stack_graphs::stitching::Stats, Err> where I: core::iter::traits::collect::IntoIterator<Item = metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>>, A: metaslang_stack_graphs::stitching::Appendable, Db: metaslang_stack_graphs::stitching::ToAppendable<H, A>, C: metaslang_stack_graphs::stitching::ForwardCandidates<H, A, Db, Err>, F: core::ops::function::FnMut(&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::partial::PartialPath), Err: core::convert::From<metaslang_stack_graphs::CancellationError>
+impl<H: core::clone::Clone> metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::is_complete(&self) -> bool
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::previous_phase_partial_paths(&self) -> impl core::iter::traits::iterator::Iterator<Item = &metaslang_stack_graphs::partial::PartialPath> + '_
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::previous_phase_partial_paths_slice(&mut self) -> &[metaslang_stack_graphs::partial::PartialPath]
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::previous_phase_partial_paths_slice_mut(&mut self) -> &mut [metaslang_stack_graphs::partial::PartialPath]
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::process_next_phase<A, Db, C, E, Err>(&mut self, candidates: &mut C, extend_while: E) where A: metaslang_stack_graphs::stitching::Appendable, Db: metaslang_stack_graphs::stitching::ToAppendable<H, A>, C: metaslang_stack_graphs::stitching::ForwardCandidates<H, A, Db, Err>, E: core::ops::function::Fn(&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::partial::PartialPath) -> bool
+impl<H> metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::from_partial_paths<I>(_graph: &metaslang_stack_graphs::graph::StackGraph, _partials: &mut metaslang_stack_graphs::partial::PartialPaths, initial_partial_paths: I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = metaslang_stack_graphs::partial::PartialPath>
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::into_stats(self) -> metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::set_check_only_join_nodes(&mut self, check_only_join_nodes: bool)
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::set_collect_stats(&mut self, collect_stats: bool)
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::set_max_work_per_phase(&mut self, max_work_per_phase: usize)
+pub fn metaslang_stack_graphs::stitching::ForwardPartialPathStitcher<H>::set_similar_path_detection(&mut self, detect_similar_paths: bool)
+pub struct metaslang_stack_graphs::stitching::GraphEdgeCandidates<'a>
+impl<'a> metaslang_stack_graphs::stitching::GraphEdgeCandidates<'a>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'a>::new(graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths, file: core::option::Option<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::File>>) -> Self
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::stitching::GraphEdges, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::GraphEdges)
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+pub struct metaslang_stack_graphs::stitching::GraphEdges
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::stitching::GraphEdges, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::GraphEdges)
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge> for metaslang_stack_graphs::stitching::GraphEdges
+pub fn metaslang_stack_graphs::stitching::GraphEdges::get_appendable<'a>(&'a self, edge: &'a metaslang_stack_graphs::graph::Edge) -> &'a metaslang_stack_graphs::graph::Edge
+pub struct metaslang_stack_graphs::stitching::Stats
+pub metaslang_stack_graphs::stitching::Stats::accepted_path_length: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::candidates_per_node_path: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::candidates_per_root_path: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::extensions_per_node_path: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::extensions_per_root_path: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::initial_paths: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::node_visits: metaslang_stack_graphs::stats::FrequencyDistribution<metaslang_stack_graphs::graph::NodeID>
+pub metaslang_stack_graphs::stitching::Stats::processed_paths_per_phase: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::queued_paths_per_phase: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+pub metaslang_stack_graphs::stitching::Stats::root_visits: usize
+pub metaslang_stack_graphs::stitching::Stats::similar_paths_stats: metaslang_stack_graphs::cycles::SimilarPathStats
+pub metaslang_stack_graphs::stitching::Stats::terminal_path_lengh: metaslang_stack_graphs::stats::FrequencyDistribution<usize>
+impl core::clone::Clone for metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::Stats::clone(&self) -> metaslang_stack_graphs::stitching::Stats
+impl core::default::Default for metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::Stats::default() -> metaslang_stack_graphs::stitching::Stats
+impl core::fmt::Debug for metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::Stats::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::arith::AddAssign for metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::Stats::add_assign(&mut self, rhs: Self)
+impl core::ops::arith::AddAssign<&metaslang_stack_graphs::stitching::Stats> for metaslang_stack_graphs::stitching::Stats
+pub fn metaslang_stack_graphs::stitching::Stats::add_assign(&mut self, rhs: &Self)
+pub struct metaslang_stack_graphs::stitching::StitcherConfig
+impl metaslang_stack_graphs::stitching::StitcherConfig
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::collect_stats(&self) -> bool
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::detect_similar_paths(&self) -> bool
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::with_collect_stats(self, collect_stats: bool) -> Self
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::with_detect_similar_paths(self, detect_similar_paths: bool) -> Self
+impl core::clone::Clone for metaslang_stack_graphs::stitching::StitcherConfig
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::clone(&self) -> metaslang_stack_graphs::stitching::StitcherConfig
+impl core::convert::Into<metaslang_stack_graphs::stitching::StitcherConfig> for metaslang_stack_graphs::c::sg_stitcher_config
+pub fn metaslang_stack_graphs::c::sg_stitcher_config::into(self) -> metaslang_stack_graphs::stitching::StitcherConfig
+impl core::default::Default for metaslang_stack_graphs::stitching::StitcherConfig
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::default() -> Self
+impl core::fmt::Debug for metaslang_stack_graphs::stitching::StitcherConfig
+pub fn metaslang_stack_graphs::stitching::StitcherConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for metaslang_stack_graphs::stitching::StitcherConfig
+pub struct metaslang_stack_graphs::stitching::SymbolStackKey
+impl metaslang_stack_graphs::stitching::SymbolStackKey
+pub fn metaslang_stack_graphs::stitching::SymbolStackKey::from_partial_symbol_stack(partials: &mut metaslang_stack_graphs::partial::PartialPaths, db: &mut metaslang_stack_graphs::stitching::Database, stack: metaslang_stack_graphs::partial::PartialSymbolStack) -> metaslang_stack_graphs::stitching::SymbolStackKey
+impl core::clone::Clone for metaslang_stack_graphs::stitching::SymbolStackKey
+pub fn metaslang_stack_graphs::stitching::SymbolStackKey::clone(&self) -> metaslang_stack_graphs::stitching::SymbolStackKey
+impl core::marker::Copy for metaslang_stack_graphs::stitching::SymbolStackKey
+pub trait metaslang_stack_graphs::stitching::Appendable
+pub fn metaslang_stack_graphs::stitching::Appendable::append_to(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &mut metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::stitching::Appendable::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> alloc::boxed::Box<(dyn core::fmt::Display + 'a)>
+pub fn metaslang_stack_graphs::stitching::Appendable::end_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::stitching::Appendable::start_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl metaslang_stack_graphs::stitching::Appendable for metaslang_stack_graphs::graph::Edge
+pub fn metaslang_stack_graphs::graph::Edge::append_to(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &mut metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::graph::Edge::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, _partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> alloc::boxed::Box<(dyn core::fmt::Display + 'a)>
+pub fn metaslang_stack_graphs::graph::Edge::end_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::graph::Edge::start_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+impl metaslang_stack_graphs::stitching::Appendable for metaslang_stack_graphs::partial::PartialPath
+pub fn metaslang_stack_graphs::partial::PartialPath::append_to(&self, graph: &metaslang_stack_graphs::graph::StackGraph, partials: &mut metaslang_stack_graphs::partial::PartialPaths, path: &mut metaslang_stack_graphs::partial::PartialPath) -> core::result::Result<(), metaslang_stack_graphs::paths::PathResolutionError>
+pub fn metaslang_stack_graphs::partial::PartialPath::display<'a>(&'a self, graph: &'a metaslang_stack_graphs::graph::StackGraph, partials: &'a mut metaslang_stack_graphs::partial::PartialPaths) -> alloc::boxed::Box<(dyn core::fmt::Display + 'a)>
+pub fn metaslang_stack_graphs::partial::PartialPath::end_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub fn metaslang_stack_graphs::partial::PartialPath::start_node(&self) -> metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::graph::Node>
+pub trait metaslang_stack_graphs::stitching::ForwardCandidates<H, A, Db, Err> where A: metaslang_stack_graphs::stitching::Appendable, Db: metaslang_stack_graphs::stitching::ToAppendable<H, A>
+pub fn metaslang_stack_graphs::stitching::ForwardCandidates::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<H>
+pub fn metaslang_stack_graphs::stitching::ForwardCandidates::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &Db)
+pub fn metaslang_stack_graphs::stitching::ForwardCandidates::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+pub fn metaslang_stack_graphs::stitching::ForwardCandidates::load_forward_candidates(&mut self, _path: &metaslang_stack_graphs::partial::PartialPath, _cancellation_flag: &dyn metaslang_stack_graphs::CancellationFlag) -> core::result::Result<(), Err>
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::stitching::GraphEdges, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::GraphEdges)
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+pub trait metaslang_stack_graphs::stitching::ToAppendable<H, A> where A: metaslang_stack_graphs::stitching::Appendable
+pub fn metaslang_stack_graphs::stitching::ToAppendable::get_appendable<'a>(&'a self, handle: &'a H) -> &'a A
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath> for metaslang_stack_graphs::stitching::Database
+pub fn metaslang_stack_graphs::stitching::Database::get_appendable<'a>(&'a self, handle: &'a metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>) -> &'a metaslang_stack_graphs::partial::PartialPath
+impl metaslang_stack_graphs::stitching::ToAppendable<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge> for metaslang_stack_graphs::stitching::GraphEdges
+pub fn metaslang_stack_graphs::stitching::GraphEdges::get_appendable<'a>(&'a self, edge: &'a metaslang_stack_graphs::graph::Edge) -> &'a metaslang_stack_graphs::graph::Edge
+pub macro metaslang_stack_graphs::copious_debugging!
+pub struct metaslang_stack_graphs::CancelAfterDuration
+impl metaslang_stack_graphs::CancelAfterDuration
+pub fn metaslang_stack_graphs::CancelAfterDuration::new(limit: core::time::Duration) -> Self
+impl metaslang_stack_graphs::CancellationFlag for metaslang_stack_graphs::CancelAfterDuration
+pub fn metaslang_stack_graphs::CancelAfterDuration::check(&self, at: &'static str) -> core::result::Result<(), metaslang_stack_graphs::CancellationError>
+pub struct metaslang_stack_graphs::CancellationError(pub &'static str)
+impl core::clone::Clone for metaslang_stack_graphs::CancellationError
+pub fn metaslang_stack_graphs::CancellationError::clone(&self) -> metaslang_stack_graphs::CancellationError
+impl core::convert::From<metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::assert::AssertionError
+pub fn metaslang_stack_graphs::assert::AssertionError::from(value: metaslang_stack_graphs::CancellationError) -> Self
+impl core::error::Error for metaslang_stack_graphs::CancellationError
+impl core::fmt::Debug for metaslang_stack_graphs::CancellationError
+pub fn metaslang_stack_graphs::CancellationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for metaslang_stack_graphs::CancellationError
+pub fn metaslang_stack_graphs::CancellationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>, metaslang_stack_graphs::partial::PartialPath, metaslang_stack_graphs::stitching::Database, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::DatabaseCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::arena::Handle<metaslang_stack_graphs::partial::PartialPath>>
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::Database)
+pub fn metaslang_stack_graphs::stitching::DatabaseCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+impl metaslang_stack_graphs::stitching::ForwardCandidates<metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::graph::Edge, metaslang_stack_graphs::stitching::GraphEdges, metaslang_stack_graphs::CancellationError> for metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_forward_candidates<R>(&mut self, path: &metaslang_stack_graphs::partial::PartialPath, result: &mut R) where R: core::iter::traits::collect::Extend<metaslang_stack_graphs::graph::Edge>
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_graph_partials_and_db(&mut self) -> (&metaslang_stack_graphs::graph::StackGraph, &mut metaslang_stack_graphs::partial::PartialPaths, &metaslang_stack_graphs::stitching::GraphEdges)
+pub fn metaslang_stack_graphs::stitching::GraphEdgeCandidates<'_>::get_joining_candidate_degree(&self, path: &metaslang_stack_graphs::partial::PartialPath) -> metaslang_stack_graphs::graph::Degree
+pub struct metaslang_stack_graphs::NoCancellation
+impl metaslang_stack_graphs::CancellationFlag for metaslang_stack_graphs::NoCancellation
+pub fn metaslang_stack_graphs::NoCancellation::check(&self, _at: &'static str) -> core::result::Result<(), metaslang_stack_graphs::CancellationError>
+pub trait metaslang_stack_graphs::CancellationFlag
+pub fn metaslang_stack_graphs::CancellationFlag::check(&self, at: &'static str) -> core::result::Result<(), metaslang_stack_graphs::CancellationError>
+impl metaslang_stack_graphs::CancellationFlag for metaslang_stack_graphs::CancelAfterDuration
+pub fn metaslang_stack_graphs::CancelAfterDuration::check(&self, at: &'static str) -> core::result::Result<(), metaslang_stack_graphs::CancellationError>
+impl metaslang_stack_graphs::CancellationFlag for metaslang_stack_graphs::NoCancellation
+pub fn metaslang_stack_graphs::NoCancellation::check(&self, _at: &'static str) -> core::result::Result<(), metaslang_stack_graphs::CancellationError>

--- a/crates/metaslang/stack_graphs/src/arena.rs
+++ b/crates/metaslang/stack_graphs/src/arena.rs
@@ -247,8 +247,8 @@ impl<T> Arena<T> {
 /// type if there isn't already an instance for that handle in the arena.
 ///
 /// ```
-/// # use stack_graphs::arena::Arena;
-/// # use stack_graphs::arena::SupplementalArena;
+/// # use metaslang_stack_graphs::arena::Arena;
+/// # use metaslang_stack_graphs::arena::SupplementalArena;
 /// // We need an Arena to create handles.
 /// let mut arena = Arena::<u32>::new();
 /// let handle = arena.add(1);


### PR DESCRIPTION
- added `README` and `LICENSE`
- disabled optional unused features
- enabled crate to be published along other `metaslang_*` crates