### PR TITLE
[v2] remove `Scanner::TrailingContext` field

### DIFF
--- a/crates/language-v2/definition/src/compiler/analysis/p3_references.rs
+++ b/crates/language-v2/definition/src/compiler/analysis/p3_references.rs
@@ -364,13 +364,6 @@ fn check_scanner(
         | SpannedScanner::Atom { atom: _ } => {
             // Nothing to check for now.
         }
-        SpannedScanner::TrailingContext {
-            scanner,
-            not_followed_by,
-        } => {
-            check_scanner(analysis, source, scanner, enablement);
-            check_scanner(analysis, source, not_followed_by, enablement);
-        }
         SpannedScanner::Fragment { reference } => {
             check_reference(analysis, source, reference, enablement, &[Fragment]);
         }

--- a/crates/language-v2/definition/src/model/terminals/scanner.rs
+++ b/crates/language-v2/definition/src/model/terminals/scanner.rs
@@ -33,10 +33,6 @@ pub enum Scanner {
     Atom {
         atom: String,
     },
-    TrailingContext {
-        scanner: Box<Scanner>,
-        not_followed_by: Box<Scanner>,
-    },
     Fragment {
         reference: Identifier,
     },
@@ -46,7 +42,6 @@ impl Scanner {
     pub fn is_unique(&self) -> bool {
         match self {
             Self::Sequence { scanners } => scanners.iter().all(|scanner| scanner.is_unique()),
-            Self::TrailingContext { scanner, .. } => scanner.is_unique(),
             Self::Atom { .. } => true,
             Self::Choice { .. }
             | Self::Optional { .. }

--- a/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
+++ b/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
@@ -5,3 +5,7 @@
 ## Lexical Contexts
 
 - Made `Topic::lexical_context` required, instead of creating a "default" context behind the scenes.
+
+## Terminals
+
+- Removed `Scanner::TrailingContext` as the new lexer has no backtracking, and tries to scan the longest match by default. Terminals now have a priority (to resolve ambiguities), defined by their kind (`Trivia` < `Tokens` < `Keywords`), then by their order of declaration in the grammar. Later definitions like `SingleLineNatSpecComment` (`///`) have a higher priority than earlier definitions like `SingleLineComment` (`//`).


### PR DESCRIPTION
- Removed `Scanner::TrailingContext` as the new lexer has no backtracking, and tries to scan the longest match by default. Terminals now have a priority (to resolve ambiguities), defined by their kind (`Trivia` < `Tokens` < `Keywords`), then by their order of declaration in the grammar. Later definitions like `SingleLineNatSpecComment` (`///`) have a higher priority than earlier definitions like `SingleLineComment` (`//`).

> NOTE: this is a set of PRs to add the lexer v2, to make reviewing smaller chunks easier:
>
> 1. https://github.com/NomicFoundation/slang/pull/1457
> 2. https://github.com/NomicFoundation/slang/pull/1458
> 3. https://github.com/NomicFoundation/slang/pull/1459
> 4. https://github.com/NomicFoundation/slang/pull/1460
> 5. https://github.com/NomicFoundation/slang/pull/1461
> 6. https://github.com/NomicFoundation/slang/pull/1462