### PR TITLE
fix `bencher_cli` dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,8 @@ slang_solidity_v2_parser = { path = "crates/solidity-v2/outputs/cargo/parser", v
 #
 anyhow = { version = "1.0.97", features = ["backtrace", "std"] }
 ariadne = { version = "0.2.0" }
-# Currently 'bencher' backend API is under development/unstable.
-# They recommend always running with the latest CLI version from 'main' until it is stabilized.
-bencher_cli = { git = "https://github.com/bencherdev/bencher", branch = "main" }
+# https://github.com/bencherdev/bencher/releases/tag/v0.5.8
+bencher_cli = { git = "https://github.com/bencherdev/bencher", rev = "61e6a2c2e0b4c8f61c87bef598ba9dbafa51c689"}
 bitvec = { version = "1.0.1" }
 cargo-edit = { version = "0.12.3" }
 cargo-nextest = { version = "0.9.72" }


### PR DESCRIPTION
CI perf tests are failing as `bencher_cli` moved to a newer rust version:
https://github.com/NomicFoundation/slang/actions/runs/20039038565/job/57468059474

Let's pin our dependency to a specific hash for stability.