### PR TITLE
Compute transient storage layout and apply custom base slot

### DIFF
--- a/crates/solidity/outputs/cargo/crate/src/backend/abi/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/abi/mod.rs
@@ -6,8 +6,8 @@ use sha3::{Digest, Keccak256};
 use super::binder::Definition;
 use super::ir::ast::{
     ContractDefinitionStruct, ErrorDefinitionStruct, EventDefinitionStruct,
-    FunctionDefinitionStruct, FunctionVisibility, ParametersStruct, StateVariableDefinitionStruct,
-    StateVariableMutability, StateVariableVisibility,
+    FunctionDefinitionStruct, FunctionVisibility, ParametersStruct, StateVariableDefinition,
+    StateVariableDefinitionStruct, StateVariableMutability, StateVariableVisibility,
 };
 use super::ir::ir2_flat_contracts as input_ir;
 use super::types::{Type, TypeId};
@@ -20,6 +20,7 @@ pub struct ContractAbi {
     pub file_id: String,
     pub entries: Vec<AbiEntry>,
     pub storage_layout: Vec<StorageItem>,
+    pub transient_storage_layout: Vec<StorageItem>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -229,13 +230,14 @@ impl ContractDefinitionStruct {
     pub fn compute_abi_with_file_id(&self, file_id: String) -> Option<ContractAbi> {
         let name = self.ir_node.name.unparse();
         let entries = self.compute_abi_entries()?;
-        let storage_layout = self.compute_storage_layout()?;
+        let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
         Some(ContractAbi {
             node_id: self.ir_node.node_id,
             name,
             file_id,
             entries,
             storage_layout,
+            transient_storage_layout,
         })
     }
 
@@ -265,23 +267,56 @@ impl ContractDefinitionStruct {
         Some(entries)
     }
 
-    fn compute_storage_layout(&self) -> Option<Vec<StorageItem>> {
-        let mut storage_layout = Vec::new();
-        // TODO: if the contract has a specific storage layout specifier, we
-        // need to compute its value and use it as the base
-        let mut ptr: usize = 0;
-        for state_variable in &self.compute_linearised_state_variables() {
-            let node_id = state_variable.ir_node.node_id;
-            // skip constants and immutable variables, since they are not placed in storage
-            // TODO: also, transient storage is laid out separately and we need
-            // to support that as well
-            if !matches!(
-                state_variable.mutability(),
-                StateVariableMutability::Mutable
-            ) {
-                continue;
-            }
+    /// Retrieves the custom base slot for this contract, if specified. This is
+    /// used for computing the base of the storage layout for non-transient
+    /// state variables.
+    fn base_slot(&self) -> Option<usize> {
+        let Definition::Contract(definition) = self
+            .semantic
+            .binder
+            .find_definition_by_id(self.ir_node.node_id)?
+        else {
+            unreachable!("definition is not a contract");
+        };
+        definition.base_slot
+    }
 
+    /// Computes the layouts of both permanent and transient state variables
+    fn compute_storage_layout(&self) -> Option<(Vec<StorageItem>, Vec<StorageItem>)> {
+        let all_state_variables = self.compute_linearised_state_variables();
+
+        // TODO(validation): it is an error if any contract in the hierarchy
+        // other than the leaf has a custom offset layout
+        let storage_layout = self.lay_out_state_variables(
+            self.base_slot().unwrap_or_default() * SemanticAnalysis::SLOT_SIZE,
+            all_state_variables.iter().filter(|state_variable| {
+                matches!(
+                    state_variable.mutability(),
+                    StateVariableMutability::Mutable
+                )
+            }),
+        )?;
+        let transient_storage_layout = self.lay_out_state_variables(
+            0usize,
+            all_state_variables.iter().filter(|state_variable| {
+                matches!(
+                    state_variable.mutability(),
+                    StateVariableMutability::Transient
+                )
+            }),
+        )?;
+        Some((storage_layout, transient_storage_layout))
+    }
+
+    fn lay_out_state_variables<'a>(
+        &self,
+        base_ptr: usize,
+        variables: impl Iterator<Item = &'a StateVariableDefinition>,
+    ) -> Option<Vec<StorageItem>> {
+        let mut storage_layout = Vec::new();
+        let mut ptr: usize = base_ptr;
+        for state_variable in variables {
+            let node_id = state_variable.ir_node.node_id;
             let variable_type_id = self.semantic.binder.node_typing(node_id).as_type_id()?;
             let variable_size = self.semantic.storage_size_of_type_id(variable_type_id)?;
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/binder/definitions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/binder/definitions.rs
@@ -47,6 +47,7 @@ pub struct ContractDefinition {
     pub(crate) ir_node: output_ir::ContractDefinition,
     pub bases: Option<Vec<NodeId>>,
     pub constructor_parameters_scope_id: Option<ScopeId>,
+    pub base_slot: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -316,6 +317,7 @@ impl Definition {
             ir_node: Rc::clone(ir_node),
             bases: None,
             constructor_parameters_scope_id: None,
+            base_slot: None,
         })
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
@@ -8,7 +8,7 @@ use num_traits::Num;
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
 use crate::cst::{TerminalKind, TerminalNode};
 
-pub(crate) fn evaluate_fixed_array_size<Scope>(
+pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
     expression: &input_ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/resolution.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/resolution.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use super::evaluator::{evaluate_fixed_array_size, ConstantIdentifierResolver};
+use super::evaluator::{evaluate_compile_time_uint_constant, ConstantIdentifierResolver};
 use super::Pass;
 use crate::backend::binder::{Definition, ImportDefinition, Reference, Resolution, ScopeId};
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
@@ -98,7 +98,7 @@ impl Pass<'_> {
                                 // TODO(validation): if the size of the array
                                 // cannot be evaluated, it's not a compile-time
                                 // constant
-                                let size = evaluate_fixed_array_size(
+                                let size = evaluate_compile_time_uint_constant(
                                     size_expression,
                                     self.current_contract_or_file_scope_id(),
                                     self,

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/visitor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use super::evaluator::evaluate_compile_time_uint_constant;
 use super::Pass;
 use crate::backend::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
 use crate::backend::built_ins::BuiltIn;
@@ -42,6 +43,24 @@ impl Visitor for Pass<'_> {
 
         self.current_receiver_type = None;
         self.binder.mark_user_meta_type_node(node.node_id);
+
+        if let Some(base_slot_expression) = &node.storage_layout {
+            // TODO(validation): if the base slot expression cannot be computed
+            // at this time, it's not a compile time constant and hence it's an
+            // error
+            if let Some(base_slot) = evaluate_compile_time_uint_constant(
+                base_slot_expression,
+                self.current_contract_or_file_scope_id(),
+                self,
+            ) {
+                let Definition::Contract(contract_definition) =
+                    self.binder.get_definition_mut(node.node_id)
+                else {
+                    unreachable!("the definition is not a contract");
+                };
+                contract_definition.base_slot = Some(base_slot);
+            }
+        }
     }
 
     fn enter_interface_definition(&mut self, node: &input_ir::InterfaceDefinition) -> bool {

--- a/crates/solidity/outputs/cargo/tests/src/backend/abi/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/abi/mod.rs
@@ -27,6 +27,15 @@ fn test_get_contracts_abi() -> Result<()> {
     Ok(())
 }
 
+macro_rules! assert_layout_item_eq {
+    ($item:expr, $name:expr, $slot:expr, $offset:expr, $type:expr) => {
+        assert_eq!($item.label, $name);
+        assert_eq!($item.r#type, $type);
+        assert_eq!($item.slot, $slot);
+        assert_eq!($item.offset, $offset);
+    };
+}
+
 #[test]
 fn test_storage_layout() -> Result<()> {
     let compilation_unit = fixtures::StorageLayout::build_compilation_unit()?;
@@ -56,14 +65,6 @@ fn test_storage_layout() -> Result<()> {
     // 12 [tttttttttttttttttttttttttttttttt] (t[1]:                             wwww)
     // 13 [                           ooooo]
 
-    macro_rules! assert_layout_item_eq {
-        ($item:expr, $name:expr, $slot:expr, $offset:expr, $type:expr) => {
-            assert_eq!($item.label, $name);
-            assert_eq!($item.r#type, $type);
-            assert_eq!($item.slot, $slot);
-            assert_eq!($item.offset, $offset);
-        };
-    }
     assert_eq!(layout.len(), 12);
 
     assert_layout_item_eq!(layout[0], "a", 0, 0, "uint256");
@@ -78,6 +79,46 @@ fn test_storage_layout() -> Result<()> {
     assert_layout_item_eq!(layout[9], "n", 7, 0, "bytes5[8]");
     assert_layout_item_eq!(layout[10], "t", 9, 0, "T[2]");
     assert_layout_item_eq!(layout[11], "o", 13, 0, "bytes5");
+
+    let transient_layout = &counter_abi.transient_storage_layout;
+    assert!(transient_layout.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_transient_and_custom_storage_layout() -> Result<()> {
+    let compilation_unit = fixtures::StorageLayout::build_compilation_unit()?;
+    let semantic_analysis = compilation_unit.semantic_analysis();
+
+    let d_contract = semantic_analysis
+        .find_contract_by_name("D")
+        .expect("contract can be found");
+    let d_abi = d_contract
+        .compute_abi_with_file_id("main.sol".to_string())
+        .expect("can compute ABI");
+    let d_layout = &d_abi.storage_layout;
+
+    assert_eq!(d_layout.len(), 2);
+    assert_layout_item_eq!(d_layout[0], "a", 42, 0, "uint256");
+    assert_layout_item_eq!(d_layout[1], "p", 43, 0, "uint256");
+
+    let e_contract = semantic_analysis
+        .find_contract_by_name("E")
+        .expect("contract can be found");
+    let e_abi = e_contract
+        .compute_abi_with_file_id("main.sol".to_string())
+        .expect("can compute ABI");
+    let e_layout = &e_abi.storage_layout;
+    let e_transient_layout = &e_abi.transient_storage_layout;
+
+    assert_eq!(e_layout.len(), 2);
+    assert_layout_item_eq!(e_layout[0], "q", 20, 0, "int8");
+    assert_layout_item_eq!(e_layout[1], "r", 20, 1, "bytes5");
+
+    assert_eq!(e_transient_layout.len(), 2);
+    assert_layout_item_eq!(e_transient_layout[0], "qt", 0, 0, "int8");
+    assert_layout_item_eq!(e_transient_layout[1], "rt", 0, 1, "bytes5");
 
     Ok(())
 }

--- a/crates/solidity/outputs/cargo/tests/src/backend/fixtures/storage_layout.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/fixtures/storage_layout.rs
@@ -40,6 +40,19 @@ contract C is A, B {
     T[2] t;
     bytes5 o;
 }
+
+contract D is A layout at 42 {
+    uint p;
+}
+
+uint constant BASE = 5;
+
+contract E layout at BASE * 2 + 10 {
+    int8 q;
+    int8 transient qt;
+    bytes5 r;
+    bytes5 transient rt;
+}
 "#;
 
 pub(crate) struct StorageLayout {}


### PR DESCRIPTION
This PR adds the computation of the transient storage layout, which is separate from the permanent variables. We also now apply the base slot to the permanent storage layout if the contract specifies it.
