### PR TITLE
[v2] remove obsolete `FieldsErrorRecovery` from grammar

### DIFF
--- a/crates/language-v2/definition/src/compiler/analysis/p2_version_specifiers/mod.rs
+++ b/crates/language-v2/definition/src/compiler/analysis/p2_version_specifiers/mod.rs
@@ -66,7 +66,6 @@ fn check_struct(analysis: &mut Analysis, item: &SpannedStructItem) {
         name: _,
         enabled,
         switch_lexical_context: _,
-        error_recovery: _,
         fields,
         parser_options: _,
     } = item;
@@ -138,7 +137,6 @@ fn check_precedence(analysis: &mut Analysis, item: &SpannedPrecedenceItem) {
             let SpannedPrecedenceOperator {
                 model: _,
                 enabled,
-                error_recovery: _,
                 fields,
             } = operator;
 

--- a/crates/language-v2/definition/src/compiler/analysis/p3_references/mod.rs
+++ b/crates/language-v2/definition/src/compiler/analysis/p3_references/mod.rs
@@ -98,7 +98,6 @@ fn check_struct(
         name,
         enabled,
         switch_lexical_context,
-        error_recovery: _,
         fields,
         parser_options: _,
     } = item;
@@ -250,7 +249,6 @@ fn check_precedence(
             let SpannedPrecedenceOperator {
                 model: _,
                 enabled,
-                error_recovery: _,
                 fields,
             } = operator;
 

--- a/crates/language-v2/definition/src/model/nonterminals/field.rs
+++ b/crates/language-v2/definition/src/model/nonterminals/field.rs
@@ -3,48 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{Identifier, VersionSpecifier};
 
-/// Error recovery for fields, this is used by the parser to recover in case of missing or unexpected tokens.
-///
-/// Note: Some nonterminals have both a terminator and delimiters, ie `DoWhileStatement`.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
-pub struct FieldsErrorRecovery {
-    /// Error recovery happens at a terminator.
-    ///
-    /// For example `PragmaDirective` has a `Semicolon` terminator, that could
-    /// be used to recover from an invalid `pragma` directive like
-    /// ```
-    /// pragma soldity ^0.8.0;
-    /// ```
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminator: Option<Identifier>,
-
-    /// Error recovery happens at delimiters.
-    ///
-    /// For example `TupleExpression` has a `OpenParen` and `CloseParen` delimiters,
-    /// that could be used to recover from an invalid tuple like
-    /// `(pragma, bar)`
-    ///   ~~~~~ -> This is not a valid expression
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub delimiters: Option<FieldDelimiters>,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
-pub struct FieldDelimiters {
-    pub open: Identifier,
-    pub close: Identifier,
-
-    /// How many tokens have to be matched to trigger the error recovery.
-    /// For ambiguous syntaxes this needs to be set to at least N, where N
-    /// is the token lookahead required to disambiguate the syntax.
-    ///
-    /// By default, we assume no lookahead (0) is required to recover from
-    /// unrecognized body between delimiters, so it's always triggered.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminals_matched_acceptance_threshold: Option<u8>,
-}
-
 /// A `Field` of a nonterminal that can be either required or optional.
 ///
 /// Note: `Optional` fields are versioned, `Required` fields are not.

--- a/crates/language-v2/definition/src/model/nonterminals/precedence.rs
+++ b/crates/language-v2/definition/src/model/nonterminals/precedence.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use language_v2_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{Field, FieldsErrorRecovery, Identifier, ParserOptions, VersionSpecifier};
+use crate::model::{Field, Identifier, ParserOptions, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
@@ -36,9 +36,6 @@ pub struct PrecedenceOperator {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<VersionSpecifier>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_recovery: Option<FieldsErrorRecovery>,
 
     #[serde(with = "indexmap::map::serde_seq")]
     pub fields: IndexMap<Identifier, Field>,

--- a/crates/language-v2/definition/src/model/nonterminals/struct_.rs
+++ b/crates/language-v2/definition/src/model/nonterminals/struct_.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use language_v2_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{Field, FieldsErrorRecovery, Identifier, ParserOptions, VersionSpecifier};
+use crate::model::{Field, Identifier, ParserOptions, VersionSpecifier};
 
 /// A `StructItem` is a nonterminal that can have fields.
 /// It roughly corresponds to a sequence of `Item`s.
@@ -20,10 +20,6 @@ pub struct StructItem {
     /// reference items in the specified target context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub switch_lexical_context: Option<Identifier>,
-
-    /// Error recovery information if this struct supports it
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_recovery: Option<FieldsErrorRecovery>,
 
     /// The fields of the struct, in the order they should appear in the source code
     #[serde(with = "indexmap::map::serde_seq")]

--- a/crates/language-v2/internal_macros/src/derive/spanned.rs
+++ b/crates/language-v2/internal_macros/src/derive/spanned.rs
@@ -119,8 +119,6 @@ fn get_spanned_type(input: Type) -> Type {
         | "EnumItem"
         | "EnumVariant"
         | "Field"
-        | "FieldDelimiters"
-        | "FieldsErrorRecovery"
         | "FragmentItem"
         | "InputItem"
         | "Item"

--- a/crates/language-v2/tests/src/pass/tiny_language.rs
+++ b/crates/language-v2/tests/src/pass/tiny_language.rs
@@ -62,7 +62,6 @@ fn definition() {
                                     name: "Foo".into(),
                                     enabled: None,
                                     switch_lexical_context: None,
-                                    error_recovery: None,
                                     fields: [
                                         (
                                             "bar".into(),

--- a/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
+++ b/crates/solidity-v2/inputs/language/src/BREAKING_CHANGES.md
@@ -16,6 +16,10 @@
 - Promoted `TokenDefinition::enabled` to `TokenItem::enabled`, as the new lexer doesn't version individual definitions (all of them are matched in all versions). We can decide on whether to keep or remove the additional `TokenDefinition` structure after we consider how to handle post-lexing processing (e.g. `DecimalLiteral` and `YulIdentifier` version breaks).
 - Promoted `KeywordDefinition::enabled` to `KeywordItem::enabled`, as the new lexer doesn't version individual definitions (all of them are matched in all versions). We can decide on whether to keep or remove the additional `KeywordDefinition` structure after we consider how to handle variations in `reserved` status between them (mainly the four `*fixed*` keywords).
 
+## Nonterminals
+
+- Removed `FieldsErrorRecovery` and `FieldDelimiters` types, since they are an artifact of the old v1 parser.
+
 ## Grammar
 
 The following changes modify the language definition to support the new parser and resolve grammar ambiguities.

--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -365,7 +365,6 @@ language_v2_macros::compile!(Language(
                                 Struct(
                                     name = PragmaDirective,
                                     switch_lexical_context = Pragma,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         pragma_keyword = Required(PragmaKeyword),
                                         pragma = Required(Pragma),
@@ -374,7 +373,6 @@ language_v2_macros::compile!(Language(
                                 ),
                                 Struct(
                                     name = ImportDirective,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         import_keyword = Required(ImportKeyword),
                                         clause = Required(ImportClause),
@@ -383,7 +381,6 @@ language_v2_macros::compile!(Language(
                                 ),
                                 Struct(
                                     name = UsingDirective,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         using_keyword = Required(UsingKeyword),
                                         clause = Required(UsingClause),
@@ -427,10 +424,6 @@ language_v2_macros::compile!(Language(
                                 ),
                                 Struct(
                                     name = ImportDeconstruction,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         open_brace = Required(OpenBrace),
                                         symbols = Required(ImportDeconstructionSymbols),
@@ -476,10 +469,6 @@ language_v2_macros::compile!(Language(
                                 Struct(
                                     name = UsingDeconstruction,
                                     enabled = From("0.8.13"),
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         open_brace = Required(OpenBrace),
                                         symbols = Required(UsingDeconstructionSymbols),
@@ -1967,10 +1956,6 @@ language_v2_macros::compile!(Language(
                             items = [
                                 Struct(
                                     name = ContractDefinition,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         abstract_keyword = Optional(
                                             reference = AbstractKeyword
@@ -2122,10 +2107,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             items = [
                                 Struct(
                                     name = InterfaceDefinition,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         interface_keyword = Required(InterfaceKeyword),
                                         name = Required(Identifier),
@@ -2147,10 +2128,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             items = [
                                 Struct(
                                     name = LibraryDefinition,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         library_keyword = Required(LibraryKeyword),
                                         name = Required(Identifier),
@@ -2171,10 +2148,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             items = [
                                 Struct(
                                     name = StructDefinition,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         struct_keyword = Required(StructKeyword),
                                         name = Required(Identifier),
@@ -2190,7 +2163,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                                 ),
                                 Struct(
                                     name = StructMember,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         type_name = Required(TypeName),
                                         name = Required(Identifier),
@@ -2204,10 +2176,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             items = [
                                 Struct(
                                     name = EnumDefinition,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         enum_keyword = Required(EnumKeyword),
                                         name = Required(Identifier),
@@ -2228,7 +2196,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             title = "Constants",
                             items = [Struct(
                                 name = ConstantDefinition,
-                                error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                 fields = (
                                     type_name = Required(TypeName),
                                     constant_keyword = Required(ConstantKeyword),
@@ -2244,7 +2211,6 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                             items = [
                                 Struct(
                                     name = StateVariableDefinition,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         type_name = Required(TypeName),
                                         attributes = Required(StateVariableAttributes),
@@ -2372,10 +2338,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                 ),
                                 Struct(
                                     name = ParametersDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         parameters = Required(Parameters),
@@ -2425,10 +2387,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                 ),
                                 Struct(
                                     name = OverridePathsDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         paths = Required(OverridePaths),
@@ -2569,7 +2527,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                             items = [
                                 Struct(
                                     name = EventDefinition,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         event_keyword = Required(EventKeyword),
                                         name = Required(Identifier),
@@ -2580,10 +2537,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                 ),
                                 Struct(
                                     name = EventParametersDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         parameters = Required(EventParameters),
@@ -2611,7 +2564,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                             items = [Struct(
                                 name = UserDefinedValueTypeDefinition,
                                 enabled = From("0.8.8"),
-                                error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                 fields = (
                                     type_keyword = Required(TypeKeyword),
                                     name = Required(Identifier),
@@ -2627,7 +2579,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                 Struct(
                                     name = ErrorDefinition,
                                     enabled = From("0.8.4"),
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         error_keyword = Required(ErrorKeyword),
                                         name = Required(Identifier),
@@ -2639,10 +2590,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                 Struct(
                                     name = ErrorParametersDeclaration,
                                     enabled = From("0.8.4"),
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         parameters = Required(ErrorParameters),
@@ -2680,12 +2627,6 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                         name = ArrayTypeName,
                                         operators = [PrecedenceOperator(
                                             model = Postfix,
-                                            error_recovery = FieldsErrorRecovery(
-                                                delimiters = FieldDelimiters(
-                                                    open = open_bracket,
-                                                    close = close_bracket
-                                                )
-                                            ),
                                             fields = (
                                                 open_bracket = Required(OpenBracket),
                                                 index = Optional(reference = Expression),
@@ -2780,10 +2721,6 @@ FunctionTypeInternalReturn: FunctionType = {
                                 ),
                                 Struct(
                                     name = MappingType,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         mapping_keyword = Required(MappingKeyword),
                                         open_paren = Required(OpenParen),
@@ -2859,10 +2796,6 @@ FunctionTypeInternalReturn: FunctionType = {
                             items = [
                                 Struct(
                                     name = Block,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         open_brace = Required(OpenBrace),
                                         statements = Required(Statements),
@@ -2989,7 +2922,6 @@ IdentifierPathNoRevert: IdentifierPath = {
                                 ),
                                 Struct(
                                     name = ExpressionStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         expression = Required(Expression),
                                         semicolon = Required(Semicolon)
@@ -3023,7 +2955,6 @@ IdentifierPathNoRevert: IdentifierPath = {
                                 ),
                                 Struct(
                                     name = VariableDeclarationStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         target = Required(VariableDeclarationTarget),
                                         semicolon = Required(Semicolon)
@@ -3045,10 +2976,6 @@ IdentifierPathNoRevert: IdentifierPath = {
                                 ),
                                 Struct(
                                     name = MultiTypedDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         elements = Required(MultiTypedDeclarationElements),
@@ -3117,10 +3044,6 @@ TuplePrefix: usize = {
                             items = [
                                 Struct(
                                     name = IfStatement,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         if_keyword = Required(IfKeyword),
                                         open_paren = Required(OpenParen),
@@ -3147,10 +3070,6 @@ IfStatement<TrailingElse>: IfStatement = {
                                 ),
                                 Struct(
                                     name = ForStatement,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         for_keyword = Required(ForKeyword),
                                         open_paren = Required(OpenParen),
@@ -3185,10 +3104,6 @@ ForStatement<TrailingElse>: ForStatement = {
                                 ),
                                 Struct(
                                     name = WhileStatement,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         while_keyword = Required(WhileKeyword),
                                         open_paren = Required(OpenParen),
@@ -3206,11 +3121,6 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                 ),
                                 Struct(
                                     name = DoWhileStatement,
-                                    error_recovery = FieldsErrorRecovery(
-                                        terminator = semicolon,
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         do_keyword = Required(DoKeyword),
                                         body = Required(Statement),
@@ -3223,7 +3133,6 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                 ),
                                 Struct(
                                     name = ContinueStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         continue_keyword = Required(ContinueKeyword),
                                         semicolon = Required(Semicolon)
@@ -3231,7 +3140,6 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                 ),
                                 Struct(
                                     name = BreakStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         break_keyword = Required(BreakKeyword),
                                         semicolon = Required(Semicolon)
@@ -3239,7 +3147,6 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                 ),
                                 Struct(
                                     name = ReturnStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         return_keyword = Required(ReturnKeyword),
                                         expression = Optional(reference = Expression),
@@ -3248,7 +3155,6 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                 ),
                                 Struct(
                                     name = EmitStatement,
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         emit_keyword = Required(EmitKeyword),
                                         event = Required(IdentifierPath),
@@ -3315,7 +3221,6 @@ ExpressionTrailingBlock: (Expression, Block) = {
                                 Struct(
                                     name = RevertStatement,
                                     enabled = From("0.8.4"),
-                                    error_recovery = FieldsErrorRecovery(terminator = semicolon),
                                     fields = (
                                         revert_keyword = Required(RevertKeyword),
                                         error = Required(IdentifierPath),
@@ -3592,29 +3497,6 @@ ExpressionTrailingBlock: (Expression, Block) = {
                                             name = CallOptionsExpression,
                                             operators = [PrecedenceOperator(
                                                 model = Postfix,
-                                                error_recovery = FieldsErrorRecovery(
-                                                    delimiters = FieldDelimiters(
-                                                        open = open_brace,
-                                                        close = close_brace,
-                                                        // NOTE: Despite `CallOptions` requiring at least one element, we should
-                                                        // only recover if we found at least two tokens ('Identifier' + 'Colon')
-                                                        // between the braces, as  otherwise, this may be ambiguous when followed
-                                                        // by an empty 'Block' node, for example, in a 'TryStatement':
-                                                        //
-                                                        //     try <EXPR> {
-                                                        //         /* not call options  */
-                                                        //     } catch {
-                                                        //     }
-                                                        //
-                                                        // Or in 'ContractDefinition' that has a 'StorageLayoutSpecifier':
-                                                        //
-                                                        //     contract Foo layout at <EXPR> {
-                                                        //         /* not call options  */
-                                                        //     }
-                                                        //
-                                                        terminals_matched_acceptance_threshold = 2
-                                                    )
-                                                ),
                                                 fields = (
                                                     open_brace = Required(OpenBrace),
                                                     options = Required(CallOptions),
@@ -3636,12 +3518,6 @@ ExpressionTrailingBlock: (Expression, Block) = {
                                             name = IndexAccessExpression,
                                             operators = [PrecedenceOperator(
                                                 model = Postfix,
-                                                error_recovery = FieldsErrorRecovery(
-                                                    delimiters = FieldDelimiters(
-                                                        open = open_bracket,
-                                                        close = close_bracket
-                                                    )
-                                                ),
                                                 fields = (
                                                     open_bracket = Required(OpenBracket),
                                                     start = Optional(reference = Expression),
@@ -3996,10 +3872,6 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
                                 ),
                                 Struct(
                                     name = PositionalArgumentsDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         arguments = Required(PositionalArguments),
@@ -4014,10 +3886,6 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
                                 ),
                                 Struct(
                                     name = NamedArgumentsDeclaration,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         arguments = Required(NamedArgumentGroup),
@@ -4026,10 +3894,6 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
                                 ),
                                 Struct(
                                     name = NamedArgumentGroup,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_brace, close = close_brace)
-                                    ),
                                     fields = (
                                         open_brace = Required(OpenBrace),
                                         arguments = Required(NamedArguments),
@@ -4064,10 +3928,6 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
                             items = [
                                 Struct(
                                     name = TypeExpression,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         type_keyword = Required(TypeKeyword),
                                         open_paren = Required(OpenParen),
@@ -4099,10 +3959,6 @@ NoFunctionType: FunctionType = {};
                                 ),
                                 Struct(
                                     name = TupleExpression,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters =
-                                            FieldDelimiters(open = open_paren, close = close_paren)
-                                    ),
                                     fields = (
                                         open_paren = Required(OpenParen),
                                         items = Required(TupleValues),
@@ -4141,12 +3997,6 @@ TupleValues: TupleValues = {
                                 ),
                                 Struct(
                                     name = ArrayExpression,
-                                    error_recovery = FieldsErrorRecovery(
-                                        delimiters = FieldDelimiters(
-                                            open = open_bracket,
-                                            close = close_bracket
-                                        )
-                                    ),
                                     fields = (
                                         open_bracket = Required(OpenBracket),
                                         items = Required(ArrayValues),
@@ -4516,10 +4366,6 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                             Struct(
                                 name = YulFlagsDeclaration,
                                 enabled = From("0.8.13"),
-                                error_recovery = FieldsErrorRecovery(
-                                    delimiters =
-                                        FieldDelimiters(open = open_paren, close = close_paren)
-                                ),
                                 fields = (
                                     open_paren = Required(YulOpenParen),
                                     flags = Required(YulFlags),
@@ -4534,10 +4380,6 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                             ),
                             Struct(
                                 name = YulBlock,
-                                error_recovery = FieldsErrorRecovery(
-                                    delimiters =
-                                        FieldDelimiters(open = open_brace, close = close_brace)
-                                ),
                                 fields = (
                                     open_brace = Required(YulOpenBrace),
                                     statements = Required(YulStatements),
@@ -4577,10 +4419,6 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                             ),
                             Struct(
                                 name = YulParametersDeclaration,
-                                error_recovery = FieldsErrorRecovery(
-                                    delimiters =
-                                        FieldDelimiters(open = open_paren, close = close_paren)
-                                ),
                                 fields = (
                                     open_paren = Required(YulOpenParen),
                                     parameters = Required(YulParameters),
@@ -4700,12 +4538,6 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                                     name = YulFunctionCallExpression,
                                     operators = [PrecedenceOperator(
                                         model = Postfix,
-                                        error_recovery = FieldsErrorRecovery(
-                                            delimiters = FieldDelimiters(
-                                                open = open_paren,
-                                                close = close_paren
-                                            )
-                                        ),
                                         fields = (
                                             open_paren = Required(YulOpenParen),
                                             arguments = Required(YulArguments),


### PR DESCRIPTION
A v1 artifact that is no longer used.