### PR TITLE
fix publish pipeline

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,6 @@ overrides:
 minimumReleaseAge: 10080 # 1 week
 
 # CLI Settings
-npmPath: "./bin/npm"
 engineStrict: true
 packageManagerStrictVersion: true
 


### PR DESCRIPTION
Fixes the build break by removing `npmPath` from `pnpm-workspace.yaml`, and using `npm` from `PATH` directly, which should be set correctly by `hermit`:

- https://github.com/NomicFoundation/slang/actions/runs/20037276669/job/57462018201

cc @teofr 