### PR TITLE
[v2] use serde tagged enums

### DIFF
--- a/crates/language-v2/definition/src/model/built_ins.rs
+++ b/crates/language-v2/definition/src/model/built_ins.rs
@@ -16,6 +16,7 @@ pub struct BuiltInContext {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, EnumDiscriminants, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum BuiltIn {
     BuiltInFunction { item: Rc<BuiltInFunction> },
     BuiltInType { item: Rc<BuiltInType> },

--- a/crates/language-v2/definition/src/model/item.rs
+++ b/crates/language-v2/definition/src/model/item.rs
@@ -11,6 +11,7 @@ use crate::model::{
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, EnumDiscriminants, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum Item {
     Struct { item: Rc<StructItem> },
     Enum { item: Rc<EnumItem> },

--- a/crates/language-v2/definition/src/model/nonterminals/field.rs
+++ b/crates/language-v2/definition/src/model/nonterminals/field.rs
@@ -31,6 +31,7 @@ pub struct FieldDelimiters {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum Field {
     Required {
         reference: Identifier,

--- a/crates/language-v2/definition/src/model/terminals/keyword.rs
+++ b/crates/language-v2/definition/src/model/terminals/keyword.rs
@@ -37,6 +37,7 @@ pub struct KeywordDefinition {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum KeywordValue {
     Sequence { values: Vec<KeywordValue> },
     Optional { value: Box<KeywordValue> },

--- a/crates/language-v2/definition/src/model/terminals/scanner.rs
+++ b/crates/language-v2/definition/src/model/terminals/scanner.rs
@@ -6,6 +6,7 @@ use crate::model::Identifier;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum Scanner {
     Sequence {
         scanners: Vec<Scanner>,

--- a/crates/language-v2/definition/src/model/terminals/trivia.rs
+++ b/crates/language-v2/definition/src/model/terminals/trivia.rs
@@ -5,6 +5,7 @@ use crate::model::{Identifier, Scanner};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum TriviaParser {
     Sequence { parsers: Vec<TriviaParser> },
     Choice { parsers: Vec<TriviaParser> },

--- a/crates/language-v2/definition/src/model/utils/version_specifier.rs
+++ b/crates/language-v2/definition/src/model/utils/version_specifier.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
+#[serde(tag = "type")]
 pub enum VersionSpecifier {
     Never,
     From { from: Version },


### PR DESCRIPTION
Use serde tagged enums in the serialized definition, to make matching on specific variants easier.

> NOTE: this is a set of PRs to add the lexer v2, to make reviewing smaller chunks easier:
>
> 1. https://github.com/NomicFoundation/slang/pull/1457
> 2. https://github.com/NomicFoundation/slang/pull/1458
> 3. https://github.com/NomicFoundation/slang/pull/1459
> 4. https://github.com/NomicFoundation/slang/pull/1460
> 5. https://github.com/NomicFoundation/slang/pull/1461
> 6. https://github.com/NomicFoundation/slang/pull/1462