### PR TITLE
[v2] make `Topic::lexical_context` required

### DIFF
--- a/crates/language-v2/definition/src/model/manifest.rs
+++ b/crates/language-v2/definition/src/model/manifest.rs
@@ -168,10 +168,7 @@ impl Section {
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
 pub struct Topic {
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lexical_context: Option<Identifier>,
-
+    pub lexical_context: Identifier,
     pub items: Vec<Item>,
 }
 

--- a/crates/language-v2/tests/src/fail/p0_parsing/duplicate_map_key/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/duplicate_map_key/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p0_parsing/duplicate_map_key/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/duplicate_map_key/test.stderr
@@ -1,5 +1,5 @@
 error: Duplicate map key.
-  --> src/fail/p0_parsing/duplicate_map_key/test.rs:19:25
+  --> src/fail/p0_parsing/duplicate_map_key/test.rs:20:25
    |
-19 |                         field_1 = Required(Baz),
+20 |                         field_1 = Required(Baz),
    |                         ^^^^^^^

--- a/crates/language-v2/tests/src/fail/p0_parsing/duplicate_set_entry/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/duplicate_set_entry/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [Token(
                 name = Bar,
                 definitions = [TokenDefinition(scanner = Atom("bar"))]

--- a/crates/language-v2/tests/src/fail/p0_parsing/empty_string/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/empty_string/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [Token(
                 name = Bar,
                 definitions = [TokenDefinition(scanner = Atom(""))]

--- a/crates/language-v2/tests/src/fail/p0_parsing/empty_string/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/empty_string/test.stderr
@@ -1,5 +1,5 @@
 error: Expected a non-empty string.
-  --> src/fail/p0_parsing/empty_string/test.rs:16:63
+  --> src/fail/p0_parsing/empty_string/test.rs:17:63
    |
-16 |                 definitions = [TokenDefinition(scanner = Atom(""))]
+17 |                 definitions = [TokenDefinition(scanner = Atom(""))]
    |                                                               ^^

--- a/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_field/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_field/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [Token(
                 name = Bar,
                 definitions = [TokenDefinition(scanner = Atom("bar"))]

--- a/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_field/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_field/test.stderr
@@ -1,5 +1,5 @@
 error: unexpected token, expected `)`
-  --> src/fail/p0_parsing/unrecognized_field/test.rs:18:13
+  --> src/fail/p0_parsing/unrecognized_field/test.rs:19:13
    |
-18 |             unrecognized_field = true
+19 |             unrecognized_field = true
    |             ^^^^^^^^^^^^^^^^^^

--- a/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_variant/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_variant/test.rs
@@ -12,12 +12,17 @@ language_v2_macros::compile!(Language(
         topics = [
             Topic(
                 title = "Topic One",
+                lexical_context = Foo,
                 items = [
                     Struct(name = Bar1, fields = (field = Required(Bar2))),
                     Struct(name = Bar2, fields = (field = Required(Bar1)))
                 ]
             ),
-            Topic(title = "Topic Two", items = [Unrecognized(true)])
+            Topic(
+                title = "Topic Two",
+                lexical_context = Foo,
+                items = [Unrecognized(true)]
+            )
         ]
     )],
     built_ins = []

--- a/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_variant/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/unrecognized_variant/test.stderr
@@ -1,5 +1,5 @@
 error: Expected a variant: 'Struct' or 'Enum' or 'Repeated' or 'Separated' or 'Precedence' or 'Trivia' or 'Keyword' or 'Token' or 'Fragment'
-  --> src/fail/p0_parsing/unrecognized_variant/test.rs:20:49
+  --> src/fail/p0_parsing/unrecognized_variant/test.rs:24:26
    |
-20 |             Topic(title = "Topic Two", items = [Unrecognized(true)])
-   |                                                 ^^^^^^^^^^^^
+24 |                 items = [Unrecognized(true)]
+   |                          ^^^^^^^^^^^^

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_expression_name/test.rs
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_expression_name/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Precedence(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_expression_name/test.stderr
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_expression_name/test.stderr
@@ -1,5 +1,5 @@
 error: An expression with the name 'Expression1' already exists.
-  --> src/fail/p1_definitions/duplicate_expression_name/test.rs:33:36
+  --> src/fail/p1_definitions/duplicate_expression_name/test.rs:34:36
    |
-33 | ...                   name = Expression1,
+34 | ...                   name = Expression1,
    |                              ^^^^^^^^^^^

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_item_name/test.rs
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_item_name/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(name = Bar1, fields = (field = Required(Bar2))),
                 Struct(name = Bar1, fields = (field = Required(Bar2))),

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_item_name/test.stderr
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_item_name/test.stderr
@@ -1,5 +1,5 @@
 error: An item with the name 'Bar1' already exists.
-  --> src/fail/p1_definitions/duplicate_item_name/test.rs:16:31
+  --> src/fail/p1_definitions/duplicate_item_name/test.rs:17:31
    |
-16 |                 Struct(name = Bar1, fields = (field = Required(Bar2))),
+17 |                 Struct(name = Bar1, fields = (field = Required(Bar2))),
    |                               ^^^^

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_variant_name/test.rs
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_variant_name/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Enum(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p1_definitions/duplicate_variant_name/test.stderr
+++ b/crates/language-v2/tests/src/fail/p1_definitions/duplicate_variant_name/test.stderr
@@ -1,5 +1,5 @@
 error: A variant referencing 'Baz1' already exists.
-  --> src/fail/p1_definitions/duplicate_variant_name/test.rs:20:49
+  --> src/fail/p1_definitions/duplicate_variant_name/test.rs:21:49
    |
-20 |                         EnumVariant(reference = Baz1)
+21 |                         EnumVariant(reference = Baz1)
    |                                                 ^^^^

--- a/crates/language-v2/tests/src/fail/p1_definitions/operator_mismatch/test.rs
+++ b/crates/language-v2/tests/src/fail/p1_definitions/operator_mismatch/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Precedence(
                     name = Expression,

--- a/crates/language-v2/tests/src/fail/p1_definitions/operator_mismatch/test.stderr
+++ b/crates/language-v2/tests/src/fail/p1_definitions/operator_mismatch/test.stderr
@@ -1,5 +1,5 @@
 error: All operators under the same expression must have the same model and type.
-  --> src/fail/p1_definitions/operator_mismatch/test.rs:18:32
+  --> src/fail/p1_definitions/operator_mismatch/test.rs:19:32
    |
-18 |                         name = Foo,
+19 |                         name = Foo,
    |                                ^^^

--- a/crates/language-v2/tests/src/fail/p2_version_specifiers/unordered_version_pair/test.rs
+++ b/crates/language-v2/tests/src/fail/p2_version_specifiers/unordered_version_pair/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = One,

--- a/crates/language-v2/tests/src/fail/p2_version_specifiers/unordered_version_pair/test.stderr
+++ b/crates/language-v2/tests/src/fail/p2_version_specifiers/unordered_version_pair/test.stderr
@@ -1,5 +1,5 @@
 error: Version '3.0.0' must be less than corresponding version '2.0.0'.
-  --> src/fail/p2_version_specifiers/unordered_version_pair/test.rs:20:52
+  --> src/fail/p2_version_specifiers/unordered_version_pair/test.rs:21:52
    |
-20 | ...                   enabled = Range(from = "3.0.0", till = "2.0.0")
+21 | ...                   enabled = Range(from = "3.0.0", till = "2.0.0")
    |                                              ^^^^^^^

--- a/crates/language-v2/tests/src/fail/p2_version_specifiers/version_not_found/test.rs
+++ b/crates/language-v2/tests/src/fail/p2_version_specifiers/version_not_found/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = One,

--- a/crates/language-v2/tests/src/fail/p2_version_specifiers/version_not_found/test.stderr
+++ b/crates/language-v2/tests/src/fail/p2_version_specifiers/version_not_found/test.stderr
@@ -1,5 +1,5 @@
 error: Version '3.0.0' does not exist in the language definition.
-  --> src/fail/p2_version_specifiers/version_not_found/test.rs:18:76
+  --> src/fail/p2_version_specifiers/version_not_found/test.rs:19:76
    |
-18 |                         field_1 = Optional(reference = Two, enabled = From("3.0.0")),
+19 |                         field_1 = Optional(reference = Two, enabled = From("3.0.0")),
    |                                                                            ^^^^^^^

--- a/crates/language-v2/tests/src/fail/p3_references/disabled_too_late/test.rs
+++ b/crates/language-v2/tests/src/fail/p3_references/disabled_too_late/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = One,

--- a/crates/language-v2/tests/src/fail/p3_references/disabled_too_late/test.stderr
+++ b/crates/language-v2/tests/src/fail/p3_references/disabled_too_late/test.stderr
@@ -1,5 +1,5 @@
 error: Parent scope is only enabled in '2.0.0..3.0.0'.
-  --> src/fail/p3_references/disabled_too_late/test.rs:28:79
+  --> src/fail/p3_references/disabled_too_late/test.rs:29:79
    |
-28 |                     fields = (field_1 = Optional(reference = Three, enabled = Till("4.0.0")))
+29 |                     fields = (field_1 = Optional(reference = Three, enabled = Till("4.0.0")))
    |                                                                               ^^^^

--- a/crates/language-v2/tests/src/fail/p3_references/enabled_too_early/test.rs
+++ b/crates/language-v2/tests/src/fail/p3_references/enabled_too_early/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = One,

--- a/crates/language-v2/tests/src/fail/p3_references/enabled_too_early/test.stderr
+++ b/crates/language-v2/tests/src/fail/p3_references/enabled_too_early/test.stderr
@@ -1,5 +1,5 @@
 error: Parent scope is only enabled in '2.0.0..3.0.0'.
-  --> src/fail/p3_references/enabled_too_early/test.rs:28:79
+  --> src/fail/p3_references/enabled_too_early/test.rs:29:79
    |
-28 |                     fields = (field_1 = Optional(reference = Three, enabled = From("1.0.0")))
+29 |                     fields = (field_1 = Optional(reference = Three, enabled = From("1.0.0")))
    |                                                                               ^^^^

--- a/crates/language-v2/tests/src/fail/p3_references/invalid_filter/test.rs
+++ b/crates/language-v2/tests/src/fail/p3_references/invalid_filter/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(name = Bar, fields = (field = Required(Baz))),
                 Fragment(name = Baz, scanner = Atom("baz"))

--- a/crates/language-v2/tests/src/fail/p3_references/invalid_filter/test.stderr
+++ b/crates/language-v2/tests/src/fail/p3_references/invalid_filter/test.stderr
@@ -1,5 +1,5 @@
 error: Reference 'Baz' of kind 'Fragment' is not valid. Expected: [Struct, Enum, Repeated, Separated, Precedence, Keyword, Token]
-  --> src/fail/p3_references/invalid_filter/test.rs:15:63
+  --> src/fail/p3_references/invalid_filter/test.rs:16:63
    |
-15 |                 Struct(name = Bar, fields = (field = Required(Baz))),
+16 |                 Struct(name = Bar, fields = (field = Required(Baz))),
    |                                                               ^^^

--- a/crates/language-v2/tests/src/fail/p3_references/invalid_version/test.rs
+++ b/crates/language-v2/tests/src/fail/p3_references/invalid_version/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p3_references/invalid_version/test.stderr
+++ b/crates/language-v2/tests/src/fail/p3_references/invalid_version/test.stderr
@@ -1,17 +1,17 @@
 error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '3.0.0..MAX'.
-  --> src/fail/p3_references/invalid_version/test.rs:20:41
+  --> src/fail/p3_references/invalid_version/test.rs:21:41
    |
-20 | ...                   reference = Baz,
+21 | ...                   reference = Baz,
    |                                   ^^^
 
 error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '1.0.0..2.0.0'.
-  --> src/fail/p3_references/invalid_version/test.rs:25:41
+  --> src/fail/p3_references/invalid_version/test.rs:26:41
    |
-25 | ...                   reference = Baz,
+26 | ...                   reference = Baz,
    |                                   ^^^
 
 error: Reference 'Baz' is only defined in '2.0.0..3.0.0', but not in '1.0.0..2.0.0 | 3.0.0..MAX'.
-  --> src/fail/p3_references/invalid_version/test.rs:30:41
+  --> src/fail/p3_references/invalid_version/test.rs:31:41
    |
-30 | ...                   reference = Baz
+31 | ...                   reference = Baz
    |                                   ^^^

--- a/crates/language-v2/tests/src/fail/p3_references/unknown_reference/test.rs
+++ b/crates/language-v2/tests/src/fail/p3_references/unknown_reference/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p3_references/unknown_reference/test.stderr
+++ b/crates/language-v2/tests/src/fail/p3_references/unknown_reference/test.stderr
@@ -1,5 +1,5 @@
 error: Reference to unknown item 'Unknown'.
-  --> src/fail/p3_references/unknown_reference/test.rs:17:75
+  --> src/fail/p3_references/unknown_reference/test.rs:18:75
    |
-17 |                     fields = (field_1 = Required(Baz), field_2 = Required(Unknown))
+18 |                     fields = (field_1 = Required(Baz), field_2 = Required(Unknown))
    |                                                                           ^^^^^^^

--- a/crates/language-v2/tests/src/fail/p4_unreachabe_items/unreachable/test.rs
+++ b/crates/language-v2/tests/src/fail/p4_unreachabe_items/unreachable/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 // reachable (from root)
                 Struct(name = Bar1, fields = (field = Required(Bar2))),

--- a/crates/language-v2/tests/src/fail/p4_unreachabe_items/unreachable/test.stderr
+++ b/crates/language-v2/tests/src/fail/p4_unreachabe_items/unreachable/test.stderr
@@ -1,11 +1,11 @@
 error: Item 'Baz1' is not reachable from grammar root.
-  --> src/fail/p4_unreachabe_items/unreachable/test.rs:19:31
+  --> src/fail/p4_unreachabe_items/unreachable/test.rs:20:31
    |
-19 |                 Struct(name = Baz1, fields = (field = Required(Baz2))),
+20 |                 Struct(name = Baz1, fields = (field = Required(Baz2))),
    |                               ^^^^
 
 error: Item 'Baz2' is not reachable from grammar root.
-  --> src/fail/p4_unreachabe_items/unreachable/test.rs:20:31
+  --> src/fail/p4_unreachabe_items/unreachable/test.rs:21:31
    |
-20 |                 Struct(name = Baz2, fields = (field = Required(Baz1)))
+21 |                 Struct(name = Baz2, fields = (field = Required(Baz1)))
    |                               ^^^^

--- a/crates/language-v2/tests/src/fail/p5_unused_versions/unused_version/test.rs
+++ b/crates/language-v2/tests/src/fail/p5_unused_versions/unused_version/test.rs
@@ -11,6 +11,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Foo,
             items = [
                 Struct(
                     name = Bar,

--- a/crates/language-v2/tests/src/fail/p5_unused_versions/unused_version/test.stderr
+++ b/crates/language-v2/tests/src/fail/p5_unused_versions/unused_version/test.stderr
@@ -1,5 +1,5 @@
 error: Item 'Baz' is not used in versions: 1.0.0..2.0.0
-  --> src/fail/p5_unused_versions/unused_version/test.rs:20:28
+  --> src/fail/p5_unused_versions/unused_version/test.rs:21:28
    |
-20 |                     name = Baz,
+21 |                     name = Baz,
    |                            ^^^

--- a/crates/language-v2/tests/src/pass/tiny_language.rs
+++ b/crates/language-v2/tests/src/pass/tiny_language.rs
@@ -15,6 +15,7 @@ language_v2_macros::compile!(Language(
         title = "Section One",
         topics = [Topic(
             title = "Topic One",
+            lexical_context = Tiny,
             items = [
                 Struct(
                     name = Foo,
@@ -58,7 +59,7 @@ fn definition() {
                 title: "Section One".into(),
                 topics: vec![Topic {
                     title: "Topic One".into(),
-                    lexical_context: None,
+                    lexical_context: "Tiny".into(),
                     items: [
                         Item::Struct {
                             item: StructItem {

--- a/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
+++ b/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
@@ -1,0 +1,7 @@
+# Breaking Changes
+
+> The following changes have been done to the language grammar/manifest, to adopt the new v2 lexer/parser system:
+
+## Lexical Contexts
+
+- Made `Topic::lexical_context` required, instead of creating a "default" context behind the scenes.

--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -35,6 +35,7 @@ language_v2_macros::compile!(Language(
             topics = [
                 Topic(
                     title = "Source Unit",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = SourceUnit,
@@ -242,6 +243,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Import Directives",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = ImportDirective,
@@ -313,6 +315,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Using Directives",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = UsingDirective,
@@ -404,6 +407,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Trivia",
+                    lexical_context = Solidity,
                     items = [
                         Trivia(
                             name = Whitespace,
@@ -460,6 +464,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Keywords",
+                    lexical_context = Solidity,
                     items = [
                         Keyword(
                             name = AbicoderKeyword,
@@ -1938,6 +1943,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Punctuation",
+                    lexical_context = Solidity,
                     items = [
                         Token(
                             name = OpenParen,
@@ -2160,6 +2166,7 @@ language_v2_macros::compile!(Language(
             topics = [
                 Topic(
                     title = "Contracts",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = ContractDefinition,
@@ -2263,6 +2270,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Interfaces",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = InterfaceDefinition,
@@ -2288,6 +2296,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Libraries",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = LibraryDefinition,
@@ -2312,6 +2321,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Structs",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = StructDefinition,
@@ -2345,6 +2355,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Enums",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = EnumDefinition,
@@ -2370,6 +2381,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Constants",
+                    lexical_context = Solidity,
                     items = [Struct(
                         name = ConstantDefinition,
                         enabled = From("0.7.4"),
@@ -2386,6 +2398,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "State Variables",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = StateVariableDefinition,
@@ -2423,6 +2436,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Functions",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = FunctionDefinition,
@@ -2663,6 +2677,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Modifiers",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = ModifierDefinition,
@@ -2697,6 +2712,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Events",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = EventDefinition,
@@ -2739,6 +2755,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "User Defined Value Types",
+                    lexical_context = Solidity,
                     items = [Struct(
                         name = UserDefinedValueTypeDefinition,
                         enabled = From("0.8.8"),
@@ -2754,6 +2771,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Errors",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = ErrorDefinition,
@@ -2803,6 +2821,7 @@ language_v2_macros::compile!(Language(
             topics = [
                 Topic(
                     title = "Advanced Types",
+                    lexical_context = Solidity,
                     items = [
                         Precedence(
                             name = TypeName,
@@ -2897,6 +2916,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Elementary Types",
+                    lexical_context = Solidity,
                     items = [
                         Enum(
                             name = ElementaryType,
@@ -2929,6 +2949,7 @@ language_v2_macros::compile!(Language(
             topics = [
                 Topic(
                     title = "Blocks",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = Block,
@@ -3016,6 +3037,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Declaration Statements",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = TupleDeconstructionStatement,
@@ -3100,6 +3122,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Control Statements",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = IfStatement,
@@ -3226,6 +3249,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Error Handling",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = TryStatement,
@@ -3289,6 +3313,7 @@ language_v2_macros::compile!(Language(
             topics = [
                 Topic(
                     title = "Base Expressions",
+                    lexical_context = Solidity,
                     items = [
                         Precedence(
                             name = Expression,
@@ -3646,6 +3671,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Function Calls",
+                    lexical_context = Solidity,
                     items = [
                         Enum(
                             name = ArgumentsDeclaration,
@@ -3722,6 +3748,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Primary Expressions",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = TypeExpression,
@@ -3786,6 +3813,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Numbers",
+                    lexical_context = Solidity,
                     items = [
                         Struct(
                             name = HexNumberExpression,
@@ -3951,6 +3979,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Strings",
+                    lexical_context = Solidity,
                     items = [
                         Enum(
                             name = StringExpression,
@@ -4218,6 +4247,7 @@ language_v2_macros::compile!(Language(
                 ),
                 Topic(
                     title = "Identifiers",
+                    lexical_context = Solidity,
                     items = [
                         Separated(
                             name = IdentifierPath,


### PR DESCRIPTION
Made `Topic::lexical_context` required, instead of creating a "default" context behind the scenes.

> NOTE: this is a set of PRs to add the lexer v2, to make reviewing smaller chunks easier:
>
> 1. https://github.com/NomicFoundation/slang/pull/1457
> 2. https://github.com/NomicFoundation/slang/pull/1458
> 3. https://github.com/NomicFoundation/slang/pull/1459
> 4. https://github.com/NomicFoundation/slang/pull/1460
> 5. https://github.com/NomicFoundation/slang/pull/1461
> 6. https://github.com/NomicFoundation/slang/pull/1462