### PR TITLE
Remove unnecessary `--provenance` flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     permissions:
       contents: "write" # to create new branches and releases
-      id-token: "write" # OIDC token for publishing to NPM with provenance
+      id-token: "write" # OIDC token (needed for trusted publishing)
       pull-requests: "write" # to create new pull requests for changesets
 
     steps:

--- a/crates/infra/cli/src/commands/publish/npm/mod.rs
+++ b/crates/infra/cli/src/commands/publish/npm/mod.rs
@@ -35,7 +35,6 @@ impl NpmController {
 
         let mut command = Command::new("pnpm")
             .args(["publish", package_dir.unwrap_str()])
-            .flag("--provenance")
             .property("--access", "public");
 
         if self.dry_run.get() {


### PR DESCRIPTION
With [trusted publishing](https://docs.npmjs.com/trusted-publishers), `npm` _automatically_ generates and attaches [provenance attestations](https://docs.npmjs.com/generating-provenance-statements) to each published package. Addresses https://github.com/NomicFoundation/slang/pull/1489#issuecomment-3638673115.