### PR TITLE
Allow serialization of IR2 nodes to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,6 +3960,7 @@ dependencies = [
  "metaslang_graph_builder",
  "regex",
  "semver 1.0.26",
+ "serde_json",
  "slang_solidity",
  "slang_solidity_v2_parser",
  "solidity_language",

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/common/_nodes.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/common/_nodes.rs.jinja2
@@ -4,6 +4,7 @@
   use std::vec::Vec;
   use crate::cst::TerminalNode;
   use metaslang_cst::nodes::NodeId;
+  use serde::Serialize;
 
   //
   // Sequences:
@@ -12,8 +13,9 @@
   {% for parent_type, sequence in target.sequences %}
     pub type {{ parent_type }} = Rc<{{ parent_type }}Struct>;
 
-    #[derive(Debug)]
+    #[derive(Debug, Serialize)]
     pub struct {{ parent_type }}Struct {
+      #[serde(skip)]
       pub node_id: NodeId,
       {%- for field in sequence.fields %}
         pub {{ field.label | snake_case }}:
@@ -46,7 +48,7 @@
   //
 
   {% for parent_type, choice in target.choices %}
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Serialize)]
     pub enum {{ parent_type }} {
       {% for nonterminal in choice.variants | filter(attribute="kind", value="Nonterminal") -%}
         {{ nonterminal.name }}({{ nonterminal.name }}),

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/nodes.generated.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/nodes.generated.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use std::vec::Vec;
 
 use metaslang_cst::nodes::NodeId;
+use serde::Serialize;
 
 use crate::cst::TerminalNode;
 
@@ -13,48 +14,54 @@ use crate::cst::TerminalNode;
 
 pub type SourceUnit = Rc<SourceUnitStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SourceUnitStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub members: SourceUnitMembers,
 }
 
 pub type PragmaDirective = Rc<PragmaDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PragmaDirectiveStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub pragma: Pragma,
 }
 
 pub type AbicoderPragma = Rc<AbicoderPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AbicoderPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub version: AbicoderVersion,
 }
 
 pub type ExperimentalPragma = Rc<ExperimentalPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExperimentalPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub feature: ExperimentalFeature,
 }
 
 pub type VersionPragma = Rc<VersionPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub sets: VersionExpressionSets,
 }
 
 pub type VersionRange = Rc<VersionRangeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionRangeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub start: VersionLiteral,
     pub end: VersionLiteral,
@@ -62,8 +69,9 @@ pub struct VersionRangeStruct {
 
 pub type VersionTerm = Rc<VersionTermStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionTermStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operator: Option<VersionOperator>,
     pub literal: VersionLiteral,
@@ -71,16 +79,18 @@ pub struct VersionTermStruct {
 
 pub type ImportDirective = Rc<ImportDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportDirectiveStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub clause: ImportClause,
 }
 
 pub type PathImport = Rc<PathImportStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PathImportStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub path: StringLiteral,
     pub alias: Option<ImportAlias>,
@@ -88,8 +98,9 @@ pub struct PathImportStruct {
 
 pub type NamedImport = Rc<NamedImportStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NamedImportStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub alias: ImportAlias,
     pub path: StringLiteral,
@@ -97,8 +108,9 @@ pub struct NamedImportStruct {
 
 pub type ImportDeconstruction = Rc<ImportDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportDeconstructionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub symbols: ImportDeconstructionSymbols,
     pub path: StringLiteral,
@@ -106,8 +118,9 @@ pub struct ImportDeconstructionStruct {
 
 pub type ImportDeconstructionSymbol = Rc<ImportDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportDeconstructionSymbolStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub alias: Option<ImportAlias>,
@@ -115,16 +128,18 @@ pub struct ImportDeconstructionSymbolStruct {
 
 pub type ImportAlias = Rc<ImportAliasStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportAliasStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub identifier: Rc<TerminalNode>,
 }
 
 pub type UsingDirective = Rc<UsingDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDirectiveStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub clause: UsingClause,
     pub target: UsingTarget,
@@ -133,16 +148,18 @@ pub struct UsingDirectiveStruct {
 
 pub type UsingDeconstruction = Rc<UsingDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDeconstructionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub symbols: UsingDeconstructionSymbols,
 }
 
 pub type UsingDeconstructionSymbol = Rc<UsingDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDeconstructionSymbolStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: IdentifierPath,
     pub alias: Option<UsingAlias>,
@@ -150,16 +167,18 @@ pub struct UsingDeconstructionSymbolStruct {
 
 pub type UsingAlias = Rc<UsingAliasStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingAliasStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operator: UsingOperator,
 }
 
 pub type ContractDefinition = Rc<ContractDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ContractDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub abstract_keyword: bool,
     pub name: Rc<TerminalNode>,
@@ -169,16 +188,18 @@ pub struct ContractDefinitionStruct {
 
 pub type InheritanceSpecifier = Rc<InheritanceSpecifierStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InheritanceSpecifierStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub types: InheritanceTypes,
 }
 
 pub type InheritanceType = Rc<InheritanceTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InheritanceTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
@@ -186,16 +207,18 @@ pub struct InheritanceTypeStruct {
 
 pub type StorageLayoutSpecifier = Rc<StorageLayoutSpecifierStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StorageLayoutSpecifierStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
 }
 
 pub type InterfaceDefinition = Rc<InterfaceDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InterfaceDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub inheritance: Option<InheritanceSpecifier>,
@@ -204,8 +227,9 @@ pub struct InterfaceDefinitionStruct {
 
 pub type LibraryDefinition = Rc<LibraryDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct LibraryDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: LibraryMembers,
@@ -213,8 +237,9 @@ pub struct LibraryDefinitionStruct {
 
 pub type StructDefinition = Rc<StructDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StructDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: StructMembers,
@@ -222,8 +247,9 @@ pub struct StructDefinitionStruct {
 
 pub type StructMember = Rc<StructMemberStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StructMemberStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Rc<TerminalNode>,
@@ -231,8 +257,9 @@ pub struct StructMemberStruct {
 
 pub type EnumDefinition = Rc<EnumDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EnumDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: EnumMembers,
@@ -240,8 +267,9 @@ pub struct EnumDefinitionStruct {
 
 pub type ConstantDefinition = Rc<ConstantDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConstantDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Rc<TerminalNode>,
@@ -250,8 +278,9 @@ pub struct ConstantDefinitionStruct {
 
 pub type StateVariableDefinition = Rc<StateVariableDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StateVariableDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub attributes: StateVariableAttributes,
@@ -261,16 +290,18 @@ pub struct StateVariableDefinitionStruct {
 
 pub type StateVariableDefinitionValue = Rc<StateVariableDefinitionValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StateVariableDefinitionValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub value: Expression,
 }
 
 pub type FunctionDefinition = Rc<FunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: FunctionName,
     pub parameters: ParametersDeclaration,
@@ -281,16 +312,18 @@ pub struct FunctionDefinitionStruct {
 
 pub type ParametersDeclaration = Rc<ParametersDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ParametersDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: Parameters,
 }
 
 pub type Parameter = Rc<ParameterStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ParameterStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
@@ -299,32 +332,36 @@ pub struct ParameterStruct {
 
 pub type OverrideSpecifier = Rc<OverrideSpecifierStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OverrideSpecifierStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub overridden: Option<OverridePathsDeclaration>,
 }
 
 pub type OverridePathsDeclaration = Rc<OverridePathsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OverridePathsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub paths: OverridePaths,
 }
 
 pub type ReturnsDeclaration = Rc<ReturnsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReturnsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: ParametersDeclaration,
 }
 
 pub type ConstructorDefinition = Rc<ConstructorDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConstructorDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ParametersDeclaration,
     pub attributes: ConstructorAttributes,
@@ -333,8 +370,9 @@ pub struct ConstructorDefinitionStruct {
 
 pub type UnnamedFunctionDefinition = Rc<UnnamedFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UnnamedFunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ParametersDeclaration,
     pub attributes: UnnamedFunctionAttributes,
@@ -343,8 +381,9 @@ pub struct UnnamedFunctionDefinitionStruct {
 
 pub type FallbackFunctionDefinition = Rc<FallbackFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FallbackFunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ParametersDeclaration,
     pub attributes: FallbackFunctionAttributes,
@@ -354,8 +393,9 @@ pub struct FallbackFunctionDefinitionStruct {
 
 pub type ReceiveFunctionDefinition = Rc<ReceiveFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReceiveFunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ParametersDeclaration,
     pub attributes: ReceiveFunctionAttributes,
@@ -364,8 +404,9 @@ pub struct ReceiveFunctionDefinitionStruct {
 
 pub type ModifierDefinition = Rc<ModifierDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ModifierDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub parameters: Option<ParametersDeclaration>,
@@ -375,8 +416,9 @@ pub struct ModifierDefinitionStruct {
 
 pub type ModifierInvocation = Rc<ModifierInvocationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ModifierInvocationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
@@ -384,8 +426,9 @@ pub struct ModifierInvocationStruct {
 
 pub type EventDefinition = Rc<EventDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EventDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub parameters: EventParametersDeclaration,
@@ -394,16 +437,18 @@ pub struct EventDefinitionStruct {
 
 pub type EventParametersDeclaration = Rc<EventParametersDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EventParametersDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: EventParameters,
 }
 
 pub type EventParameter = Rc<EventParameterStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EventParameterStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub indexed_keyword: bool,
@@ -412,8 +457,9 @@ pub struct EventParameterStruct {
 
 pub type UserDefinedValueTypeDefinition = Rc<UserDefinedValueTypeDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UserDefinedValueTypeDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub value_type: ElementaryType,
@@ -421,8 +467,9 @@ pub struct UserDefinedValueTypeDefinitionStruct {
 
 pub type ErrorDefinition = Rc<ErrorDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ErrorDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: ErrorParametersDeclaration,
@@ -430,16 +477,18 @@ pub struct ErrorDefinitionStruct {
 
 pub type ErrorParametersDeclaration = Rc<ErrorParametersDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ErrorParametersDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ErrorParameters,
 }
 
 pub type ErrorParameter = Rc<ErrorParameterStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ErrorParameterStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Option<Rc<TerminalNode>>,
@@ -447,8 +496,9 @@ pub struct ErrorParameterStruct {
 
 pub type ArrayTypeName = Rc<ArrayTypeNameStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ArrayTypeNameStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: TypeName,
     pub index: Option<Expression>,
@@ -456,8 +506,9 @@ pub struct ArrayTypeNameStruct {
 
 pub type FunctionType = Rc<FunctionTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: ParametersDeclaration,
     pub attributes: FunctionTypeAttributes,
@@ -466,8 +517,9 @@ pub struct FunctionTypeStruct {
 
 pub type MappingType = Rc<MappingTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MappingTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub key_type: MappingKey,
     pub value_type: MappingValue,
@@ -475,8 +527,9 @@ pub struct MappingTypeStruct {
 
 pub type MappingKey = Rc<MappingKeyStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MappingKeyStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub key_type: MappingKeyType,
     pub name: Option<Rc<TerminalNode>>,
@@ -484,8 +537,9 @@ pub struct MappingKeyStruct {
 
 pub type MappingValue = Rc<MappingValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MappingValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Option<Rc<TerminalNode>>,
@@ -493,40 +547,45 @@ pub struct MappingValueStruct {
 
 pub type AddressType = Rc<AddressTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AddressTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub payable_keyword: bool,
 }
 
 pub type Block = Rc<BlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub statements: Statements,
 }
 
 pub type UncheckedBlock = Rc<UncheckedBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UncheckedBlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub block: Block,
 }
 
 pub type ExpressionStatement = Rc<ExpressionStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExpressionStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
 }
 
 pub type AssemblyStatement = Rc<AssemblyStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AssemblyStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub label: Option<StringLiteral>,
     pub flags: Option<AssemblyFlagsDeclaration>,
@@ -535,16 +594,18 @@ pub struct AssemblyStatementStruct {
 
 pub type AssemblyFlagsDeclaration = Rc<AssemblyFlagsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AssemblyFlagsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub flags: AssemblyFlags,
 }
 
 pub type TupleDeconstructionStatement = Rc<TupleDeconstructionStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleDeconstructionStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub var_keyword: bool,
     pub elements: TupleDeconstructionElements,
@@ -553,16 +614,18 @@ pub struct TupleDeconstructionStatementStruct {
 
 pub type TupleDeconstructionElement = Rc<TupleDeconstructionElementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleDeconstructionElementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub member: Option<TupleMember>,
 }
 
 pub type TypedTupleMember = Rc<TypedTupleMemberStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TypedTupleMemberStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
@@ -571,8 +634,9 @@ pub struct TypedTupleMemberStruct {
 
 pub type UntypedTupleMember = Rc<UntypedTupleMemberStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UntypedTupleMemberStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub storage_location: Option<StorageLocation>,
     pub name: Rc<TerminalNode>,
@@ -580,8 +644,9 @@ pub struct UntypedTupleMemberStruct {
 
 pub type VariableDeclarationStatement = Rc<VariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VariableDeclarationStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variable_type: VariableDeclarationType,
     pub storage_location: Option<StorageLocation>,
@@ -591,16 +656,18 @@ pub struct VariableDeclarationStatementStruct {
 
 pub type VariableDeclarationValue = Rc<VariableDeclarationValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VariableDeclarationValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
 }
 
 pub type IfStatement = Rc<IfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct IfStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: Expression,
     pub body: Statement,
@@ -609,16 +676,18 @@ pub struct IfStatementStruct {
 
 pub type ElseBranch = Rc<ElseBranchStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ElseBranchStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: Statement,
 }
 
 pub type ForStatement = Rc<ForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ForStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub initialization: ForStatementInitialization,
     pub condition: ForStatementCondition,
@@ -628,8 +697,9 @@ pub struct ForStatementStruct {
 
 pub type WhileStatement = Rc<WhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct WhileStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: Expression,
     pub body: Statement,
@@ -637,8 +707,9 @@ pub struct WhileStatementStruct {
 
 pub type DoWhileStatement = Rc<DoWhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DoWhileStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: Statement,
     pub condition: Expression,
@@ -646,30 +717,34 @@ pub struct DoWhileStatementStruct {
 
 pub type ContinueStatement = Rc<ContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ContinueStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type BreakStatement = Rc<BreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BreakStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type ReturnStatement = Rc<ReturnStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReturnStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Option<Expression>,
 }
 
 pub type EmitStatement = Rc<EmitStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EmitStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub event: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
@@ -677,8 +752,9 @@ pub struct EmitStatementStruct {
 
 pub type TryStatement = Rc<TryStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TryStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
     pub returns: Option<ReturnsDeclaration>,
@@ -688,8 +764,9 @@ pub struct TryStatementStruct {
 
 pub type CatchClause = Rc<CatchClauseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CatchClauseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub error: Option<CatchClauseError>,
     pub body: Block,
@@ -697,8 +774,9 @@ pub struct CatchClauseStruct {
 
 pub type CatchClauseError = Rc<CatchClauseErrorStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CatchClauseErrorStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Option<Rc<TerminalNode>>,
     pub parameters: ParametersDeclaration,
@@ -706,8 +784,9 @@ pub struct CatchClauseErrorStruct {
 
 pub type RevertStatement = Rc<RevertStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct RevertStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub error: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
@@ -715,15 +794,17 @@ pub struct RevertStatementStruct {
 
 pub type ThrowStatement = Rc<ThrowStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ThrowStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AssignmentExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -732,8 +813,9 @@ pub struct AssignmentExpressionStruct {
 
 pub type ConditionalExpression = Rc<ConditionalExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConditionalExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub true_expression: Expression,
@@ -742,8 +824,9 @@ pub struct ConditionalExpressionStruct {
 
 pub type OrExpression = Rc<OrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OrExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -751,8 +834,9 @@ pub struct OrExpressionStruct {
 
 pub type AndExpression = Rc<AndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AndExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -760,8 +844,9 @@ pub struct AndExpressionStruct {
 
 pub type EqualityExpression = Rc<EqualityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EqualityExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -770,8 +855,9 @@ pub struct EqualityExpressionStruct {
 
 pub type InequalityExpression = Rc<InequalityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InequalityExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -780,8 +866,9 @@ pub struct InequalityExpressionStruct {
 
 pub type BitwiseOrExpression = Rc<BitwiseOrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseOrExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -789,8 +876,9 @@ pub struct BitwiseOrExpressionStruct {
 
 pub type BitwiseXorExpression = Rc<BitwiseXorExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseXorExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -798,8 +886,9 @@ pub struct BitwiseXorExpressionStruct {
 
 pub type BitwiseAndExpression = Rc<BitwiseAndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseAndExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -807,8 +896,9 @@ pub struct BitwiseAndExpressionStruct {
 
 pub type ShiftExpression = Rc<ShiftExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ShiftExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -817,8 +907,9 @@ pub struct ShiftExpressionStruct {
 
 pub type AdditiveExpression = Rc<AdditiveExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AdditiveExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -827,8 +918,9 @@ pub struct AdditiveExpressionStruct {
 
 pub type MultiplicativeExpression = Rc<MultiplicativeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MultiplicativeExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -837,8 +929,9 @@ pub struct MultiplicativeExpressionStruct {
 
 pub type ExponentiationExpression = Rc<ExponentiationExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExponentiationExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -847,8 +940,9 @@ pub struct ExponentiationExpressionStruct {
 
 pub type PostfixExpression = Rc<PostfixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PostfixExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -856,8 +950,9 @@ pub struct PostfixExpressionStruct {
 
 pub type PrefixExpression = Rc<PrefixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PrefixExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operator: Rc<TerminalNode>,
     pub operand: Expression,
@@ -865,8 +960,9 @@ pub struct PrefixExpressionStruct {
 
 pub type FunctionCallExpression = Rc<FunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionCallExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub arguments: ArgumentsDeclaration,
@@ -874,8 +970,9 @@ pub struct FunctionCallExpressionStruct {
 
 pub type CallOptionsExpression = Rc<CallOptionsExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CallOptionsExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub options: CallOptions,
@@ -883,8 +980,9 @@ pub struct CallOptionsExpressionStruct {
 
 pub type MemberAccessExpression = Rc<MemberAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MemberAccessExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub member: Rc<TerminalNode>,
@@ -892,8 +990,9 @@ pub struct MemberAccessExpressionStruct {
 
 pub type IndexAccessExpression = Rc<IndexAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct IndexAccessExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub start: Option<Expression>,
@@ -902,40 +1001,45 @@ pub struct IndexAccessExpressionStruct {
 
 pub type IndexAccessEnd = Rc<IndexAccessEndStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct IndexAccessEndStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub end: Option<Expression>,
 }
 
 pub type PositionalArgumentsDeclaration = Rc<PositionalArgumentsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PositionalArgumentsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub arguments: PositionalArguments,
 }
 
 pub type NamedArgumentsDeclaration = Rc<NamedArgumentsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NamedArgumentsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub arguments: Option<NamedArgumentGroup>,
 }
 
 pub type NamedArgumentGroup = Rc<NamedArgumentGroupStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NamedArgumentGroupStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub arguments: NamedArguments,
 }
 
 pub type NamedArgument = Rc<NamedArgumentStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NamedArgumentStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub value: Expression,
@@ -943,48 +1047,54 @@ pub struct NamedArgumentStruct {
 
 pub type TypeExpression = Rc<TypeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TypeExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
 }
 
 pub type NewExpression = Rc<NewExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NewExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
 }
 
 pub type TupleExpression = Rc<TupleExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub items: TupleValues,
 }
 
 pub type TupleValue = Rc<TupleValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Option<Expression>,
 }
 
 pub type ArrayExpression = Rc<ArrayExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ArrayExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub items: ArrayValues,
 }
 
 pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct HexNumberExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
     pub unit: Option<NumberUnit>,
@@ -992,8 +1102,9 @@ pub struct HexNumberExpressionStruct {
 
 pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DecimalNumberExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
     pub unit: Option<NumberUnit>,
@@ -1001,16 +1112,18 @@ pub struct DecimalNumberExpressionStruct {
 
 pub type YulBlock = Rc<YulBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulBlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub statements: YulStatements,
 }
 
 pub type YulFunctionDefinition = Rc<YulFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulFunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub parameters: YulParametersDeclaration,
@@ -1020,24 +1133,27 @@ pub struct YulFunctionDefinitionStruct {
 
 pub type YulParametersDeclaration = Rc<YulParametersDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulParametersDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: YulParameters,
 }
 
 pub type YulReturnsDeclaration = Rc<YulReturnsDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulReturnsDeclarationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: YulVariableNames,
 }
 
 pub type YulVariableDeclarationStatement = Rc<YulVariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableDeclarationStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: YulVariableNames,
     pub value: Option<YulVariableDeclarationValue>,
@@ -1045,8 +1161,9 @@ pub struct YulVariableDeclarationStatementStruct {
 
 pub type YulVariableDeclarationValue = Rc<YulVariableDeclarationValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableDeclarationValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub assignment: YulAssignmentOperator,
     pub expression: YulExpression,
@@ -1054,8 +1171,9 @@ pub struct YulVariableDeclarationValueStruct {
 
 pub type YulVariableAssignmentStatement = Rc<YulVariableAssignmentStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableAssignmentStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: YulPaths,
     pub assignment: YulAssignmentOperator,
@@ -1064,15 +1182,17 @@ pub struct YulVariableAssignmentStatementStruct {
 
 pub type YulColonAndEqual = Rc<YulColonAndEqualStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulColonAndEqualStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulStackAssignmentStatement = Rc<YulStackAssignmentStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulStackAssignmentStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub assignment: YulStackAssignmentOperator,
     pub variable: Rc<TerminalNode>,
@@ -1080,15 +1200,17 @@ pub struct YulStackAssignmentStatementStruct {
 
 pub type YulEqualAndColon = Rc<YulEqualAndColonStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulEqualAndColonStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulIfStatement = Rc<YulIfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulIfStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: YulExpression,
     pub body: YulBlock,
@@ -1096,8 +1218,9 @@ pub struct YulIfStatementStruct {
 
 pub type YulForStatement = Rc<YulForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulForStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub initialization: YulBlock,
     pub condition: YulExpression,
@@ -1107,8 +1230,9 @@ pub struct YulForStatementStruct {
 
 pub type YulSwitchStatement = Rc<YulSwitchStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulSwitchStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: YulExpression,
     pub cases: YulSwitchCases,
@@ -1116,16 +1240,18 @@ pub struct YulSwitchStatementStruct {
 
 pub type YulDefaultCase = Rc<YulDefaultCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulDefaultCaseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: YulBlock,
 }
 
 pub type YulValueCase = Rc<YulValueCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulValueCaseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub value: YulLiteral,
     pub body: YulBlock,
@@ -1133,37 +1259,42 @@ pub struct YulValueCaseStruct {
 
 pub type YulLeaveStatement = Rc<YulLeaveStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulLeaveStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulBreakStatement = Rc<YulBreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulBreakStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulContinueStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulLabel = Rc<YulLabelStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulLabelStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub label: Rc<TerminalNode>,
 }
 
 pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulFunctionCallExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: YulExpression,
     pub arguments: YulArguments,
@@ -1173,7 +1304,7 @@ pub struct YulFunctionCallExpressionStruct {
 // Choices:
 //
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum SourceUnitMember {
     PragmaDirective(PragmaDirective),
     ImportDirective(ImportDirective),
@@ -1190,33 +1321,33 @@ pub enum SourceUnitMember {
     ConstantDefinition(ConstantDefinition),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Pragma {
     VersionPragma(VersionPragma),
     AbicoderPragma(AbicoderPragma),
     ExperimentalPragma(ExperimentalPragma),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum AbicoderVersion {
     AbicoderV1Keyword,
     AbicoderV2Keyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ExperimentalFeature {
     StringLiteral(StringLiteral),
     ABIEncoderV2Keyword,
     SMTCheckerKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionExpression {
     VersionRange(VersionRange),
     VersionTerm(VersionTerm),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionOperator {
     Caret,
     Tilde,
@@ -1227,27 +1358,27 @@ pub enum VersionOperator {
     GreaterThanEqual,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionLiteral {
     SimpleVersionLiteral(SimpleVersionLiteral),
     SingleQuotedVersionLiteral(Rc<TerminalNode>),
     DoubleQuotedVersionLiteral(Rc<TerminalNode>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ImportClause {
     PathImport(PathImport),
     NamedImport(NamedImport),
     ImportDeconstruction(ImportDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingClause {
     IdentifierPath(IdentifierPath),
     UsingDeconstruction(UsingDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingOperator {
     Ampersand,
     Asterisk,
@@ -1266,19 +1397,19 @@ pub enum UsingOperator {
     Tilde,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingTarget {
     TypeName(TypeName),
     Asterisk,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ContractSpecifier {
     InheritanceSpecifier(InheritanceSpecifier),
     StorageLayoutSpecifier(StorageLayoutSpecifier),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ContractMember {
     UsingDirective(UsingDirective),
     FunctionDefinition(FunctionDefinition),
@@ -1295,7 +1426,7 @@ pub enum ContractMember {
     StateVariableDefinition(StateVariableDefinition),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StateVariableAttribute {
     OverrideSpecifier(OverrideSpecifier),
     ConstantKeyword,
@@ -1306,14 +1437,14 @@ pub enum StateVariableAttribute {
     TransientKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionName {
     Identifier(Rc<TerminalNode>),
     FallbackKeyword,
     ReceiveKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     OverrideSpecifier(OverrideSpecifier),
@@ -1328,13 +1459,13 @@ pub enum FunctionAttribute {
     VirtualKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionBody {
     Block(Block),
     Semicolon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ConstructorAttribute {
     ModifierInvocation(ModifierInvocation),
     InternalKeyword,
@@ -1344,7 +1475,7 @@ pub enum ConstructorAttribute {
     VirtualKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UnnamedFunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     ExternalKeyword,
@@ -1354,7 +1485,7 @@ pub enum UnnamedFunctionAttribute {
     PublicKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FallbackFunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     OverrideSpecifier(OverrideSpecifier),
@@ -1365,7 +1496,7 @@ pub enum FallbackFunctionAttribute {
     VirtualKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ReceiveFunctionAttribute {
     ModifierInvocation(ModifierInvocation),
     OverrideSpecifier(OverrideSpecifier),
@@ -1374,13 +1505,13 @@ pub enum ReceiveFunctionAttribute {
     VirtualKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ModifierAttribute {
     OverrideSpecifier(OverrideSpecifier),
     VirtualKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum TypeName {
     ArrayTypeName(ArrayTypeName),
     FunctionType(FunctionType),
@@ -1389,7 +1520,7 @@ pub enum TypeName {
     IdentifierPath(IdentifierPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionTypeAttribute {
     InternalKeyword,
     ExternalKeyword,
@@ -1401,13 +1532,13 @@ pub enum FunctionTypeAttribute {
     PayableKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum MappingKeyType {
     ElementaryType(ElementaryType),
     IdentifierPath(IdentifierPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ElementaryType {
     AddressType(AddressType),
     BytesKeyword(Rc<TerminalNode>),
@@ -1420,7 +1551,7 @@ pub enum ElementaryType {
     StringKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Statement {
     IfStatement(IfStatement),
     ForStatement(ForStatement),
@@ -1441,26 +1572,26 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum TupleMember {
     TypedTupleMember(TypedTupleMember),
     UntypedTupleMember(UntypedTupleMember),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VariableDeclarationType {
     TypeName(TypeName),
     VarKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StorageLocation {
     MemoryKeyword,
     StorageKeyword,
     CallDataKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ForStatementInitialization {
     TupleDeconstructionStatement(TupleDeconstructionStatement),
     VariableDeclarationStatement(VariableDeclarationStatement),
@@ -1468,13 +1599,13 @@ pub enum ForStatementInitialization {
     Semicolon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ForStatementCondition {
     ExpressionStatement(ExpressionStatement),
     Semicolon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Expression {
     AssignmentExpression(AssignmentExpression),
     ConditionalExpression(ConditionalExpression),
@@ -1511,13 +1642,13 @@ pub enum Expression {
     FalseKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ArgumentsDeclaration {
     PositionalArgumentsDeclaration(PositionalArgumentsDeclaration),
     NamedArgumentsDeclaration(NamedArgumentsDeclaration),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum NumberUnit {
     WeiKeyword,
     GweiKeyword,
@@ -1532,7 +1663,7 @@ pub enum NumberUnit {
     YearsKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StringExpression {
     StringLiteral(StringLiteral),
     StringLiterals(StringLiterals),
@@ -1541,25 +1672,25 @@ pub enum StringExpression {
     UnicodeStringLiterals(UnicodeStringLiterals),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StringLiteral {
     SingleQuotedStringLiteral(Rc<TerminalNode>),
     DoubleQuotedStringLiteral(Rc<TerminalNode>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum HexStringLiteral {
     SingleQuotedHexStringLiteral(Rc<TerminalNode>),
     DoubleQuotedHexStringLiteral(Rc<TerminalNode>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UnicodeStringLiteral {
     SingleQuotedUnicodeStringLiteral(Rc<TerminalNode>),
     DoubleQuotedUnicodeStringLiteral(Rc<TerminalNode>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),
@@ -1576,32 +1707,32 @@ pub enum YulStatement {
     YulExpression(YulExpression),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulAssignmentOperator {
     YulColonAndEqual(YulColonAndEqual),
     ColonEqual,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulStackAssignmentOperator {
     YulEqualAndColon(YulEqualAndColon),
     EqualColon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulSwitchCase {
     YulDefaultCase(YulDefaultCase),
     YulValueCase(YulValueCase),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulExpression {
     YulFunctionCallExpression(YulFunctionCallExpression),
     YulLiteral(YulLiteral),
     YulPath(YulPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulLiteral {
     HexStringLiteral(HexStringLiteral),
     StringLiteral(StringLiteral),

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/nodes.generated.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/nodes.generated.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use std::vec::Vec;
 
 use metaslang_cst::nodes::NodeId;
+use serde::Serialize;
 
 use crate::cst::TerminalNode;
 
@@ -13,48 +14,54 @@ use crate::cst::TerminalNode;
 
 pub type SourceUnit = Rc<SourceUnitStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SourceUnitStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub members: SourceUnitMembers,
 }
 
 pub type PragmaDirective = Rc<PragmaDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PragmaDirectiveStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub pragma: Pragma,
 }
 
 pub type AbicoderPragma = Rc<AbicoderPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AbicoderPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub version: AbicoderVersion,
 }
 
 pub type ExperimentalPragma = Rc<ExperimentalPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExperimentalPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub feature: ExperimentalFeature,
 }
 
 pub type VersionPragma = Rc<VersionPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionPragmaStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub sets: VersionExpressionSets,
 }
 
 pub type VersionRange = Rc<VersionRangeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionRangeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub start: VersionLiteral,
     pub end: VersionLiteral,
@@ -62,8 +69,9 @@ pub struct VersionRangeStruct {
 
 pub type VersionTerm = Rc<VersionTermStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VersionTermStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operator: Option<VersionOperator>,
     pub literal: VersionLiteral,
@@ -71,8 +79,9 @@ pub struct VersionTermStruct {
 
 pub type PathImport = Rc<PathImportStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PathImportStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub alias: Option<Rc<TerminalNode>>,
     pub path: Rc<TerminalNode>,
@@ -80,8 +89,9 @@ pub struct PathImportStruct {
 
 pub type ImportDeconstruction = Rc<ImportDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportDeconstructionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub symbols: ImportDeconstructionSymbols,
     pub path: Rc<TerminalNode>,
@@ -89,8 +99,9 @@ pub struct ImportDeconstructionStruct {
 
 pub type ImportDeconstructionSymbol = Rc<ImportDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ImportDeconstructionSymbolStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub alias: Option<Rc<TerminalNode>>,
@@ -98,8 +109,9 @@ pub struct ImportDeconstructionSymbolStruct {
 
 pub type UsingDirective = Rc<UsingDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDirectiveStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub clause: UsingClause,
     pub target: UsingTarget,
@@ -108,16 +120,18 @@ pub struct UsingDirectiveStruct {
 
 pub type UsingDeconstruction = Rc<UsingDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDeconstructionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub symbols: UsingDeconstructionSymbols,
 }
 
 pub type UsingDeconstructionSymbol = Rc<UsingDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UsingDeconstructionSymbolStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: IdentifierPath,
     pub alias: Option<UsingOperator>,
@@ -125,8 +139,9 @@ pub struct UsingDeconstructionSymbolStruct {
 
 pub type ContractDefinition = Rc<ContractDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ContractDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub abstract_keyword: bool,
     pub name: Rc<TerminalNode>,
@@ -137,8 +152,9 @@ pub struct ContractDefinitionStruct {
 
 pub type InheritanceType = Rc<InheritanceTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InheritanceTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
@@ -146,8 +162,9 @@ pub struct InheritanceTypeStruct {
 
 pub type InterfaceDefinition = Rc<InterfaceDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InterfaceDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub inheritance: Option<InheritanceTypes>,
@@ -156,8 +173,9 @@ pub struct InterfaceDefinitionStruct {
 
 pub type LibraryDefinition = Rc<LibraryDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct LibraryDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: LibraryMembers,
@@ -165,8 +183,9 @@ pub struct LibraryDefinitionStruct {
 
 pub type StructDefinition = Rc<StructDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StructDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: StructMembers,
@@ -174,8 +193,9 @@ pub struct StructDefinitionStruct {
 
 pub type StructMember = Rc<StructMemberStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StructMemberStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Rc<TerminalNode>,
@@ -183,8 +203,9 @@ pub struct StructMemberStruct {
 
 pub type EnumDefinition = Rc<EnumDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EnumDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub members: EnumMembers,
@@ -192,8 +213,9 @@ pub struct EnumDefinitionStruct {
 
 pub type ConstantDefinition = Rc<ConstantDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConstantDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Rc<TerminalNode>,
@@ -203,8 +225,9 @@ pub struct ConstantDefinitionStruct {
 
 pub type StateVariableDefinition = Rc<StateVariableDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StateVariableDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub name: Rc<TerminalNode>,
@@ -216,8 +239,9 @@ pub struct StateVariableDefinitionStruct {
 
 pub type FunctionDefinition = Rc<FunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: Parameters,
     pub returns: Option<Parameters>,
@@ -233,8 +257,9 @@ pub struct FunctionDefinitionStruct {
 
 pub type Parameter = Rc<ParameterStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ParameterStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
@@ -244,16 +269,18 @@ pub struct ParameterStruct {
 
 pub type OverrideSpecifier = Rc<OverrideSpecifierStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OverrideSpecifierStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub overridden: Option<OverridePaths>,
 }
 
 pub type ModifierInvocation = Rc<ModifierInvocationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ModifierInvocationStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
@@ -261,8 +288,9 @@ pub struct ModifierInvocationStruct {
 
 pub type EventDefinition = Rc<EventDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EventDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub anonymous_keyword: bool,
@@ -271,8 +299,9 @@ pub struct EventDefinitionStruct {
 
 pub type UserDefinedValueTypeDefinition = Rc<UserDefinedValueTypeDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UserDefinedValueTypeDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub value_type: ElementaryType,
@@ -280,8 +309,9 @@ pub struct UserDefinedValueTypeDefinitionStruct {
 
 pub type ErrorDefinition = Rc<ErrorDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ErrorDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub parameters: Parameters,
@@ -289,8 +319,9 @@ pub struct ErrorDefinitionStruct {
 
 pub type ArrayTypeName = Rc<ArrayTypeNameStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ArrayTypeNameStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: TypeName,
     pub index: Option<Expression>,
@@ -298,8 +329,9 @@ pub struct ArrayTypeNameStruct {
 
 pub type FunctionType = Rc<FunctionTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub parameters: Parameters,
     pub returns: Option<Parameters>,
@@ -309,8 +341,9 @@ pub struct FunctionTypeStruct {
 
 pub type MappingType = Rc<MappingTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MappingTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub key_type: Parameter,
     pub value_type: Parameter,
@@ -318,40 +351,45 @@ pub struct MappingTypeStruct {
 
 pub type AddressType = Rc<AddressTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AddressTypeStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub payable_keyword: bool,
 }
 
 pub type Block = Rc<BlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub statements: Statements,
 }
 
 pub type UncheckedBlock = Rc<UncheckedBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UncheckedBlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub block: Block,
 }
 
 pub type ExpressionStatement = Rc<ExpressionStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExpressionStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
 }
 
 pub type AssemblyStatement = Rc<AssemblyStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AssemblyStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: YulBlock,
     pub flags: AssemblyFlags,
@@ -360,8 +398,9 @@ pub struct AssemblyStatementStruct {
 
 pub type TupleDeconstructionStatement = Rc<TupleDeconstructionStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleDeconstructionStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
     pub members: TupleDeconstructionMembers,
@@ -369,8 +408,9 @@ pub struct TupleDeconstructionStatementStruct {
 
 pub type VariableDeclarationStatement = Rc<VariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VariableDeclarationStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub storage_location: Option<StorageLocation>,
     pub name: Rc<TerminalNode>,
@@ -380,8 +420,9 @@ pub struct VariableDeclarationStatementStruct {
 
 pub type IfStatement = Rc<IfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct IfStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: Expression,
     pub body: Statement,
@@ -390,8 +431,9 @@ pub struct IfStatementStruct {
 
 pub type ForStatement = Rc<ForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ForStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub initialization: ForStatementInitialization,
     pub condition: ForStatementCondition,
@@ -401,8 +443,9 @@ pub struct ForStatementStruct {
 
 pub type WhileStatement = Rc<WhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct WhileStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: Expression,
     pub body: Statement,
@@ -410,8 +453,9 @@ pub struct WhileStatementStruct {
 
 pub type DoWhileStatement = Rc<DoWhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DoWhileStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: Statement,
     pub condition: Expression,
@@ -419,30 +463,34 @@ pub struct DoWhileStatementStruct {
 
 pub type ContinueStatement = Rc<ContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ContinueStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type BreakStatement = Rc<BreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BreakStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type ReturnStatement = Rc<ReturnStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReturnStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Option<Expression>,
 }
 
 pub type EmitStatement = Rc<EmitStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EmitStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub event: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
@@ -450,8 +498,9 @@ pub struct EmitStatementStruct {
 
 pub type TryStatement = Rc<TryStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TryStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Expression,
     pub returns: Option<Parameters>,
@@ -461,8 +510,9 @@ pub struct TryStatementStruct {
 
 pub type CatchClause = Rc<CatchClauseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CatchClauseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub error: Option<CatchClauseError>,
     pub body: Block,
@@ -470,8 +520,9 @@ pub struct CatchClauseStruct {
 
 pub type CatchClauseError = Rc<CatchClauseErrorStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CatchClauseErrorStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Option<Rc<TerminalNode>>,
     pub parameters: Parameters,
@@ -479,8 +530,9 @@ pub struct CatchClauseErrorStruct {
 
 pub type RevertStatement = Rc<RevertStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct RevertStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub error: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
@@ -488,15 +540,17 @@ pub struct RevertStatementStruct {
 
 pub type ThrowStatement = Rc<ThrowStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ThrowStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AssignmentExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -505,8 +559,9 @@ pub struct AssignmentExpressionStruct {
 
 pub type ConditionalExpression = Rc<ConditionalExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConditionalExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub true_expression: Expression,
@@ -515,8 +570,9 @@ pub struct ConditionalExpressionStruct {
 
 pub type OrExpression = Rc<OrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OrExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -524,8 +580,9 @@ pub struct OrExpressionStruct {
 
 pub type AndExpression = Rc<AndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AndExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -533,8 +590,9 @@ pub struct AndExpressionStruct {
 
 pub type EqualityExpression = Rc<EqualityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct EqualityExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -543,8 +601,9 @@ pub struct EqualityExpressionStruct {
 
 pub type InequalityExpression = Rc<InequalityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InequalityExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -553,8 +612,9 @@ pub struct InequalityExpressionStruct {
 
 pub type BitwiseOrExpression = Rc<BitwiseOrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseOrExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -562,8 +622,9 @@ pub struct BitwiseOrExpressionStruct {
 
 pub type BitwiseXorExpression = Rc<BitwiseXorExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseXorExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -571,8 +632,9 @@ pub struct BitwiseXorExpressionStruct {
 
 pub type BitwiseAndExpression = Rc<BitwiseAndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitwiseAndExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
@@ -580,8 +642,9 @@ pub struct BitwiseAndExpressionStruct {
 
 pub type ShiftExpression = Rc<ShiftExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ShiftExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -590,8 +653,9 @@ pub struct ShiftExpressionStruct {
 
 pub type AdditiveExpression = Rc<AdditiveExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AdditiveExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -600,8 +664,9 @@ pub struct AdditiveExpressionStruct {
 
 pub type MultiplicativeExpression = Rc<MultiplicativeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MultiplicativeExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -610,8 +675,9 @@ pub struct MultiplicativeExpressionStruct {
 
 pub type ExponentiationExpression = Rc<ExponentiationExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ExponentiationExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub left_operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -620,8 +686,9 @@ pub struct ExponentiationExpressionStruct {
 
 pub type PostfixExpression = Rc<PostfixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PostfixExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub operator: Rc<TerminalNode>,
@@ -629,8 +696,9 @@ pub struct PostfixExpressionStruct {
 
 pub type PrefixExpression = Rc<PrefixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PrefixExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operator: Rc<TerminalNode>,
     pub operand: Expression,
@@ -638,8 +706,9 @@ pub struct PrefixExpressionStruct {
 
 pub type FunctionCallExpression = Rc<FunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FunctionCallExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub arguments: ArgumentsDeclaration,
@@ -647,8 +716,9 @@ pub struct FunctionCallExpressionStruct {
 
 pub type CallOptionsExpression = Rc<CallOptionsExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CallOptionsExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub options: CallOptions,
@@ -656,8 +726,9 @@ pub struct CallOptionsExpressionStruct {
 
 pub type MemberAccessExpression = Rc<MemberAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MemberAccessExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub member: Rc<TerminalNode>,
@@ -665,8 +736,9 @@ pub struct MemberAccessExpressionStruct {
 
 pub type IndexAccessExpression = Rc<IndexAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct IndexAccessExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: Expression,
     pub start: Option<Expression>,
@@ -675,8 +747,9 @@ pub struct IndexAccessExpressionStruct {
 
 pub type NamedArgument = Rc<NamedArgumentStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NamedArgumentStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub value: Expression,
@@ -684,48 +757,54 @@ pub struct NamedArgumentStruct {
 
 pub type TypeExpression = Rc<TypeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TypeExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
 }
 
 pub type NewExpression = Rc<NewExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NewExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub type_name: TypeName,
 }
 
 pub type TupleExpression = Rc<TupleExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub items: TupleValues,
 }
 
 pub type TupleValue = Rc<TupleValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TupleValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: Option<Expression>,
 }
 
 pub type ArrayExpression = Rc<ArrayExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ArrayExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub items: ArrayValues,
 }
 
 pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct HexNumberExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
     pub unit: Option<NumberUnit>,
@@ -733,8 +812,9 @@ pub struct HexNumberExpressionStruct {
 
 pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DecimalNumberExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub literal: Rc<TerminalNode>,
     pub unit: Option<NumberUnit>,
@@ -742,16 +822,18 @@ pub struct DecimalNumberExpressionStruct {
 
 pub type YulBlock = Rc<YulBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulBlockStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub statements: YulStatements,
 }
 
 pub type YulFunctionDefinition = Rc<YulFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulFunctionDefinitionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub name: Rc<TerminalNode>,
     pub parameters: YulParameters,
@@ -761,8 +843,9 @@ pub struct YulFunctionDefinitionStruct {
 
 pub type YulVariableDeclarationStatement = Rc<YulVariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableDeclarationStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: YulVariableNames,
     pub value: Option<YulVariableDeclarationValue>,
@@ -770,8 +853,9 @@ pub struct YulVariableDeclarationStatementStruct {
 
 pub type YulVariableDeclarationValue = Rc<YulVariableDeclarationValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableDeclarationValueStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub assignment: YulAssignmentOperator,
     pub expression: YulExpression,
@@ -779,8 +863,9 @@ pub struct YulVariableDeclarationValueStruct {
 
 pub type YulVariableAssignmentStatement = Rc<YulVariableAssignmentStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulVariableAssignmentStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub variables: YulPaths,
     pub assignment: YulAssignmentOperator,
@@ -789,15 +874,17 @@ pub struct YulVariableAssignmentStatementStruct {
 
 pub type YulColonAndEqual = Rc<YulColonAndEqualStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulColonAndEqualStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulStackAssignmentStatement = Rc<YulStackAssignmentStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulStackAssignmentStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub assignment: YulStackAssignmentOperator,
     pub variable: Rc<TerminalNode>,
@@ -805,15 +892,17 @@ pub struct YulStackAssignmentStatementStruct {
 
 pub type YulEqualAndColon = Rc<YulEqualAndColonStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulEqualAndColonStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulIfStatement = Rc<YulIfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulIfStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub condition: YulExpression,
     pub body: YulBlock,
@@ -821,8 +910,9 @@ pub struct YulIfStatementStruct {
 
 pub type YulForStatement = Rc<YulForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulForStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub initialization: YulBlock,
     pub condition: YulExpression,
@@ -832,8 +922,9 @@ pub struct YulForStatementStruct {
 
 pub type YulSwitchStatement = Rc<YulSwitchStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulSwitchStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub expression: YulExpression,
     pub cases: YulSwitchCases,
@@ -841,16 +932,18 @@ pub struct YulSwitchStatementStruct {
 
 pub type YulDefaultCase = Rc<YulDefaultCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulDefaultCaseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub body: YulBlock,
 }
 
 pub type YulValueCase = Rc<YulValueCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulValueCaseStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub value: YulLiteral,
     pub body: YulBlock,
@@ -858,37 +951,42 @@ pub struct YulValueCaseStruct {
 
 pub type YulLeaveStatement = Rc<YulLeaveStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulLeaveStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulBreakStatement = Rc<YulBreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulBreakStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulContinueStatementStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
 }
 
 pub type YulLabel = Rc<YulLabelStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulLabelStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub label: Rc<TerminalNode>,
 }
 
 pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct YulFunctionCallExpressionStruct {
+    #[serde(skip)]
     pub node_id: NodeId,
     pub operand: YulExpression,
     pub arguments: YulArguments,
@@ -898,7 +996,7 @@ pub struct YulFunctionCallExpressionStruct {
 // Choices:
 //
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum SourceUnitMember {
     PragmaDirective(PragmaDirective),
     ContractDefinition(ContractDefinition),
@@ -915,33 +1013,33 @@ pub enum SourceUnitMember {
     ImportClause(ImportClause),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Pragma {
     VersionPragma(VersionPragma),
     AbicoderPragma(AbicoderPragma),
     ExperimentalPragma(ExperimentalPragma),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum AbicoderVersion {
     AbicoderV1Keyword,
     AbicoderV2Keyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ExperimentalFeature {
     StringLiteral(Rc<TerminalNode>),
     ABIEncoderV2Keyword,
     SMTCheckerKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionExpression {
     VersionRange(VersionRange),
     VersionTerm(VersionTerm),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionOperator {
     Caret,
     Tilde,
@@ -952,26 +1050,26 @@ pub enum VersionOperator {
     GreaterThanEqual,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum VersionLiteral {
     SimpleVersionLiteral(SimpleVersionLiteral),
     SingleQuotedVersionLiteral(Rc<TerminalNode>),
     DoubleQuotedVersionLiteral(Rc<TerminalNode>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ImportClause {
     PathImport(PathImport),
     ImportDeconstruction(ImportDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingClause {
     IdentifierPath(IdentifierPath),
     UsingDeconstruction(UsingDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingOperator {
     Ampersand,
     Asterisk,
@@ -990,13 +1088,13 @@ pub enum UsingOperator {
     Tilde,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum UsingTarget {
     TypeName(TypeName),
     Asterisk,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ContractMember {
     UsingDirective(UsingDirective),
     FunctionDefinition(FunctionDefinition),
@@ -1009,7 +1107,7 @@ pub enum ContractMember {
     ConstantDefinition(ConstantDefinition),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum TypeName {
     ArrayTypeName(ArrayTypeName),
     FunctionType(FunctionType),
@@ -1018,7 +1116,7 @@ pub enum TypeName {
     IdentifierPath(IdentifierPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ElementaryType {
     AddressType(AddressType),
     BytesKeyword(Rc<TerminalNode>),
@@ -1031,7 +1129,7 @@ pub enum ElementaryType {
     StringKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Statement {
     IfStatement(IfStatement),
     ForStatement(ForStatement),
@@ -1052,14 +1150,14 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StorageLocation {
     MemoryKeyword,
     StorageKeyword,
     CallDataKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ForStatementInitialization {
     TupleDeconstructionStatement(TupleDeconstructionStatement),
     VariableDeclarationStatement(VariableDeclarationStatement),
@@ -1067,13 +1165,13 @@ pub enum ForStatementInitialization {
     Semicolon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ForStatementCondition {
     ExpressionStatement(ExpressionStatement),
     Semicolon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Expression {
     AssignmentExpression(AssignmentExpression),
     ConditionalExpression(ConditionalExpression),
@@ -1110,13 +1208,13 @@ pub enum Expression {
     FalseKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ArgumentsDeclaration {
     PositionalArguments(PositionalArguments),
     NamedArguments(NamedArguments),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum NumberUnit {
     WeiKeyword,
     GweiKeyword,
@@ -1131,14 +1229,14 @@ pub enum NumberUnit {
     YearsKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StringExpression {
     Strings(Strings),
     HexStrings(HexStrings),
     UnicodeStrings(UnicodeStrings),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),
@@ -1155,32 +1253,32 @@ pub enum YulStatement {
     YulExpression(YulExpression),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulAssignmentOperator {
     YulColonAndEqual(YulColonAndEqual),
     ColonEqual,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulStackAssignmentOperator {
     YulEqualAndColon(YulEqualAndColon),
     EqualColon,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulSwitchCase {
     YulDefaultCase(YulDefaultCase),
     YulValueCase(YulValueCase),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulExpression {
     YulFunctionCallExpression(YulFunctionCallExpression),
     YulLiteral(YulLiteral),
     YulPath(YulPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum YulLiteral {
     YulDecimalLiteral(Rc<TerminalNode>),
     YulHexLiteral(Rc<TerminalNode>),
@@ -1190,7 +1288,7 @@ pub enum YulLiteral {
     YulFalseKeyword,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionKind {
     Regular,
     Constructor,
@@ -1200,7 +1298,7 @@ pub enum FunctionKind {
     Modifier,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionVisibility {
     Public,
     Private,
@@ -1208,7 +1306,7 @@ pub enum FunctionVisibility {
     External,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum FunctionMutability {
     Pure,
     View,
@@ -1216,14 +1314,14 @@ pub enum FunctionMutability {
     Payable,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StateVariableVisibility {
     Public,
     Private,
     Internal,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum StateVariableMutability {
     Mutable,
     Constant,
@@ -1231,7 +1329,7 @@ pub enum StateVariableMutability {
     Transient,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum TupleDeconstructionMember {
     VariableDeclarationStatement(VariableDeclarationStatement),
     Identifier(Rc<TerminalNode>),

--- a/crates/solidity/outputs/cargo/tests/Cargo.toml
+++ b/crates/solidity/outputs/cargo/tests/Cargo.toml
@@ -18,6 +18,7 @@ metaslang_bindings = { workspace = true, features = [
 metaslang_graph_builder = { workspace = true }
 regex = { workspace = true }
 semver = { workspace = true }
+serde_json = { workspace = true }
 slang_solidity = { workspace = true, features = [
   "__private_ariadne_errors",
   "__private_testing_utils",

--- a/crates/solidity/outputs/cargo/tests/src/backend/ir/ir2_flat_contracts/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/ir/ir2_flat_contracts/mod.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use serde_json;
+use slang_solidity::backend::ir::ir1_structured_ast;
+use slang_solidity::backend::passes::p1_flatten_contracts;
+use slang_solidity::parser::Parser;
+use slang_solidity::utils::LanguageFacts;
+
+#[test]
+fn test_output_ir2_as_json() -> Result<()> {
+    let language_version = LanguageFacts::LATEST_VERSION;
+    let parser = Parser::create(language_version.clone())?;
+    let output = parser.parse_file_contents(
+        r###"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >= 0.8.17;
+
+contract MyContract {
+    address owner;
+    constructor() {
+         owner = msg.sender;
+    }
+    function test() view public returns (bool) {
+         return owner == msg.sender;
+    }
+}
+    "###,
+    );
+    assert!(output.is_valid());
+
+    let ast = ir1_structured_ast::builder::build_source_unit(output.tree())
+        .expect("can build structured AST");
+    let source_unit = p1_flatten_contracts::run_file(&language_version, &ast);
+
+    let expected_json = r#"{"members":[{"PragmaDirective":{"pragma":{"VersionPragma":{"sets":[[{"VersionTerm":{"operator":"GreaterThanEqual","literal":{"SimpleVersionLiteral":[{"kind":"VersionSpecifier","text":"0"},{"kind":"VersionSpecifier","text":"8"},{"kind":"VersionSpecifier","text":"17"}]}}}]]}}}},{"ContractDefinition":{"abstract_keyword":false,"name":{"kind":"Identifier","text":"MyContract"},"members":[{"StateVariableDefinition":{"type_name":{"ElementaryType":{"AddressType":{"payable_keyword":false}}},"name":{"kind":"Identifier","text":"owner"},"value":null,"visibility":"Internal","mutability":"Mutable","override_specifier":null}},{"FunctionDefinition":{"parameters":[],"returns":null,"kind":"Constructor","name":null,"body":{"statements":[{"ExpressionStatement":{"expression":{"AssignmentExpression":{"left_operand":{"Identifier":{"kind":"Identifier","text":"owner"}},"operator":{"kind":"Equal","text":"="},"right_operand":{"MemberAccessExpression":{"operand":{"Identifier":{"kind":"Identifier","text":"msg"}},"member":{"kind":"Identifier","text":"sender"}}}}}}}]},"visibility":"Public","mutability":"NonPayable","virtual_keyword":false,"override_specifier":null,"modifier_invocations":[]}},{"FunctionDefinition":{"parameters":[],"returns":[{"type_name":{"ElementaryType":"BoolKeyword"},"storage_location":null,"name":null,"indexed":false}],"kind":"Regular","name":{"kind":"Identifier","text":"test"},"body":{"statements":[{"ReturnStatement":{"expression":{"EqualityExpression":{"left_operand":{"Identifier":{"kind":"Identifier","text":"owner"}},"operator":{"kind":"EqualEqual","text":"=="},"right_operand":{"MemberAccessExpression":{"operand":{"Identifier":{"kind":"Identifier","text":"msg"}},"member":{"kind":"Identifier","text":"sender"}}}}}}}]},"visibility":"Public","mutability":"View","virtual_keyword":false,"override_specifier":null,"modifier_invocations":[]}}],"inheritance_types":[],"storage_layout":null}}]}"#;
+    assert_eq!(serde_json::to_string(&source_unit)?, expected_json);
+
+    Ok(())
+}

--- a/crates/solidity/outputs/cargo/tests/src/backend/ir/mod.rs
+++ b/crates/solidity/outputs/cargo/tests/src/backend/ir/mod.rs
@@ -1,1 +1,2 @@
 pub mod ir1_structured_ast;
+pub mod ir2_flat_contracts;


### PR DESCRIPTION
This is intended for debugging purposes, as requested by @hedgar2017.

Deserialization is not possible because we don't serialize the associated CST tree, which is linked through the `node_id` field (skipped for serialization).

An undesired side effect is that serialization is also added to IR1, which should not be needed. I don't think it's important because this should be temporary anyways, since we're migrating the code to v2 and all the `backend` module is under a feature flag, but if it's a problem, I can make it to emit the derivations conditionally.
