### PR TITLE
faster infra commands

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -26,7 +26,8 @@ set -euo pipefail
 }
 
 #
-# This installs the minimal profile of the '$RUST_STABLE_VERSION' toolchain.
+# This checks if the rust '$RUST_STABLE_VERSION' toolchain is already installed.
+# If not, it will install the minimal profile of that toolchain.
 # Any additional toolchains, or optional components, should be installed
 # during 'infra setup cargo' step instead of here, as this is the hot path
 # for every other command.
@@ -35,7 +36,10 @@ set -euo pipefail
 # $REPO_ROOT/crates/infra/cli/src/commands/setup/cargo/mod.rs
 #
 
-if ! output=$(
+if cargo --version | grep -zq "${RUST_STABLE_VERSION:?}"; then
+  # Already installed. Do nothing.
+  true
+elif ! output=$(
   rustup install --no-self-update --profile "minimal" "${RUST_STABLE_VERSION:?}" \
     && rustup default "${RUST_STABLE_VERSION:?}" \
       2>&1

--- a/scripts/bin/infra
+++ b/scripts/bin/infra
@@ -14,27 +14,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 # spawned by 'infra_cli'. We have to build and run the binary directly to ensure it has a clean env.
 # Otherwise, they leak into cross-platform or multi-target builds, and cause build failures.
 #
+
 crate_dir="${REPO_ROOT:?}/crates/infra/cli"
 
-if [[ -n "${CI:-}" ]]; then
-  (
+cargo build \
+  --bin "infra_cli" \
+  --manifest-path "${crate_dir}/Cargo.toml" \
+  --target-dir "${crate_dir}/target"
 
-    cargo build \
-      --bin "infra_cli" \
-      --release \
-      --manifest-path "${crate_dir}/Cargo.toml" \
-      --target-dir "${crate_dir}/target"
-
-    "${crate_dir}/target/release/infra_cli" "$@"
-  )
-else
-  (
-    cargo build \
-      --bin "infra_cli" \
-      --manifest-path "${crate_dir}/Cargo.toml" \
-      --target-dir "${crate_dir}/target"
-
-    "${crate_dir}/target/debug/infra_cli" "$@"
-  )
-fi
+"${crate_dir}/target/debug/infra_cli" "$@"
 


### PR DESCRIPTION
check if `cargo --version` is correct before running `rustup`, since the latter (infrequently) does a network call to update its local index, which fails when working offline.

also build `infra_cli` in debug mode by default, since the extra build time trumps any runtime savings in CI.