### PR TITLE
Fix BindingGraph panic on incomplete dot expressions (#1531)

### DIFF
--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1445,6 +1445,20 @@ inherit .star_extension
   edge @id_path.all_pop_begin -> @name.pop
 }
 
+; Malformed identifier paths (eg. `x.` during editing — trailing Period
+; with no following Identifier). Provide defaults so that parent stanzas
+; (like TypeName) don't panic on missing scoped variables.
+@id_path [IdentifierPath @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.push_ns = (node)
+  edge @name.ref -> @id_path.push_ns
+  edge @id_path.push_ns -> @id_path.push_end
+
+  let @id_path.pop_end = @name.pop
+}
+
 ; Single identifier paths
 @id_path [IdentifierPath . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name

--- a/crates/solidity/outputs/cargo/crate/src/bindings/binding_rules.generated.rs
+++ b/crates/solidity/outputs/cargo/crate/src/bindings/binding_rules.generated.rs
@@ -1449,6 +1449,20 @@ inherit .star_extension
   edge @id_path.all_pop_begin -> @name.pop
 }
 
+; Malformed identifier paths (eg. `x.` during editing — trailing Period
+; with no following Identifier). Provide defaults so that parent stanzas
+; (like TypeName) don't panic on missing scoped variables.
+@id_path [IdentifierPath @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.push_ns = (node)
+  edge @name.ref -> @id_path.push_ns
+  edge @id_path.push_ns -> @id_path.push_end
+
+  let @id_path.pop_end = @name.pop
+}
+
 ; Single identifier paths
 @id_path [IdentifierPath . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name

--- a/crates/solidity/outputs/cargo/tests/src/bindings/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/mod.rs
@@ -1,3 +1,4 @@
 mod binding_resolver;
 mod binding_rules;
 mod bindings_output;
+mod test_incomplete_dot_access;

--- a/crates/solidity/outputs/cargo/tests/src/bindings/test_incomplete_dot_access.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/test_incomplete_dot_access.rs
@@ -1,0 +1,172 @@
+use std::rc::Rc;
+
+use anyhow::Result;
+use semver::Version;
+use slang_solidity::bindings;
+use slang_solidity::parser::Parser;
+
+use crate::compilation::resolver::TestsPathResolver;
+
+const TEST_VERSION: Version = Version::new(0, 8, 26);
+
+#[test]
+fn test_struct_incomplete_dot_access() -> Result<()> {
+    let source = r#"
+contract Test {
+    struct Data {
+        uint120 value;
+        uint120 count;
+    }
+
+    Data public data;
+
+    function update() public {
+        data.
+    }
+}
+"#;
+
+    let parser = Parser::create(TEST_VERSION.clone())?;
+    let mut builder = bindings::create_with_resolver(&TEST_VERSION, Rc::new(TestsPathResolver {}));
+
+    let parse_output = parser.parse_file_contents(source);
+    builder.add_user_file("test.sol", parse_output.create_tree_cursor());
+
+    let _graph = builder.build();
+
+    Ok(())
+}
+
+#[test]
+fn test_nested_struct_incomplete_dot_access() -> Result<()> {
+    let source = r#"
+contract Test {
+    struct Inner {
+        uint120 value;
+    }
+
+    struct Outer {
+        Inner inner;
+        uint120 count;
+    }
+
+    Outer public data;
+
+    function f() public {
+        data.inner.
+    }
+}
+"#;
+
+    let parser = Parser::create(TEST_VERSION.clone())?;
+    let mut builder = bindings::create_with_resolver(&TEST_VERSION, Rc::new(TestsPathResolver {}));
+
+    let parse_output = parser.parse_file_contents(source);
+    builder.add_user_file("test.sol", parse_output.create_tree_cursor());
+
+    let _graph = builder.build();
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_array_member_incomplete_dot_access() -> Result<()> {
+    let source = r#"
+contract Test {
+    struct Container {
+        int256[] items;
+    }
+
+    Container private container;
+
+    function f() public {
+        container.items.
+    }
+}
+"#;
+
+    let parser = Parser::create(TEST_VERSION.clone())?;
+    let mut builder = bindings::create_with_resolver(&TEST_VERSION, Rc::new(TestsPathResolver {}));
+
+    let parse_output = parser.parse_file_contents(source);
+    builder.add_user_file("test.sol", parse_output.create_tree_cursor());
+
+    let _graph = builder.build();
+
+    Ok(())
+}
+
+#[test]
+fn test_imported_contract_type_variable() -> Result<()> {
+    let foo_source = r#"
+contract Foo {
+    string public name = "Foo";
+}
+"#;
+
+    let example_source = r#"
+import "./Foo.sol";
+contract Example {
+    Foo public foo = new Foo();
+}
+"#;
+
+    let parser = Parser::create(TEST_VERSION.clone())?;
+    let mut builder = bindings::create_with_resolver(&TEST_VERSION, Rc::new(TestsPathResolver {}));
+
+    let foo_output = parser.parse_file_contents(foo_source);
+    builder.add_user_file("Foo.sol", foo_output.create_tree_cursor());
+
+    let example_output = parser.parse_file_contents(example_source);
+    builder.add_user_file("Example.sol", example_output.create_tree_cursor());
+
+    let _graph = builder.build();
+
+    Ok(())
+}
+
+#[test]
+fn test_project_wide_compilation_with_incomplete_expression() -> Result<()> {
+    let foo_source = r#"
+contract Foo {
+    string public name = "Foo";
+}
+"#;
+
+    let example_source = r#"
+import "./Foo.sol";
+contract Example {
+    Foo public foo = new Foo();
+}
+"#;
+
+    let incomplete_source = r#"
+contract Incomplete {
+    struct Data {
+        uint120 value;
+    }
+
+    Data public data;
+
+    function f() public {
+        data.
+    }
+}
+"#;
+
+    let parser = Parser::create(TEST_VERSION.clone())?;
+    let mut builder = bindings::create_with_resolver(&TEST_VERSION, Rc::new(TestsPathResolver {}));
+
+    let foo_output = parser.parse_file_contents(foo_source);
+    builder.add_user_file("Foo.sol", foo_output.create_tree_cursor());
+
+    let example_output = parser.parse_file_contents(example_source);
+    builder.add_user_file("Example.sol", example_output.create_tree_cursor());
+
+    let incomplete_output = parser.parse_file_contents(incomplete_source);
+    builder.add_user_file("Incomplete.sol", incomplete_output.create_tree_cursor());
+
+    let _graph = builder.build();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes the `UndefinedScopedVariable ... push_begin` panic in the BindingGraph builder when processing Solidity files with incomplete dot expressions (e.g., `x.` during editing).

## Root Cause

When a user types `something.` (incomplete member access), the Slang parser produces an `IdentifierPath` with children `[Identifier("hero"), Period(".")]`. The existing binding rule stanzas for `IdentifierPath` only match when the last child is an `Identifier`:

- Single path: `[IdentifierPath . @name [Identifier] .]` -- last child must be Identifier
- Multi path: `[IdentifierPath [_] . @name [Identifier] .]` -- last child must be Identifier

When the last child is `Period` (malformed path), neither stanza matches. The scoped variables `push_begin`, `push_ns`, `pop_end`, and `rightmost_identifier` are never defined. The parent `[TypeName [IdentifierPath]]` stanza then tries to read `@id_path.push_begin` and panics.

## Fix

Added a new stanza that matches malformed `IdentifierPath` nodes ending with a `Period`:

```
@id_path [IdentifierPath @name [Identifier] . [Period] .] {
  let @id_path.rightmost_identifier = @name
  let @id_path.push_begin = @name.ref
  let @id_path.push_ns = (node)
  ...
}
```

This provides the same scoped variable definitions as the single-path stanza, using the `Identifier` before the trailing `Period`. The binding graph won't resolve anything meaningful (the path is incomplete), but it won't crash either.

## Tests

- 5 new tests added covering the issues in the bug. 
- All existing binding snapshot tests pass
- All 6 existing binding resolver tests pass
- Verified on the zip file repro in the reported bug with an end-to-end local wasm build of slang. 