### PR TITLE
regenerate jinja from vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,8 +38,9 @@
     "**/package-lock.json": true,
     "**/Pipfile.lock": true
   },
+  "triggerTaskOnSave.restart": true,
   "triggerTaskOnSave.tasks": {
-    "Run Rust Analyzer Checks": ["**/*.jinja2"]
+    "Regenerate Jinja Templates": ["**/*.jinja2"]
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "yaml.validate": false // Disable LSP validation for YAML files, as it is handled by our own cargo tasks

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,20 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Regenerate Jinja Templates",
+      "dependsOrder": "sequence",
+      "dependsOn": ["Run 'infra check codegen'", "Run Rust Analyzer Checks"]
+    },
+    {
+      "label": "Run 'infra check codegen'",
+      "command": "${workspaceFolder}/scripts/bin/infra",
+      "args": ["check", "codegen"],
+      "presentation": {
+        "reveal": "silent",
+        "clear": true
+      }
+    },
+    {
       "label": "Run Rust Analyzer Checks",
       "command": "${command:rust-analyzer.runFlycheck}"
     }


### PR DESCRIPTION
fixes the existing `tasks.json` to trigger infra check codegen` before Rust Analyzer checks when  saving template files.