### PR TITLE
use devcontainer named volumes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,12 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postAttachCommand": "/bin/bash scripts/bin/infra setup",
+  "postCreateCommand": {
+    // Fix target volume permissions, if it is owned by root:
+    "fixTargetVolumePermissions_hermit": "sudo chown -R $(whoami): /workspaces/${localWorkspaceFolderBasename}/.hermit",
+    "fixTargetVolumePermissions_node_modules": "sudo chown -R $(whoami): /workspaces/${localWorkspaceFolderBasename}/node_modules",
+    "fixTargetVolumePermissions_target": "sudo chown -R $(whoami): /workspaces/${localWorkspaceFolderBasename}/target"
+  },
   "portsAttributes": {
     // _MKDOCS_WATCH_PORT_ | keep in sync with the port number defined in "$REPO_ROOT/crates/infra/cli/src/toolchains/mkdocs/mod.rs"
     "5353": {
@@ -44,5 +49,24 @@
         "GitHub.vscode-pull-request-github"
       ]
     }
-  }
+  },
+  "mounts": [
+    // Use Docker named volumes for I/O-intensive directories to speed up builds:
+    // https://docs.docker.com/engine/storage/volumes/
+    {
+      "source": "slang_hermit_mount",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/.hermit",
+      "type": "volume"
+    },
+    {
+      "source": "slang_node_modules_mount",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/node_modules",
+      "type": "volume"
+    },
+    {
+      "source": "slang_target_mount",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/target",
+      "type": "volume"
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
 
-      # NOTE:
-      # No need to run 'infra setup', as it runs automatically when the devcontainer is launched.
+      - name: "infra setup pipenv"
+        uses: "./.github/actions/devcontainer/run"
+        with:
+          runCmd: "./scripts/bin/infra setup pipenv"
 
       - name: "infra lint mkdocs"
         uses: "./.github/actions/devcontainer/run"


### PR DESCRIPTION
Following https://github.com/NomicFoundation/edr/pull/1101

- Disabled `Rust Analyzer` vscode extension.
- Ran vscode command `Dev Containers: Rebuild Container Without Cache`
- Run script: `time scripts/bin/infra check`

Before PR:

```log
scripts/bin/infra check  44.44s user 8.89s system 108% cpu 49.289 total
```

After PR:

```log
scripts/bin/infra check  33.69s user 3.25s system 137% cpu 26.921 total
```