### PR TITLE
[v2] Generate controlled IDs for IR nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,7 @@ dependencies = [
  "anyhow",
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
+ "slang_solidity_v2_cst",
  "slang_solidity_v2_ir",
  "slang_solidity_v2_parser",
  "slang_solidity_v2_semantic",

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -4,7 +4,8 @@ use std::cmp::Ordering;
 use std::rc::Rc;
 
 use sha3::{Digest, Keccak256};
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{Type, TypeId};

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/definitions.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use paste::paste;
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::SemanticContext;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifiers.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifiers.rs
@@ -1,5 +1,5 @@
 use slang_solidity_v2_common::built_ins::BuiltIn;
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder;
 
 use super::super::nodes::{IdentifierPathStruct, IdentifierStruct};

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -4,7 +4,8 @@
 #![allow(non_camel_case_types)]
 use std::rc::Rc;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 
 use super::types::Type;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -3,7 +3,8 @@
 #![allow(non_camel_case_types)]
 use std::rc::Rc;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use super::types::Type;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/references.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/references.rs
@@ -1,7 +1,8 @@
 use std::rc::Rc;
 
 use slang_solidity_v2_common::built_ins::BuiltIn;
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 
 use super::{create_identifier, Definition, Identifier};

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -1,7 +1,8 @@
 use std::rc::Rc;
 
 use paste::paste;
-use slang_solidity_v2_ir::ir::{FunctionMutability, FunctionVisibility, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir::{FunctionMutability, FunctionVisibility};
 use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{self, DataLocation, TypeId};
 

--- a/crates/solidity-v2/outputs/cargo/common/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod built_ins;
+pub mod nodes;
 pub mod versions;

--- a/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
@@ -1,0 +1,9 @@
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct NodeId(usize);
+
+impl From<usize> for NodeId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
@@ -19,10 +19,10 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }
 
 [dev-dependencies]
-slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_parser = { workspace = true }
 
 [lints]

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -11,6 +11,7 @@ use slang_solidity_v2_cst::structured_cst::nodes as input;
 use crate::ir::nodes as output;
 
 pub trait Builder {
+    fn next_id(&mut self) -> output::NodeId;
     fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
 
     //
@@ -18,15 +19,17 @@ pub trait Builder {
     //
 
     fn build_abicoder_pragma(&mut self, source: &input::AbicoderPragma) -> output::AbicoderPragma {
+        let id = self.next_id();
         let version = self.build_abicoder_version(&source.version);
 
-        Rc::new(output::AbicoderPragmaStruct { version })
+        Rc::new(output::AbicoderPragmaStruct { id, version })
     }
 
     fn build_additive_expression(
         &mut self,
         source: &input::AdditiveExpression,
     ) -> output::AdditiveExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_additive_expression_operator = self
             .build_expression_additive_expression_operator(
@@ -35,6 +38,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::AdditiveExpressionStruct {
+            id,
             left_operand,
             expression_additive_expression_operator,
             right_operand,
@@ -42,16 +46,22 @@ pub trait Builder {
     }
 
     fn build_address_type(&mut self, source: &input::AddressType) -> output::AddressType {
+        let id = self.next_id();
         let payable_keyword = source.payable_keyword.is_some();
 
-        Rc::new(output::AddressTypeStruct { payable_keyword })
+        Rc::new(output::AddressTypeStruct {
+            id,
+            payable_keyword,
+        })
     }
 
     fn build_and_expression(&mut self, source: &input::AndExpression) -> output::AndExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::AndExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
@@ -61,25 +71,28 @@ pub trait Builder {
         &mut self,
         source: &input::ArrayExpression,
     ) -> output::ArrayExpression {
+        let id = self.next_id();
         let items = self.build_array_values(&source.items);
 
-        Rc::new(output::ArrayExpressionStruct { items })
+        Rc::new(output::ArrayExpressionStruct { id, items })
     }
 
     fn build_array_type_name(&mut self, source: &input::ArrayTypeName) -> output::ArrayTypeName {
+        let id = self.next_id();
         let operand = self.build_type_name(&source.operand);
         let index = source
             .index
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::ArrayTypeNameStruct { operand, index })
+        Rc::new(output::ArrayTypeNameStruct { id, operand, index })
     }
 
     fn build_assembly_statement(
         &mut self,
         source: &input::AssemblyStatement,
     ) -> output::AssemblyStatement {
+        let id = self.next_id();
         let label = source
             .label
             .as_ref()
@@ -90,13 +103,19 @@ pub trait Builder {
             .map(|value| self.build_yul_flags_declaration(value));
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::AssemblyStatementStruct { label, flags, body })
+        Rc::new(output::AssemblyStatementStruct {
+            id,
+            label,
+            flags,
+            body,
+        })
     }
 
     fn build_assignment_expression(
         &mut self,
         source: &input::AssignmentExpression,
     ) -> output::AssignmentExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_assignment_expression_operator = self
             .build_expression_assignment_expression_operator(
@@ -105,6 +124,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::AssignmentExpressionStruct {
+            id,
             left_operand,
             expression_assignment_expression_operator,
             right_operand,
@@ -115,10 +135,12 @@ pub trait Builder {
         &mut self,
         source: &input::BitwiseAndExpression,
     ) -> output::BitwiseAndExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseAndExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
@@ -128,10 +150,12 @@ pub trait Builder {
         &mut self,
         source: &input::BitwiseOrExpression,
     ) -> output::BitwiseOrExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseOrExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
@@ -141,67 +165,85 @@ pub trait Builder {
         &mut self,
         source: &input::BitwiseXorExpression,
     ) -> output::BitwiseXorExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseXorExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
     }
 
     fn build_block(&mut self, source: &input::Block) -> output::Block {
+        let id = self.next_id();
         let statements = self.build_statements(&source.statements);
 
-        Rc::new(output::BlockStruct { statements })
+        Rc::new(output::BlockStruct { id, statements })
     }
 
     fn build_break_statement(&mut self, source: &input::BreakStatement) -> output::BreakStatement {
-        Rc::new(output::BreakStatementStruct {})
+        let id = self.next_id();
+
+        Rc::new(output::BreakStatementStruct { id })
     }
 
     fn build_call_options_expression(
         &mut self,
         source: &input::CallOptionsExpression,
     ) -> output::CallOptionsExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let options = self.build_call_options(&source.options);
 
-        Rc::new(output::CallOptionsExpressionStruct { operand, options })
+        Rc::new(output::CallOptionsExpressionStruct {
+            id,
+            operand,
+            options,
+        })
     }
 
     fn build_catch_clause(&mut self, source: &input::CatchClause) -> output::CatchClause {
+        let id = self.next_id();
         let error = source
             .error
             .as_ref()
             .map(|value| self.build_catch_clause_error(value));
         let body = self.build_block(&source.body);
 
-        Rc::new(output::CatchClauseStruct { error, body })
+        Rc::new(output::CatchClauseStruct { id, error, body })
     }
 
     fn build_catch_clause_error(
         &mut self,
         source: &input::CatchClauseError,
     ) -> output::CatchClauseError {
+        let id = self.next_id();
         let name = source
             .name
             .as_ref()
             .map(|value| self.build_identifier(value));
         let parameters = self.build_parameters_declaration(&source.parameters);
 
-        Rc::new(output::CatchClauseErrorStruct { name, parameters })
+        Rc::new(output::CatchClauseErrorStruct {
+            id,
+            name,
+            parameters,
+        })
     }
 
     fn build_conditional_expression(
         &mut self,
         source: &input::ConditionalExpression,
     ) -> output::ConditionalExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let true_expression = self.build_expression(&source.true_expression);
         let false_expression = self.build_expression(&source.false_expression);
 
         Rc::new(output::ConditionalExpressionStruct {
+            id,
             operand,
             true_expression,
             false_expression,
@@ -217,7 +259,9 @@ pub trait Builder {
         &mut self,
         source: &input::ContinueStatement,
     ) -> output::ContinueStatement {
-        Rc::new(output::ContinueStatementStruct {})
+        let id = self.next_id();
+
+        Rc::new(output::ContinueStatementStruct { id })
     }
 
     fn build_contract_definition(
@@ -229,43 +273,56 @@ pub trait Builder {
         &mut self,
         source: &input::DecimalNumberExpression,
     ) -> output::DecimalNumberExpression {
+        let id = self.next_id();
         let literal = self.build_decimal_literal(&source.literal);
         let unit = source
             .unit
             .as_ref()
             .map(|value| self.build_number_unit(value));
 
-        Rc::new(output::DecimalNumberExpressionStruct { literal, unit })
+        Rc::new(output::DecimalNumberExpressionStruct { id, literal, unit })
     }
 
     fn build_do_while_statement(
         &mut self,
         source: &input::DoWhileStatement,
     ) -> output::DoWhileStatement {
+        let id = self.next_id();
         let body = self.build_statement(&source.body);
         let condition = self.build_expression(&source.condition);
 
-        Rc::new(output::DoWhileStatementStruct { body, condition })
+        Rc::new(output::DoWhileStatementStruct {
+            id,
+            body,
+            condition,
+        })
     }
 
     fn build_emit_statement(&mut self, source: &input::EmitStatement) -> output::EmitStatement {
+        let id = self.next_id();
         let event = self.build_identifier_path(&source.event);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
-        Rc::new(output::EmitStatementStruct { event, arguments })
+        Rc::new(output::EmitStatementStruct {
+            id,
+            event,
+            arguments,
+        })
     }
 
     fn build_enum_definition(&mut self, source: &input::EnumDefinition) -> output::EnumDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let members = self.build_enum_members(&source.members);
 
-        Rc::new(output::EnumDefinitionStruct { name, members })
+        Rc::new(output::EnumDefinitionStruct { id, name, members })
     }
 
     fn build_equality_expression(
         &mut self,
         source: &input::EqualityExpression,
     ) -> output::EqualityExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_equality_expression_operator = self
             .build_expression_equality_expression_operator(
@@ -274,6 +331,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::EqualityExpressionStruct {
+            id,
             left_operand,
             expression_equality_expression_operator,
             right_operand,
@@ -294,19 +352,22 @@ pub trait Builder {
         &mut self,
         source: &input::ExperimentalPragma,
     ) -> output::ExperimentalPragma {
+        let id = self.next_id();
         let feature = self.build_experimental_feature(&source.feature);
 
-        Rc::new(output::ExperimentalPragmaStruct { feature })
+        Rc::new(output::ExperimentalPragmaStruct { id, feature })
     }
 
     fn build_exponentiation_expression(
         &mut self,
         source: &input::ExponentiationExpression,
     ) -> output::ExponentiationExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::ExponentiationExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
@@ -316,12 +377,14 @@ pub trait Builder {
         &mut self,
         source: &input::ExpressionStatement,
     ) -> output::ExpressionStatement {
+        let id = self.next_id();
         let expression = self.build_expression(&source.expression);
 
-        Rc::new(output::ExpressionStatementStruct { expression })
+        Rc::new(output::ExpressionStatementStruct { id, expression })
     }
 
     fn build_for_statement(&mut self, source: &input::ForStatement) -> output::ForStatement {
+        let id = self.next_id();
         let initialization = self.build_for_statement_initialization(&source.initialization);
         let condition = self.build_for_statement_condition(&source.condition);
         let iterator = source
@@ -331,6 +394,7 @@ pub trait Builder {
         let body = self.build_statement(&source.body);
 
         Rc::new(output::ForStatementStruct {
+            id,
             initialization,
             condition,
             iterator,
@@ -342,10 +406,15 @@ pub trait Builder {
         &mut self,
         source: &input::FunctionCallExpression,
     ) -> output::FunctionCallExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
-        Rc::new(output::FunctionCallExpressionStruct { operand, arguments })
+        Rc::new(output::FunctionCallExpressionStruct {
+            id,
+            operand,
+            arguments,
+        })
     }
 
     fn build_function_definition(
@@ -359,12 +428,14 @@ pub trait Builder {
         &mut self,
         source: &input::HexNumberExpression,
     ) -> output::HexNumberExpression {
+        let id = self.next_id();
         let literal = self.build_hex_literal(&source.literal);
 
-        Rc::new(output::HexNumberExpressionStruct { literal })
+        Rc::new(output::HexNumberExpressionStruct { id, literal })
     }
 
     fn build_if_statement(&mut self, source: &input::IfStatement) -> output::IfStatement {
+        let id = self.next_id();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
         let else_branch = source
@@ -373,6 +444,7 @@ pub trait Builder {
             .map(|value| self.build_else_branch(value));
 
         Rc::new(output::IfStatementStruct {
+            id,
             condition,
             body,
             else_branch,
@@ -383,23 +455,25 @@ pub trait Builder {
         &mut self,
         source: &input::ImportDeconstruction,
     ) -> output::ImportDeconstruction {
+        let id = self.next_id();
         let symbols = self.build_import_deconstruction_symbols(&source.symbols);
         let path = self.build_string_literal(&source.path);
 
-        Rc::new(output::ImportDeconstructionStruct { symbols, path })
+        Rc::new(output::ImportDeconstructionStruct { id, symbols, path })
     }
 
     fn build_import_deconstruction_symbol(
         &mut self,
         source: &input::ImportDeconstructionSymbol,
     ) -> output::ImportDeconstructionSymbol {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_import_alias(value));
 
-        Rc::new(output::ImportDeconstructionSymbolStruct { name, alias })
+        Rc::new(output::ImportDeconstructionSymbolStruct { id, name, alias })
     }
 
     fn build_index_access_expression(
@@ -411,6 +485,7 @@ pub trait Builder {
         &mut self,
         source: &input::InequalityExpression,
     ) -> output::InequalityExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_inequality_expression_operator = self
             .build_expression_inequality_expression_operator(
@@ -419,6 +494,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::InequalityExpressionStruct {
+            id,
             left_operand,
             expression_inequality_expression_operator,
             right_operand,
@@ -429,6 +505,7 @@ pub trait Builder {
         &mut self,
         source: &input::InheritanceType,
     ) -> output::InheritanceType {
+        let id = self.next_id();
         let type_name = self.build_identifier_path(&source.type_name);
         let arguments = source
             .arguments
@@ -436,6 +513,7 @@ pub trait Builder {
             .map(|value| self.build_arguments_declaration(value));
 
         Rc::new(output::InheritanceTypeStruct {
+            id,
             type_name,
             arguments,
         })
@@ -445,6 +523,7 @@ pub trait Builder {
         &mut self,
         source: &input::InterfaceDefinition,
     ) -> output::InterfaceDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let inheritance = source
             .inheritance
@@ -453,6 +532,7 @@ pub trait Builder {
         let members = self.build_interface_members(&source.members);
 
         Rc::new(output::InterfaceDefinitionStruct {
+            id,
             name,
             inheritance,
             members,
@@ -463,10 +543,11 @@ pub trait Builder {
         &mut self,
         source: &input::LibraryDefinition,
     ) -> output::LibraryDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let members = self.build_library_members(&source.members);
 
-        Rc::new(output::LibraryDefinitionStruct { name, members })
+        Rc::new(output::LibraryDefinitionStruct { id, name, members })
     }
 
     fn build_mapping_type(&mut self, source: &input::MappingType) -> output::MappingType;
@@ -475,51 +556,68 @@ pub trait Builder {
         &mut self,
         source: &input::MemberAccessExpression,
     ) -> output::MemberAccessExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let member = self.build_identifier_path_element(&source.member);
 
-        Rc::new(output::MemberAccessExpressionStruct { operand, member })
+        Rc::new(output::MemberAccessExpressionStruct {
+            id,
+            operand,
+            member,
+        })
     }
 
     fn build_modifier_invocation(
         &mut self,
         source: &input::ModifierInvocation,
     ) -> output::ModifierInvocation {
+        let id = self.next_id();
         let name = self.build_identifier_path(&source.name);
         let arguments = source
             .arguments
             .as_ref()
             .map(|value| self.build_arguments_declaration(value));
 
-        Rc::new(output::ModifierInvocationStruct { name, arguments })
+        Rc::new(output::ModifierInvocationStruct {
+            id,
+            name,
+            arguments,
+        })
     }
 
     fn build_multi_typed_declaration(
         &mut self,
         source: &input::MultiTypedDeclaration,
     ) -> output::MultiTypedDeclaration {
+        let id = self.next_id();
         let elements = self.build_multi_typed_declaration_elements(&source.elements);
         let value = self.build_variable_declaration_value(&source.value);
 
-        Rc::new(output::MultiTypedDeclarationStruct { elements, value })
+        Rc::new(output::MultiTypedDeclarationStruct {
+            id,
+            elements,
+            value,
+        })
     }
 
     fn build_multi_typed_declaration_element(
         &mut self,
         source: &input::MultiTypedDeclarationElement,
     ) -> output::MultiTypedDeclarationElement {
+        let id = self.next_id();
         let member = source
             .member
             .as_ref()
             .map(|value| self.build_variable_declaration(value));
 
-        Rc::new(output::MultiTypedDeclarationElementStruct { member })
+        Rc::new(output::MultiTypedDeclarationElementStruct { id, member })
     }
 
     fn build_multiplicative_expression(
         &mut self,
         source: &input::MultiplicativeExpression,
     ) -> output::MultiplicativeExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_multiplicative_expression_operator = self
             .build_expression_multiplicative_expression_operator(
@@ -528,6 +626,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::MultiplicativeExpressionStruct {
+            id,
             left_operand,
             expression_multiplicative_expression_operator,
             right_operand,
@@ -535,23 +634,27 @@ pub trait Builder {
     }
 
     fn build_named_argument(&mut self, source: &input::NamedArgument) -> output::NamedArgument {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let value = self.build_expression(&source.value);
 
-        Rc::new(output::NamedArgumentStruct { name, value })
+        Rc::new(output::NamedArgumentStruct { id, name, value })
     }
 
     fn build_new_expression(&mut self, source: &input::NewExpression) -> output::NewExpression {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
 
-        Rc::new(output::NewExpressionStruct { type_name })
+        Rc::new(output::NewExpressionStruct { id, type_name })
     }
 
     fn build_or_expression(&mut self, source: &input::OrExpression) -> output::OrExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::OrExpressionStruct {
+            id,
             left_operand,
             right_operand,
         })
@@ -560,19 +663,21 @@ pub trait Builder {
     fn build_parameter(&mut self, source: &input::Parameter) -> output::Parameter;
 
     fn build_path_import(&mut self, source: &input::PathImport) -> output::PathImport {
+        let id = self.next_id();
         let path = self.build_string_literal(&source.path);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_import_alias(value));
 
-        Rc::new(output::PathImportStruct { path, alias })
+        Rc::new(output::PathImportStruct { id, path, alias })
     }
 
     fn build_postfix_expression(
         &mut self,
         source: &input::PostfixExpression,
     ) -> output::PostfixExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let expression_postfix_expression_operator = self
             .build_expression_postfix_expression_operator(
@@ -580,6 +685,7 @@ pub trait Builder {
             );
 
         Rc::new(output::PostfixExpressionStruct {
+            id,
             operand,
             expression_postfix_expression_operator,
         })
@@ -589,15 +695,17 @@ pub trait Builder {
         &mut self,
         source: &input::PragmaDirective,
     ) -> output::PragmaDirective {
+        let id = self.next_id();
         let pragma = self.build_pragma(&source.pragma);
 
-        Rc::new(output::PragmaDirectiveStruct { pragma })
+        Rc::new(output::PragmaDirectiveStruct { id, pragma })
     }
 
     fn build_prefix_expression(
         &mut self,
         source: &input::PrefixExpression,
     ) -> output::PrefixExpression {
+        let id = self.next_id();
         let expression_prefix_expression_operator = self
             .build_expression_prefix_expression_operator(
                 &source.expression_prefix_expression_operator,
@@ -605,6 +713,7 @@ pub trait Builder {
         let operand = self.build_expression(&source.operand);
 
         Rc::new(output::PrefixExpressionStruct {
+            id,
             expression_prefix_expression_operator,
             operand,
         })
@@ -614,28 +723,35 @@ pub trait Builder {
         &mut self,
         source: &input::ReturnStatement,
     ) -> output::ReturnStatement {
+        let id = self.next_id();
         let expression = source
             .expression
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::ReturnStatementStruct { expression })
+        Rc::new(output::ReturnStatementStruct { id, expression })
     }
 
     fn build_revert_statement(
         &mut self,
         source: &input::RevertStatement,
     ) -> output::RevertStatement {
+        let id = self.next_id();
         let error = self.build_identifier_path(&source.error);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
-        Rc::new(output::RevertStatementStruct { error, arguments })
+        Rc::new(output::RevertStatementStruct {
+            id,
+            error,
+            arguments,
+        })
     }
 
     fn build_shift_expression(
         &mut self,
         source: &input::ShiftExpression,
     ) -> output::ShiftExpression {
+        let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_shift_expression_operator = self.build_expression_shift_expression_operator(
             &source.expression_shift_expression_operator,
@@ -643,6 +759,7 @@ pub trait Builder {
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::ShiftExpressionStruct {
+            id,
             left_operand,
             expression_shift_expression_operator,
             right_operand,
@@ -653,19 +770,25 @@ pub trait Builder {
         &mut self,
         source: &input::SingleTypedDeclaration,
     ) -> output::SingleTypedDeclaration {
+        let id = self.next_id();
         let declaration = self.build_variable_declaration(&source.declaration);
         let value = source
             .value
             .as_ref()
             .map(|value| self.build_variable_declaration_value(value));
 
-        Rc::new(output::SingleTypedDeclarationStruct { declaration, value })
+        Rc::new(output::SingleTypedDeclarationStruct {
+            id,
+            declaration,
+            value,
+        })
     }
 
     fn build_source_unit(&mut self, source: &input::SourceUnit) -> output::SourceUnit {
+        let id = self.next_id();
         let members = self.build_source_unit_members(&source.members);
 
-        Rc::new(output::SourceUnitStruct { members })
+        Rc::new(output::SourceUnitStruct { id, members })
     }
 
     fn build_state_variable_definition(
@@ -677,20 +800,27 @@ pub trait Builder {
         &mut self,
         source: &input::StructDefinition,
     ) -> output::StructDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let members = self.build_struct_members(&source.members);
 
-        Rc::new(output::StructDefinitionStruct { name, members })
+        Rc::new(output::StructDefinitionStruct { id, name, members })
     }
 
     fn build_struct_member(&mut self, source: &input::StructMember) -> output::StructMember {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
 
-        Rc::new(output::StructMemberStruct { type_name, name })
+        Rc::new(output::StructMemberStruct {
+            id,
+            type_name,
+            name,
+        })
     }
 
     fn build_try_statement(&mut self, source: &input::TryStatement) -> output::TryStatement {
+        let id = self.next_id();
         let expression = self.build_expression(&source.expression);
         let returns = source
             .returns
@@ -700,6 +830,7 @@ pub trait Builder {
         let catch_clauses = self.build_catch_clauses(&source.catch_clauses);
 
         Rc::new(output::TryStatementStruct {
+            id,
             expression,
             returns,
             body,
@@ -711,70 +842,83 @@ pub trait Builder {
         &mut self,
         source: &input::TupleExpression,
     ) -> output::TupleExpression {
+        let id = self.next_id();
         let items = self.build_tuple_values(&source.items);
 
-        Rc::new(output::TupleExpressionStruct { items })
+        Rc::new(output::TupleExpressionStruct { id, items })
     }
 
     fn build_tuple_value(&mut self, source: &input::TupleValue) -> output::TupleValue {
+        let id = self.next_id();
         let expression = source
             .expression
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::TupleValueStruct { expression })
+        Rc::new(output::TupleValueStruct { id, expression })
     }
 
     fn build_type_expression(&mut self, source: &input::TypeExpression) -> output::TypeExpression {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
 
-        Rc::new(output::TypeExpressionStruct { type_name })
+        Rc::new(output::TypeExpressionStruct { id, type_name })
     }
 
     fn build_unchecked_block(&mut self, source: &input::UncheckedBlock) -> output::UncheckedBlock {
+        let id = self.next_id();
         let block = self.build_block(&source.block);
 
-        Rc::new(output::UncheckedBlockStruct { block })
+        Rc::new(output::UncheckedBlockStruct { id, block })
     }
 
     fn build_user_defined_value_type_definition(
         &mut self,
         source: &input::UserDefinedValueTypeDefinition,
     ) -> output::UserDefinedValueTypeDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let value_type = self.build_elementary_type(&source.value_type);
 
-        Rc::new(output::UserDefinedValueTypeDefinitionStruct { name, value_type })
+        Rc::new(output::UserDefinedValueTypeDefinitionStruct {
+            id,
+            name,
+            value_type,
+        })
     }
 
     fn build_using_deconstruction(
         &mut self,
         source: &input::UsingDeconstruction,
     ) -> output::UsingDeconstruction {
+        let id = self.next_id();
         let symbols = self.build_using_deconstruction_symbols(&source.symbols);
 
-        Rc::new(output::UsingDeconstructionStruct { symbols })
+        Rc::new(output::UsingDeconstructionStruct { id, symbols })
     }
 
     fn build_using_deconstruction_symbol(
         &mut self,
         source: &input::UsingDeconstructionSymbol,
     ) -> output::UsingDeconstructionSymbol {
+        let id = self.next_id();
         let name = self.build_identifier_path(&source.name);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_using_alias(value));
 
-        Rc::new(output::UsingDeconstructionSymbolStruct { name, alias })
+        Rc::new(output::UsingDeconstructionSymbolStruct { id, name, alias })
     }
 
     fn build_using_directive(&mut self, source: &input::UsingDirective) -> output::UsingDirective {
+        let id = self.next_id();
         let clause = self.build_using_clause(&source.clause);
         let target = self.build_using_target(&source.target);
         let global_keyword = source.global_keyword.is_some();
 
         Rc::new(output::UsingDirectiveStruct {
+            id,
             clause,
             target,
             global_keyword,
@@ -785,6 +929,7 @@ pub trait Builder {
         &mut self,
         source: &input::VariableDeclaration,
     ) -> output::VariableDeclaration {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let storage_location = source
             .storage_location
@@ -793,6 +938,7 @@ pub trait Builder {
         let name = self.build_identifier(&source.name);
 
         Rc::new(output::VariableDeclarationStruct {
+            id,
             type_name,
             storage_location,
             name,
@@ -803,77 +949,98 @@ pub trait Builder {
         &mut self,
         source: &input::VariableDeclarationStatement,
     ) -> output::VariableDeclarationStatement {
+        let id = self.next_id();
         let target = self.build_variable_declaration_target(&source.target);
 
-        Rc::new(output::VariableDeclarationStatementStruct { target })
+        Rc::new(output::VariableDeclarationStatementStruct { id, target })
     }
 
     fn build_version_pragma(&mut self, source: &input::VersionPragma) -> output::VersionPragma {
+        let id = self.next_id();
         let sets = self.build_version_expression_sets(&source.sets);
 
-        Rc::new(output::VersionPragmaStruct { sets })
+        Rc::new(output::VersionPragmaStruct { id, sets })
     }
 
     fn build_version_range(&mut self, source: &input::VersionRange) -> output::VersionRange {
+        let id = self.next_id();
         let start = self.build_version_literal(&source.start);
         let end = self.build_version_literal(&source.end);
 
-        Rc::new(output::VersionRangeStruct { start, end })
+        Rc::new(output::VersionRangeStruct { id, start, end })
     }
 
     fn build_version_term(&mut self, source: &input::VersionTerm) -> output::VersionTerm {
+        let id = self.next_id();
         let operator = source
             .operator
             .as_ref()
             .map(|value| self.build_version_operator(value));
         let literal = self.build_version_literal(&source.literal);
 
-        Rc::new(output::VersionTermStruct { operator, literal })
+        Rc::new(output::VersionTermStruct {
+            id,
+            operator,
+            literal,
+        })
     }
 
     fn build_while_statement(&mut self, source: &input::WhileStatement) -> output::WhileStatement {
+        let id = self.next_id();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
 
-        Rc::new(output::WhileStatementStruct { condition, body })
+        Rc::new(output::WhileStatementStruct {
+            id,
+            condition,
+            body,
+        })
     }
 
     fn build_yul_block(&mut self, source: &input::YulBlock) -> output::YulBlock {
+        let id = self.next_id();
         let statements = self.build_yul_statements(&source.statements);
 
-        Rc::new(output::YulBlockStruct { statements })
+        Rc::new(output::YulBlockStruct { id, statements })
     }
 
     fn build_yul_break_statement(
         &mut self,
         source: &input::YulBreakStatement,
     ) -> output::YulBreakStatement {
-        Rc::new(output::YulBreakStatementStruct {})
+        let id = self.next_id();
+
+        Rc::new(output::YulBreakStatementStruct { id })
     }
 
     fn build_yul_continue_statement(
         &mut self,
         source: &input::YulContinueStatement,
     ) -> output::YulContinueStatement {
-        Rc::new(output::YulContinueStatementStruct {})
+        let id = self.next_id();
+
+        Rc::new(output::YulContinueStatementStruct { id })
     }
 
     fn build_yul_default_case(&mut self, source: &input::YulDefaultCase) -> output::YulDefaultCase {
+        let id = self.next_id();
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::YulDefaultCaseStruct { body })
+        Rc::new(output::YulDefaultCaseStruct { id, body })
     }
 
     fn build_yul_for_statement(
         &mut self,
         source: &input::YulForStatement,
     ) -> output::YulForStatement {
+        let id = self.next_id();
         let initialization = self.build_yul_block(&source.initialization);
         let condition = self.build_yul_expression(&source.condition);
         let iterator = self.build_yul_block(&source.iterator);
         let body = self.build_yul_block(&source.body);
 
         Rc::new(output::YulForStatementStruct {
+            id,
             initialization,
             condition,
             iterator,
@@ -885,16 +1052,22 @@ pub trait Builder {
         &mut self,
         source: &input::YulFunctionCallExpression,
     ) -> output::YulFunctionCallExpression {
+        let id = self.next_id();
         let operand = self.build_yul_expression(&source.operand);
         let arguments = self.build_yul_arguments(&source.arguments);
 
-        Rc::new(output::YulFunctionCallExpressionStruct { operand, arguments })
+        Rc::new(output::YulFunctionCallExpressionStruct {
+            id,
+            operand,
+            arguments,
+        })
     }
 
     fn build_yul_function_definition(
         &mut self,
         source: &input::YulFunctionDefinition,
     ) -> output::YulFunctionDefinition {
+        let id = self.next_id();
         let name = self.build_yul_identifier(&source.name);
         let parameters = self.build_yul_parameters_declaration(&source.parameters);
         let returns = source
@@ -904,6 +1077,7 @@ pub trait Builder {
         let body = self.build_yul_block(&source.body);
 
         Rc::new(output::YulFunctionDefinitionStruct {
+            id,
             name,
             parameters,
             returns,
@@ -912,44 +1086,59 @@ pub trait Builder {
     }
 
     fn build_yul_if_statement(&mut self, source: &input::YulIfStatement) -> output::YulIfStatement {
+        let id = self.next_id();
         let condition = self.build_yul_expression(&source.condition);
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::YulIfStatementStruct { condition, body })
+        Rc::new(output::YulIfStatementStruct {
+            id,
+            condition,
+            body,
+        })
     }
 
     fn build_yul_leave_statement(
         &mut self,
         source: &input::YulLeaveStatement,
     ) -> output::YulLeaveStatement {
-        Rc::new(output::YulLeaveStatementStruct {})
+        let id = self.next_id();
+
+        Rc::new(output::YulLeaveStatementStruct { id })
     }
 
     fn build_yul_switch_statement(
         &mut self,
         source: &input::YulSwitchStatement,
     ) -> output::YulSwitchStatement {
+        let id = self.next_id();
         let expression = self.build_yul_expression(&source.expression);
         let cases = self.build_yul_switch_cases(&source.cases);
 
-        Rc::new(output::YulSwitchStatementStruct { expression, cases })
+        Rc::new(output::YulSwitchStatementStruct {
+            id,
+            expression,
+            cases,
+        })
     }
 
     fn build_yul_value_case(&mut self, source: &input::YulValueCase) -> output::YulValueCase {
+        let id = self.next_id();
         let value = self.build_yul_literal(&source.value);
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::YulValueCaseStruct { value, body })
+        Rc::new(output::YulValueCaseStruct { id, value, body })
     }
 
     fn build_yul_variable_assignment_statement(
         &mut self,
         source: &input::YulVariableAssignmentStatement,
     ) -> output::YulVariableAssignmentStatement {
+        let id = self.next_id();
         let variables = self.build_yul_paths(&source.variables);
         let expression = self.build_yul_expression(&source.expression);
 
         Rc::new(output::YulVariableAssignmentStatementStruct {
+            id,
             variables,
             expression,
         })
@@ -959,22 +1148,28 @@ pub trait Builder {
         &mut self,
         source: &input::YulVariableDeclarationStatement,
     ) -> output::YulVariableDeclarationStatement {
+        let id = self.next_id();
         let variables = self.build_yul_variable_names(&source.variables);
         let value = source
             .value
             .as_ref()
             .map(|value| self.build_yul_variable_declaration_value(value));
 
-        Rc::new(output::YulVariableDeclarationStatementStruct { variables, value })
+        Rc::new(output::YulVariableDeclarationStatementStruct {
+            id,
+            variables,
+            value,
+        })
     }
 
     fn build_yul_variable_declaration_value(
         &mut self,
         source: &input::YulVariableDeclarationValue,
     ) -> output::YulVariableDeclarationValue {
+        let id = self.next_id();
         let expression = self.build_yul_expression(&source.expression);
 
-        Rc::new(output::YulVariableDeclarationValueStruct { expression })
+        Rc::new(output::YulVariableDeclarationValueStruct { id, expression })
     }
 
     //
@@ -2227,6 +2422,7 @@ pub trait Builder {
             input::IdentifierPathElement::Identifier(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
+                    id: self.next_id(),
                     range: terminal.range.clone(),
                     text,
                 })
@@ -2234,6 +2430,7 @@ pub trait Builder {
             input::IdentifierPathElement::AddressKeyword(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
+                    id: self.next_id(),
                     range: terminal.range.clone(),
                     text,
                 })
@@ -2566,6 +2763,7 @@ pub trait Builder {
     fn build_bytes_keyword(&mut self, source: &input::BytesKeyword) -> output::BytesKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::BytesKeywordStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2574,6 +2772,7 @@ pub trait Builder {
     fn build_decimal_literal(&mut self, source: &input::DecimalLiteral) -> output::DecimalLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2582,6 +2781,7 @@ pub trait Builder {
     fn build_fixed_keyword(&mut self, source: &input::FixedKeyword) -> output::FixedKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::FixedKeywordStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2590,6 +2790,7 @@ pub trait Builder {
     fn build_hex_literal(&mut self, source: &input::HexLiteral) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2601,6 +2802,7 @@ pub trait Builder {
     ) -> output::HexStringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2609,6 +2811,7 @@ pub trait Builder {
     fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IdentifierStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2617,6 +2820,7 @@ pub trait Builder {
     fn build_int_keyword(&mut self, source: &input::IntKeyword) -> output::IntKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IntKeywordStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2625,6 +2829,7 @@ pub trait Builder {
     fn build_string_literal(&mut self, source: &input::StringLiteral) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::StringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2633,6 +2838,7 @@ pub trait Builder {
     fn build_ufixed_keyword(&mut self, source: &input::UfixedKeyword) -> output::UfixedKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::UfixedKeywordStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2641,6 +2847,7 @@ pub trait Builder {
     fn build_uint_keyword(&mut self, source: &input::UintKeyword) -> output::UintKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::UintKeywordStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2652,6 +2859,7 @@ pub trait Builder {
     ) -> output::UnicodeStringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::UnicodeStringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2663,6 +2871,7 @@ pub trait Builder {
     ) -> output::VersionSpecifier {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::VersionSpecifierStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2678,6 +2887,7 @@ pub trait Builder {
     ) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::StringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2689,6 +2899,7 @@ pub trait Builder {
     ) -> output::DecimalLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2697,6 +2908,7 @@ pub trait Builder {
     fn build_yul_hex_literal(&mut self, source: &input::YulHexLiteral) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2708,6 +2920,7 @@ pub trait Builder {
     ) -> output::HexStringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2716,6 +2929,7 @@ pub trait Builder {
     fn build_yul_identifier(&mut self, source: &input::YulIdentifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IdentifierStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })
@@ -2727,6 +2941,7 @@ pub trait Builder {
     ) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::StringLiteralStruct {
+            id: self.next_id(),
             range: source.range.clone(),
             text,
         })

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -8,24 +8,25 @@ use std::rc::Rc;
 
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 
-use crate::ir::nodes as output;
+use super::CstToIrBuilder;
+use crate::ir::{nodes as output, Source};
 
-pub trait Builder {
-    fn next_id(&mut self) -> output::NodeId;
-    fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
-
+impl<S: Source> CstToIrBuilder<'_, S> {
     //
     // Sequences
     //
 
-    fn build_abicoder_pragma(&mut self, source: &input::AbicoderPragma) -> output::AbicoderPragma {
+    pub(super) fn build_abicoder_pragma(
+        &mut self,
+        source: &input::AbicoderPragma,
+    ) -> output::AbicoderPragma {
         let id = self.next_id();
         let version = self.build_abicoder_version(&source.version);
 
         Rc::new(output::AbicoderPragmaStruct { id, version })
     }
 
-    fn build_additive_expression(
+    pub(super) fn build_additive_expression(
         &mut self,
         source: &input::AdditiveExpression,
     ) -> output::AdditiveExpression {
@@ -45,7 +46,10 @@ pub trait Builder {
         })
     }
 
-    fn build_address_type(&mut self, source: &input::AddressType) -> output::AddressType {
+    pub(super) fn build_address_type(
+        &mut self,
+        source: &input::AddressType,
+    ) -> output::AddressType {
         let id = self.next_id();
         let payable_keyword = source.payable_keyword.is_some();
 
@@ -55,7 +59,10 @@ pub trait Builder {
         })
     }
 
-    fn build_and_expression(&mut self, source: &input::AndExpression) -> output::AndExpression {
+    pub(super) fn build_and_expression(
+        &mut self,
+        source: &input::AndExpression,
+    ) -> output::AndExpression {
         let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
@@ -67,7 +74,7 @@ pub trait Builder {
         })
     }
 
-    fn build_array_expression(
+    pub(super) fn build_array_expression(
         &mut self,
         source: &input::ArrayExpression,
     ) -> output::ArrayExpression {
@@ -77,7 +84,10 @@ pub trait Builder {
         Rc::new(output::ArrayExpressionStruct { id, items })
     }
 
-    fn build_array_type_name(&mut self, source: &input::ArrayTypeName) -> output::ArrayTypeName {
+    pub(super) fn build_array_type_name(
+        &mut self,
+        source: &input::ArrayTypeName,
+    ) -> output::ArrayTypeName {
         let id = self.next_id();
         let operand = self.build_type_name(&source.operand);
         let index = source
@@ -88,7 +98,7 @@ pub trait Builder {
         Rc::new(output::ArrayTypeNameStruct { id, operand, index })
     }
 
-    fn build_assembly_statement(
+    pub(super) fn build_assembly_statement(
         &mut self,
         source: &input::AssemblyStatement,
     ) -> output::AssemblyStatement {
@@ -111,7 +121,7 @@ pub trait Builder {
         })
     }
 
-    fn build_assignment_expression(
+    pub(super) fn build_assignment_expression(
         &mut self,
         source: &input::AssignmentExpression,
     ) -> output::AssignmentExpression {
@@ -131,7 +141,7 @@ pub trait Builder {
         })
     }
 
-    fn build_bitwise_and_expression(
+    pub(super) fn build_bitwise_and_expression(
         &mut self,
         source: &input::BitwiseAndExpression,
     ) -> output::BitwiseAndExpression {
@@ -146,7 +156,7 @@ pub trait Builder {
         })
     }
 
-    fn build_bitwise_or_expression(
+    pub(super) fn build_bitwise_or_expression(
         &mut self,
         source: &input::BitwiseOrExpression,
     ) -> output::BitwiseOrExpression {
@@ -161,7 +171,7 @@ pub trait Builder {
         })
     }
 
-    fn build_bitwise_xor_expression(
+    pub(super) fn build_bitwise_xor_expression(
         &mut self,
         source: &input::BitwiseXorExpression,
     ) -> output::BitwiseXorExpression {
@@ -176,20 +186,23 @@ pub trait Builder {
         })
     }
 
-    fn build_block(&mut self, source: &input::Block) -> output::Block {
+    pub(super) fn build_block(&mut self, source: &input::Block) -> output::Block {
         let id = self.next_id();
         let statements = self.build_statements(&source.statements);
 
         Rc::new(output::BlockStruct { id, statements })
     }
 
-    fn build_break_statement(&mut self, source: &input::BreakStatement) -> output::BreakStatement {
+    pub(super) fn build_break_statement(
+        &mut self,
+        source: &input::BreakStatement,
+    ) -> output::BreakStatement {
         let id = self.next_id();
 
         Rc::new(output::BreakStatementStruct { id })
     }
 
-    fn build_call_options_expression(
+    pub(super) fn build_call_options_expression(
         &mut self,
         source: &input::CallOptionsExpression,
     ) -> output::CallOptionsExpression {
@@ -204,7 +217,10 @@ pub trait Builder {
         })
     }
 
-    fn build_catch_clause(&mut self, source: &input::CatchClause) -> output::CatchClause {
+    pub(super) fn build_catch_clause(
+        &mut self,
+        source: &input::CatchClause,
+    ) -> output::CatchClause {
         let id = self.next_id();
         let error = source
             .error
@@ -215,7 +231,7 @@ pub trait Builder {
         Rc::new(output::CatchClauseStruct { id, error, body })
     }
 
-    fn build_catch_clause_error(
+    pub(super) fn build_catch_clause_error(
         &mut self,
         source: &input::CatchClauseError,
     ) -> output::CatchClauseError {
@@ -233,7 +249,7 @@ pub trait Builder {
         })
     }
 
-    fn build_conditional_expression(
+    pub(super) fn build_conditional_expression(
         &mut self,
         source: &input::ConditionalExpression,
     ) -> output::ConditionalExpression {
@@ -250,12 +266,7 @@ pub trait Builder {
         })
     }
 
-    fn build_constant_definition(
-        &mut self,
-        source: &input::ConstantDefinition,
-    ) -> output::ConstantDefinition;
-
-    fn build_continue_statement(
+    pub(super) fn build_continue_statement(
         &mut self,
         source: &input::ContinueStatement,
     ) -> output::ContinueStatement {
@@ -264,12 +275,7 @@ pub trait Builder {
         Rc::new(output::ContinueStatementStruct { id })
     }
 
-    fn build_contract_definition(
-        &mut self,
-        source: &input::ContractDefinition,
-    ) -> output::ContractDefinition;
-
-    fn build_decimal_number_expression(
+    pub(super) fn build_decimal_number_expression(
         &mut self,
         source: &input::DecimalNumberExpression,
     ) -> output::DecimalNumberExpression {
@@ -283,7 +289,7 @@ pub trait Builder {
         Rc::new(output::DecimalNumberExpressionStruct { id, literal, unit })
     }
 
-    fn build_do_while_statement(
+    pub(super) fn build_do_while_statement(
         &mut self,
         source: &input::DoWhileStatement,
     ) -> output::DoWhileStatement {
@@ -298,7 +304,10 @@ pub trait Builder {
         })
     }
 
-    fn build_emit_statement(&mut self, source: &input::EmitStatement) -> output::EmitStatement {
+    pub(super) fn build_emit_statement(
+        &mut self,
+        source: &input::EmitStatement,
+    ) -> output::EmitStatement {
         let id = self.next_id();
         let event = self.build_identifier_path(&source.event);
         let arguments = self.build_arguments_declaration(&source.arguments);
@@ -310,7 +319,10 @@ pub trait Builder {
         })
     }
 
-    fn build_enum_definition(&mut self, source: &input::EnumDefinition) -> output::EnumDefinition {
+    pub(super) fn build_enum_definition(
+        &mut self,
+        source: &input::EnumDefinition,
+    ) -> output::EnumDefinition {
         let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let members = self.build_enum_members(&source.members);
@@ -318,7 +330,7 @@ pub trait Builder {
         Rc::new(output::EnumDefinitionStruct { id, name, members })
     }
 
-    fn build_equality_expression(
+    pub(super) fn build_equality_expression(
         &mut self,
         source: &input::EqualityExpression,
     ) -> output::EqualityExpression {
@@ -338,17 +350,7 @@ pub trait Builder {
         })
     }
 
-    fn build_error_definition(
-        &mut self,
-        source: &input::ErrorDefinition,
-    ) -> output::ErrorDefinition;
-
-    fn build_event_definition(
-        &mut self,
-        source: &input::EventDefinition,
-    ) -> output::EventDefinition;
-
-    fn build_experimental_pragma(
+    pub(super) fn build_experimental_pragma(
         &mut self,
         source: &input::ExperimentalPragma,
     ) -> output::ExperimentalPragma {
@@ -358,7 +360,7 @@ pub trait Builder {
         Rc::new(output::ExperimentalPragmaStruct { id, feature })
     }
 
-    fn build_exponentiation_expression(
+    pub(super) fn build_exponentiation_expression(
         &mut self,
         source: &input::ExponentiationExpression,
     ) -> output::ExponentiationExpression {
@@ -373,7 +375,7 @@ pub trait Builder {
         })
     }
 
-    fn build_expression_statement(
+    pub(super) fn build_expression_statement(
         &mut self,
         source: &input::ExpressionStatement,
     ) -> output::ExpressionStatement {
@@ -383,7 +385,10 @@ pub trait Builder {
         Rc::new(output::ExpressionStatementStruct { id, expression })
     }
 
-    fn build_for_statement(&mut self, source: &input::ForStatement) -> output::ForStatement {
+    pub(super) fn build_for_statement(
+        &mut self,
+        source: &input::ForStatement,
+    ) -> output::ForStatement {
         let id = self.next_id();
         let initialization = self.build_for_statement_initialization(&source.initialization);
         let condition = self.build_for_statement_condition(&source.condition);
@@ -402,7 +407,7 @@ pub trait Builder {
         })
     }
 
-    fn build_function_call_expression(
+    pub(super) fn build_function_call_expression(
         &mut self,
         source: &input::FunctionCallExpression,
     ) -> output::FunctionCallExpression {
@@ -417,14 +422,7 @@ pub trait Builder {
         })
     }
 
-    fn build_function_definition(
-        &mut self,
-        source: &input::FunctionDefinition,
-    ) -> output::FunctionDefinition;
-
-    fn build_function_type(&mut self, source: &input::FunctionType) -> output::FunctionType;
-
-    fn build_hex_number_expression(
+    pub(super) fn build_hex_number_expression(
         &mut self,
         source: &input::HexNumberExpression,
     ) -> output::HexNumberExpression {
@@ -434,7 +432,10 @@ pub trait Builder {
         Rc::new(output::HexNumberExpressionStruct { id, literal })
     }
 
-    fn build_if_statement(&mut self, source: &input::IfStatement) -> output::IfStatement {
+    pub(super) fn build_if_statement(
+        &mut self,
+        source: &input::IfStatement,
+    ) -> output::IfStatement {
         let id = self.next_id();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
@@ -451,7 +452,7 @@ pub trait Builder {
         })
     }
 
-    fn build_import_deconstruction(
+    pub(super) fn build_import_deconstruction(
         &mut self,
         source: &input::ImportDeconstruction,
     ) -> output::ImportDeconstruction {
@@ -462,7 +463,7 @@ pub trait Builder {
         Rc::new(output::ImportDeconstructionStruct { id, symbols, path })
     }
 
-    fn build_import_deconstruction_symbol(
+    pub(super) fn build_import_deconstruction_symbol(
         &mut self,
         source: &input::ImportDeconstructionSymbol,
     ) -> output::ImportDeconstructionSymbol {
@@ -476,12 +477,7 @@ pub trait Builder {
         Rc::new(output::ImportDeconstructionSymbolStruct { id, name, alias })
     }
 
-    fn build_index_access_expression(
-        &mut self,
-        source: &input::IndexAccessExpression,
-    ) -> output::IndexAccessExpression;
-
-    fn build_inequality_expression(
+    pub(super) fn build_inequality_expression(
         &mut self,
         source: &input::InequalityExpression,
     ) -> output::InequalityExpression {
@@ -501,7 +497,7 @@ pub trait Builder {
         })
     }
 
-    fn build_inheritance_type(
+    pub(super) fn build_inheritance_type(
         &mut self,
         source: &input::InheritanceType,
     ) -> output::InheritanceType {
@@ -519,7 +515,7 @@ pub trait Builder {
         })
     }
 
-    fn build_interface_definition(
+    pub(super) fn build_interface_definition(
         &mut self,
         source: &input::InterfaceDefinition,
     ) -> output::InterfaceDefinition {
@@ -539,7 +535,7 @@ pub trait Builder {
         })
     }
 
-    fn build_library_definition(
+    pub(super) fn build_library_definition(
         &mut self,
         source: &input::LibraryDefinition,
     ) -> output::LibraryDefinition {
@@ -550,9 +546,7 @@ pub trait Builder {
         Rc::new(output::LibraryDefinitionStruct { id, name, members })
     }
 
-    fn build_mapping_type(&mut self, source: &input::MappingType) -> output::MappingType;
-
-    fn build_member_access_expression(
+    pub(super) fn build_member_access_expression(
         &mut self,
         source: &input::MemberAccessExpression,
     ) -> output::MemberAccessExpression {
@@ -567,7 +561,7 @@ pub trait Builder {
         })
     }
 
-    fn build_modifier_invocation(
+    pub(super) fn build_modifier_invocation(
         &mut self,
         source: &input::ModifierInvocation,
     ) -> output::ModifierInvocation {
@@ -585,7 +579,7 @@ pub trait Builder {
         })
     }
 
-    fn build_multi_typed_declaration(
+    pub(super) fn build_multi_typed_declaration(
         &mut self,
         source: &input::MultiTypedDeclaration,
     ) -> output::MultiTypedDeclaration {
@@ -600,7 +594,7 @@ pub trait Builder {
         })
     }
 
-    fn build_multi_typed_declaration_element(
+    pub(super) fn build_multi_typed_declaration_element(
         &mut self,
         source: &input::MultiTypedDeclarationElement,
     ) -> output::MultiTypedDeclarationElement {
@@ -613,7 +607,7 @@ pub trait Builder {
         Rc::new(output::MultiTypedDeclarationElementStruct { id, member })
     }
 
-    fn build_multiplicative_expression(
+    pub(super) fn build_multiplicative_expression(
         &mut self,
         source: &input::MultiplicativeExpression,
     ) -> output::MultiplicativeExpression {
@@ -633,7 +627,10 @@ pub trait Builder {
         })
     }
 
-    fn build_named_argument(&mut self, source: &input::NamedArgument) -> output::NamedArgument {
+    pub(super) fn build_named_argument(
+        &mut self,
+        source: &input::NamedArgument,
+    ) -> output::NamedArgument {
         let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let value = self.build_expression(&source.value);
@@ -641,14 +638,20 @@ pub trait Builder {
         Rc::new(output::NamedArgumentStruct { id, name, value })
     }
 
-    fn build_new_expression(&mut self, source: &input::NewExpression) -> output::NewExpression {
+    pub(super) fn build_new_expression(
+        &mut self,
+        source: &input::NewExpression,
+    ) -> output::NewExpression {
         let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
 
         Rc::new(output::NewExpressionStruct { id, type_name })
     }
 
-    fn build_or_expression(&mut self, source: &input::OrExpression) -> output::OrExpression {
+    pub(super) fn build_or_expression(
+        &mut self,
+        source: &input::OrExpression,
+    ) -> output::OrExpression {
         let id = self.next_id();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
@@ -660,9 +663,7 @@ pub trait Builder {
         })
     }
 
-    fn build_parameter(&mut self, source: &input::Parameter) -> output::Parameter;
-
-    fn build_path_import(&mut self, source: &input::PathImport) -> output::PathImport {
+    pub(super) fn build_path_import(&mut self, source: &input::PathImport) -> output::PathImport {
         let id = self.next_id();
         let path = self.build_string_literal(&source.path);
         let alias = source
@@ -673,7 +674,7 @@ pub trait Builder {
         Rc::new(output::PathImportStruct { id, path, alias })
     }
 
-    fn build_postfix_expression(
+    pub(super) fn build_postfix_expression(
         &mut self,
         source: &input::PostfixExpression,
     ) -> output::PostfixExpression {
@@ -691,7 +692,7 @@ pub trait Builder {
         })
     }
 
-    fn build_pragma_directive(
+    pub(super) fn build_pragma_directive(
         &mut self,
         source: &input::PragmaDirective,
     ) -> output::PragmaDirective {
@@ -701,7 +702,7 @@ pub trait Builder {
         Rc::new(output::PragmaDirectiveStruct { id, pragma })
     }
 
-    fn build_prefix_expression(
+    pub(super) fn build_prefix_expression(
         &mut self,
         source: &input::PrefixExpression,
     ) -> output::PrefixExpression {
@@ -719,7 +720,7 @@ pub trait Builder {
         })
     }
 
-    fn build_return_statement(
+    pub(super) fn build_return_statement(
         &mut self,
         source: &input::ReturnStatement,
     ) -> output::ReturnStatement {
@@ -732,7 +733,7 @@ pub trait Builder {
         Rc::new(output::ReturnStatementStruct { id, expression })
     }
 
-    fn build_revert_statement(
+    pub(super) fn build_revert_statement(
         &mut self,
         source: &input::RevertStatement,
     ) -> output::RevertStatement {
@@ -747,7 +748,7 @@ pub trait Builder {
         })
     }
 
-    fn build_shift_expression(
+    pub(super) fn build_shift_expression(
         &mut self,
         source: &input::ShiftExpression,
     ) -> output::ShiftExpression {
@@ -766,7 +767,7 @@ pub trait Builder {
         })
     }
 
-    fn build_single_typed_declaration(
+    pub(super) fn build_single_typed_declaration(
         &mut self,
         source: &input::SingleTypedDeclaration,
     ) -> output::SingleTypedDeclaration {
@@ -784,19 +785,14 @@ pub trait Builder {
         })
     }
 
-    fn build_source_unit(&mut self, source: &input::SourceUnit) -> output::SourceUnit {
+    pub(super) fn build_source_unit(&mut self, source: &input::SourceUnit) -> output::SourceUnit {
         let id = self.next_id();
         let members = self.build_source_unit_members(&source.members);
 
         Rc::new(output::SourceUnitStruct { id, members })
     }
 
-    fn build_state_variable_definition(
-        &mut self,
-        source: &input::StateVariableDefinition,
-    ) -> output::StateVariableDefinition;
-
-    fn build_struct_definition(
+    pub(super) fn build_struct_definition(
         &mut self,
         source: &input::StructDefinition,
     ) -> output::StructDefinition {
@@ -807,7 +803,10 @@ pub trait Builder {
         Rc::new(output::StructDefinitionStruct { id, name, members })
     }
 
-    fn build_struct_member(&mut self, source: &input::StructMember) -> output::StructMember {
+    pub(super) fn build_struct_member(
+        &mut self,
+        source: &input::StructMember,
+    ) -> output::StructMember {
         let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
@@ -819,7 +818,10 @@ pub trait Builder {
         })
     }
 
-    fn build_try_statement(&mut self, source: &input::TryStatement) -> output::TryStatement {
+    pub(super) fn build_try_statement(
+        &mut self,
+        source: &input::TryStatement,
+    ) -> output::TryStatement {
         let id = self.next_id();
         let expression = self.build_expression(&source.expression);
         let returns = source
@@ -838,7 +840,7 @@ pub trait Builder {
         })
     }
 
-    fn build_tuple_expression(
+    pub(super) fn build_tuple_expression(
         &mut self,
         source: &input::TupleExpression,
     ) -> output::TupleExpression {
@@ -848,7 +850,7 @@ pub trait Builder {
         Rc::new(output::TupleExpressionStruct { id, items })
     }
 
-    fn build_tuple_value(&mut self, source: &input::TupleValue) -> output::TupleValue {
+    pub(super) fn build_tuple_value(&mut self, source: &input::TupleValue) -> output::TupleValue {
         let id = self.next_id();
         let expression = source
             .expression
@@ -858,21 +860,27 @@ pub trait Builder {
         Rc::new(output::TupleValueStruct { id, expression })
     }
 
-    fn build_type_expression(&mut self, source: &input::TypeExpression) -> output::TypeExpression {
+    pub(super) fn build_type_expression(
+        &mut self,
+        source: &input::TypeExpression,
+    ) -> output::TypeExpression {
         let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
 
         Rc::new(output::TypeExpressionStruct { id, type_name })
     }
 
-    fn build_unchecked_block(&mut self, source: &input::UncheckedBlock) -> output::UncheckedBlock {
+    pub(super) fn build_unchecked_block(
+        &mut self,
+        source: &input::UncheckedBlock,
+    ) -> output::UncheckedBlock {
         let id = self.next_id();
         let block = self.build_block(&source.block);
 
         Rc::new(output::UncheckedBlockStruct { id, block })
     }
 
-    fn build_user_defined_value_type_definition(
+    pub(super) fn build_user_defined_value_type_definition(
         &mut self,
         source: &input::UserDefinedValueTypeDefinition,
     ) -> output::UserDefinedValueTypeDefinition {
@@ -887,7 +895,7 @@ pub trait Builder {
         })
     }
 
-    fn build_using_deconstruction(
+    pub(super) fn build_using_deconstruction(
         &mut self,
         source: &input::UsingDeconstruction,
     ) -> output::UsingDeconstruction {
@@ -897,7 +905,7 @@ pub trait Builder {
         Rc::new(output::UsingDeconstructionStruct { id, symbols })
     }
 
-    fn build_using_deconstruction_symbol(
+    pub(super) fn build_using_deconstruction_symbol(
         &mut self,
         source: &input::UsingDeconstructionSymbol,
     ) -> output::UsingDeconstructionSymbol {
@@ -911,7 +919,10 @@ pub trait Builder {
         Rc::new(output::UsingDeconstructionSymbolStruct { id, name, alias })
     }
 
-    fn build_using_directive(&mut self, source: &input::UsingDirective) -> output::UsingDirective {
+    pub(super) fn build_using_directive(
+        &mut self,
+        source: &input::UsingDirective,
+    ) -> output::UsingDirective {
         let id = self.next_id();
         let clause = self.build_using_clause(&source.clause);
         let target = self.build_using_target(&source.target);
@@ -925,7 +936,7 @@ pub trait Builder {
         })
     }
 
-    fn build_variable_declaration(
+    pub(super) fn build_variable_declaration(
         &mut self,
         source: &input::VariableDeclaration,
     ) -> output::VariableDeclaration {
@@ -945,7 +956,7 @@ pub trait Builder {
         })
     }
 
-    fn build_variable_declaration_statement(
+    pub(super) fn build_variable_declaration_statement(
         &mut self,
         source: &input::VariableDeclarationStatement,
     ) -> output::VariableDeclarationStatement {
@@ -955,14 +966,20 @@ pub trait Builder {
         Rc::new(output::VariableDeclarationStatementStruct { id, target })
     }
 
-    fn build_version_pragma(&mut self, source: &input::VersionPragma) -> output::VersionPragma {
+    pub(super) fn build_version_pragma(
+        &mut self,
+        source: &input::VersionPragma,
+    ) -> output::VersionPragma {
         let id = self.next_id();
         let sets = self.build_version_expression_sets(&source.sets);
 
         Rc::new(output::VersionPragmaStruct { id, sets })
     }
 
-    fn build_version_range(&mut self, source: &input::VersionRange) -> output::VersionRange {
+    pub(super) fn build_version_range(
+        &mut self,
+        source: &input::VersionRange,
+    ) -> output::VersionRange {
         let id = self.next_id();
         let start = self.build_version_literal(&source.start);
         let end = self.build_version_literal(&source.end);
@@ -970,7 +987,10 @@ pub trait Builder {
         Rc::new(output::VersionRangeStruct { id, start, end })
     }
 
-    fn build_version_term(&mut self, source: &input::VersionTerm) -> output::VersionTerm {
+    pub(super) fn build_version_term(
+        &mut self,
+        source: &input::VersionTerm,
+    ) -> output::VersionTerm {
         let id = self.next_id();
         let operator = source
             .operator
@@ -985,7 +1005,10 @@ pub trait Builder {
         })
     }
 
-    fn build_while_statement(&mut self, source: &input::WhileStatement) -> output::WhileStatement {
+    pub(super) fn build_while_statement(
+        &mut self,
+        source: &input::WhileStatement,
+    ) -> output::WhileStatement {
         let id = self.next_id();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
@@ -997,14 +1020,14 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_block(&mut self, source: &input::YulBlock) -> output::YulBlock {
+    pub(super) fn build_yul_block(&mut self, source: &input::YulBlock) -> output::YulBlock {
         let id = self.next_id();
         let statements = self.build_yul_statements(&source.statements);
 
         Rc::new(output::YulBlockStruct { id, statements })
     }
 
-    fn build_yul_break_statement(
+    pub(super) fn build_yul_break_statement(
         &mut self,
         source: &input::YulBreakStatement,
     ) -> output::YulBreakStatement {
@@ -1013,7 +1036,7 @@ pub trait Builder {
         Rc::new(output::YulBreakStatementStruct { id })
     }
 
-    fn build_yul_continue_statement(
+    pub(super) fn build_yul_continue_statement(
         &mut self,
         source: &input::YulContinueStatement,
     ) -> output::YulContinueStatement {
@@ -1022,14 +1045,17 @@ pub trait Builder {
         Rc::new(output::YulContinueStatementStruct { id })
     }
 
-    fn build_yul_default_case(&mut self, source: &input::YulDefaultCase) -> output::YulDefaultCase {
+    pub(super) fn build_yul_default_case(
+        &mut self,
+        source: &input::YulDefaultCase,
+    ) -> output::YulDefaultCase {
         let id = self.next_id();
         let body = self.build_yul_block(&source.body);
 
         Rc::new(output::YulDefaultCaseStruct { id, body })
     }
 
-    fn build_yul_for_statement(
+    pub(super) fn build_yul_for_statement(
         &mut self,
         source: &input::YulForStatement,
     ) -> output::YulForStatement {
@@ -1048,7 +1074,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_function_call_expression(
+    pub(super) fn build_yul_function_call_expression(
         &mut self,
         source: &input::YulFunctionCallExpression,
     ) -> output::YulFunctionCallExpression {
@@ -1063,7 +1089,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_function_definition(
+    pub(super) fn build_yul_function_definition(
         &mut self,
         source: &input::YulFunctionDefinition,
     ) -> output::YulFunctionDefinition {
@@ -1085,7 +1111,10 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_if_statement(&mut self, source: &input::YulIfStatement) -> output::YulIfStatement {
+    pub(super) fn build_yul_if_statement(
+        &mut self,
+        source: &input::YulIfStatement,
+    ) -> output::YulIfStatement {
         let id = self.next_id();
         let condition = self.build_yul_expression(&source.condition);
         let body = self.build_yul_block(&source.body);
@@ -1097,7 +1126,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_leave_statement(
+    pub(super) fn build_yul_leave_statement(
         &mut self,
         source: &input::YulLeaveStatement,
     ) -> output::YulLeaveStatement {
@@ -1106,7 +1135,7 @@ pub trait Builder {
         Rc::new(output::YulLeaveStatementStruct { id })
     }
 
-    fn build_yul_switch_statement(
+    pub(super) fn build_yul_switch_statement(
         &mut self,
         source: &input::YulSwitchStatement,
     ) -> output::YulSwitchStatement {
@@ -1121,7 +1150,10 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_value_case(&mut self, source: &input::YulValueCase) -> output::YulValueCase {
+    pub(super) fn build_yul_value_case(
+        &mut self,
+        source: &input::YulValueCase,
+    ) -> output::YulValueCase {
         let id = self.next_id();
         let value = self.build_yul_literal(&source.value);
         let body = self.build_yul_block(&source.body);
@@ -1129,7 +1161,7 @@ pub trait Builder {
         Rc::new(output::YulValueCaseStruct { id, value, body })
     }
 
-    fn build_yul_variable_assignment_statement(
+    pub(super) fn build_yul_variable_assignment_statement(
         &mut self,
         source: &input::YulVariableAssignmentStatement,
     ) -> output::YulVariableAssignmentStatement {
@@ -1144,7 +1176,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_variable_declaration_statement(
+    pub(super) fn build_yul_variable_declaration_statement(
         &mut self,
         source: &input::YulVariableDeclarationStatement,
     ) -> output::YulVariableDeclarationStatement {
@@ -1162,7 +1194,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_variable_declaration_value(
+    pub(super) fn build_yul_variable_declaration_value(
         &mut self,
         source: &input::YulVariableDeclarationValue,
     ) -> output::YulVariableDeclarationValue {
@@ -1176,93 +1208,99 @@ pub trait Builder {
     // Collapsed sequences
     //
 
-    fn build_else_branch(&mut self, source: &input::ElseBranch) -> output::Statement {
+    pub(super) fn build_else_branch(&mut self, source: &input::ElseBranch) -> output::Statement {
         self.build_statement(&source.body)
     }
 
-    fn build_import_alias(&mut self, source: &input::ImportAlias) -> output::Identifier {
+    pub(super) fn build_import_alias(&mut self, source: &input::ImportAlias) -> output::Identifier {
         self.build_identifier(&source.identifier)
     }
 
-    fn build_import_directive(&mut self, source: &input::ImportDirective) -> output::ImportClause {
+    pub(super) fn build_import_directive(
+        &mut self,
+        source: &input::ImportDirective,
+    ) -> output::ImportClause {
         self.build_import_clause(&source.clause)
     }
 
-    fn build_inheritance_specifier(
+    pub(super) fn build_inheritance_specifier(
         &mut self,
         source: &input::InheritanceSpecifier,
     ) -> output::InheritanceTypes {
         self.build_inheritance_types(&source.types)
     }
 
-    fn build_named_argument_group(
+    pub(super) fn build_named_argument_group(
         &mut self,
         source: &input::NamedArgumentGroup,
     ) -> output::NamedArguments {
         self.build_named_arguments(&source.arguments)
     }
 
-    fn build_override_paths_declaration(
+    pub(super) fn build_override_paths_declaration(
         &mut self,
         source: &input::OverridePathsDeclaration,
     ) -> output::OverridePaths {
         self.build_override_paths(&source.paths)
     }
 
-    fn build_parameters_declaration(
+    pub(super) fn build_parameters_declaration(
         &mut self,
         source: &input::ParametersDeclaration,
     ) -> output::Parameters {
         self.build_parameters(&source.parameters)
     }
 
-    fn build_returns_declaration(
+    pub(super) fn build_returns_declaration(
         &mut self,
         source: &input::ReturnsDeclaration,
     ) -> output::Parameters {
         self.build_parameters_declaration(&source.variables)
     }
 
-    fn build_state_variable_definition_value(
+    pub(super) fn build_state_variable_definition_value(
         &mut self,
         source: &input::StateVariableDefinitionValue,
     ) -> output::Expression {
         self.build_expression(&source.value)
     }
 
-    fn build_storage_layout_specifier(
+    pub(super) fn build_storage_layout_specifier(
         &mut self,
         source: &input::StorageLayoutSpecifier,
     ) -> output::Expression {
         self.build_expression(&source.expression)
     }
 
-    fn build_using_alias(&mut self, source: &input::UsingAlias) -> output::UsingOperator {
+    pub(super) fn build_using_alias(
+        &mut self,
+        source: &input::UsingAlias,
+    ) -> output::UsingOperator {
         self.build_using_operator(&source.operator)
     }
 
-    fn build_variable_declaration_value(
+    pub(super) fn build_variable_declaration_value(
         &mut self,
         source: &input::VariableDeclarationValue,
     ) -> output::Expression {
         self.build_expression(&source.expression)
     }
 
-    fn build_yul_flags_declaration(
+    pub(super) fn build_yul_flags_declaration(
         &mut self,
         source: &input::YulFlagsDeclaration,
     ) -> output::YulFlags {
         self.build_yul_flags(&source.flags)
     }
 
-    fn build_yul_parameters_declaration(
+    pub(super) fn build_yul_parameters_declaration(
         &mut self,
         source: &input::YulParametersDeclaration,
     ) -> output::YulParameters {
         self.build_yul_parameters(&source.parameters)
     }
 
-    fn build_yul_returns_declaration(
+    pub(super) fn build_yul_returns_declaration(
         &mut self,
         source: &input::YulReturnsDeclaration,
     ) -> output::YulVariableNames {
@@ -1273,7 +1311,8 @@ pub trait Builder {
     // Choices
     //
 
-    fn default_build_abicoder_version(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_abicoder_version(
         &mut self,
         source: &input::AbicoderVersion,
     ) -> output::AbicoderVersion {
@@ -1288,15 +1327,10 @@ pub trait Builder {
             }
         }
     }
-    fn build_abicoder_version(
-        &mut self,
-        source: &input::AbicoderVersion,
-    ) -> output::AbicoderVersion {
-        self.default_build_abicoder_version(source)
-    }
 
+    #[allow(clippy::unused_self)]
     #[allow(dead_code)]
-    fn default_build_arguments_declaration(
+    pub(super) fn default_build_arguments_declaration(
         &mut self,
         source: &input::ArgumentsDeclaration,
     ) -> output::ArgumentsDeclaration {
@@ -1306,13 +1340,10 @@ pub trait Builder {
             _ => panic!("Unexpected variant {source:?}"),
         }
     }
-    fn build_arguments_declaration(
-        &mut self,
-        source: &input::ArgumentsDeclaration,
-    ) -> output::ArgumentsDeclaration;
 
+    #[allow(clippy::unused_self)]
     #[allow(dead_code)]
-    fn default_build_contract_member(
+    pub(super) fn default_build_contract_member(
         &mut self,
         source: &input::ContractMember,
     ) -> output::ContractMember {
@@ -1358,9 +1389,9 @@ pub trait Builder {
             _ => panic!("Unexpected variant {source:?}"),
         }
     }
-    fn build_contract_member(&mut self, source: &input::ContractMember) -> output::ContractMember;
 
-    fn default_build_elementary_type(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_elementary_type(
         &mut self,
         source: &input::ElementaryType,
     ) -> output::ElementaryType {
@@ -1389,11 +1420,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_elementary_type(&mut self, source: &input::ElementaryType) -> output::ElementaryType {
-        self.default_build_elementary_type(source)
-    }
 
-    fn default_build_experimental_feature(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_experimental_feature(
         &mut self,
         source: &input::ExperimentalFeature,
     ) -> output::ExperimentalFeature {
@@ -1413,14 +1442,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_experimental_feature(
-        &mut self,
-        source: &input::ExperimentalFeature,
-    ) -> output::ExperimentalFeature {
-        self.default_build_experimental_feature(source)
-    }
 
-    fn default_build_expression(&mut self, source: &input::Expression) -> output::Expression {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression(&mut self, source: &input::Expression) -> output::Expression {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -1553,11 +1577,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression(&mut self, source: &input::Expression) -> output::Expression {
-        self.default_build_expression(source)
-    }
 
-    fn default_build_expression_additive_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_additive_expression_operator(
         &mut self,
         source: &input::Expression_AdditiveExpression_Operator,
     ) -> output::Expression_AdditiveExpression_Operator {
@@ -1572,14 +1594,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_additive_expression_operator(
-        &mut self,
-        source: &input::Expression_AdditiveExpression_Operator,
-    ) -> output::Expression_AdditiveExpression_Operator {
-        self.default_build_expression_additive_expression_operator(source)
-    }
 
-    fn default_build_expression_assignment_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_assignment_expression_operator(
         &mut self,
         source: &input::Expression_AssignmentExpression_Operator,
     ) -> output::Expression_AssignmentExpression_Operator {
@@ -1624,14 +1641,9 @@ pub trait Builder {
                 }
               }
     }
-    fn build_expression_assignment_expression_operator(
-        &mut self,
-        source: &input::Expression_AssignmentExpression_Operator,
-    ) -> output::Expression_AssignmentExpression_Operator {
-        self.default_build_expression_assignment_expression_operator(source)
-    }
 
-    fn default_build_expression_equality_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_equality_expression_operator(
         &mut self,
         source: &input::Expression_EqualityExpression_Operator,
     ) -> output::Expression_EqualityExpression_Operator {
@@ -1646,14 +1658,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_equality_expression_operator(
-        &mut self,
-        source: &input::Expression_EqualityExpression_Operator,
-    ) -> output::Expression_EqualityExpression_Operator {
-        self.default_build_expression_equality_expression_operator(source)
-    }
 
-    fn default_build_expression_inequality_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_inequality_expression_operator(
         &mut self,
         source: &input::Expression_InequalityExpression_Operator,
     ) -> output::Expression_InequalityExpression_Operator {
@@ -1674,14 +1681,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_inequality_expression_operator(
-        &mut self,
-        source: &input::Expression_InequalityExpression_Operator,
-    ) -> output::Expression_InequalityExpression_Operator {
-        self.default_build_expression_inequality_expression_operator(source)
-    }
 
-    fn default_build_expression_multiplicative_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_multiplicative_expression_operator(
         &mut self,
         source: &input::Expression_MultiplicativeExpression_Operator,
     ) -> output::Expression_MultiplicativeExpression_Operator {
@@ -1699,14 +1701,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_multiplicative_expression_operator(
-        &mut self,
-        source: &input::Expression_MultiplicativeExpression_Operator,
-    ) -> output::Expression_MultiplicativeExpression_Operator {
-        self.default_build_expression_multiplicative_expression_operator(source)
-    }
 
-    fn default_build_expression_postfix_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_postfix_expression_operator(
         &mut self,
         source: &input::Expression_PostfixExpression_Operator,
     ) -> output::Expression_PostfixExpression_Operator {
@@ -1721,14 +1718,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_postfix_expression_operator(
-        &mut self,
-        source: &input::Expression_PostfixExpression_Operator,
-    ) -> output::Expression_PostfixExpression_Operator {
-        self.default_build_expression_postfix_expression_operator(source)
-    }
 
-    fn default_build_expression_prefix_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_prefix_expression_operator(
         &mut self,
         source: &input::Expression_PrefixExpression_Operator,
     ) -> output::Expression_PrefixExpression_Operator {
@@ -1755,14 +1747,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_prefix_expression_operator(
-        &mut self,
-        source: &input::Expression_PrefixExpression_Operator,
-    ) -> output::Expression_PrefixExpression_Operator {
-        self.default_build_expression_prefix_expression_operator(source)
-    }
 
-    fn default_build_expression_shift_expression_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_expression_shift_expression_operator(
         &mut self,
         source: &input::Expression_ShiftExpression_Operator,
     ) -> output::Expression_ShiftExpression_Operator {
@@ -1780,14 +1767,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_expression_shift_expression_operator(
-        &mut self,
-        source: &input::Expression_ShiftExpression_Operator,
-    ) -> output::Expression_ShiftExpression_Operator {
-        self.default_build_expression_shift_expression_operator(source)
-    }
 
-    fn default_build_for_statement_condition(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_for_statement_condition(
         &mut self,
         source: &input::ForStatementCondition,
     ) -> output::ForStatementCondition {
@@ -1802,14 +1784,9 @@ pub trait Builder {
             input::ForStatementCondition::Semicolon(_) => output::ForStatementCondition::Semicolon,
         }
     }
-    fn build_for_statement_condition(
-        &mut self,
-        source: &input::ForStatementCondition,
-    ) -> output::ForStatementCondition {
-        self.default_build_for_statement_condition(source)
-    }
 
-    fn default_build_for_statement_initialization(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_for_statement_initialization(
         &mut self,
         source: &input::ForStatementInitialization,
     ) -> output::ForStatementInitialization {
@@ -1831,15 +1808,10 @@ pub trait Builder {
             }
         }
     }
-    fn build_for_statement_initialization(
-        &mut self,
-        source: &input::ForStatementInitialization,
-    ) -> output::ForStatementInitialization {
-        self.default_build_for_statement_initialization(source)
-    }
 
+    #[allow(clippy::unused_self)]
     #[allow(dead_code)]
-    fn default_build_import_clause(
+    pub(super) fn default_build_import_clause(
         &mut self,
         source: &input::ImportClause,
     ) -> output::ImportClause {
@@ -1857,9 +1829,9 @@ pub trait Builder {
             _ => panic!("Unexpected variant {source:?}"),
         }
     }
-    fn build_import_clause(&mut self, source: &input::ImportClause) -> output::ImportClause;
 
-    fn default_build_number_unit(&mut self, source: &input::NumberUnit) -> output::NumberUnit {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_number_unit(&mut self, source: &input::NumberUnit) -> output::NumberUnit {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -1873,11 +1845,9 @@ pub trait Builder {
             input::NumberUnit::WeeksKeyword(_) => output::NumberUnit::WeeksKeyword,
         }
     }
-    fn build_number_unit(&mut self, source: &input::NumberUnit) -> output::NumberUnit {
-        self.default_build_number_unit(source)
-    }
 
-    fn default_build_pragma(&mut self, source: &input::Pragma) -> output::Pragma {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_pragma(&mut self, source: &input::Pragma) -> output::Pragma {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -1894,11 +1864,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_pragma(&mut self, source: &input::Pragma) -> output::Pragma {
-        self.default_build_pragma(source)
-    }
 
-    fn default_build_source_unit_member(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_source_unit_member(
         &mut self,
         source: &input::SourceUnitMember,
     ) -> output::SourceUnitMember {
@@ -1972,14 +1940,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_source_unit_member(
-        &mut self,
-        source: &input::SourceUnitMember,
-    ) -> output::SourceUnitMember {
-        self.default_build_source_unit_member(source)
-    }
 
-    fn default_build_statement(&mut self, source: &input::Statement) -> output::Statement {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_statement(&mut self, source: &input::Statement) -> output::Statement {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -2038,11 +2001,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_statement(&mut self, source: &input::Statement) -> output::Statement {
-        self.default_build_statement(source)
-    }
 
-    fn default_build_storage_location(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_storage_location(
         &mut self,
         source: &input::StorageLocation,
     ) -> output::StorageLocation {
@@ -2054,14 +2015,9 @@ pub trait Builder {
             input::StorageLocation::CallDataKeyword(_) => output::StorageLocation::CallDataKeyword,
         }
     }
-    fn build_storage_location(
-        &mut self,
-        source: &input::StorageLocation,
-    ) -> output::StorageLocation {
-        self.default_build_storage_location(source)
-    }
 
-    fn default_build_string_expression(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_string_expression(
         &mut self,
         source: &input::StringExpression,
     ) -> output::StringExpression {
@@ -2085,14 +2041,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_string_expression(
-        &mut self,
-        source: &input::StringExpression,
-    ) -> output::StringExpression {
-        self.default_build_string_expression(source)
-    }
 
-    fn default_build_type_name(&mut self, source: &input::TypeName) -> output::TypeName {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_type_name(&mut self, source: &input::TypeName) -> output::TypeName {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -2113,11 +2064,12 @@ pub trait Builder {
             }
         }
     }
-    fn build_type_name(&mut self, source: &input::TypeName) -> output::TypeName {
-        self.default_build_type_name(source)
-    }
 
-    fn default_build_using_clause(&mut self, source: &input::UsingClause) -> output::UsingClause {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_using_clause(
+        &mut self,
+        source: &input::UsingClause,
+    ) -> output::UsingClause {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -2131,11 +2083,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_using_clause(&mut self, source: &input::UsingClause) -> output::UsingClause {
-        self.default_build_using_clause(source)
-    }
 
-    fn default_build_using_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_using_operator(
         &mut self,
         source: &input::UsingOperator,
     ) -> output::UsingOperator {
@@ -2159,11 +2109,12 @@ pub trait Builder {
             input::UsingOperator::Tilde(_) => output::UsingOperator::Tilde,
         }
     }
-    fn build_using_operator(&mut self, source: &input::UsingOperator) -> output::UsingOperator {
-        self.default_build_using_operator(source)
-    }
 
-    fn default_build_using_target(&mut self, source: &input::UsingTarget) -> output::UsingTarget {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_using_target(
+        &mut self,
+        source: &input::UsingTarget,
+    ) -> output::UsingTarget {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -2173,11 +2124,9 @@ pub trait Builder {
             input::UsingTarget::Asterisk(_) => output::UsingTarget::Asterisk,
         }
     }
-    fn build_using_target(&mut self, source: &input::UsingTarget) -> output::UsingTarget {
-        self.default_build_using_target(source)
-    }
 
-    fn default_build_variable_declaration_target(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_variable_declaration_target(
         &mut self,
         source: &input::VariableDeclarationTarget,
     ) -> output::VariableDeclarationTarget {
@@ -2196,14 +2145,9 @@ pub trait Builder {
             ),
         }
     }
-    fn build_variable_declaration_target(
-        &mut self,
-        source: &input::VariableDeclarationTarget,
-    ) -> output::VariableDeclarationTarget {
-        self.default_build_variable_declaration_target(source)
-    }
 
-    fn default_build_version_expression(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_version_expression(
         &mut self,
         source: &input::VersionExpression,
     ) -> output::VersionExpression {
@@ -2218,14 +2162,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_version_expression(
-        &mut self,
-        source: &input::VersionExpression,
-    ) -> output::VersionExpression {
-        self.default_build_version_expression(source)
-    }
 
-    fn default_build_version_literal(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_version_literal(
         &mut self,
         source: &input::VersionLiteral,
     ) -> output::VersionLiteral {
@@ -2244,11 +2183,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_version_literal(&mut self, source: &input::VersionLiteral) -> output::VersionLiteral {
-        self.default_build_version_literal(source)
-    }
 
-    fn default_build_version_operator(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_version_operator(
         &mut self,
         source: &input::VersionOperator,
     ) -> output::VersionOperator {
@@ -2270,14 +2207,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_version_operator(
-        &mut self,
-        source: &input::VersionOperator,
-    ) -> output::VersionOperator {
-        self.default_build_version_operator(source)
-    }
 
-    fn default_build_yul_expression(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_yul_expression(
         &mut self,
         source: &input::YulExpression,
     ) -> output::YulExpression {
@@ -2297,11 +2229,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_yul_expression(&mut self, source: &input::YulExpression) -> output::YulExpression {
-        self.default_build_yul_expression(source)
-    }
 
-    fn default_build_yul_literal(&mut self, source: &input::YulLiteral) -> output::YulLiteral {
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_yul_literal(&mut self, source: &input::YulLiteral) -> output::YulLiteral {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -2325,11 +2255,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_yul_literal(&mut self, source: &input::YulLiteral) -> output::YulLiteral {
-        self.default_build_yul_literal(source)
-    }
 
-    fn default_build_yul_statement(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_yul_statement(
         &mut self,
         source: &input::YulStatement,
     ) -> output::YulStatement {
@@ -2387,11 +2315,9 @@ pub trait Builder {
             }
         }
     }
-    fn build_yul_statement(&mut self, source: &input::YulStatement) -> output::YulStatement {
-        self.default_build_yul_statement(source)
-    }
 
-    fn default_build_yul_switch_case(
+    #[allow(clippy::unused_self)]
+    pub(super) fn build_yul_switch_case(
         &mut self,
         source: &input::YulSwitchCase,
     ) -> output::YulSwitchCase {
@@ -2406,15 +2332,12 @@ pub trait Builder {
             }
         }
     }
-    fn build_yul_switch_case(&mut self, source: &input::YulSwitchCase) -> output::YulSwitchCase {
-        self.default_build_yul_switch_case(source)
-    }
 
     //
     // Collapsed choices
     //
 
-    fn build_identifier_path_element(
+    pub(super) fn build_identifier_path_element(
         &mut self,
         source: &input::IdentifierPathElement,
     ) -> output::Identifier {
@@ -2442,7 +2365,10 @@ pub trait Builder {
     // Repeated & Separated
     //
 
-    fn build_array_values(&mut self, source: &input::ArrayValues) -> output::ArrayValues {
+    pub(super) fn build_array_values(
+        &mut self,
+        source: &input::ArrayValues,
+    ) -> output::ArrayValues {
         source
             .elements
             .iter()
@@ -2450,7 +2376,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_call_options(&mut self, source: &input::CallOptions) -> output::CallOptions {
+    pub(super) fn build_call_options(
+        &mut self,
+        source: &input::CallOptions,
+    ) -> output::CallOptions {
         source
             .elements
             .iter()
@@ -2458,7 +2387,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_catch_clauses(&mut self, source: &input::CatchClauses) -> output::CatchClauses {
+    pub(super) fn build_catch_clauses(
+        &mut self,
+        source: &input::CatchClauses,
+    ) -> output::CatchClauses {
         source
             .elements
             .iter()
@@ -2466,7 +2398,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_contract_members(
+    pub(super) fn build_contract_members(
         &mut self,
         source: &input::ContractMembers,
     ) -> output::ContractMembers {
@@ -2477,7 +2409,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_enum_members(&mut self, source: &input::EnumMembers) -> output::EnumMembers {
+    pub(super) fn build_enum_members(
+        &mut self,
+        source: &input::EnumMembers,
+    ) -> output::EnumMembers {
         source
             .elements
             .iter()
@@ -2485,7 +2420,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_hex_string_literals(
+    pub(super) fn build_hex_string_literals(
         &mut self,
         source: &input::HexStringLiterals,
     ) -> output::HexStringLiterals {
@@ -2496,7 +2431,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_identifier_path(&mut self, source: &input::IdentifierPath) -> output::IdentifierPath {
+    pub(super) fn build_identifier_path(
+        &mut self,
+        source: &input::IdentifierPath,
+    ) -> output::IdentifierPath {
         source
             .elements
             .iter()
@@ -2504,7 +2442,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_import_deconstruction_symbols(
+    pub(super) fn build_import_deconstruction_symbols(
         &mut self,
         source: &input::ImportDeconstructionSymbols,
     ) -> output::ImportDeconstructionSymbols {
@@ -2515,7 +2453,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_inheritance_types(
+    pub(super) fn build_inheritance_types(
         &mut self,
         source: &input::InheritanceTypes,
     ) -> output::InheritanceTypes {
@@ -2526,7 +2464,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_interface_members(
+    pub(super) fn build_interface_members(
         &mut self,
         source: &input::InterfaceMembers,
     ) -> output::InterfaceMembers {
@@ -2537,7 +2475,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_library_members(&mut self, source: &input::LibraryMembers) -> output::LibraryMembers {
+    pub(super) fn build_library_members(
+        &mut self,
+        source: &input::LibraryMembers,
+    ) -> output::LibraryMembers {
         source
             .elements
             .iter()
@@ -2545,7 +2486,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_multi_typed_declaration_elements(
+    pub(super) fn build_multi_typed_declaration_elements(
         &mut self,
         source: &input::MultiTypedDeclarationElements,
     ) -> output::MultiTypedDeclarationElements {
@@ -2556,7 +2497,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_named_arguments(&mut self, source: &input::NamedArguments) -> output::NamedArguments {
+    pub(super) fn build_named_arguments(
+        &mut self,
+        source: &input::NamedArguments,
+    ) -> output::NamedArguments {
         source
             .elements
             .iter()
@@ -2564,7 +2508,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_override_paths(&mut self, source: &input::OverridePaths) -> output::OverridePaths {
+    pub(super) fn build_override_paths(
+        &mut self,
+        source: &input::OverridePaths,
+    ) -> output::OverridePaths {
         source
             .elements
             .iter()
@@ -2572,7 +2519,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_parameters(&mut self, source: &input::Parameters) -> output::Parameters {
+    pub(super) fn build_parameters(&mut self, source: &input::Parameters) -> output::Parameters {
         source
             .elements
             .iter()
@@ -2580,7 +2527,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_positional_arguments(
+    pub(super) fn build_positional_arguments(
         &mut self,
         source: &input::PositionalArguments,
     ) -> output::PositionalArguments {
@@ -2591,7 +2538,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_simple_version_literal(
+    pub(super) fn build_simple_version_literal(
         &mut self,
         source: &input::SimpleVersionLiteral,
     ) -> output::SimpleVersionLiteral {
@@ -2602,7 +2549,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_source_unit_members(
+    pub(super) fn build_source_unit_members(
         &mut self,
         source: &input::SourceUnitMembers,
     ) -> output::SourceUnitMembers {
@@ -2613,7 +2560,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_statements(&mut self, source: &input::Statements) -> output::Statements {
+    pub(super) fn build_statements(&mut self, source: &input::Statements) -> output::Statements {
         source
             .elements
             .iter()
@@ -2621,7 +2568,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_string_literals(&mut self, source: &input::StringLiterals) -> output::StringLiterals {
+    pub(super) fn build_string_literals(
+        &mut self,
+        source: &input::StringLiterals,
+    ) -> output::StringLiterals {
         source
             .elements
             .iter()
@@ -2629,7 +2579,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_struct_members(&mut self, source: &input::StructMembers) -> output::StructMembers {
+    pub(super) fn build_struct_members(
+        &mut self,
+        source: &input::StructMembers,
+    ) -> output::StructMembers {
         source
             .elements
             .iter()
@@ -2637,7 +2590,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_tuple_values(&mut self, source: &input::TupleValues) -> output::TupleValues {
+    pub(super) fn build_tuple_values(
+        &mut self,
+        source: &input::TupleValues,
+    ) -> output::TupleValues {
         source
             .elements
             .iter()
@@ -2645,7 +2601,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_unicode_string_literals(
+    pub(super) fn build_unicode_string_literals(
         &mut self,
         source: &input::UnicodeStringLiterals,
     ) -> output::UnicodeStringLiterals {
@@ -2656,7 +2612,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_using_deconstruction_symbols(
+    pub(super) fn build_using_deconstruction_symbols(
         &mut self,
         source: &input::UsingDeconstructionSymbols,
     ) -> output::UsingDeconstructionSymbols {
@@ -2667,7 +2623,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_version_expression_set(
+    pub(super) fn build_version_expression_set(
         &mut self,
         source: &input::VersionExpressionSet,
     ) -> output::VersionExpressionSet {
@@ -2678,7 +2634,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_version_expression_sets(
+    pub(super) fn build_version_expression_sets(
         &mut self,
         source: &input::VersionExpressionSets,
     ) -> output::VersionExpressionSets {
@@ -2689,7 +2645,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_arguments(&mut self, source: &input::YulArguments) -> output::YulArguments {
+    pub(super) fn build_yul_arguments(
+        &mut self,
+        source: &input::YulArguments,
+    ) -> output::YulArguments {
         source
             .elements
             .iter()
@@ -2697,7 +2656,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_flags(&mut self, source: &input::YulFlags) -> output::YulFlags {
+    pub(super) fn build_yul_flags(&mut self, source: &input::YulFlags) -> output::YulFlags {
         source
             .elements
             .iter()
@@ -2705,7 +2664,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_parameters(&mut self, source: &input::YulParameters) -> output::YulParameters {
+    pub(super) fn build_yul_parameters(
+        &mut self,
+        source: &input::YulParameters,
+    ) -> output::YulParameters {
         source
             .elements
             .iter()
@@ -2713,7 +2675,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_path(&mut self, source: &input::YulPath) -> output::YulPath {
+    pub(super) fn build_yul_path(&mut self, source: &input::YulPath) -> output::YulPath {
         source
             .elements
             .iter()
@@ -2721,7 +2683,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_paths(&mut self, source: &input::YulPaths) -> output::YulPaths {
+    pub(super) fn build_yul_paths(&mut self, source: &input::YulPaths) -> output::YulPaths {
         source
             .elements
             .iter()
@@ -2729,7 +2691,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_statements(&mut self, source: &input::YulStatements) -> output::YulStatements {
+    pub(super) fn build_yul_statements(
+        &mut self,
+        source: &input::YulStatements,
+    ) -> output::YulStatements {
         source
             .elements
             .iter()
@@ -2737,7 +2702,10 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_switch_cases(&mut self, source: &input::YulSwitchCases) -> output::YulSwitchCases {
+    pub(super) fn build_yul_switch_cases(
+        &mut self,
+        source: &input::YulSwitchCases,
+    ) -> output::YulSwitchCases {
         source
             .elements
             .iter()
@@ -2745,7 +2713,7 @@ pub trait Builder {
             .collect()
     }
 
-    fn build_yul_variable_names(
+    pub(super) fn build_yul_variable_names(
         &mut self,
         source: &input::YulVariableNames,
     ) -> output::YulVariableNames {
@@ -2760,7 +2728,10 @@ pub trait Builder {
     // Terminals
     //
 
-    fn build_bytes_keyword(&mut self, source: &input::BytesKeyword) -> output::BytesKeyword {
+    pub(super) fn build_bytes_keyword(
+        &mut self,
+        source: &input::BytesKeyword,
+    ) -> output::BytesKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::BytesKeywordStruct {
             id: self.next_id(),
@@ -2769,7 +2740,10 @@ pub trait Builder {
         })
     }
 
-    fn build_decimal_literal(&mut self, source: &input::DecimalLiteral) -> output::DecimalLiteral {
+    pub(super) fn build_decimal_literal(
+        &mut self,
+        source: &input::DecimalLiteral,
+    ) -> output::DecimalLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
             id: self.next_id(),
@@ -2778,7 +2752,10 @@ pub trait Builder {
         })
     }
 
-    fn build_fixed_keyword(&mut self, source: &input::FixedKeyword) -> output::FixedKeyword {
+    pub(super) fn build_fixed_keyword(
+        &mut self,
+        source: &input::FixedKeyword,
+    ) -> output::FixedKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::FixedKeywordStruct {
             id: self.next_id(),
@@ -2787,7 +2764,7 @@ pub trait Builder {
         })
     }
 
-    fn build_hex_literal(&mut self, source: &input::HexLiteral) -> output::HexLiteral {
+    pub(super) fn build_hex_literal(&mut self, source: &input::HexLiteral) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             id: self.next_id(),
@@ -2796,7 +2773,7 @@ pub trait Builder {
         })
     }
 
-    fn build_hex_string_literal(
+    pub(super) fn build_hex_string_literal(
         &mut self,
         source: &input::HexStringLiteral,
     ) -> output::HexStringLiteral {
@@ -2808,7 +2785,7 @@ pub trait Builder {
         })
     }
 
-    fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
+    pub(super) fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IdentifierStruct {
             id: self.next_id(),
@@ -2817,7 +2794,7 @@ pub trait Builder {
         })
     }
 
-    fn build_int_keyword(&mut self, source: &input::IntKeyword) -> output::IntKeyword {
+    pub(super) fn build_int_keyword(&mut self, source: &input::IntKeyword) -> output::IntKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IntKeywordStruct {
             id: self.next_id(),
@@ -2826,7 +2803,10 @@ pub trait Builder {
         })
     }
 
-    fn build_string_literal(&mut self, source: &input::StringLiteral) -> output::StringLiteral {
+    pub(super) fn build_string_literal(
+        &mut self,
+        source: &input::StringLiteral,
+    ) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             id: self.next_id(),
@@ -2835,7 +2815,10 @@ pub trait Builder {
         })
     }
 
-    fn build_ufixed_keyword(&mut self, source: &input::UfixedKeyword) -> output::UfixedKeyword {
+    pub(super) fn build_ufixed_keyword(
+        &mut self,
+        source: &input::UfixedKeyword,
+    ) -> output::UfixedKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::UfixedKeywordStruct {
             id: self.next_id(),
@@ -2844,7 +2827,10 @@ pub trait Builder {
         })
     }
 
-    fn build_uint_keyword(&mut self, source: &input::UintKeyword) -> output::UintKeyword {
+    pub(super) fn build_uint_keyword(
+        &mut self,
+        source: &input::UintKeyword,
+    ) -> output::UintKeyword {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::UintKeywordStruct {
             id: self.next_id(),
@@ -2853,7 +2839,7 @@ pub trait Builder {
         })
     }
 
-    fn build_unicode_string_literal(
+    pub(super) fn build_unicode_string_literal(
         &mut self,
         source: &input::UnicodeStringLiteral,
     ) -> output::UnicodeStringLiteral {
@@ -2865,7 +2851,7 @@ pub trait Builder {
         })
     }
 
-    fn build_version_specifier(
+    pub(super) fn build_version_specifier(
         &mut self,
         source: &input::VersionSpecifier,
     ) -> output::VersionSpecifier {
@@ -2881,7 +2867,7 @@ pub trait Builder {
     // Normalized Terminals
     //
 
-    fn build_pragma_string_literal(
+    pub(super) fn build_pragma_string_literal(
         &mut self,
         source: &input::PragmaStringLiteral,
     ) -> output::StringLiteral {
@@ -2893,7 +2879,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_decimal_literal(
+    pub(super) fn build_yul_decimal_literal(
         &mut self,
         source: &input::YulDecimalLiteral,
     ) -> output::DecimalLiteral {
@@ -2905,7 +2891,10 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_hex_literal(&mut self, source: &input::YulHexLiteral) -> output::HexLiteral {
+    pub(super) fn build_yul_hex_literal(
+        &mut self,
+        source: &input::YulHexLiteral,
+    ) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             id: self.next_id(),
@@ -2914,7 +2903,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_hex_string_literal(
+    pub(super) fn build_yul_hex_string_literal(
         &mut self,
         source: &input::YulHexStringLiteral,
     ) -> output::HexStringLiteral {
@@ -2926,7 +2915,10 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_identifier(&mut self, source: &input::YulIdentifier) -> output::Identifier {
+    pub(super) fn build_yul_identifier(
+        &mut self,
+        source: &input::YulIdentifier,
+    ) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::IdentifierStruct {
             id: self.next_id(),
@@ -2935,7 +2927,7 @@ pub trait Builder {
         })
     }
 
-    fn build_yul_string_literal(
+    pub(super) fn build_yul_string_literal(
         &mut self,
         source: &input::YulStringLiteral,
     ) -> output::StringLiteral {

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -9,6 +9,7 @@ use crate::ir::nodes as output;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 
 pub trait Builder {
+  fn next_id(&mut self) -> output::NodeId;
   fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
 
   //
@@ -18,7 +19,8 @@ pub trait Builder {
     fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }}
     {% if not sequence.has_added_fields %}
       {
-        {% for field in sequence.fields %}
+        let id = self.next_id();
+        {%- for field in sequence.fields %}
           let {{ field.label | snake_case }} =
           {%- if field.is_optional -%}
             {%- if field.type.kind == "UniqueTerminal" -%}
@@ -35,6 +37,7 @@ pub trait Builder {
         {%- endfor %}
 
         Rc::new(output::{{ parent_type }}Struct {
+          id,
           {%- for field in sequence.fields -%}
             {{ field.label | snake_case }},
           {%- endfor %}
@@ -106,6 +109,7 @@ pub trait Builder {
           input::{{ parent_type }}::{{ variant.source.name }}(terminal) => {
             let text = self.unparse_range(terminal.range.clone());
             Rc::new(output::{{ collapsed.target.name }}Struct {
+              id: self.next_id(),
               range: terminal.range.clone(),
               text,
             })
@@ -140,6 +144,7 @@ pub trait Builder {
       fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::{{ terminal_type }}Struct {
+          id: self.next_id(),
           range: source.range.clone(),
           text,
         })
@@ -155,6 +160,7 @@ pub trait Builder {
       fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::{{ normalized.target }}Struct {
+          id: self.next_id(),
           range: source.range.clone(),
           text,
         })

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -6,18 +6,17 @@
 
 use std::rc::Rc;
 use crate::ir::nodes as output;
+use crate::ir::Source;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
+use super::CstToIrBuilder;
 
-pub trait Builder {
-  fn next_id(&mut self) -> output::NodeId;
-  fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
-
+impl<S: Source> CstToIrBuilder<'_, S> {
   //
   // Sequences
   //
   {% for parent_type, sequence in builder.sequences %}
-    fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }}
     {% if not sequence.has_added_fields %}
+      pub(super) fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }}
       {
         let id = self.next_id();
         {%- for field in sequence.fields %}
@@ -43,8 +42,6 @@ pub trait Builder {
           {%- endfor %}
         })
       }
-    {% else %}
-      ;
     {% endif %}
   {% endfor %}
 
@@ -52,7 +49,7 @@ pub trait Builder {
   // Collapsed sequences
   //
   {% for parent_type, collapsed in builder.collapsed_sequences %}
-    fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ collapsed.target_type.name }}
+    pub(super) fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ collapsed.target_type.name }}
     {
       self.build_{{ collapsed.type.name | snake_case }}(&source.{{ collapsed.label }})
     }
@@ -63,10 +60,18 @@ pub trait Builder {
   //
   {% for parent_type, choice in builder.choices %}
     {% if not choice.is_new -%}
+      #[allow(clippy::unused_self)]
       {% if choice.has_removed_variants -%}
         #[allow(dead_code)]
+        pub(super) fn default_build_{{ parent_type | snake_case }}(
+          &mut self, source: &input::{{ parent_type }},
+        ) -> output::{{ parent_type }}
+      {%- else -%}
+        pub(super) fn build_{{ parent_type | snake_case }}(
+          &mut self, source: &input::{{ parent_type }},
+        ) -> output::{{ parent_type }}
       {%- endif %}
-      fn default_build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }} {
+      {
         #[allow(clippy::match_wildcard_for_single_variants)]
         #[allow(clippy::match_single_binding)]
         match source {
@@ -88,14 +93,6 @@ pub trait Builder {
           {% endif -%}
         }
       }
-      fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }}
-      {%- if choice.has_removed_variants -%}
-        ;
-      {%- else -%}
-        {
-          self.default_build_{{ parent_type | snake_case }}(source)
-        }
-      {%- endif %}
     {%- endif %}
   {% endfor %}
 
@@ -103,7 +100,7 @@ pub trait Builder {
   // Collapsed choices
   //
   {% for parent_type, collapsed in builder.collapsed_choices %}
-    fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ collapsed.target.name }} {
+    pub(super) fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ collapsed.target.name }} {
       match source {
         {% for variant in collapsed.variants -%}
           input::{{ parent_type }}::{{ variant.source.name }}(terminal) => {
@@ -125,7 +122,7 @@ pub trait Builder {
 
   {% for parent_type, collection in builder.collections %}
     {% if not collection.is_new -%}
-      fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }} {
+      pub(super) fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }} {
         source.elements.iter().map(|item|
           self.build_{{ collection.item_type.name | snake_case }}(item)
         ).collect()
@@ -141,7 +138,7 @@ pub trait Builder {
     {# Unique terminals don't need cloning because they are not present in the IR, #}
     {# and new terminals cannot be automatically built #}
     {% if not terminal.is_new and not terminal.is_unique %}
-      fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
+      pub(super) fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::{{ terminal_type }}Struct {
           id: self.next_id(),
@@ -157,7 +154,7 @@ pub trait Builder {
   //
   {% for source_type, normalized in builder.normalized_terminals %}
     {% if not normalized.is_unique %}
-      fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
+      pub(super) fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
         let text = self.unparse_range(source.range.clone());
         Rc::new(output::{{ normalized.target }}Struct {
           id: self.next_id(),

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -15,10 +15,6 @@ pub struct NodeIdGenerator {
 }
 
 impl NodeIdGenerator {
-    pub fn new(initial: usize) -> Self {
-        Self { next_id: initial }
-    }
-
     /// Returns a `NodeId` greater than any previously returned by this
     /// generator.
     /// The returned ID is unique and suitable for use as a total-order key.
@@ -31,7 +27,7 @@ impl NodeIdGenerator {
 
 impl Default for NodeIdGenerator {
     fn default() -> Self {
-        Self::new(1usize)
+        Self { next_id: 1usize }
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -4,7 +4,6 @@ use slang_solidity_v2_cst::structured_cst::nodes as input;
 
 #[path = "default.generated.rs"]
 mod default;
-use default::Builder;
 
 use super::Source;
 use crate::ir::nodes as output;
@@ -43,12 +42,12 @@ pub fn build_source_unit(
     builder.build_source_unit(source_unit)
 }
 
-struct CstToIrBuilder<'a, S: Source> {
+pub(crate) struct CstToIrBuilder<'a, S: Source> {
     source: &'a S,
     id_generator: &'a mut NodeIdGenerator,
 }
 
-impl<S: Source> Builder for CstToIrBuilder<'_, S> {
+impl<S: Source> CstToIrBuilder<'_, S> {
     fn next_id(&mut self) -> output::NodeId {
         self.id_generator.next_id()
     }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -9,19 +9,54 @@ use default::Builder;
 use super::Source;
 use crate::ir::nodes as output;
 
+/// A strictly monotonically increasing `NodeId` generator.
+pub struct NodeIdGenerator {
+    next_id: usize,
+}
+
+impl NodeIdGenerator {
+    pub fn new(initial: usize) -> Self {
+        Self { next_id: initial }
+    }
+
+    /// Returns a `NodeId` greater than any previously returned by this
+    /// generator.
+    /// The returned ID is unique and suitable for use as a total-order key.
+    pub fn next_id(&mut self) -> output::NodeId {
+        let id = self.next_id;
+        self.next_id += 1;
+        id.into()
+    }
+}
+
+impl Default for NodeIdGenerator {
+    fn default() -> Self {
+        Self::new(1usize)
+    }
+}
+
 pub fn build_source_unit(
     source_unit: &input::SourceUnit,
     source: &impl Source,
+    id_generator: &mut NodeIdGenerator,
 ) -> output::SourceUnit {
-    let mut builder = CstToIrBuilder { source };
+    let mut builder = CstToIrBuilder {
+        source,
+        id_generator,
+    };
     builder.build_source_unit(source_unit)
 }
 
 struct CstToIrBuilder<'a, S: Source> {
-    pub source: &'a S,
+    source: &'a S,
+    id_generator: &'a mut NodeIdGenerator,
 }
 
 impl<S: Source> Builder for CstToIrBuilder<'_, S> {
+    fn next_id(&mut self) -> output::NodeId {
+        self.id_generator.next_id()
+    }
+
     fn unparse_range(&self, range: std::ops::Range<usize>) -> String {
         self.source.text(range).to_owned()
     }
@@ -34,12 +69,14 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ConstantDefinition,
     ) -> output::ConstantDefinition {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
         let visibility = None;
         let value = Some(self.build_expression(&source.value));
 
         Rc::new(output::ConstantDefinitionStruct {
+            id,
             type_name,
             name,
             visibility,
@@ -51,6 +88,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ContractDefinition,
     ) -> output::ContractDefinition {
+        let id = self.next_id();
         let abstract_keyword = source.abstract_keyword.is_some();
         let name = self.build_identifier(&source.name);
         let members = self.build_contract_members(&source.members);
@@ -75,6 +113,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         });
 
         Rc::new(output::ContractDefinitionStruct {
+            id,
             abstract_keyword,
             name,
             inheritance_types,
@@ -87,6 +126,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ErrorDefinition,
     ) -> output::ErrorDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let parameters = source
             .members
@@ -96,13 +136,18 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
             .map(|parameter| self.build_error_parameter(parameter))
             .collect();
 
-        Rc::new(output::ErrorDefinitionStruct { name, parameters })
+        Rc::new(output::ErrorDefinitionStruct {
+            id,
+            name,
+            parameters,
+        })
     }
 
     fn build_event_definition(
         &mut self,
         source: &input::EventDefinition,
     ) -> output::EventDefinition {
+        let id = self.next_id();
         let name = self.build_identifier(&source.name);
         let anonymous_keyword = source.anonymous_keyword.is_some();
         let parameters = source
@@ -114,6 +159,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
             .collect();
 
         Rc::new(output::EventDefinitionStruct {
+            id,
             name,
             anonymous_keyword,
             parameters,
@@ -124,6 +170,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::FunctionDefinition,
     ) -> output::FunctionDefinition {
+        let id = self.next_id();
         let (kind, name) = match &source.name {
             input::FunctionName::Identifier(identifier) => (
                 output::FunctionKind::Regular,
@@ -150,6 +197,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         let body = self.build_function_body(&source.body);
 
         Rc::new(output::FunctionDefinitionStruct {
+            id,
             kind,
             name,
             parameters,
@@ -164,6 +212,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
     }
 
     fn build_function_type(&mut self, source: &input::FunctionType) -> output::FunctionType {
+        let id = self.next_id();
         let parameters = self.build_parameters_declaration(&source.parameters);
         let visibility = Self::function_type_visibility(&source.attributes);
         let mutability = Self::function_type_mutability(&source.attributes);
@@ -173,6 +222,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
             .map(|returns| self.build_returns_declaration(returns));
 
         Rc::new(output::FunctionTypeStruct {
+            id,
             parameters,
             visibility,
             mutability,
@@ -184,6 +234,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::IndexAccessExpression,
     ) -> output::IndexAccessExpression {
+        let id = self.next_id();
         let operand = self.build_expression(&source.operand);
         let start = source
             .start
@@ -195,6 +246,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
             .and_then(|end| end.end.as_ref().map(|end| self.build_expression(end)));
 
         Rc::new(output::IndexAccessExpressionStruct {
+            id,
             operand,
             start,
             end,
@@ -202,16 +254,19 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
     }
 
     fn build_mapping_type(&mut self, source: &input::MappingType) -> output::MappingType {
+        let id = self.next_id();
         let key_type = self.build_mapping_key_as_parameter(&source.key_type);
         let value_type = self.build_mapping_value_as_parameter(&source.value_type);
 
         Rc::new(output::MappingTypeStruct {
+            id,
             key_type,
             value_type,
         })
     }
 
     fn build_parameter(&mut self, source: &input::Parameter) -> output::Parameter {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let storage_location = source
             .storage_location
@@ -220,6 +275,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
+            id,
             type_name,
             storage_location,
             name,
@@ -231,6 +287,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::StateVariableDefinition,
     ) -> output::StateVariableDefinition {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
         let value = source
@@ -242,6 +299,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         let override_specifier = self.state_variable_override_specifier(&source.attributes);
 
         Rc::new(output::StateVariableDefinitionStruct {
+            id,
             type_name,
             name,
             value,
@@ -446,6 +504,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ConstructorDefinition,
     ) -> output::FunctionDefinition {
+        let id = self.next_id();
         let kind = output::FunctionKind::Constructor;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -460,6 +519,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let body = Some(self.build_block(&source.body));
 
         Rc::new(output::FunctionDefinitionStruct {
+            id,
             kind,
             name,
             parameters,
@@ -523,6 +583,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::FallbackFunctionDefinition,
     ) -> output::FunctionDefinition {
+        let id = self.next_id();
         let kind = output::FunctionKind::Fallback;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -544,6 +605,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let body = self.build_function_body(&source.body);
 
         Rc::new(output::FunctionDefinitionStruct {
+            id,
             kind,
             name,
             parameters,
@@ -611,6 +673,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ReceiveFunctionDefinition,
     ) -> output::FunctionDefinition {
+        let id = self.next_id();
         let kind = output::FunctionKind::Receive;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -630,6 +693,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let body = self.build_function_body(&source.body);
 
         Rc::new(output::FunctionDefinitionStruct {
+            id,
             kind,
             name,
             parameters,
@@ -677,6 +741,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::ModifierDefinition,
     ) -> output::FunctionDefinition {
+        let id = self.next_id();
         let kind = output::FunctionKind::Modifier;
         let name = Some(self.build_identifier(&source.name));
         let parameters = source.parameters.as_ref().map_or(Vec::new(), |parameter| {
@@ -696,6 +761,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let body = self.build_function_body(&source.body);
 
         Rc::new(output::FunctionDefinitionStruct {
+            id,
             kind,
             name,
             parameters,
@@ -786,6 +852,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         state_variable_definition: output::StateVariableDefinitionStruct,
     ) -> output::ConstantDefinition {
         Rc::new(output::ConstantDefinitionStruct {
+            id: state_variable_definition.id(),
             type_name: state_variable_definition.type_name,
             name: state_variable_definition.name,
             visibility: Some(state_variable_definition.visibility),
@@ -814,10 +881,12 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     //
 
     fn build_mapping_key_as_parameter(&mut self, source: &input::MappingKey) -> output::Parameter {
+        let id = self.next_id();
         let type_name = self.build_mapping_key_type(&source.key_type);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
+            id,
             type_name,
             storage_location: None,
             name,
@@ -840,10 +909,12 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::MappingValue,
     ) -> output::Parameter {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
+            id,
             type_name,
             storage_location: None,
             name,
@@ -859,10 +930,11 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         source: &input::NamedImport,
     ) -> output::PathImport {
+        let id = self.next_id();
         let path = self.build_string_literal(&source.path);
         let alias = Some(self.build_import_alias(&source.alias));
 
-        Rc::new(output::PathImportStruct { path, alias })
+        Rc::new(output::PathImportStruct { id, path, alias })
     }
 
     //
@@ -870,11 +942,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     //
 
     fn build_event_parameter(&mut self, source: &input::EventParameter) -> output::Parameter {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let indexed = source.indexed_keyword.is_some();
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
+            id,
             type_name,
             storage_location: None,
             name,
@@ -883,10 +957,12 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     }
 
     fn build_error_parameter(&mut self, source: &input::ErrorParameter) -> output::Parameter {
+        let id = self.next_id();
         let type_name = self.build_type_name(&source.type_name);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
+            id,
             type_name,
             storage_location: None,
             name,

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/mod.rs
@@ -10,4 +10,4 @@ pub use source::Source;
 #[path = "visitor.generated.rs"]
 pub mod visitor;
 
-pub use builder::build_source_unit as build;
+pub use builder::{build_source_unit as build, NodeIdGenerator};

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -6,15 +6,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::vec::Vec;
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(transparent)]
-pub struct NodeId(usize);
-
-impl From<usize> for NodeId {
-    fn from(value: usize) -> Self {
-        Self(value)
-    }
-}
+pub use slang_solidity_v2_common::nodes::NodeId;
 
 //
 // Sequences

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -10,6 +10,12 @@ use std::vec::Vec;
 #[repr(transparent)]
 pub struct NodeId(usize);
 
+impl From<usize> for NodeId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
 //
 // Sequences
 //
@@ -18,12 +24,13 @@ pub type AbicoderPragma = Rc<AbicoderPragmaStruct>;
 
 #[derive(Debug)]
 pub struct AbicoderPragmaStruct {
+    pub(crate) id: NodeId,
     pub version: AbicoderVersion,
 }
 
 impl AbicoderPragmaStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -31,14 +38,15 @@ pub type AdditiveExpression = Rc<AdditiveExpressionStruct>;
 
 #[derive(Debug)]
 pub struct AdditiveExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_additive_expression_operator: Expression_AdditiveExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl AdditiveExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -46,12 +54,13 @@ pub type AddressType = Rc<AddressTypeStruct>;
 
 #[derive(Debug)]
 pub struct AddressTypeStruct {
+    pub(crate) id: NodeId,
     pub payable_keyword: bool,
 }
 
 impl AddressTypeStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -59,13 +68,14 @@ pub type AndExpression = Rc<AndExpressionStruct>;
 
 #[derive(Debug)]
 pub struct AndExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl AndExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -73,12 +83,13 @@ pub type ArrayExpression = Rc<ArrayExpressionStruct>;
 
 #[derive(Debug)]
 pub struct ArrayExpressionStruct {
+    pub(crate) id: NodeId,
     pub items: ArrayValues,
 }
 
 impl ArrayExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -86,13 +97,14 @@ pub type ArrayTypeName = Rc<ArrayTypeNameStruct>;
 
 #[derive(Debug)]
 pub struct ArrayTypeNameStruct {
+    pub(crate) id: NodeId,
     pub operand: TypeName,
     pub index: Option<Expression>,
 }
 
 impl ArrayTypeNameStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -100,14 +112,15 @@ pub type AssemblyStatement = Rc<AssemblyStatementStruct>;
 
 #[derive(Debug)]
 pub struct AssemblyStatementStruct {
+    pub(crate) id: NodeId,
     pub label: Option<StringLiteral>,
     pub flags: Option<YulFlags>,
     pub body: YulBlock,
 }
 
 impl AssemblyStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -115,14 +128,15 @@ pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
 
 #[derive(Debug)]
 pub struct AssignmentExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_assignment_expression_operator: Expression_AssignmentExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl AssignmentExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -130,13 +144,14 @@ pub type BitwiseAndExpression = Rc<BitwiseAndExpressionStruct>;
 
 #[derive(Debug)]
 pub struct BitwiseAndExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl BitwiseAndExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -144,13 +159,14 @@ pub type BitwiseOrExpression = Rc<BitwiseOrExpressionStruct>;
 
 #[derive(Debug)]
 pub struct BitwiseOrExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl BitwiseOrExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -158,13 +174,14 @@ pub type BitwiseXorExpression = Rc<BitwiseXorExpressionStruct>;
 
 #[derive(Debug)]
 pub struct BitwiseXorExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl BitwiseXorExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -172,23 +189,26 @@ pub type Block = Rc<BlockStruct>;
 
 #[derive(Debug)]
 pub struct BlockStruct {
+    pub(crate) id: NodeId,
     pub statements: Statements,
 }
 
 impl BlockStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
 pub type BreakStatement = Rc<BreakStatementStruct>;
 
 #[derive(Debug)]
-pub struct BreakStatementStruct {}
+pub struct BreakStatementStruct {
+    pub(crate) id: NodeId,
+}
 
 impl BreakStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -196,13 +216,14 @@ pub type CallOptionsExpression = Rc<CallOptionsExpressionStruct>;
 
 #[derive(Debug)]
 pub struct CallOptionsExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub options: CallOptions,
 }
 
 impl CallOptionsExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -210,13 +231,14 @@ pub type CatchClause = Rc<CatchClauseStruct>;
 
 #[derive(Debug)]
 pub struct CatchClauseStruct {
+    pub(crate) id: NodeId,
     pub error: Option<CatchClauseError>,
     pub body: Block,
 }
 
 impl CatchClauseStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -224,13 +246,14 @@ pub type CatchClauseError = Rc<CatchClauseErrorStruct>;
 
 #[derive(Debug)]
 pub struct CatchClauseErrorStruct {
+    pub(crate) id: NodeId,
     pub name: Option<Identifier>,
     pub parameters: Parameters,
 }
 
 impl CatchClauseErrorStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -238,14 +261,15 @@ pub type ConditionalExpression = Rc<ConditionalExpressionStruct>;
 
 #[derive(Debug)]
 pub struct ConditionalExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub true_expression: Expression,
     pub false_expression: Expression,
 }
 
 impl ConditionalExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -253,6 +277,7 @@ pub type ConstantDefinition = Rc<ConstantDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct ConstantDefinitionStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
     pub name: Identifier,
     pub visibility: Option<StateVariableVisibility>,
@@ -260,19 +285,21 @@ pub struct ConstantDefinitionStruct {
 }
 
 impl ConstantDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
 pub type ContinueStatement = Rc<ContinueStatementStruct>;
 
 #[derive(Debug)]
-pub struct ContinueStatementStruct {}
+pub struct ContinueStatementStruct {
+    pub(crate) id: NodeId,
+}
 
 impl ContinueStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -280,6 +307,7 @@ pub type ContractDefinition = Rc<ContractDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct ContractDefinitionStruct {
+    pub(crate) id: NodeId,
     pub abstract_keyword: bool,
     pub name: Identifier,
     pub inheritance_types: InheritanceTypes,
@@ -288,8 +316,8 @@ pub struct ContractDefinitionStruct {
 }
 
 impl ContractDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -297,13 +325,14 @@ pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
 
 #[derive(Debug)]
 pub struct DecimalNumberExpressionStruct {
+    pub(crate) id: NodeId,
     pub literal: DecimalLiteral,
     pub unit: Option<NumberUnit>,
 }
 
 impl DecimalNumberExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -311,13 +340,14 @@ pub type DoWhileStatement = Rc<DoWhileStatementStruct>;
 
 #[derive(Debug)]
 pub struct DoWhileStatementStruct {
+    pub(crate) id: NodeId,
     pub body: Statement,
     pub condition: Expression,
 }
 
 impl DoWhileStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -325,13 +355,14 @@ pub type EmitStatement = Rc<EmitStatementStruct>;
 
 #[derive(Debug)]
 pub struct EmitStatementStruct {
+    pub(crate) id: NodeId,
     pub event: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
 }
 
 impl EmitStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -339,13 +370,14 @@ pub type EnumDefinition = Rc<EnumDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct EnumDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub members: EnumMembers,
 }
 
 impl EnumDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -353,14 +385,15 @@ pub type EqualityExpression = Rc<EqualityExpressionStruct>;
 
 #[derive(Debug)]
 pub struct EqualityExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_equality_expression_operator: Expression_EqualityExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl EqualityExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -368,13 +401,14 @@ pub type ErrorDefinition = Rc<ErrorDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct ErrorDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub parameters: Parameters,
 }
 
 impl ErrorDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -382,14 +416,15 @@ pub type EventDefinition = Rc<EventDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct EventDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub anonymous_keyword: bool,
     pub parameters: Parameters,
 }
 
 impl EventDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -397,12 +432,13 @@ pub type ExperimentalPragma = Rc<ExperimentalPragmaStruct>;
 
 #[derive(Debug)]
 pub struct ExperimentalPragmaStruct {
+    pub(crate) id: NodeId,
     pub feature: ExperimentalFeature,
 }
 
 impl ExperimentalPragmaStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -410,13 +446,14 @@ pub type ExponentiationExpression = Rc<ExponentiationExpressionStruct>;
 
 #[derive(Debug)]
 pub struct ExponentiationExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl ExponentiationExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -424,12 +461,13 @@ pub type ExpressionStatement = Rc<ExpressionStatementStruct>;
 
 #[derive(Debug)]
 pub struct ExpressionStatementStruct {
+    pub(crate) id: NodeId,
     pub expression: Expression,
 }
 
 impl ExpressionStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -437,6 +475,7 @@ pub type ForStatement = Rc<ForStatementStruct>;
 
 #[derive(Debug)]
 pub struct ForStatementStruct {
+    pub(crate) id: NodeId,
     pub initialization: ForStatementInitialization,
     pub condition: ForStatementCondition,
     pub iterator: Option<Expression>,
@@ -444,8 +483,8 @@ pub struct ForStatementStruct {
 }
 
 impl ForStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -453,13 +492,14 @@ pub type FunctionCallExpression = Rc<FunctionCallExpressionStruct>;
 
 #[derive(Debug)]
 pub struct FunctionCallExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub arguments: ArgumentsDeclaration,
 }
 
 impl FunctionCallExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -467,6 +507,7 @@ pub type FunctionDefinition = Rc<FunctionDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct FunctionDefinitionStruct {
+    pub(crate) id: NodeId,
     pub kind: FunctionKind,
     pub name: Option<Identifier>,
     pub parameters: Parameters,
@@ -480,8 +521,8 @@ pub struct FunctionDefinitionStruct {
 }
 
 impl FunctionDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -489,6 +530,7 @@ pub type FunctionType = Rc<FunctionTypeStruct>;
 
 #[derive(Debug)]
 pub struct FunctionTypeStruct {
+    pub(crate) id: NodeId,
     pub parameters: Parameters,
     pub visibility: FunctionVisibility,
     pub mutability: FunctionMutability,
@@ -496,8 +538,8 @@ pub struct FunctionTypeStruct {
 }
 
 impl FunctionTypeStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -505,12 +547,13 @@ pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 
 #[derive(Debug)]
 pub struct HexNumberExpressionStruct {
+    pub(crate) id: NodeId,
     pub literal: HexLiteral,
 }
 
 impl HexNumberExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -518,14 +561,15 @@ pub type IfStatement = Rc<IfStatementStruct>;
 
 #[derive(Debug)]
 pub struct IfStatementStruct {
+    pub(crate) id: NodeId,
     pub condition: Expression,
     pub body: Statement,
     pub else_branch: Option<Statement>,
 }
 
 impl IfStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -533,13 +577,14 @@ pub type ImportDeconstruction = Rc<ImportDeconstructionStruct>;
 
 #[derive(Debug)]
 pub struct ImportDeconstructionStruct {
+    pub(crate) id: NodeId,
     pub symbols: ImportDeconstructionSymbols,
     pub path: StringLiteral,
 }
 
 impl ImportDeconstructionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -547,13 +592,14 @@ pub type ImportDeconstructionSymbol = Rc<ImportDeconstructionSymbolStruct>;
 
 #[derive(Debug)]
 pub struct ImportDeconstructionSymbolStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub alias: Option<Identifier>,
 }
 
 impl ImportDeconstructionSymbolStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -561,14 +607,15 @@ pub type IndexAccessExpression = Rc<IndexAccessExpressionStruct>;
 
 #[derive(Debug)]
 pub struct IndexAccessExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub start: Option<Expression>,
     pub end: Option<Expression>,
 }
 
 impl IndexAccessExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -576,14 +623,15 @@ pub type InequalityExpression = Rc<InequalityExpressionStruct>;
 
 #[derive(Debug)]
 pub struct InequalityExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_inequality_expression_operator: Expression_InequalityExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl InequalityExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -591,13 +639,14 @@ pub type InheritanceType = Rc<InheritanceTypeStruct>;
 
 #[derive(Debug)]
 pub struct InheritanceTypeStruct {
+    pub(crate) id: NodeId,
     pub type_name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
 }
 
 impl InheritanceTypeStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -605,14 +654,15 @@ pub type InterfaceDefinition = Rc<InterfaceDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct InterfaceDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub inheritance: Option<InheritanceTypes>,
     pub members: InterfaceMembers,
 }
 
 impl InterfaceDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -620,13 +670,14 @@ pub type LibraryDefinition = Rc<LibraryDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct LibraryDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub members: LibraryMembers,
 }
 
 impl LibraryDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -634,13 +685,14 @@ pub type MappingType = Rc<MappingTypeStruct>;
 
 #[derive(Debug)]
 pub struct MappingTypeStruct {
+    pub(crate) id: NodeId,
     pub key_type: Parameter,
     pub value_type: Parameter,
 }
 
 impl MappingTypeStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -648,13 +700,14 @@ pub type MemberAccessExpression = Rc<MemberAccessExpressionStruct>;
 
 #[derive(Debug)]
 pub struct MemberAccessExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub member: Identifier,
 }
 
 impl MemberAccessExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -662,13 +715,14 @@ pub type ModifierInvocation = Rc<ModifierInvocationStruct>;
 
 #[derive(Debug)]
 pub struct ModifierInvocationStruct {
+    pub(crate) id: NodeId,
     pub name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
 }
 
 impl ModifierInvocationStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -676,13 +730,14 @@ pub type MultiTypedDeclaration = Rc<MultiTypedDeclarationStruct>;
 
 #[derive(Debug)]
 pub struct MultiTypedDeclarationStruct {
+    pub(crate) id: NodeId,
     pub elements: MultiTypedDeclarationElements,
     pub value: Expression,
 }
 
 impl MultiTypedDeclarationStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -690,12 +745,13 @@ pub type MultiTypedDeclarationElement = Rc<MultiTypedDeclarationElementStruct>;
 
 #[derive(Debug)]
 pub struct MultiTypedDeclarationElementStruct {
+    pub(crate) id: NodeId,
     pub member: Option<VariableDeclaration>,
 }
 
 impl MultiTypedDeclarationElementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -703,14 +759,15 @@ pub type MultiplicativeExpression = Rc<MultiplicativeExpressionStruct>;
 
 #[derive(Debug)]
 pub struct MultiplicativeExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_multiplicative_expression_operator: Expression_MultiplicativeExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl MultiplicativeExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -718,13 +775,14 @@ pub type NamedArgument = Rc<NamedArgumentStruct>;
 
 #[derive(Debug)]
 pub struct NamedArgumentStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub value: Expression,
 }
 
 impl NamedArgumentStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -732,12 +790,13 @@ pub type NewExpression = Rc<NewExpressionStruct>;
 
 #[derive(Debug)]
 pub struct NewExpressionStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
 }
 
 impl NewExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -745,13 +804,14 @@ pub type OrExpression = Rc<OrExpressionStruct>;
 
 #[derive(Debug)]
 pub struct OrExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
 
 impl OrExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -759,6 +819,7 @@ pub type Parameter = Rc<ParameterStruct>;
 
 #[derive(Debug)]
 pub struct ParameterStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
     pub name: Option<Identifier>,
@@ -766,8 +827,8 @@ pub struct ParameterStruct {
 }
 
 impl ParameterStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -775,13 +836,14 @@ pub type PathImport = Rc<PathImportStruct>;
 
 #[derive(Debug)]
 pub struct PathImportStruct {
+    pub(crate) id: NodeId,
     pub path: StringLiteral,
     pub alias: Option<Identifier>,
 }
 
 impl PathImportStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -789,13 +851,14 @@ pub type PostfixExpression = Rc<PostfixExpressionStruct>;
 
 #[derive(Debug)]
 pub struct PostfixExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: Expression,
     pub expression_postfix_expression_operator: Expression_PostfixExpression_Operator,
 }
 
 impl PostfixExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -803,12 +866,13 @@ pub type PragmaDirective = Rc<PragmaDirectiveStruct>;
 
 #[derive(Debug)]
 pub struct PragmaDirectiveStruct {
+    pub(crate) id: NodeId,
     pub pragma: Pragma,
 }
 
 impl PragmaDirectiveStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -816,13 +880,14 @@ pub type PrefixExpression = Rc<PrefixExpressionStruct>;
 
 #[derive(Debug)]
 pub struct PrefixExpressionStruct {
+    pub(crate) id: NodeId,
     pub expression_prefix_expression_operator: Expression_PrefixExpression_Operator,
     pub operand: Expression,
 }
 
 impl PrefixExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -830,12 +895,13 @@ pub type ReturnStatement = Rc<ReturnStatementStruct>;
 
 #[derive(Debug)]
 pub struct ReturnStatementStruct {
+    pub(crate) id: NodeId,
     pub expression: Option<Expression>,
 }
 
 impl ReturnStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -843,13 +909,14 @@ pub type RevertStatement = Rc<RevertStatementStruct>;
 
 #[derive(Debug)]
 pub struct RevertStatementStruct {
+    pub(crate) id: NodeId,
     pub error: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
 }
 
 impl RevertStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -857,14 +924,15 @@ pub type ShiftExpression = Rc<ShiftExpressionStruct>;
 
 #[derive(Debug)]
 pub struct ShiftExpressionStruct {
+    pub(crate) id: NodeId,
     pub left_operand: Expression,
     pub expression_shift_expression_operator: Expression_ShiftExpression_Operator,
     pub right_operand: Expression,
 }
 
 impl ShiftExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -872,13 +940,14 @@ pub type SingleTypedDeclaration = Rc<SingleTypedDeclarationStruct>;
 
 #[derive(Debug)]
 pub struct SingleTypedDeclarationStruct {
+    pub(crate) id: NodeId,
     pub declaration: VariableDeclaration,
     pub value: Option<Expression>,
 }
 
 impl SingleTypedDeclarationStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -886,12 +955,13 @@ pub type SourceUnit = Rc<SourceUnitStruct>;
 
 #[derive(Debug)]
 pub struct SourceUnitStruct {
+    pub(crate) id: NodeId,
     pub members: SourceUnitMembers,
 }
 
 impl SourceUnitStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -899,6 +969,7 @@ pub type StateVariableDefinition = Rc<StateVariableDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct StateVariableDefinitionStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
     pub name: Identifier,
     pub value: Option<Expression>,
@@ -908,8 +979,8 @@ pub struct StateVariableDefinitionStruct {
 }
 
 impl StateVariableDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -917,13 +988,14 @@ pub type StructDefinition = Rc<StructDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct StructDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub members: StructMembers,
 }
 
 impl StructDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -931,13 +1003,14 @@ pub type StructMember = Rc<StructMemberStruct>;
 
 #[derive(Debug)]
 pub struct StructMemberStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
     pub name: Identifier,
 }
 
 impl StructMemberStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -945,6 +1018,7 @@ pub type TryStatement = Rc<TryStatementStruct>;
 
 #[derive(Debug)]
 pub struct TryStatementStruct {
+    pub(crate) id: NodeId,
     pub expression: Expression,
     pub returns: Option<Parameters>,
     pub body: Block,
@@ -952,8 +1026,8 @@ pub struct TryStatementStruct {
 }
 
 impl TryStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -961,12 +1035,13 @@ pub type TupleExpression = Rc<TupleExpressionStruct>;
 
 #[derive(Debug)]
 pub struct TupleExpressionStruct {
+    pub(crate) id: NodeId,
     pub items: TupleValues,
 }
 
 impl TupleExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -974,12 +1049,13 @@ pub type TupleValue = Rc<TupleValueStruct>;
 
 #[derive(Debug)]
 pub struct TupleValueStruct {
+    pub(crate) id: NodeId,
     pub expression: Option<Expression>,
 }
 
 impl TupleValueStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -987,12 +1063,13 @@ pub type TypeExpression = Rc<TypeExpressionStruct>;
 
 #[derive(Debug)]
 pub struct TypeExpressionStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
 }
 
 impl TypeExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1000,12 +1077,13 @@ pub type UncheckedBlock = Rc<UncheckedBlockStruct>;
 
 #[derive(Debug)]
 pub struct UncheckedBlockStruct {
+    pub(crate) id: NodeId,
     pub block: Block,
 }
 
 impl UncheckedBlockStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1013,13 +1091,14 @@ pub type UserDefinedValueTypeDefinition = Rc<UserDefinedValueTypeDefinitionStruc
 
 #[derive(Debug)]
 pub struct UserDefinedValueTypeDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub value_type: ElementaryType,
 }
 
 impl UserDefinedValueTypeDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1027,12 +1106,13 @@ pub type UsingDeconstruction = Rc<UsingDeconstructionStruct>;
 
 #[derive(Debug)]
 pub struct UsingDeconstructionStruct {
+    pub(crate) id: NodeId,
     pub symbols: UsingDeconstructionSymbols,
 }
 
 impl UsingDeconstructionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1040,13 +1120,14 @@ pub type UsingDeconstructionSymbol = Rc<UsingDeconstructionSymbolStruct>;
 
 #[derive(Debug)]
 pub struct UsingDeconstructionSymbolStruct {
+    pub(crate) id: NodeId,
     pub name: IdentifierPath,
     pub alias: Option<UsingOperator>,
 }
 
 impl UsingDeconstructionSymbolStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1054,14 +1135,15 @@ pub type UsingDirective = Rc<UsingDirectiveStruct>;
 
 #[derive(Debug)]
 pub struct UsingDirectiveStruct {
+    pub(crate) id: NodeId,
     pub clause: UsingClause,
     pub target: UsingTarget,
     pub global_keyword: bool,
 }
 
 impl UsingDirectiveStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1069,14 +1151,15 @@ pub type VariableDeclaration = Rc<VariableDeclarationStruct>;
 
 #[derive(Debug)]
 pub struct VariableDeclarationStruct {
+    pub(crate) id: NodeId,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
     pub name: Identifier,
 }
 
 impl VariableDeclarationStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1084,12 +1167,13 @@ pub type VariableDeclarationStatement = Rc<VariableDeclarationStatementStruct>;
 
 #[derive(Debug)]
 pub struct VariableDeclarationStatementStruct {
+    pub(crate) id: NodeId,
     pub target: VariableDeclarationTarget,
 }
 
 impl VariableDeclarationStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1097,12 +1181,13 @@ pub type VersionPragma = Rc<VersionPragmaStruct>;
 
 #[derive(Debug)]
 pub struct VersionPragmaStruct {
+    pub(crate) id: NodeId,
     pub sets: VersionExpressionSets,
 }
 
 impl VersionPragmaStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1110,13 +1195,14 @@ pub type VersionRange = Rc<VersionRangeStruct>;
 
 #[derive(Debug)]
 pub struct VersionRangeStruct {
+    pub(crate) id: NodeId,
     pub start: VersionLiteral,
     pub end: VersionLiteral,
 }
 
 impl VersionRangeStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1124,13 +1210,14 @@ pub type VersionTerm = Rc<VersionTermStruct>;
 
 #[derive(Debug)]
 pub struct VersionTermStruct {
+    pub(crate) id: NodeId,
     pub operator: Option<VersionOperator>,
     pub literal: VersionLiteral,
 }
 
 impl VersionTermStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1138,13 +1225,14 @@ pub type WhileStatement = Rc<WhileStatementStruct>;
 
 #[derive(Debug)]
 pub struct WhileStatementStruct {
+    pub(crate) id: NodeId,
     pub condition: Expression,
     pub body: Statement,
 }
 
 impl WhileStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1152,34 +1240,39 @@ pub type YulBlock = Rc<YulBlockStruct>;
 
 #[derive(Debug)]
 pub struct YulBlockStruct {
+    pub(crate) id: NodeId,
     pub statements: YulStatements,
 }
 
 impl YulBlockStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
 pub type YulBreakStatement = Rc<YulBreakStatementStruct>;
 
 #[derive(Debug)]
-pub struct YulBreakStatementStruct {}
+pub struct YulBreakStatementStruct {
+    pub(crate) id: NodeId,
+}
 
 impl YulBreakStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
 pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 
 #[derive(Debug)]
-pub struct YulContinueStatementStruct {}
+pub struct YulContinueStatementStruct {
+    pub(crate) id: NodeId,
+}
 
 impl YulContinueStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1187,12 +1280,13 @@ pub type YulDefaultCase = Rc<YulDefaultCaseStruct>;
 
 #[derive(Debug)]
 pub struct YulDefaultCaseStruct {
+    pub(crate) id: NodeId,
     pub body: YulBlock,
 }
 
 impl YulDefaultCaseStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1200,6 +1294,7 @@ pub type YulForStatement = Rc<YulForStatementStruct>;
 
 #[derive(Debug)]
 pub struct YulForStatementStruct {
+    pub(crate) id: NodeId,
     pub initialization: YulBlock,
     pub condition: YulExpression,
     pub iterator: YulBlock,
@@ -1207,8 +1302,8 @@ pub struct YulForStatementStruct {
 }
 
 impl YulForStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1216,13 +1311,14 @@ pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
 
 #[derive(Debug)]
 pub struct YulFunctionCallExpressionStruct {
+    pub(crate) id: NodeId,
     pub operand: YulExpression,
     pub arguments: YulArguments,
 }
 
 impl YulFunctionCallExpressionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1230,6 +1326,7 @@ pub type YulFunctionDefinition = Rc<YulFunctionDefinitionStruct>;
 
 #[derive(Debug)]
 pub struct YulFunctionDefinitionStruct {
+    pub(crate) id: NodeId,
     pub name: Identifier,
     pub parameters: YulParameters,
     pub returns: Option<YulVariableNames>,
@@ -1237,8 +1334,8 @@ pub struct YulFunctionDefinitionStruct {
 }
 
 impl YulFunctionDefinitionStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1246,24 +1343,27 @@ pub type YulIfStatement = Rc<YulIfStatementStruct>;
 
 #[derive(Debug)]
 pub struct YulIfStatementStruct {
+    pub(crate) id: NodeId,
     pub condition: YulExpression,
     pub body: YulBlock,
 }
 
 impl YulIfStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
 pub type YulLeaveStatement = Rc<YulLeaveStatementStruct>;
 
 #[derive(Debug)]
-pub struct YulLeaveStatementStruct {}
+pub struct YulLeaveStatementStruct {
+    pub(crate) id: NodeId,
+}
 
 impl YulLeaveStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1271,13 +1371,14 @@ pub type YulSwitchStatement = Rc<YulSwitchStatementStruct>;
 
 #[derive(Debug)]
 pub struct YulSwitchStatementStruct {
+    pub(crate) id: NodeId,
     pub expression: YulExpression,
     pub cases: YulSwitchCases,
 }
 
 impl YulSwitchStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1285,13 +1386,14 @@ pub type YulValueCase = Rc<YulValueCaseStruct>;
 
 #[derive(Debug)]
 pub struct YulValueCaseStruct {
+    pub(crate) id: NodeId,
     pub value: YulLiteral,
     pub body: YulBlock,
 }
 
 impl YulValueCaseStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1299,13 +1401,14 @@ pub type YulVariableAssignmentStatement = Rc<YulVariableAssignmentStatementStruc
 
 #[derive(Debug)]
 pub struct YulVariableAssignmentStatementStruct {
+    pub(crate) id: NodeId,
     pub variables: YulPaths,
     pub expression: YulExpression,
 }
 
 impl YulVariableAssignmentStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1313,13 +1416,14 @@ pub type YulVariableDeclarationStatement = Rc<YulVariableDeclarationStatementStr
 
 #[derive(Debug)]
 pub struct YulVariableDeclarationStatementStruct {
+    pub(crate) id: NodeId,
     pub variables: YulVariableNames,
     pub value: Option<YulVariableDeclarationValue>,
 }
 
 impl YulVariableDeclarationStatementStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1327,12 +1431,13 @@ pub type YulVariableDeclarationValue = Rc<YulVariableDeclarationValueStruct>;
 
 #[derive(Debug)]
 pub struct YulVariableDeclarationValueStruct {
+    pub(crate) id: NodeId,
     pub expression: YulExpression,
 }
 
 impl YulVariableDeclarationValueStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -1804,13 +1909,14 @@ pub type BytesKeyword = Rc<BytesKeywordStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BytesKeywordStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl BytesKeywordStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1822,13 +1928,14 @@ pub type DecimalLiteral = Rc<DecimalLiteralStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DecimalLiteralStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl DecimalLiteralStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1840,13 +1947,14 @@ pub type FixedKeyword = Rc<FixedKeywordStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FixedKeywordStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl FixedKeywordStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1858,13 +1966,14 @@ pub type HexLiteral = Rc<HexLiteralStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HexLiteralStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl HexLiteralStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1876,13 +1985,14 @@ pub type HexStringLiteral = Rc<HexStringLiteralStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HexStringLiteralStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl HexStringLiteralStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1894,13 +2004,14 @@ pub type Identifier = Rc<IdentifierStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdentifierStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl IdentifierStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1912,13 +2023,14 @@ pub type IntKeyword = Rc<IntKeywordStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IntKeywordStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl IntKeywordStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1930,13 +2042,14 @@ pub type StringLiteral = Rc<StringLiteralStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StringLiteralStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl StringLiteralStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1948,13 +2061,14 @@ pub type UfixedKeyword = Rc<UfixedKeywordStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UfixedKeywordStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl UfixedKeywordStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1966,13 +2080,14 @@ pub type UintKeyword = Rc<UintKeywordStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UintKeywordStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl UintKeywordStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -1984,13 +2099,14 @@ pub type UnicodeStringLiteral = Rc<UnicodeStringLiteralStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnicodeStringLiteralStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl UnicodeStringLiteralStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {
@@ -2002,13 +2118,14 @@ pub type VersionSpecifier = Rc<VersionSpecifierStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VersionSpecifierStruct {
+    pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub text: String,
 }
 
 impl VersionSpecifierStruct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 
     pub fn unparse(&self) -> &str {

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::vec::Vec;
 
-pub use slang_solidity_v2_common::nodes::NodeId;
+pub(super) use slang_solidity_v2_common::nodes::NodeId;
 
 //
 // Sequences

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -9,6 +9,12 @@ use std::vec::Vec;
 #[repr(transparent)]
 pub struct NodeId(usize);
 
+impl From<usize> for NodeId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
 //
 // Sequences
 //
@@ -18,6 +24,7 @@ pub struct NodeId(usize);
 
   #[derive(Debug)]
   pub struct {{ parent_type }}Struct {
+    pub(crate) id: NodeId,
     {%- for field in sequence.fields %}
       pub {{ field.label | snake_case }}:
       {%- if field.type.kind == "UniqueTerminal" -%}
@@ -37,8 +44,8 @@ pub struct NodeId(usize);
   }
 
   impl {{ parent_type }}Struct {
-    pub fn id(self: &Rc<Self>) -> NodeId {
-      NodeId(Rc::as_ptr(self) as usize)
+    pub fn id(&self) -> NodeId {
+      self.id
     }
   }
 
@@ -93,13 +100,14 @@ pub struct NodeId(usize);
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct {{ terminal_type }}Struct {
+      pub(crate) id: NodeId,
       pub range: Range<usize>,
       pub text: String,
     }
 
     impl {{ terminal_type }}Struct {
-      pub fn id(self: &Rc<Self>) -> NodeId {
-        NodeId(Rc::as_ptr(self) as usize)
+      pub fn id(&self) -> NodeId {
+        self.id
       }
 
       pub fn unparse(&self) -> &str {

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -5,15 +5,7 @@ use std::rc::Rc;
 use std::ops::Range;
 use std::vec::Vec;
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(transparent)]
-pub struct NodeId(usize);
-
-impl From<usize> for NodeId {
-    fn from(value: usize) -> Self {
-        Self(value)
-    }
-}
+pub use slang_solidity_v2_common::nodes::NodeId;
 
 //
 // Sequences

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::ops::Range;
 use std::vec::Vec;
 
-pub use slang_solidity_v2_common::nodes::NodeId;
+pub(super) use slang_solidity_v2_common::nodes::NodeId;
 
 //
 // Sequences

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -24,10 +24,10 @@ contract MyContract {
         source_unit,
         errors,
     } = Parser::parse(CONTENTS, LanguageVersion::V0_8_30);
-
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut id_generator = ir::NodeIdGenerator::default();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut id_generator);
     assert_eq!(2, source_unit.members.len());
     assert!(matches!(
         source_unit.members[0],
@@ -88,11 +88,14 @@ contract Test is Base layout at 0 {}
         source_unit,
         errors,
     } = Parser::parse(CONTENTS, LanguageVersion::V0_8_30);
-
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut id_generator = ir::NodeIdGenerator::default();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut id_generator);
+    let sentinel_node_id = id_generator.next_id();
+
     assert_eq!(2, source_unit.members.len());
+    assert!(source_unit.id() < sentinel_node_id);
 
     let ir::SourceUnitMember::ContractDefinition(base_contract) = &source_unit.members[0] else {
         panic!("Expected ContractDefinition");
@@ -100,6 +103,8 @@ contract Test is Base layout at 0 {}
     assert_eq!("Base", base_contract.name.unparse());
     assert!(base_contract.inheritance_types.is_empty());
     assert!(base_contract.storage_layout.is_none());
+    assert!(base_contract.id() < sentinel_node_id);
+    assert!(base_contract.name.id() < sentinel_node_id);
 
     let ir::SourceUnitMember::ContractDefinition(test_contract) = &source_unit.members[1] else {
         panic!("Expected ContractDefinition");
@@ -116,4 +121,6 @@ contract Test is Base layout at 0 {}
             .join(".")
     );
     assert!(test_contract.storage_layout.is_some());
+    assert!(test_contract.id() < sentinel_node_id);
+    assert!(test_contract.name.id() < sentinel_node_id);
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
@@ -80,10 +80,10 @@ contract Counter is Ownable {
         source_unit,
         errors,
     } = Parser::parse(CONTENTS, LanguageVersion::V0_8_30);
-
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut id_generator = ir::NodeIdGenerator::default();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut id_generator);
 
     let mut visitor = CounterVisitor::new(true);
     ir::visitor::accept_source_unit(&source_unit, &mut visitor);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use super::ScopeId;
 use crate::types::TypeId;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 
 use super::built_ins::BuiltIn;
 use super::types::{Type, TypeId};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
@@ -1,4 +1,5 @@
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use crate::built_ins::BuiltIn;
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use super::ScopeId;
 use crate::types::TypeId;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/internal.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/internal.generated.rs
@@ -1,8 +1,8 @@
 // This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
 use slang_solidity_v2_common::built_ins::BuiltIn as PublicBuiltIn;
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::{LanguageVersion, LanguageVersionSpecifier};
-use slang_solidity_v2_ir::ir::NodeId;
 
 use crate::types::TypeId;
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/internal.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/internal.rs.jinja2
@@ -1,6 +1,6 @@
 use slang_solidity_v2_common::versions::{LanguageVersion, LanguageVersionSpecifier};
 use slang_solidity_v2_common::built_ins::BuiltIn as PublicBuiltIn;
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 use crate::types::TypeId;
 
 /// This is the internal representation of a built-in resolution and typing.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,7 +1,8 @@
 use std::rc::Rc;
 
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Reference, Scope};
 use crate::passes::{

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -1,5 +1,6 @@
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
-use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Definition, FileScope, ParametersScope, Scope, ScopeId};
 use crate::context::SemanticFile;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use super::common::resolve_identifier_path_in_scope;
 use crate::binder::{Binder, ContractDefinition, Definition, InterfaceDefinition, ScopeId};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -328,10 +328,11 @@ mod tests {
             source_unit,
             errors,
         } = Parser::parse(&source, version);
-
         assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-        let source_unit = ir::build(&source_unit, &source);
+        let mut id_generator = ir::NodeIdGenerator::default();
+        let source_unit = ir::build(&source_unit, &source, &mut id_generator);
+
         let member = source_unit.members.first().expect("no source unit members");
         match member {
             ir::SourceUnitMember::ConstantDefinition(definition) => definition

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,4 +1,5 @@
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
 use crate::context::SemanticFile;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -1,5 +1,5 @@
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_ir::ir::NodeId;
 
 use super::Pass;
 use crate::binder::{Definition, Scope};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
@@ -1,4 +1,4 @@
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 
 use super::Pass;
 use crate::binder::{Definition, ParameterDefinition, Scope, Typing};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/mod.rs
@@ -1,5 +1,6 @@
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Scope, ScopeId};
 use crate::built_ins::BuiltInsResolver;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use super::{Pass, ScopeFrame};
 use crate::binder::{

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -1,4 +1,5 @@
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_ir::ir::{self, NodeId, NodeIdGenerator};
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
 use crate::binder::{Binder, Resolution};
@@ -30,7 +30,7 @@ impl SemanticFile for TestFile {
     }
 }
 
-fn build_file(name: &str, contents: &str) -> TestFile {
+fn build_file(name: &str, contents: &str, id_generator: &mut NodeIdGenerator) -> TestFile {
     let ParseOutput {
         source_unit,
         errors,
@@ -38,7 +38,7 @@ fn build_file(name: &str, contents: &str) -> TestFile {
 
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let ir_root = ir::build(&source_unit, &contents);
+    let ir_root = ir::build(&source_unit, &contents, id_generator);
     TestFile {
         id: name.to_string(),
         ir_root,
@@ -52,7 +52,8 @@ contract Base {}
 contract Test is Base layout at 0 {}
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -104,7 +105,8 @@ abstract contract B is C {}
 interface A is C {}
 "#;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -143,7 +145,8 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
 }
 "#;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -189,7 +192,8 @@ contract Test is Base {
 }
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -241,7 +245,8 @@ contract Test is Base {
 }
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
 
     let files = [file];
     let mut binder = Binder::default();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId, NodeIdGenerator};
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
 use crate::binder::{Binder, Resolution};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,4 +1,5 @@
-use slang_solidity_v2_ir::ir::{self, FunctionMutability, FunctionVisibility, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir::{self, FunctionMutability, FunctionVisibility};
 
 mod parsing;
 mod registry;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["compilers", "utilities"]
 [dependencies]
 slang_solidity_v2_ast = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
+slang_solidity_v2_cst = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }
 slang_solidity_v2_parser = { workspace = true }
 slang_solidity_v2_semantic = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -87,12 +87,12 @@ impl<E, C: CompilationBuilderConfig<Error = E>> CompilationBuilder<E, C> {
 
         if let Some(source) = source {
             // TODO(v2): move to a proper diagnostics API (reporter)
-            let AddFileResponse { import_paths } = self
-                .internal
-                .add_file(file_id.into(), &source)
-                .map_err(|err| CompilationBuilderError::ParserError(err))?;
+            let AddFileResponse { import_paths } =
+                self.internal
+                    .add_file(file_id.into(), source)
+                    .map_err(|err| CompilationBuilderError::ParserError(err))?;
 
-            for (node_id, import_path) in import_paths {
+            for import_path in import_paths {
                 let import_id = self
                     .config
                     .resolve_import(file_id, &import_path)
@@ -100,7 +100,7 @@ impl<E, C: CompilationBuilderConfig<Error = E>> CompilationBuilder<E, C> {
 
                 if let Some(import_id) = &import_id {
                     self.internal
-                        .resolve_import(file_id, node_id, import_id.clone())
+                        .resolve_import(file_id, import_path, import_id.clone())
                         .unwrap_or_else(|_| panic!("{file_id} should have been added"));
                     self.add_file(import_id)?;
                 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticFile;
 
 pub struct File {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -1,19 +1,25 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId, NodeIdGenerator};
+use slang_solidity_v2_cst::structured_cst::nodes as cst;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_parser::{ParseOutput, Parser, ParserError};
 use slang_solidity_v2_semantic::context::{extract_import_paths_from_source_unit, SemanticContext};
 
 use super::file::File;
 use super::unit::CompilationUnit;
 
+pub(crate) struct InternalFile {
+    source_unit: cst::SourceUnit,
+    contents: String,
+    resolved_imports: BTreeMap<String, String>,
+}
+
 #[doc(hidden)]
-pub struct InternalCompilationBuilder {
+pub(crate) struct InternalCompilationBuilder {
     language_version: LanguageVersion,
-    files: BTreeMap<String, File>,
-    id_generator: NodeIdGenerator,
+    files: BTreeMap<String, InternalFile>,
 }
 
 impl InternalCompilationBuilder {
@@ -21,32 +27,33 @@ impl InternalCompilationBuilder {
         Self {
             language_version,
             files: BTreeMap::new(),
-            id_generator: NodeIdGenerator::default(),
         }
     }
 
     pub fn add_file(
         &mut self,
         id: String,
-        contents: &str,
+        contents: String,
     ) -> Result<AddFileResponse, Vec<ParserError>> {
         if self.files.contains_key(&id) {
             // Already added. No need to process it again:
             return Ok(AddFileResponse {
-                import_paths: vec![],
+                import_paths: BTreeSet::new(),
             });
         }
 
         let ParseOutput {
             source_unit,
             errors,
-        } = Parser::parse(contents, self.language_version);
+        } = Parser::parse(&contents, self.language_version);
+        let import_paths = extract_import_paths_from_cst(&source_unit, &contents);
 
-        let source_unit = ir::build(&source_unit, &contents, &mut self.id_generator);
-        let import_paths = extract_import_paths_from_source_unit(&source_unit);
-
-        let file = File::new(id.clone(), source_unit);
-        self.files.insert(id, file);
+        let internal_file = InternalFile {
+            source_unit,
+            contents,
+            resolved_imports: BTreeMap::new(),
+        };
+        self.files.insert(id, internal_file);
 
         if !errors.is_empty() {
             return Err(errors);
@@ -58,28 +65,57 @@ impl InternalCompilationBuilder {
     pub fn resolve_import(
         &mut self,
         source_file_id: &str,
-        node_id: NodeId,
+        import_path: String,
         destination_file_id: String,
     ) -> Result<(), ResolveImportError> {
-        self.files
+        let internal_file = self
+            .files
             .get_mut(source_file_id)
-            .ok_or_else(|| ResolveImportError::SourceFileNotFound(source_file_id.to_owned()))?
-            .add_resolved_import(node_id, destination_file_id);
+            .ok_or_else(|| ResolveImportError::SourceFileNotFound(source_file_id.to_owned()))?;
+
+        internal_file
+            .resolved_imports
+            .insert(import_path, destination_file_id);
 
         Ok(())
     }
 
-    pub fn build(self) -> CompilationUnit {
-        let files: Vec<File> = self.files.into_values().collect();
-        let semantic = SemanticContext::build_from(self.language_version, &files);
+    fn build_files(self) -> Vec<File> {
+        let mut id_generator = ir::NodeIdGenerator::default();
+        self.files
+            .into_iter()
+            .map(|(file_id, internal_file)| {
+                let ir_root = ir::build(
+                    &internal_file.source_unit,
+                    &internal_file.contents,
+                    &mut id_generator,
+                );
+                let import_paths = extract_import_paths_from_source_unit(&ir_root);
+                let mut file = File::new(file_id, ir_root);
+                for (node_id, import_path) in import_paths {
+                    let Some(target_file_id) = internal_file.resolved_imports.get(&import_path)
+                    else {
+                        continue;
+                    };
+                    file.add_resolved_import(node_id, target_file_id.clone());
+                }
+                file
+            })
+            .collect()
+    }
 
-        CompilationUnit::create(self.language_version, files, Rc::new(semantic))
+    pub fn build(self) -> CompilationUnit {
+        let language_version = self.language_version;
+        let files = self.build_files();
+        let semantic = SemanticContext::build_from(language_version, &files);
+
+        CompilationUnit::create(language_version, files, Rc::new(semantic))
     }
 }
 
 #[doc(hidden)]
-pub struct AddFileResponse {
-    pub import_paths: Vec<(NodeId, String)>,
+pub(crate) struct AddFileResponse {
+    pub import_paths: BTreeSet<String>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -89,4 +125,26 @@ pub enum ResolveImportError {
         "Source file not found: '{0}'. Make sure to add it first, before resolving its imports."
     )]
     SourceFileNotFound(String),
+}
+
+fn extract_import_paths_from_cst(
+    source_unit: &cst::SourceUnit,
+    contents: &str,
+) -> BTreeSet<String> {
+    let mut import_paths = BTreeSet::new();
+
+    for member in &source_unit.members.elements {
+        let cst::SourceUnitMember::ImportDirective(import_directive) = member else {
+            continue;
+        };
+        let range = match &import_directive.clause {
+            cst::ImportClause::PathImport(path_import) => &path_import.path.range,
+            cst::ImportClause::NamedImport(named_import) => &named_import.path.range,
+            cst::ImportClause::ImportDeconstruction(import_deconstruction) => {
+                &import_deconstruction.path.range
+            }
+        };
+        import_paths.insert(contents[range.clone()].to_owned());
+    }
+    import_paths
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_ir::ir::{self, NodeId, NodeIdGenerator};
 use slang_solidity_v2_parser::{ParseOutput, Parser, ParserError};
 use slang_solidity_v2_semantic::context::{extract_import_paths_from_source_unit, SemanticContext};
 
@@ -13,6 +13,7 @@ use super::unit::CompilationUnit;
 pub struct InternalCompilationBuilder {
     language_version: LanguageVersion,
     files: BTreeMap<String, File>,
+    id_generator: NodeIdGenerator,
 }
 
 impl InternalCompilationBuilder {
@@ -20,6 +21,7 @@ impl InternalCompilationBuilder {
         Self {
             language_version,
             files: BTreeMap::new(),
+            id_generator: NodeIdGenerator::default(),
         }
     }
 
@@ -40,7 +42,7 @@ impl InternalCompilationBuilder {
             errors,
         } = Parser::parse(contents, self.language_version);
 
-        let source_unit = ir::build(&source_unit, &contents);
+        let source_unit = ir::build(&source_unit, &contents, &mut self.id_generator);
         let import_paths = extract_import_paths_from_source_unit(&source_unit);
 
         let file = File::new(id.clone(), source_unit);

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use anyhow::Result;
 use ariadne::{Color, Config, Label, Report, ReportBuilder, ReportKind, Source};
-use slang_solidity_v2_ir::ir::NodeId;
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_parser::ParserError;
 use slang_solidity_v2_semantic::binder::Resolution;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
@@ -3,8 +3,9 @@ use std::fmt::Display;
 use std::ops::Range;
 
 use slang_solidity_v2::compilation::unit::CompilationUnit;
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir::visitor::{accept_source_unit, Visitor};
-use slang_solidity_v2_ir::ir::{Identifier, NodeId};
+use slang_solidity_v2_ir::ir::Identifier;
 use slang_solidity_v2_parser::ParserError;
 use slang_solidity_v2_semantic::binder::{Definition, Resolution, Typing};
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -1,5 +1,5 @@
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit as InputSourceUnit;
-use slang_solidity_v2_ir::ir::{self, SourceUnit, SourceUnitMember};
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator, SourceUnit, SourceUnitMember};
 
 use crate::dataset::SolidityProject;
 
@@ -20,6 +20,7 @@ pub fn test(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
 ) -> Vec<SourceUnit> {
+    let mut id_generator = NodeIdGenerator::default();
     let mut ir_source_units = Vec::new();
     for (name, source) in sources {
         ir_source_units.push(ir::build(
@@ -28,6 +29,7 @@ pub fn test(
                 .sources
                 .get(&name)
                 .expect("Source not found in project"),
+            &mut id_generator,
         ));
     }
     ir_source_units

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::{
     extract_import_paths_from_source_unit, SemanticContext, SemanticFile,
@@ -29,7 +30,7 @@ impl SemanticFile for File {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, node_id: ir::NodeId) -> Option<&String> {
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String> {
         self.resolved_imports.get(&node_id)
     }
 }


### PR DESCRIPTION
This PR replaces pointer-based `NodeId` generation with deterministic IDs, provided by a new `NodeIdGenerator`. That means each node now stores its id.

Having stable and predictable IDs may help with debugging and more importantly would allow us to be able to identify the source file of IR nodes by assigning different ID ranges to each file in a `CompilationUnit`. Having stable IDs is also a requirement for solx integration.
