### PR TITLE
fix binding incomplete `IdentifierPath` expressions

### DIFF
--- a/.changeset/hungry-glasses-argue.md
+++ b/.changeset/hungry-glasses-argue.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/slang": patch
+---
+
+Fixed a panic during constructing binding graphs, when the input has incomplete `IdentifierPath` expressions.

--- a/crates/solidity/inputs/language/bindings/rules.msgb
+++ b/crates/solidity/inputs/language/bindings/rules.msgb
@@ -1425,6 +1425,7 @@ inherit .star_extension
 ;; the path. This allows creating additional referencing paths with guards right
 ;; before the unqualified identifier (eg. for modifiers).
 
+; For the parent:
 @id_path [IdentifierPath] {
   ; This node connects to all parts of the path, for popping. This allows to
   ; connect at any point of the path. Useful for `using` directives when the
@@ -1434,6 +1435,7 @@ inherit .star_extension
   node @id_path.push_end
 }
 
+; For each identifier:
 @id_path [IdentifierPath @name [Identifier]] {
   node @name.ref
   attr (@name.ref) node_reference = @name
@@ -1445,7 +1447,7 @@ inherit .star_extension
   edge @id_path.all_pop_begin -> @name.pop
 }
 
-; Single identifier paths
+; For single identifier paths:
 @id_path [IdentifierPath . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name
 
@@ -1458,14 +1460,40 @@ inherit .star_extension
   let @id_path.pop_end = @name.pop
 }
 
-; Multiple identifier paths
-@id_path [IdentifierPath [_] . @name [Identifier] .] {
+; For single identifier paths, allowing an optional trailing period, to resolve incomplete paths like "x.":
+@id_path [IdentifierPath . @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.push_ns = (node)
+  edge @name.ref -> @id_path.push_ns
+  edge @id_path.push_ns -> @id_path.push_end
+
+  let @id_path.pop_begin = @name.pop
+  let @id_path.pop_end = @name.pop
+}
+
+; For multiple identifier paths:
+@id_path [IdentifierPath @last_period [Period] . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name
 
   let @id_path.push_begin = @name.ref
   let @id_path.pop_end = @name.pop
+
+  let @id_path.push_ns = @last_period.ref_member
 }
 
+; For multiple identifier paths, allowing an optional trailing period, to resolve incomplete paths like "x.y.":
+@id_path [IdentifierPath @last_period [Period] . @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.pop_end = @name.pop
+
+  let @id_path.push_ns = @last_period.ref_member
+}
+
+; For each consecutive pair of identifiers:
 [IdentifierPath @left_name [Identifier] . @period [Period] . @right_name [Identifier]] {
   node @period.ref_member
   attr (@period.ref_member) push_symbol = "."
@@ -1480,11 +1508,8 @@ inherit .star_extension
   edge @period.pop_member -> @right_name.pop
 }
 
-@id_path [IdentifierPath @last_period [Period] . [Identifier] . ] {
-  let @id_path.push_ns = @last_period.ref_member
-}
-
-@id_path [IdentifierPath . @name [Identifier] . [_]] {
+; For the first identifier of multiple:
+@id_path [IdentifierPath . @name [Identifier] . [Period] . [_]] {
   edge @name.ref -> @id_path.push_end
   let @id_path.pop_begin = @name.pop
 }

--- a/crates/solidity/outputs/cargo/crate/src/bindings/binding_rules.generated.rs
+++ b/crates/solidity/outputs/cargo/crate/src/bindings/binding_rules.generated.rs
@@ -1429,6 +1429,7 @@ inherit .star_extension
 ;; the path. This allows creating additional referencing paths with guards right
 ;; before the unqualified identifier (eg. for modifiers).
 
+; For the parent:
 @id_path [IdentifierPath] {
   ; This node connects to all parts of the path, for popping. This allows to
   ; connect at any point of the path. Useful for `using` directives when the
@@ -1438,6 +1439,7 @@ inherit .star_extension
   node @id_path.push_end
 }
 
+; For each identifier:
 @id_path [IdentifierPath @name [Identifier]] {
   node @name.ref
   attr (@name.ref) node_reference = @name
@@ -1449,7 +1451,7 @@ inherit .star_extension
   edge @id_path.all_pop_begin -> @name.pop
 }
 
-; Single identifier paths
+; For single identifier paths:
 @id_path [IdentifierPath . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name
 
@@ -1462,14 +1464,40 @@ inherit .star_extension
   let @id_path.pop_end = @name.pop
 }
 
-; Multiple identifier paths
-@id_path [IdentifierPath [_] . @name [Identifier] .] {
+; For single identifier paths, allowing an optional trailing period, to resolve incomplete paths like "x.":
+@id_path [IdentifierPath . @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.push_ns = (node)
+  edge @name.ref -> @id_path.push_ns
+  edge @id_path.push_ns -> @id_path.push_end
+
+  let @id_path.pop_begin = @name.pop
+  let @id_path.pop_end = @name.pop
+}
+
+; For multiple identifier paths:
+@id_path [IdentifierPath @last_period [Period] . @name [Identifier] .] {
   let @id_path.rightmost_identifier = @name
 
   let @id_path.push_begin = @name.ref
   let @id_path.pop_end = @name.pop
+
+  let @id_path.push_ns = @last_period.ref_member
 }
 
+; For multiple identifier paths, allowing an optional trailing period, to resolve incomplete paths like "x.y.":
+@id_path [IdentifierPath @last_period [Period] . @name [Identifier] . [Period] .] {
+  let @id_path.rightmost_identifier = @name
+
+  let @id_path.push_begin = @name.ref
+  let @id_path.pop_end = @name.pop
+
+  let @id_path.push_ns = @last_period.ref_member
+}
+
+; For each consecutive pair of identifiers:
 [IdentifierPath @left_name [Identifier] . @period [Period] . @right_name [Identifier]] {
   node @period.ref_member
   attr (@period.ref_member) push_symbol = "."
@@ -1484,11 +1512,8 @@ inherit .star_extension
   edge @period.pop_member -> @right_name.pop
 }
 
-@id_path [IdentifierPath @last_period [Period] . [Identifier] . ] {
-  let @id_path.push_ns = @last_period.ref_member
-}
-
-@id_path [IdentifierPath . @name [Identifier] . [_]] {
+; For the first identifier of multiple:
+@id_path [IdentifierPath . @name [Identifier] . [Period] . [_]] {
   edge @name.ref -> @id_path.push_end
   let @id_path.pop_begin = @name.pop
 }

--- a/crates/solidity/outputs/cargo/tests/src/binder/generated/expressions.rs
+++ b/crates/solidity/outputs/cargo/tests/src/binder/generated/expressions.rs
@@ -97,6 +97,11 @@ fn funcalls_overload_using_for() -> Result<()> {
 }
 
 #[test]
+fn incomplete_member_access() -> Result<()> {
+    run(T, "incomplete_member_access")
+}
+
+#[test]
 fn legacy_call_options() -> Result<()> {
     run(T, "legacy_call_options")
 }

--- a/crates/solidity/outputs/cargo/tests/src/binder/generated/variables.rs
+++ b/crates/solidity/outputs/cargo/tests/src/binder/generated/variables.rs
@@ -12,6 +12,11 @@ fn destructuring() -> Result<()> {
 }
 
 #[test]
+fn incomplete_type_name() -> Result<()> {
+    run(T, "incomplete_type_name")
+}
+
+#[test]
 fn local_vars() -> Result<()> {
     run(T, "local_vars")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/expressions.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/expressions.rs
@@ -97,6 +97,11 @@ fn funcalls_overload_using_for() -> Result<()> {
 }
 
 #[test]
+fn incomplete_member_access() -> Result<()> {
+    run(T, "incomplete_member_access")
+}
+
+#[test]
 fn legacy_call_options() -> Result<()> {
     run(T, "legacy_call_options")
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/variables.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/generated/variables.rs
@@ -12,6 +12,11 @@ fn destructuring() -> Result<()> {
 }
 
 #[test]
+fn incomplete_type_name() -> Result<()> {
+    run(T, "incomplete_type_name")
+}
+
+#[test]
 fn local_vars() -> Result<()> {
     run(T, "local_vars")
 }

--- a/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/diff/generated/0.4.11-failure-diff.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/diff/generated/0.4.11-failure-diff.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+reference `data` at input.sol:13:9 not found in new binder output
+
+Definitions and/or references from binding graph and new binder DIFFER

--- a/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/generated/0.4.11-failure.txt
@@ -1,0 +1,67 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected Identifier.
+    ╭─[input.sol:14:5]
+    │
+ 14 │     }
+    │     │ 
+    │     ╰─ Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     struct Data {
+    │            ──┬─  
+    │              ╰─── name: 2
+  3 │         uint120 field;
+    │                 ──┬──  
+    │                   ╰──── name: 3
+    │ 
+  6 │     Data public data;
+    │     ──┬─        ──┬─  
+    │       ╰─────────────── ref: 2
+    │                   │   
+    │                   ╰─── name: 4
+    │ 
+  8 │     function foo() public {
+    │              ─┬─  
+    │               ╰─── name: 5
+    │ 
+ 10 │         data.field = 0;
+    │         ──┬─ ──┬──  
+    │           ╰───────── ref: 4
+    │                │    
+    │                ╰──── ref: 3
+    │ 
+ 13 │         data.
+    │         ──┬─  
+    │           ╰─── unresolved
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ ╭───│ ──▶ contract Test {
+  2 │ │   ╭───▶     struct Data {
+  3 │ │   │             uint120 field;
+    │ │   │     ───────────┬───────────  
+    │ │   │                ╰───────────── definiens: 3
+  4 │ │   ├─│ ▶     }
+    │ │   │ │           
+    │ │   ╰───────────── definiens: 2
+  5 │ │     ╭─▶ 
+  6 │ │ │   ├─▶     Data public data;
+    │ │ │   │                           
+    │ │ │   ╰─────────────────────────── definiens: 4
+  7 │ │ ╭─────▶ 
+    ┆ ┆ ┆       
+ 14 │ │ ├─────▶     }
+    │ │ │               
+    │ │ ╰─────────────── definiens: 5
+ 15 │ ├───────▶ }
+    │ │             
+    │ ╰───────────── definiens: 1
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/input.sol
@@ -1,0 +1,15 @@
+contract Test {
+    struct Data {
+        uint120 field;
+    }
+
+    Data public data;
+
+    function foo() public {
+        // complete:
+        data.field = 0;
+
+        // incomplete:
+        data.
+    }
+}

--- a/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/v2/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/expressions/incomplete_member_access/v2/generated/0.4.11-failure.txt
@@ -1,0 +1,67 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected Identifier.
+    ╭─[input.sol:14:5]
+    │
+ 14 │     }
+    │     │ 
+    │     ╰─ Error occurred here.
+────╯
+
+------------------------------------------------------------------------
+
+Definitions (5):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["Data" @ input.sol:2:12] (struct)
+- Def: #3 ["field" @ input.sol:3:17] (struct member, type: uint120)
+- Def: #4 ["data" @ input.sol:6:17] (state var, type: Data storage)
+- Def: #5 ["foo" @ input.sol:8:14] (function, type: function () returns void)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["Data" @ input.sol:6:5] -> #2
+- Ref: ["data" @ input.sol:10:9] -> #4
+- Ref: ["field" @ input.sol:10:14] -> #3
+
+------------------------------------------------------------------------
+
+Unbound identifiers (1):
+- ???: ["data" @ input.sol:13:9]
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     struct Data {
+    │            ──┬─  
+    │              ╰─── name: 2
+  3 │         uint120 field;
+    │                 ──┬──  
+    │                   ╰──── name: 3
+    │ 
+  6 │     Data public data;
+    │     ──┬─        ──┬─  
+    │       ╰─────────────── ref: 2
+    │                   │   
+    │                   ╰─── name: 4
+    │ 
+  8 │     function foo() public {
+    │              ─┬─  
+    │               ╰─── name: 5
+    │ 
+ 10 │         data.field = 0;
+    │         ──┬─ ──┬──  
+    │           ╰───────── ref: 4
+    │                │    
+    │                ╰──── ref: 3
+    │ 
+ 13 │         data.
+    │         ──┬─  
+    │           ╰─── ???
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/diff/generated/0.4.11-failure-diff.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/diff/generated/0.4.11-failure-diff.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+reference `Test` at input.sol:10:5 not found in new binder output
+
+Definitions and/or references from binding graph and new binder DIFFER

--- a/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/generated/0.4.11-failure.txt
@@ -1,0 +1,56 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected Identifier.
+    ╭─[input.sol:11:1]
+    │
+ 11 │ }
+    │ │ 
+    │ ╰─ Error occurred here.
+────╯
+References and definitions: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     struct Data {
+    │            ──┬─  
+    │              ╰─── name: 2
+  3 │         uint120 field;
+    │                 ──┬──  
+    │                   ╰──── name: 3
+    │ 
+  7 │     Test.Data public data;
+    │     ──┬─ ──┬─        ──┬─  
+    │       ╰──────────────────── ref: 1
+    │            │           │   
+    │            ╰─────────────── ref: 2
+    │                        │   
+    │                        ╰─── name: 4
+    │ 
+ 10 │     Test.
+    │     ──┬─  
+    │       ╰─── unresolved
+────╯
+Definiens: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ ╭─│ ──▶ contract Test {
+  2 │ │ ╭───▶     struct Data {
+  3 │ │ │             uint120 field;
+    │ │ │     ───────────┬───────────  
+    │ │ │                ╰───────────── definiens: 3
+  4 │ │ ├─│ ▶     }
+    │ │ │ │           
+    │ │ ╰───────────── definiens: 2
+  5 │ │   ╭─▶ 
+    ┆ ┆   ┆   
+  7 │ │   ├─▶     Test.Data public data;
+    │ │   │                                
+    │ │   ╰──────────────────────────────── definiens: 4
+    ┆ ┆       
+ 11 │ ├─────▶ }
+    │ │           
+    │ ╰─────────── definiens: 1
+────╯

--- a/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/input.sol
+++ b/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/input.sol
@@ -1,0 +1,11 @@
+contract Test {
+    struct Data {
+        uint120 field;
+    }
+
+    // complete:
+    Test.Data public data;
+
+    // incomplete:
+    Test.
+}

--- a/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/v2/generated/0.4.11-failure.txt
+++ b/crates/solidity/testing/snapshots/bindings_output/variables/incomplete_type_name/v2/generated/0.4.11-failure.txt
@@ -1,0 +1,57 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: Expected Identifier.
+    ╭─[input.sol:11:1]
+    │
+ 11 │ }
+    │ │ 
+    │ ╰─ Error occurred here.
+────╯
+
+------------------------------------------------------------------------
+
+Definitions (4):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["Data" @ input.sol:2:12] (struct)
+- Def: #3 ["field" @ input.sol:3:17] (struct member, type: uint120)
+- Def: #4 ["data" @ input.sol:7:22] (state var, type: Data storage)
+
+------------------------------------------------------------------------
+
+References (2):
+- Ref: ["Test" @ input.sol:7:5] -> #1
+- Ref: ["Data" @ input.sol:7:10] -> #2
+
+------------------------------------------------------------------------
+
+Unbound identifiers (1):
+- ???: ["Test" @ input.sol:10:5]
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     struct Data {
+    │            ──┬─  
+    │              ╰─── name: 2
+  3 │         uint120 field;
+    │                 ──┬──  
+    │                   ╰──── name: 3
+    │ 
+  7 │     Test.Data public data;
+    │     ──┬─ ──┬─        ──┬─  
+    │       ╰──────────────────── ref: 1
+    │            │           │   
+    │            ╰─────────────── ref: 2
+    │                        │   
+    │                        ╰─── name: 4
+    │ 
+ 10 │     Test.
+    │     ──┬─  
+    │       ╰─── ???
+────╯


### PR DESCRIPTION
Fixed a panic during constructing binding graphs, when the input has incomplete `IdentifierPath` expressions.

Closes #1531