### PR TITLE
ci: add persist-credentials: false to all checkout actions

### DIFF
--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       # Cache is updated in this workflow, and reused in subsequent workflows.
       # Always start with a fresh cache when running on the main branch.
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "infra setup pipenv"
         uses: "./.github/actions/devcontainer/run"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"
       - name: "Build Test Binary"
@@ -140,6 +142,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"
@@ -173,6 +177,8 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Restore Cache"
         uses: "./.github/actions/cache/restore"


### PR DESCRIPTION
Prevents the GitHub token from being persisted in the local git config after checkout, reducing the risk of credential leakage to subsequent workflow steps.