### PR TITLE
update changesets

### DIFF
--- a/.changeset/spotty-ducks-behave.md
+++ b/.changeset/spotty-ducks-behave.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/slang": minor
+"@nomicfoundation/slang": patch
 ---
 
-Fixed the old style revert calls (`revert("oops!")`) to be parsed as a normal function call rather than a `revert` statement.
+Fixed the old style revert calls (`revert("oops!")`) to be parsed as a `FunctionCallExpression` rather than a `RevertStatement`.


### PR DESCRIPTION
Following up on #1502, cc @teofr:

- use exact node kinds/identifiers in the messaging.
- use `patch` instead of `minor`, as it is a grammar bug fix.