### PR TITLE
[WIP] [v2] Implement string interning and apply to IR terminals and file IDs internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,6 +3949,7 @@ dependencies = [
 name = "slang_solidity_v2_ir"
 version = "1.3.4"
 dependencies = [
+ "indexmap",
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
  "slang_solidity_v2_parser",

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -398,7 +398,7 @@ pub(crate) fn type_as_abi_parameter(
             };
             let mut components = Vec::new();
             for member in &definition.ir_node.members {
-                let name = member.name.unparse().to_string();
+                let name = member.name.unparse(semantic.interner()).to_string();
                 let member_type_id = semantic.binder().node_typing(member.id()).as_type_id()?;
                 let (type_name, subcomponents) = type_as_abi_parameter(semantic, member_type_id)?;
                 components.push(ParameterComponent {

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contracts.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contracts.rs
@@ -11,7 +11,11 @@ impl ContractDefinitionStruct {
     // be able to obtain it here, but for that we need bi-directional tree
     // navigation
     pub fn compute_abi_with_file_id(&self, file_id: String) -> Option<ContractAbi> {
-        let name = self.ir_node.name.unparse(self.semantic.interner()).to_string();
+        let name = self
+            .ir_node
+            .name
+            .unparse(self.semantic.interner())
+            .to_string();
         let entries = self.compute_abi_entries()?;
         let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
         Some(ContractAbi {
@@ -109,7 +113,11 @@ impl ContractDefinitionStruct {
                 ptr += remaining_bytes;
             }
 
-            let label = state_variable.ir_node.name.unparse(self.semantic.interner()).to_string();
+            let label = state_variable
+                .ir_node
+                .name
+                .unparse(self.semantic.interner())
+                .to_string();
             let slot = ptr.div(SemanticContext::SLOT_SIZE);
             let offset = ptr % SemanticContext::SLOT_SIZE;
             let type_name = self.semantic.type_internal_name(variable_type_id);

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contracts.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contracts.rs
@@ -11,7 +11,7 @@ impl ContractDefinitionStruct {
     // be able to obtain it here, but for that we need bi-directional tree
     // navigation
     pub fn compute_abi_with_file_id(&self, file_id: String) -> Option<ContractAbi> {
-        let name = self.ir_node.name.unparse().to_string();
+        let name = self.ir_node.name.unparse(self.semantic.interner()).to_string();
         let entries = self.compute_abi_entries()?;
         let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
         Some(ContractAbi {
@@ -109,7 +109,7 @@ impl ContractDefinitionStruct {
                 ptr += remaining_bytes;
             }
 
-            let label = state_variable.ir_node.name.unparse().to_string();
+            let label = state_variable.ir_node.name.unparse(self.semantic.interner()).to_string();
             let slot = ptr.div(SemanticContext::SLOT_SIZE);
             let offset = ptr % SemanticContext::SLOT_SIZE;
             let type_name = self.semantic.type_internal_name(variable_type_id);

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
@@ -7,7 +7,11 @@ impl ErrorDefinitionStruct {
 
         Some(AbiEntry::Error(AbiError {
             node_id: self.ir_node.id(),
-            name: self.ir_node.name.unparse().to_string(),
+            name: self
+                .ir_node
+                .name
+                .unparse(self.semantic.interner())
+                .to_string(),
             inputs,
         }))
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
@@ -7,7 +7,11 @@ impl EventDefinitionStruct {
 
         Some(AbiEntry::Event(AbiEvent {
             node_id: self.ir_node.id(),
-            name: self.ir_node.name.unparse().to_string(),
+            name: self
+                .ir_node
+                .name
+                .unparse(self.semantic.interner())
+                .to_string(),
             inputs,
             anonymous: self.ir_node.anonymous_keyword,
         }))

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
@@ -30,7 +30,7 @@ impl FunctionDefinitionStruct {
             .ir_node
             .name
             .as_ref()
-            .map(|name| name.unparse().to_string());
+            .map(|name| name.unparse(self.semantic.interner()).to_string());
         let state_mutability: AbiMutability = self.ir_node.mutability;
 
         match self.ir_node.kind {
@@ -62,7 +62,11 @@ impl FunctionDefinitionStruct {
         if !self.is_externally_visible() {
             return None;
         }
-        let name = self.ir_node.name.as_ref()?.unparse();
+        let name = self
+            .ir_node
+            .name
+            .as_ref()?
+            .unparse(self.semantic.interner());
         let signature = format!(
             "{name}({parameters})",
             parameters = self.parameters().compute_canonical_signature()?,
@@ -80,7 +84,7 @@ impl ParametersStruct {
             let name = parameter
                 .name
                 .as_ref()
-                .map(|name| name.unparse().to_string());
+                .map(|name| name.unparse(self.semantic.interner()).to_string());
             let indexed = parameter.indexed;
             // Bail out with `None` if any of the parameters fails typing
             let type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
@@ -30,7 +30,11 @@ impl StateVariableDefinitionStruct {
 
         Some(AbiEntry::Function(AbiFunction {
             node_id: self.ir_node.id(),
-            name: self.ir_node.name.unparse().to_string(),
+            name: self
+                .ir_node
+                .name
+                .unparse(self.semantic.interner())
+                .to_string(),
             inputs,
             outputs,
             state_mutability: AbiMutability::View,
@@ -45,7 +49,7 @@ impl StateVariableDefinitionStruct {
 
         let signature = format!(
             "{name}({parameters})",
-            name = self.ir_node.name.unparse(),
+            name = self.ir_node.name.unparse(self.semantic.interner()),
             parameters = inputs
                 .into_iter()
                 .map(|parameter| parameter.type_name().to_owned())

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/functions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/functions.rs
@@ -9,7 +9,7 @@ impl FunctionDefinitionStruct {
                 // different functions
                 self.ir_node.kind == other.ir_node.kind
             }
-            (Some(name), Some(other_name)) => name.unparse() == other_name.unparse(),
+            (Some(name), Some(other_name)) => name.string_id == other_name.string_id,
             _ => false,
         };
         if !name_matches {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifiers.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifiers.rs
@@ -12,7 +12,7 @@ impl IdentifierStruct {
     }
 
     pub fn name(&self) -> String {
-        self.ir_node.unparse().to_string()
+        self.ir_node.unparse(self.semantic.interner()).to_string()
     }
 
     pub fn is_reference(&self) -> bool {
@@ -89,7 +89,7 @@ impl IdentifierPathStruct {
     pub fn name(&self) -> String {
         self.ir_nodes
             .iter()
-            .map(|ir_node| ir_node.unparse())
+            .map(|ir_node| ir_node.unparse(self.semantic.interner()))
             .collect::<Vec<_>>()
             .join(".")
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -5708,7 +5708,7 @@ impl IdentifierStruct {
     }
 
     pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
+        self.ir_node.unparse(self.semantic.interner())
     }
 
     pub fn get_type(&self) -> Option<Type> {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -246,7 +246,7 @@ use super::types::Type;
       }
 
       pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
+        self.ir_node.unparse(self.semantic.interner())
       }
 
       pub fn get_type(&self) -> Option<Type> {

--- a/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+indexmap = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }
 
 [dev-dependencies]

--- a/crates/solidity-v2/outputs/cargo/ir/src/interner.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/interner.rs
@@ -1,0 +1,25 @@
+use indexmap::IndexSet;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct StringId(usize);
+
+#[derive(Debug, Default)]
+pub struct Interner {
+    strings: IndexSet<String>,
+}
+
+impl Interner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn intern(&mut self, text: &str) -> StringId {
+        let (index, _) = self.strings.insert_full(text.to_owned());
+        StringId(index)
+    }
+
+    pub fn resolve(&self, id: StringId) -> &str {
+        &self.strings[id.0]
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -13,7 +13,7 @@ use crate::ir::nodes as output;
 
 pub trait Builder {
     fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
-    fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId;
+    fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId;
 
     //
     // Sequences
@@ -2228,7 +2228,7 @@ pub trait Builder {
         match source {
             input::IdentifierPathElement::Identifier(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
-                let string_id = self.intern_identifier(terminal.range.clone());
+                let string_id = self.intern_string(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
                     string_id,
@@ -2237,7 +2237,7 @@ pub trait Builder {
             }
             input::IdentifierPathElement::AddressKeyword(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
-                let string_id = self.intern_identifier(terminal.range.clone());
+                let string_id = self.intern_string(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
                     string_id,
@@ -2571,32 +2571,40 @@ pub trait Builder {
 
     fn build_bytes_keyword(&mut self, source: &input::BytesKeyword) -> output::BytesKeyword {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::BytesKeywordStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_decimal_literal(&mut self, source: &input::DecimalLiteral) -> output::DecimalLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_fixed_keyword(&mut self, source: &input::FixedKeyword) -> output::FixedKeyword {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::FixedKeywordStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_hex_literal(&mut self, source: &input::HexLiteral) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2606,15 +2614,17 @@ pub trait Builder {
         source: &input::HexStringLiteral,
     ) -> output::HexStringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
-        let string_id = self.intern_identifier(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
             string_id,
@@ -2624,32 +2634,40 @@ pub trait Builder {
 
     fn build_int_keyword(&mut self, source: &input::IntKeyword) -> output::IntKeyword {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IntKeywordStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_string_literal(&mut self, source: &input::StringLiteral) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_ufixed_keyword(&mut self, source: &input::UfixedKeyword) -> output::UfixedKeyword {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UfixedKeywordStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_uint_keyword(&mut self, source: &input::UintKeyword) -> output::UintKeyword {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UintKeywordStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2659,8 +2677,10 @@ pub trait Builder {
         source: &input::UnicodeStringLiteral,
     ) -> output::UnicodeStringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UnicodeStringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2670,8 +2690,10 @@ pub trait Builder {
         source: &input::VersionSpecifier,
     ) -> output::VersionSpecifier {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::VersionSpecifierStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2685,8 +2707,10 @@ pub trait Builder {
         source: &input::PragmaStringLiteral,
     ) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2696,16 +2720,20 @@ pub trait Builder {
         source: &input::YulDecimalLiteral,
     ) -> output::DecimalLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_yul_hex_literal(&mut self, source: &input::YulHexLiteral) -> output::HexLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2715,15 +2743,17 @@ pub trait Builder {
         source: &input::YulHexStringLiteral,
     ) -> output::HexStringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
 
     fn build_yul_identifier(&mut self, source: &input::YulIdentifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
-        let string_id = self.intern_identifier(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
             string_id,
@@ -2736,8 +2766,10 @@ pub trait Builder {
         source: &input::YulStringLiteral,
     ) -> output::StringLiteral {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -12,7 +12,6 @@ use crate::interner::StringId;
 use crate::ir::nodes as output;
 
 pub trait Builder {
-    fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
     fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId;
 
     //
@@ -2227,21 +2226,17 @@ pub trait Builder {
     ) -> output::Identifier {
         match source {
             input::IdentifierPathElement::Identifier(terminal) => {
-                let text = self.unparse_range(terminal.range.clone());
                 let string_id = self.intern_string(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
                     string_id,
-                    text,
                 })
             }
             input::IdentifierPathElement::AddressKeyword(terminal) => {
-                let text = self.unparse_range(terminal.range.clone());
                 let string_id = self.intern_string(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
                     string_id,
-                    text,
                 })
             }
         }
@@ -2570,42 +2565,34 @@ pub trait Builder {
     //
 
     fn build_bytes_keyword(&mut self, source: &input::BytesKeyword) -> output::BytesKeyword {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::BytesKeywordStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_decimal_literal(&mut self, source: &input::DecimalLiteral) -> output::DecimalLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_fixed_keyword(&mut self, source: &input::FixedKeyword) -> output::FixedKeyword {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::FixedKeywordStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_hex_literal(&mut self, source: &input::HexLiteral) -> output::HexLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2613,62 +2600,50 @@ pub trait Builder {
         &mut self,
         source: &input::HexStringLiteral,
     ) -> output::HexStringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_int_keyword(&mut self, source: &input::IntKeyword) -> output::IntKeyword {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IntKeywordStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_string_literal(&mut self, source: &input::StringLiteral) -> output::StringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_ufixed_keyword(&mut self, source: &input::UfixedKeyword) -> output::UfixedKeyword {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UfixedKeywordStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_uint_keyword(&mut self, source: &input::UintKeyword) -> output::UintKeyword {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UintKeywordStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2676,12 +2651,10 @@ pub trait Builder {
         &mut self,
         source: &input::UnicodeStringLiteral,
     ) -> output::UnicodeStringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::UnicodeStringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2689,12 +2662,10 @@ pub trait Builder {
         &mut self,
         source: &input::VersionSpecifier,
     ) -> output::VersionSpecifier {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::VersionSpecifierStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2706,12 +2677,10 @@ pub trait Builder {
         &mut self,
         source: &input::PragmaStringLiteral,
     ) -> output::StringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2719,22 +2688,18 @@ pub trait Builder {
         &mut self,
         source: &input::YulDecimalLiteral,
     ) -> output::DecimalLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::DecimalLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_yul_hex_literal(&mut self, source: &input::YulHexLiteral) -> output::HexLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2742,22 +2707,18 @@ pub trait Builder {
         &mut self,
         source: &input::YulHexStringLiteral,
     ) -> output::HexStringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::HexStringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
     fn build_yul_identifier(&mut self, source: &input::YulIdentifier) -> output::Identifier {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 
@@ -2765,12 +2726,10 @@ pub trait Builder {
         &mut self,
         source: &input::YulStringLiteral,
     ) -> output::StringLiteral {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::StringLiteralStruct {
             range: source.range.clone(),
             string_id,
-            text,
         })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -8,10 +8,12 @@ use std::rc::Rc;
 
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 
+use crate::interner::StringId;
 use crate::ir::nodes as output;
 
 pub trait Builder {
     fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
+    fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId;
 
     //
     // Sequences
@@ -2226,15 +2228,19 @@ pub trait Builder {
         match source {
             input::IdentifierPathElement::Identifier(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
+                let string_id = self.intern_identifier(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
+                    string_id,
                     text,
                 })
             }
             input::IdentifierPathElement::AddressKeyword(terminal) => {
                 let text = self.unparse_range(terminal.range.clone());
+                let string_id = self.intern_identifier(terminal.range.clone());
                 Rc::new(output::IdentifierStruct {
                     range: terminal.range.clone(),
+                    string_id,
                     text,
                 })
             }
@@ -2608,8 +2614,10 @@ pub trait Builder {
 
     fn build_identifier(&mut self, source: &input::Identifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_identifier(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }
@@ -2715,8 +2723,10 @@ pub trait Builder {
 
     fn build_yul_identifier(&mut self, source: &input::YulIdentifier) -> output::Identifier {
         let text = self.unparse_range(source.range.clone());
+        let string_id = self.intern_identifier(source.range.clone());
         Rc::new(output::IdentifierStruct {
             range: source.range.clone(),
+            string_id,
             text,
         })
     }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -11,7 +11,7 @@ use slang_solidity_v2_cst::structured_cst::nodes as input;
 
 pub trait Builder {
   fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
-  fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId;
+  fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId;
 
   //
   // Sequences
@@ -107,14 +107,10 @@ pub trait Builder {
         {% for variant in collapsed.variants -%}
           input::{{ parent_type }}::{{ variant.source.name }}(terminal) => {
             let text = self.unparse_range(terminal.range.clone());
-            {% if collapsed.target_is_identifier -%}
-            let string_id = self.intern_identifier(terminal.range.clone());
-            {% endif -%}
+            let string_id = self.intern_string(terminal.range.clone());
             Rc::new(output::{{ collapsed.target.name }}Struct {
               range: terminal.range.clone(),
-              {% if collapsed.target_is_identifier -%}
               string_id,
-              {% endif -%}
               text,
             })
           }
@@ -147,14 +143,10 @@ pub trait Builder {
     {% if not terminal.is_new and not terminal.is_unique %}
       fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
         let text = self.unparse_range(source.range.clone());
-        {% if terminal.is_identifier -%}
-        let string_id = self.intern_identifier(source.range.clone());
-        {% endif -%}
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::{{ terminal_type }}Struct {
           range: source.range.clone(),
-          {% if terminal.is_identifier -%}
           string_id,
-          {% endif -%}
           text,
         })
       }
@@ -168,14 +160,10 @@ pub trait Builder {
     {% if not normalized.is_unique %}
       fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
         let text = self.unparse_range(source.range.clone());
-        {% if normalized.target_is_identifier -%}
-        let string_id = self.intern_identifier(source.range.clone());
-        {% endif -%}
+        let string_id = self.intern_string(source.range.clone());
         Rc::new(output::{{ normalized.target }}Struct {
           range: source.range.clone(),
-          {% if normalized.target_is_identifier -%}
           string_id,
-          {% endif -%}
           text,
         })
       }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -10,7 +10,6 @@ use crate::ir::nodes as output;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 
 pub trait Builder {
-  fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
   fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId;
 
   //
@@ -106,12 +105,10 @@ pub trait Builder {
       match source {
         {% for variant in collapsed.variants -%}
           input::{{ parent_type }}::{{ variant.source.name }}(terminal) => {
-            let text = self.unparse_range(terminal.range.clone());
             let string_id = self.intern_string(terminal.range.clone());
             Rc::new(output::{{ collapsed.target.name }}Struct {
               range: terminal.range.clone(),
               string_id,
-              text,
             })
           }
         {% endfor -%}
@@ -142,12 +139,10 @@ pub trait Builder {
     {# and new terminals cannot be automatically built #}
     {% if not terminal.is_new and not terminal.is_unique %}
       fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::{{ terminal_type }}Struct {
           range: source.range.clone(),
           string_id,
-          text,
         })
       }
     {% endif %}
@@ -159,12 +154,10 @@ pub trait Builder {
   {% for source_type, normalized in builder.normalized_terminals %}
     {% if not normalized.is_unique %}
       fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
-        let text = self.unparse_range(source.range.clone());
         let string_id = self.intern_string(source.range.clone());
         Rc::new(output::{{ normalized.target }}Struct {
           range: source.range.clone(),
           string_id,
-          text,
         })
       }
     {% endif %}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -5,11 +5,13 @@
 #![allow(unused_variables)]
 
 use std::rc::Rc;
+use crate::interner::StringId;
 use crate::ir::nodes as output;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 
 pub trait Builder {
   fn unparse_range(&self, range: std::ops::Range<usize>) -> String;
+  fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId;
 
   //
   // Sequences
@@ -105,8 +107,14 @@ pub trait Builder {
         {% for variant in collapsed.variants -%}
           input::{{ parent_type }}::{{ variant.source.name }}(terminal) => {
             let text = self.unparse_range(terminal.range.clone());
+            {% if collapsed.target_is_identifier -%}
+            let string_id = self.intern_identifier(terminal.range.clone());
+            {% endif -%}
             Rc::new(output::{{ collapsed.target.name }}Struct {
               range: terminal.range.clone(),
+              {% if collapsed.target_is_identifier -%}
+              string_id,
+              {% endif -%}
               text,
             })
           }
@@ -139,8 +147,14 @@ pub trait Builder {
     {% if not terminal.is_new and not terminal.is_unique %}
       fn build_{{ terminal_type | snake_case }}(&mut self, source: &input::{{ terminal_type }}) -> output::{{ terminal_type }} {
         let text = self.unparse_range(source.range.clone());
+        {% if terminal.is_identifier -%}
+        let string_id = self.intern_identifier(source.range.clone());
+        {% endif -%}
         Rc::new(output::{{ terminal_type }}Struct {
           range: source.range.clone(),
+          {% if terminal.is_identifier -%}
+          string_id,
+          {% endif -%}
           text,
         })
       }
@@ -154,8 +168,14 @@ pub trait Builder {
     {% if not normalized.is_unique %}
       fn build_{{ source_type | snake_case }}(&mut self, source: &input::{{ source_type }}) -> output::{{ normalized.target }} {
         let text = self.unparse_range(source.range.clone());
+        {% if normalized.target_is_identifier -%}
+        let string_id = self.intern_identifier(source.range.clone());
+        {% endif -%}
         Rc::new(output::{{ normalized.target }}Struct {
           range: source.range.clone(),
+          {% if normalized.target_is_identifier -%}
+          string_id,
+          {% endif -%}
           text,
         })
       }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -7,23 +7,31 @@ mod default;
 use default::Builder;
 
 use super::Source;
+use crate::interner::{Interner, StringId};
 use crate::ir::nodes as output;
 
 pub fn build_source_unit(
     source_unit: &input::SourceUnit,
     source: &impl Source,
+    interner: &mut Interner,
 ) -> output::SourceUnit {
-    let mut builder = CstToIrBuilder { source };
+    let mut builder = CstToIrBuilder { source, interner };
     builder.build_source_unit(source_unit)
 }
 
 struct CstToIrBuilder<'a, S: Source> {
     pub source: &'a S,
+    pub interner: &'a mut Interner,
 }
 
 impl<S: Source> Builder for CstToIrBuilder<'_, S> {
     fn unparse_range(&self, range: std::ops::Range<usize>) -> String {
         self.source.text(range).to_owned()
+    }
+
+    fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId {
+        let text = self.source.text(range);
+        self.interner.intern(text)
     }
 
     //

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -29,7 +29,7 @@ impl<S: Source> Builder for CstToIrBuilder<'_, S> {
         self.source.text(range).to_owned()
     }
 
-    fn intern_identifier(&mut self, range: std::ops::Range<usize>) -> StringId {
+    fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId {
         let text = self.source.text(range);
         self.interner.intern(text)
     }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -25,10 +25,6 @@ struct CstToIrBuilder<'a, S: Source> {
 }
 
 impl<S: Source> Builder for CstToIrBuilder<'_, S> {
-    fn unparse_range(&self, range: std::ops::Range<usize>) -> String {
-        self.source.text(range).to_owned()
-    }
-
     fn intern_string(&mut self, range: std::ops::Range<usize>) -> StringId {
         let text = self.source.text(range);
         self.interner.intern(text)

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::vec::Vec;
 
-use crate::interner::StringId;
+use crate::interner::{Interner, StringId};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -1808,7 +1808,6 @@ pub type BytesKeyword = Rc<BytesKeywordStruct>;
 pub struct BytesKeywordStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl BytesKeywordStruct {
@@ -1816,8 +1815,8 @@ impl BytesKeywordStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1827,7 +1826,6 @@ pub type DecimalLiteral = Rc<DecimalLiteralStruct>;
 pub struct DecimalLiteralStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl DecimalLiteralStruct {
@@ -1835,8 +1833,8 @@ impl DecimalLiteralStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1846,7 +1844,6 @@ pub type FixedKeyword = Rc<FixedKeywordStruct>;
 pub struct FixedKeywordStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl FixedKeywordStruct {
@@ -1854,8 +1851,8 @@ impl FixedKeywordStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1865,7 +1862,6 @@ pub type HexLiteral = Rc<HexLiteralStruct>;
 pub struct HexLiteralStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl HexLiteralStruct {
@@ -1873,8 +1869,8 @@ impl HexLiteralStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1884,7 +1880,6 @@ pub type HexStringLiteral = Rc<HexStringLiteralStruct>;
 pub struct HexStringLiteralStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl HexStringLiteralStruct {
@@ -1892,8 +1887,8 @@ impl HexStringLiteralStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1903,7 +1898,6 @@ pub type Identifier = Rc<IdentifierStruct>;
 pub struct IdentifierStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl IdentifierStruct {
@@ -1911,8 +1905,8 @@ impl IdentifierStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1922,7 +1916,6 @@ pub type IntKeyword = Rc<IntKeywordStruct>;
 pub struct IntKeywordStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl IntKeywordStruct {
@@ -1930,8 +1923,8 @@ impl IntKeywordStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1941,7 +1934,6 @@ pub type StringLiteral = Rc<StringLiteralStruct>;
 pub struct StringLiteralStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl StringLiteralStruct {
@@ -1949,8 +1941,8 @@ impl StringLiteralStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1960,7 +1952,6 @@ pub type UfixedKeyword = Rc<UfixedKeywordStruct>;
 pub struct UfixedKeywordStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl UfixedKeywordStruct {
@@ -1968,8 +1959,8 @@ impl UfixedKeywordStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1979,7 +1970,6 @@ pub type UintKeyword = Rc<UintKeywordStruct>;
 pub struct UintKeywordStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl UintKeywordStruct {
@@ -1987,8 +1977,8 @@ impl UintKeywordStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -1998,7 +1988,6 @@ pub type UnicodeStringLiteral = Rc<UnicodeStringLiteralStruct>;
 pub struct UnicodeStringLiteralStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl UnicodeStringLiteralStruct {
@@ -2006,8 +1995,8 @@ impl UnicodeStringLiteralStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }
 
@@ -2017,7 +2006,6 @@ pub type VersionSpecifier = Rc<VersionSpecifierStruct>;
 pub struct VersionSpecifierStruct {
     pub range: Range<usize>,
     pub string_id: StringId,
-    pub text: String,
 }
 
 impl VersionSpecifierStruct {
@@ -2025,7 +2013,7 @@ impl VersionSpecifierStruct {
         NodeId(Rc::as_ptr(self) as usize)
     }
 
-    pub fn unparse(&self) -> &str {
-        &self.text
+    pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -1807,6 +1807,7 @@ pub type BytesKeyword = Rc<BytesKeywordStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BytesKeywordStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1825,6 +1826,7 @@ pub type DecimalLiteral = Rc<DecimalLiteralStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DecimalLiteralStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1843,6 +1845,7 @@ pub type FixedKeyword = Rc<FixedKeywordStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FixedKeywordStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1861,6 +1864,7 @@ pub type HexLiteral = Rc<HexLiteralStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HexLiteralStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1879,6 +1883,7 @@ pub type HexStringLiteral = Rc<HexStringLiteralStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HexStringLiteralStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1916,6 +1921,7 @@ pub type IntKeyword = Rc<IntKeywordStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IntKeywordStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1934,6 +1940,7 @@ pub type StringLiteral = Rc<StringLiteralStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StringLiteralStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1952,6 +1959,7 @@ pub type UfixedKeyword = Rc<UfixedKeywordStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UfixedKeywordStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1970,6 +1978,7 @@ pub type UintKeyword = Rc<UintKeywordStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UintKeywordStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -1988,6 +1997,7 @@ pub type UnicodeStringLiteral = Rc<UnicodeStringLiteralStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnicodeStringLiteralStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 
@@ -2006,6 +2016,7 @@ pub type VersionSpecifier = Rc<VersionSpecifierStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VersionSpecifierStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -6,6 +6,8 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::vec::Vec;
 
+use crate::interner::StringId;
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct NodeId(usize);
@@ -1895,6 +1897,7 @@ pub type Identifier = Rc<IdentifierStruct>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdentifierStruct {
     pub range: Range<usize>,
+    pub string_id: StringId,
     pub text: String,
 }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::ops::Range;
 use std::vec::Vec;
 
-use crate::interner::StringId;
+use crate::interner::{Interner, StringId};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -97,7 +97,6 @@ pub struct NodeId(usize);
     pub struct {{ terminal_type }}Struct {
       pub range: Range<usize>,
       pub string_id: StringId,
-      pub text: String,
     }
 
     impl {{ terminal_type }}Struct {
@@ -105,8 +104,8 @@ pub struct NodeId(usize);
         NodeId(Rc::as_ptr(self) as usize)
       }
 
-      pub fn unparse(&self) -> &str {
-        &self.text
+      pub fn unparse<'a>(&self, interner: &'a Interner) -> &'a str {
+        interner.resolve(self.string_id)
       }
     }
   {% endif %}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -5,6 +5,8 @@ use std::rc::Rc;
 use std::ops::Range;
 use std::vec::Vec;
 
+use crate::interner::StringId;
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct NodeId(usize);
@@ -94,6 +96,9 @@ pub struct NodeId(usize);
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct {{ terminal_type }}Struct {
       pub range: Range<usize>,
+      {% if terminal.is_identifier -%}
+      pub string_id: StringId,
+      {% endif -%}
       pub text: String,
     }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -96,9 +96,7 @@ pub struct NodeId(usize);
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct {{ terminal_type }}Struct {
       pub range: Range<usize>,
-      {% if terminal.is_identifier -%}
       pub string_id: StringId,
-      {% endif -%}
       pub text: String,
     }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod interner;
 pub mod ir;
 
 #[cfg(test)]

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -1,6 +1,7 @@
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
+use crate::interner::Interner;
 use crate::ir;
 
 #[test]
@@ -27,7 +28,8 @@ contract MyContract {
 
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut interner = Interner::new();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut interner);
     assert_eq!(2, source_unit.members.len());
     assert!(matches!(
         source_unit.members[0],
@@ -91,7 +93,8 @@ contract Test is Base layout at 0 {}
 
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut interner = Interner::new();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut interner);
     assert_eq!(2, source_unit.members.len());
 
     let ir::SourceUnitMember::ContractDefinition(base_contract) = &source_unit.members[0] else {

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -44,14 +44,14 @@ contract MyContract {
     let ir::SourceUnitMember::ContractDefinition(ref contract) = source_unit.members[1] else {
         panic!("Expected ContractDefinition");
     };
-    assert_eq!("MyContract", contract.name.unparse());
+    assert_eq!("MyContract", contract.name.unparse(&interner));
     assert_eq!(3, contract.members.len());
 
     // MyContract.owner state variable
     let ir::ContractMember::StateVariableDefinition(ref state_var) = contract.members[0] else {
         panic!("Expected StateVariableDefinition");
     };
-    assert_eq!("owner", state_var.name.unparse());
+    assert_eq!("owner", state_var.name.unparse(&interner));
 
     // MyContract constructor
     let ir::ContractMember::FunctionDefinition(ref constructor) = contract.members[1] else {
@@ -68,7 +68,7 @@ contract MyContract {
     };
     assert_eq!(ir::FunctionKind::Regular, function.kind);
     let function_name = function.name.as_ref().expect("function has a name");
-    assert_eq!("test", function_name.unparse());
+    assert_eq!("test", function_name.unparse(&interner));
     assert_eq!(ir::FunctionVisibility::Public, function.visibility);
     assert_eq!(ir::FunctionMutability::View, function.mutability);
     assert_eq!(0, function.parameters.len());
@@ -100,21 +100,21 @@ contract Test is Base layout at 0 {}
     let ir::SourceUnitMember::ContractDefinition(base_contract) = &source_unit.members[0] else {
         panic!("Expected ContractDefinition");
     };
-    assert_eq!("Base", base_contract.name.unparse());
+    assert_eq!("Base", base_contract.name.unparse(&interner));
     assert!(base_contract.inheritance_types.is_empty());
     assert!(base_contract.storage_layout.is_none());
 
     let ir::SourceUnitMember::ContractDefinition(test_contract) = &source_unit.members[1] else {
         panic!("Expected ContractDefinition");
     };
-    assert_eq!("Test", test_contract.name.unparse());
+    assert_eq!("Test", test_contract.name.unparse(&interner));
     assert_eq!(1, test_contract.inheritance_types.len());
     assert_eq!(
         "Base",
         test_contract.inheritance_types[0]
             .type_name
             .iter()
-            .map(|node| node.unparse())
+            .map(|node| node.unparse(&interner))
             .collect::<Vec<_>>()
             .join(".")
     );

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
@@ -1,6 +1,7 @@
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
+use crate::interner::Interner;
 use crate::ir;
 
 #[derive(Default)]
@@ -83,7 +84,8 @@ contract Counter is Ownable {
 
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let source_unit = ir::build(&source_unit, &CONTENTS);
+    let mut interner = Interner::new();
+    let source_unit = ir::build(&source_unit, &CONTENTS, &mut interner);
 
     let mut visitor = CounterVisitor::new(true);
     ir::visitor::accept_source_unit(&source_unit, &mut visitor);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::ScopeId;
@@ -87,7 +88,7 @@ pub struct ImportDefinition {
 #[derive(Debug)]
 pub struct ImportedSymbolDefinition {
     pub ir_node: ir::ImportDeconstructionSymbol,
-    pub symbol: String,
+    pub symbol: StringId,
     pub resolved_file_id: Option<String>,
 }
 
@@ -356,7 +357,7 @@ impl Definition {
 
     pub(crate) fn new_imported_symbol(
         ir_node: &ir::ImportDeconstructionSymbol,
-        symbol: String,
+        symbol: StringId,
         resolved_file_id: Option<String>,
     ) -> Self {
         Self::ImportedSymbol(ImportedSymbolDefinition {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::ScopeId;
+use crate::context::FileId;
 use crate::types::TypeId;
 
 //////////////////////////////////////////////////////////////////////////////
@@ -82,14 +83,14 @@ pub struct FunctionDefinition {
 #[derive(Debug)]
 pub struct ImportDefinition {
     pub ir_node: ir::PathImport,
-    pub resolved_file_id: Option<String>,
+    pub resolved_file_id: Option<FileId>,
 }
 
 #[derive(Debug)]
 pub struct ImportedSymbolDefinition {
     pub ir_node: ir::ImportDeconstructionSymbol,
     pub symbol: StringId,
-    pub resolved_file_id: Option<String>,
+    pub resolved_file_id: Option<FileId>,
 }
 
 #[derive(Debug)]
@@ -343,7 +344,7 @@ impl Definition {
         })
     }
 
-    pub(crate) fn new_import(ir_node: &ir::PathImport, resolved_file_id: Option<String>) -> Self {
+    pub(crate) fn new_import(ir_node: &ir::PathImport, resolved_file_id: Option<FileId>) -> Self {
         assert!(
             ir_node.alias.is_some(),
             "Definition can only be created for aliased imports"
@@ -358,7 +359,7 @@ impl Definition {
     pub(crate) fn new_imported_symbol(
         ir_node: &ir::ImportDeconstructionSymbol,
         symbol: StringId,
-        resolved_file_id: Option<String>,
+        resolved_file_id: Option<FileId>,
     ) -> Self {
         Self::ImportedSymbol(ImportedSymbolDefinition {
             ir_node: Rc::clone(ir_node),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::NodeId;
 
 use super::built_ins::BuiltIn;
@@ -184,7 +185,7 @@ impl Binder {
 
     pub(crate) fn insert_definition_in_scope(&mut self, definition: Definition, scope_id: ScopeId) {
         let scope = self.get_scope_mut(scope_id);
-        let symbol = definition.identifier().unparse().to_string();
+        let symbol = definition.identifier().string_id;
         scope.insert_definition(symbol, definition.node_id());
         self.insert_definition_no_scope(definition);
     }
@@ -344,7 +345,7 @@ impl Binder {
     // Resolving a symbol in a file scope is special because of default imports.
     // We want to find *all* definitions with the given symbol reachable from
     // the file.
-    fn resolve_in_file_scope(&self, file_id: &str, symbol: &str) -> Resolution {
+    fn resolve_in_file_scope(&self, file_id: &str, symbol: StringId) -> Resolution {
         let mut found_definitions = Vec::new();
         let mut visited_files = HashSet::new();
         let mut files_to_search = VecDeque::new();
@@ -366,7 +367,7 @@ impl Binder {
     fn resolve_in_contract_scope_internal(
         &self,
         contract_scope: &ContractScope,
-        symbol: &str,
+        symbol: StringId,
         options: ResolveOptions,
     ) -> Resolution {
         // Search for the symbol in the linearised bases *in-order*.
@@ -399,7 +400,7 @@ impl Binder {
                 else {
                     unreachable!("expected the scope of a base contract to be a ContractScope");
                 };
-                let Some(definitions) = base_contract_scope.definitions.get(symbol) else {
+                let Some(definitions) = base_contract_scope.definitions.get(&symbol) else {
                     continue;
                 };
                 for definition_id in definitions {
@@ -428,7 +429,7 @@ impl Binder {
                 }
             }
             Resolution::from(results)
-        } else if let Some(definitions) = contract_scope.definitions.get(symbol) {
+        } else if let Some(definitions) = contract_scope.definitions.get(&symbol) {
             // This case shouldn't happen for valid Solidity, as all
             // contracts should have a proper linearisation
             Resolution::from(definitions.clone())
@@ -440,10 +441,10 @@ impl Binder {
     // This function attempts to lexically resolve `symbol` starting from the
     // given scope. Certain scopes can delegate to their "parent" scopes if
     // the symbol is not found there.
-    pub(crate) fn resolve_in_scope(&self, scope_id: ScopeId, symbol: &str) -> Resolution {
+    pub(crate) fn resolve_in_scope(&self, scope_id: ScopeId, symbol: StringId) -> Resolution {
         let scope = self.get_scope_by_id(scope_id);
         match scope {
-            Scope::Block(block_scope) => block_scope.definitions.get(symbol).copied().map_or_else(
+            Scope::Block(block_scope) => block_scope.definitions.get(&symbol).copied().map_or_else(
                 || self.resolve_in_scope(block_scope.parent_scope_id, symbol),
                 Resolution::Definition,
             ),
@@ -458,35 +459,37 @@ impl Binder {
                     self.resolve_in_scope(contract_scope.file_scope_id, symbol)
                 })
             }
-            Scope::Enum(enum_scope) => enum_scope.definitions.get(symbol).into(),
+            Scope::Enum(enum_scope) => enum_scope.definitions.get(&symbol).into(),
             Scope::File(file_scope) => self.resolve_in_file_scope(&file_scope.file_id, symbol),
             Scope::Function(function_scope) => function_scope
                 .definitions
-                .get(symbol)
+                .get(&symbol)
                 .copied()
                 .map_or_else(
                     || self.resolve_in_scope(function_scope.parameters_scope_id, symbol),
                     Resolution::Definition,
                 )
                 .or_else(|| self.resolve_in_scope(function_scope.parent_scope_id, symbol)),
-            Scope::Modifier(modifier_scope) => {
-                modifier_scope.definitions.get(symbol).copied().map_or_else(
+            Scope::Modifier(modifier_scope) => modifier_scope
+                .definitions
+                .get(&symbol)
+                .copied()
+                .map_or_else(
                     || self.resolve_in_scope(modifier_scope.parent_scope_id, symbol),
                     Resolution::Definition,
-                )
-            }
+                ),
             Scope::Parameters(parameters_scope) => {
                 parameters_scope.lookup_definition(symbol).into()
             }
-            Scope::Struct(struct_scope) => struct_scope.definitions.get(symbol).into(),
+            Scope::Struct(struct_scope) => struct_scope.definitions.get(&symbol).into(),
             Scope::Using(using_scope) => using_scope
                 .symbols
-                .get(symbol)
+                .get(&symbol)
                 .cloned()
                 .map_or(Resolution::Unresolved, Resolution::from),
             Scope::YulBlock(yul_block_scope) => yul_block_scope
                 .definitions
-                .get(symbol)
+                .get(&symbol)
                 .copied()
                 .map_or_else(
                     || self.resolve_in_scope(yul_block_scope.parent_scope_id, symbol),
@@ -497,7 +500,7 @@ impl Binder {
                 // cannot resolve to a Yul variable defined in a parent block
                 yul_function_scope
                     .definitions
-                    .get(symbol)
+                    .get(&symbol)
                     .copied()
                     .map_or_else(
                         || self.resolve_in_scope(yul_function_scope.parent_scope_id, symbol),
@@ -545,7 +548,7 @@ impl Binder {
                     continue;
                 };
                 working_set.extend(
-                    self.resolve_in_scope(scope_id, &imported_symbol.symbol)
+                    self.resolve_in_scope(scope_id, imported_symbol.symbol)
                         .get_definition_ids(),
                 );
             } else {
@@ -565,7 +568,7 @@ impl Binder {
     pub(crate) fn resolve_in_scope_as_namespace(
         &self,
         scope_id: ScopeId,
-        symbol: &str,
+        symbol: StringId,
     ) -> Resolution {
         let scope = self.get_scope_by_id(scope_id);
         match scope {
@@ -574,11 +577,11 @@ impl Binder {
                 symbol,
                 ResolveOptions::Qualified,
             ),
-            Scope::Enum(enum_scope) => enum_scope.definitions.get(symbol).into(),
-            Scope::Struct(struct_scope) => struct_scope.definitions.get(symbol).into(),
+            Scope::Enum(enum_scope) => enum_scope.definitions.get(&symbol).into(),
+            Scope::Struct(struct_scope) => struct_scope.definitions.get(&symbol).into(),
             Scope::Using(using_scope) => using_scope
                 .symbols
-                .get(symbol)
+                .get(&symbol)
                 .cloned()
                 .map_or(Resolution::Unresolved, Resolution::from),
             Scope::Parameters(parameters_scope) => {
@@ -597,7 +600,7 @@ impl Binder {
     pub(crate) fn resolve_in_contract_scope(
         &self,
         scope_id: ScopeId,
-        symbol: &str,
+        symbol: StringId,
         options: ResolveOptions,
     ) -> Resolution {
         let scope = self.get_scope_by_id(scope_id);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -5,6 +5,7 @@ use slang_solidity_v2_ir::ir::NodeId;
 
 use super::built_ins::BuiltIn;
 use super::types::{Type, TypeId};
+use crate::context::FileId;
 
 mod definitions;
 mod references;
@@ -92,7 +93,7 @@ pub struct Binder {
     /// Scopes (set of definitions contained and relationship to other scopes), indexed by `NodeId`
     scopes_by_node_id: HashMap<NodeId, ScopeId>,
     /// Index of root `FileScope`s for all files in the `CompilationUnit`
-    scopes_by_file_id: HashMap<String, ScopeId>,
+    scopes_by_file_id: HashMap<FileId, ScopeId>,
     /// `UsingDirective` objects registered globally (contract level directives
     /// are stored in the corresponding `ContractScope`)
     global_using_directives: Vec<UsingDirective>,
@@ -142,21 +143,17 @@ impl Binder {
         self.scopes_by_node_id.get(&node_id).copied()
     }
 
-    pub(crate) fn scope_id_for_file_id(&self, file_id: &str) -> Option<ScopeId> {
-        self.scopes_by_file_id.get(file_id).copied()
+    pub(crate) fn scope_id_for_file_id(&self, file_id: FileId) -> Option<ScopeId> {
+        self.scopes_by_file_id.get(&file_id).copied()
     }
 
     pub(crate) fn insert_scope(&mut self, scope: Scope) -> ScopeId {
         let scope_id = ScopeId(self.scopes.len());
 
         if let Scope::File(file_scope) = &scope {
-            let file_id = &file_scope.file_id;
-            if self
-                .scopes_by_file_id
-                .insert(file_id.clone(), scope_id)
-                .is_some()
-            {
-                unreachable!("attempt to insert duplicate file scope for {file_id}");
+            let file_id = file_scope.file_id;
+            if self.scopes_by_file_id.insert(file_id, scope_id).is_some() {
+                unreachable!("attempt to insert duplicate file scope for {file_id:?}");
             }
         }
 
@@ -331,9 +328,9 @@ impl Binder {
 
     // File scope resolution context
 
-    fn get_file_scope(&self, file_id: &str) -> &FileScope {
+    fn get_file_scope(&self, file_id: FileId) -> &FileScope {
         self.scopes_by_file_id
-            .get(file_id)
+            .get(&file_id)
             .and_then(|scope_id| self.scopes.get(scope_id.0))
             .and_then(|scope| match scope {
                 Scope::File(file_scope) => Some(file_scope),
@@ -345,20 +342,20 @@ impl Binder {
     // Resolving a symbol in a file scope is special because of default imports.
     // We want to find *all* definitions with the given symbol reachable from
     // the file.
-    fn resolve_in_file_scope(&self, file_id: &str, symbol: StringId) -> Resolution {
+    fn resolve_in_file_scope(&self, file_id: FileId, symbol: StringId) -> Resolution {
         let mut found_definitions = Vec::new();
         let mut visited_files = HashSet::new();
         let mut files_to_search = VecDeque::new();
-        files_to_search.push_back(file_id.to_owned());
+        files_to_search.push_back(file_id);
 
         while let Some(file_id) = files_to_search.pop_front() {
-            let file_scope = self.get_file_scope(&file_id);
+            let file_scope = self.get_file_scope(file_id);
             if !visited_files.insert(file_id) {
                 continue;
             }
 
             found_definitions.extend(file_scope.lookup_symbol(symbol));
-            files_to_search.extend(file_scope.imported_files.iter().cloned());
+            files_to_search.extend(file_scope.imported_files.iter().copied());
         }
 
         Resolution::from(found_definitions)
@@ -460,7 +457,7 @@ impl Binder {
                 })
             }
             Scope::Enum(enum_scope) => enum_scope.definitions.get(&symbol).into(),
-            Scope::File(file_scope) => self.resolve_in_file_scope(&file_scope.file_id, symbol),
+            Scope::File(file_scope) => self.resolve_in_file_scope(file_scope.file_id, symbol),
             Scope::Function(function_scope) => function_scope
                 .definitions
                 .get(&symbol)
@@ -543,7 +540,7 @@ impl Binder {
                 let Some(scope_id) = imported_symbol
                     .resolved_file_id
                     .as_ref()
-                    .and_then(|file_id| self.scope_id_for_file_id(file_id))
+                    .and_then(|file_id| self.scope_id_for_file_id(*file_id))
                 else {
                     continue;
                 };

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::ScopeId;
@@ -25,25 +26,25 @@ pub(crate) enum Scope {
 pub(crate) struct BlockScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 pub(crate) struct ContractScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, Vec<NodeId>>,
+    pub(crate) definitions: HashMap<StringId, Vec<NodeId>>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
 pub(crate) struct EnumScope {
     pub(crate) node_id: NodeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 pub(crate) struct FileScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_id: String,
-    pub(crate) definitions: HashMap<String, Vec<NodeId>>,
+    pub(crate) definitions: HashMap<StringId, Vec<NodeId>>,
     pub(crate) imported_files: HashSet<String>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
@@ -52,7 +53,7 @@ pub(crate) struct FunctionScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
     pub(crate) parameters_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 // TODO: this is similar to a function scope, but it doesn't have a separate
@@ -64,14 +65,14 @@ pub(crate) struct FunctionScope {
 pub(crate) struct ModifierScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 /// This is stored in a vector in the `ParametersScope` below preserving order
 /// for positional arguments and used by the binder, both to resolve named
 /// arguments, and disambiguate overloads of functions and events.
 pub(crate) struct ParameterDefinition {
-    pub(crate) name: Option<String>,
+    pub(crate) name: Option<StringId>,
     pub(crate) node_id: NodeId,
     /// The type of the parameter, or `None` if it's not yet computed or cannot
     /// be computed. For some parameter containers (eg. errors) it's never
@@ -85,24 +86,24 @@ pub(crate) struct ParametersScope {
 
 pub(crate) struct StructScope {
     pub(crate) node_id: NodeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 pub(crate) struct UsingScope {
     pub(crate) node_id: NodeId,
-    pub(crate) symbols: HashMap<String, Vec<NodeId>>,
+    pub(crate) symbols: HashMap<StringId, Vec<NodeId>>,
 }
 
 pub(crate) struct YulBlockScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 pub(crate) struct YulFunctionScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: HashMap<StringId, NodeId>,
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -125,7 +126,7 @@ impl Scope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         match self {
             Self::Block(block_scope) => block_scope.insert_definition(symbol, node_id),
             Self::Contract(contract_scope) => contract_scope.insert_definition(symbol, node_id),
@@ -189,7 +190,7 @@ impl Scope {
         Self::Struct(StructScope::new(node_id))
     }
 
-    pub(crate) fn new_using(node_id: NodeId, symbols: HashMap<String, Vec<NodeId>>) -> Self {
+    pub(crate) fn new_using(node_id: NodeId, symbols: HashMap<StringId, Vec<NodeId>>) -> Self {
         Self::Using(UsingScope::new(node_id, symbols))
     }
 
@@ -211,7 +212,7 @@ impl BlockScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -226,7 +227,7 @@ impl ContractScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         if let Some(definitions) = self.definitions.get_mut(&symbol) {
             definitions.push(node_id);
         } else {
@@ -243,7 +244,7 @@ impl EnumScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -259,7 +260,7 @@ impl FileScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         if let Some(definitions) = self.definitions.get_mut(&symbol) {
             definitions.push(node_id);
         } else {
@@ -271,8 +272,8 @@ impl FileScope {
         self.imported_files.insert(file_id);
     }
 
-    pub(super) fn lookup_symbol<'a>(&'a self, symbol: &str) -> impl Iterator<Item = NodeId> + 'a {
-        match self.definitions.get(symbol) {
+    pub(super) fn lookup_symbol(&self, symbol: StringId) -> impl Iterator<Item = NodeId> + '_ {
+        match self.definitions.get(&symbol) {
             Some(defs) => OptionIter::Some(defs.iter().copied()),
             None => OptionIter::Empty,
         }
@@ -289,7 +290,7 @@ impl FunctionScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -303,7 +304,7 @@ impl ModifierScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -315,9 +316,9 @@ impl ParametersScope {
         }
     }
 
-    pub(crate) fn add_parameter(&mut self, identifier: Option<&String>, node_id: NodeId) {
+    pub(crate) fn add_parameter(&mut self, name: Option<StringId>, node_id: NodeId) {
         self.parameters.push(ParameterDefinition {
-            name: identifier.cloned(),
+            name,
             node_id,
             type_id: None,
         });
@@ -332,10 +333,10 @@ impl ParametersScope {
         }
     }
 
-    pub(crate) fn lookup_definition(&self, symbol: &str) -> Option<NodeId> {
+    pub(crate) fn lookup_definition(&self, symbol: StringId) -> Option<NodeId> {
         self.parameters
             .iter()
-            .find(|parameter| parameter.name.as_ref().is_some_and(|name| name == symbol))
+            .find(|parameter| parameter.name.is_some_and(|name| name == symbol))
             .map(|parameter| parameter.node_id)
     }
 }
@@ -348,13 +349,13 @@ impl StructScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
 
 impl UsingScope {
-    fn new(node_id: NodeId, symbols: HashMap<String, Vec<NodeId>>) -> Self {
+    fn new(node_id: NodeId, symbols: HashMap<StringId, Vec<NodeId>>) -> Self {
         Self { node_id, symbols }
     }
 }
@@ -368,7 +369,7 @@ impl YulBlockScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -382,7 +383,7 @@ impl YulFunctionScope {
         }
     }
 
-    pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
+    pub(crate) fn insert_definition(&mut self, symbol: StringId, node_id: NodeId) {
         self.definitions.insert(symbol, node_id);
     }
 }
@@ -401,7 +402,7 @@ pub(crate) enum UsingDirective {
     },
     SingleTypeOperator {
         scope_id: ScopeId,
-        operator_mapping: HashMap<ir::UsingOperator, String>,
+        operator_mapping: HashMap<ir::UsingOperator, StringId>,
         type_id: TypeId,
     },
 }
@@ -418,7 +419,7 @@ impl UsingDirective {
     pub(crate) fn new_single_type_with_operators(
         scope_id: ScopeId,
         type_id: TypeId,
-        operator_mapping: HashMap<ir::UsingOperator, String>,
+        operator_mapping: HashMap<ir::UsingOperator, StringId>,
     ) -> Self {
         Self::SingleTypeOperator {
             scope_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::ScopeId;
+use crate::context::FileId;
 use crate::types::TypeId;
 
 //////////////////////////////////////////////////////////////////////////////
@@ -43,9 +44,9 @@ pub(crate) struct EnumScope {
 
 pub(crate) struct FileScope {
     pub(crate) node_id: NodeId,
-    pub(crate) file_id: String,
+    pub(crate) file_id: FileId,
     pub(crate) definitions: HashMap<StringId, Vec<NodeId>>,
-    pub(crate) imported_files: HashSet<String>,
+    pub(crate) imported_files: HashSet<FileId>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
@@ -166,7 +167,7 @@ impl Scope {
         Self::Enum(EnumScope::new(node_id))
     }
 
-    pub(crate) fn new_file(node_id: NodeId, file_id: &str) -> Self {
+    pub(crate) fn new_file(node_id: NodeId, file_id: FileId) -> Self {
         Self::File(FileScope::new(node_id, file_id))
     }
 
@@ -250,10 +251,10 @@ impl EnumScope {
 }
 
 impl FileScope {
-    fn new(node_id: NodeId, file_id: &str) -> Self {
+    fn new(node_id: NodeId, file_id: FileId) -> Self {
         Self {
             node_id,
-            file_id: file_id.to_string(),
+            file_id,
             definitions: HashMap::new(),
             imported_files: HashSet::new(),
             using_directives: Vec::new(),
@@ -268,7 +269,7 @@ impl FileScope {
         }
     }
 
-    pub(crate) fn add_imported_file(&mut self, file_id: String) {
+    pub(crate) fn add_imported_file(&mut self, file_id: FileId) {
         self.imported_files.insert(file_id);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Definition, Reference, Scope};
@@ -50,14 +51,18 @@ pub struct SemanticContext {
 }
 
 impl SemanticContext {
-    pub fn build_from(language_version: LanguageVersion, files: &[impl SemanticFile]) -> Self {
+    pub fn build_from(
+        language_version: LanguageVersion,
+        files: &[impl SemanticFile],
+        interner: &Interner,
+    ) -> Self {
         let mut binder = Binder::default();
         let mut types = TypeRegistry::default();
 
         p1_collect_definitions::run(files, &mut binder);
         p2_linearise_contracts::run(files, &mut binder);
         p3_type_definitions::run(files, &mut binder, &mut types);
-        p4_resolve_references::run(files, &mut binder, &mut types, language_version);
+        p4_resolve_references::run(files, &mut binder, &mut types, language_version, interner);
 
         Self { binder, types }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -24,6 +24,7 @@ pub trait SemanticFile {
 
 pub fn extract_import_paths_from_source_unit(
     source_unit: &ir::SourceUnit,
+    interner: &Interner,
 ) -> Vec<(NodeId, String)> {
     let mut import_paths = Vec::new();
 
@@ -33,11 +34,11 @@ pub fn extract_import_paths_from_source_unit(
         };
         let (node_id, path) = match import_clause {
             ir::ImportClause::PathImport(path_import) => {
-                (path_import.id(), path_import.path.unparse().to_owned())
+                (path_import.id(), path_import.path.unparse(interner).to_owned())
             }
             ir::ImportClause::ImportDeconstruction(import_deconstruction) => (
                 import_deconstruction.id(),
-                import_deconstruction.path.unparse().to_owned(),
+                import_deconstruction.path.unparse(interner).to_owned(),
             ),
         };
         import_paths.push((node_id, path));
@@ -46,6 +47,7 @@ pub fn extract_import_paths_from_source_unit(
 }
 
 pub struct SemanticContext {
+    interner: Rc<Interner>,
     binder: Binder,
     types: TypeRegistry,
 }
@@ -54,17 +56,25 @@ impl SemanticContext {
     pub fn build_from(
         language_version: LanguageVersion,
         files: &[impl SemanticFile],
-        interner: &Interner,
+        interner: &Rc<Interner>,
     ) -> Self {
         let mut binder = Binder::default();
         let mut types = TypeRegistry::default();
 
         p1_collect_definitions::run(files, &mut binder);
         p2_linearise_contracts::run(files, &mut binder);
-        p3_type_definitions::run(files, &mut binder, &mut types);
+        p3_type_definitions::run(files, &mut binder, &mut types, interner);
         p4_resolve_references::run(files, &mut binder, &mut types, language_version, interner);
 
-        Self { binder, types }
+        Self {
+            interner: Rc::clone(interner),
+            binder,
+            types,
+        }
+    }
+
+    pub fn interner(&self) -> &Interner {
+        &self.interner
     }
 
     // TODO: this should not be public
@@ -90,7 +100,7 @@ impl SemanticContext {
             let Definition::Contract(contract) = definition else {
                 return None;
             };
-            if definition.identifier().unparse() == name {
+            if definition.identifier().unparse(&self.interner) == name {
                 Some(Rc::clone(&contract.ir_node))
             } else {
                 None
@@ -132,7 +142,7 @@ impl SemanticContext {
             .find_definition_by_id(definition_id)
             .unwrap()
             .identifier()
-            .unparse()
+            .unparse(&self.interner)
             .to_string()
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::interner::Interner;
+use slang_solidity_v2_ir::interner::{Interner, StringId};
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Definition, Reference, Scope};
@@ -10,16 +10,18 @@ use crate::passes::{
 };
 use crate::types::{Type, TypeId, TypeRegistry};
 
+pub type FileId = StringId;
+
 /// Trait for files that can be used as input to the semantic analysis passes.
 pub trait SemanticFile {
     /// Returns the file identifier.
-    fn id(&self) -> &str;
+    fn file_id(&self) -> FileId;
 
     /// Returns the root IR node of the file.
     fn ir_root(&self) -> &ir::SourceUnit;
 
     /// Returns the resolved import target file ID for the given import node, if resolved.
-    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String>;
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<FileId>;
 }
 
 pub fn extract_import_paths_from_source_unit(
@@ -33,9 +35,10 @@ pub fn extract_import_paths_from_source_unit(
             continue;
         };
         let (node_id, path) = match import_clause {
-            ir::ImportClause::PathImport(path_import) => {
-                (path_import.id(), path_import.path.unparse(interner).to_owned())
-            }
+            ir::ImportClause::PathImport(path_import) => (
+                path_import.id(),
+                path_import.path.unparse(interner).to_owned(),
+            ),
             ir::ImportClause::ImportDeconstruction(import_deconstruction) => (
                 import_deconstruction.id(),
                 import_deconstruction.path.unparse(interner).to_owned(),
@@ -115,7 +118,7 @@ impl SemanticContext {
         let Scope::File(file_scope) = self.binder().get_scope_by_id(scope_id) else {
             return None;
         };
-        Some(file_scope.file_id.clone())
+        Some(self.interner.resolve(file_scope.file_id).to_owned())
     }
 
     pub fn resolve_reference_identifier_to_definition_id(&self, node_id: NodeId) -> Option<NodeId> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
@@ -54,7 +54,7 @@ pub(super) fn resolve_identifier_path_in_scope(
                     resolved_file_id, ..
                 }) => resolved_file_id
                     .as_ref()
-                    .and_then(|resolved_file_id| binder.scope_id_for_file_id(resolved_file_id)),
+                    .and_then(|resolved_file_id| binder.scope_id_for_file_id(*resolved_file_id)),
                 Definition::Contract(_) | Definition::Interface(_) | Definition::Library(_) => {
                     use_lexical_resolution = false;
                     binder.scope_id_for_node_id(definition.node_id())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
@@ -18,7 +18,7 @@ pub(super) fn resolve_identifier_path_in_scope(
     let mut last_resolution: Resolution = Resolution::Unresolved;
 
     for identifier in identifier_path {
-        let symbol = identifier.unparse();
+        let symbol = identifier.string_id;
         let resolution = if let Some(scope_id) = scope_id {
             if use_lexical_resolution {
                 binder.resolve_in_scope(scope_id, symbol)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -269,10 +269,10 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                     let current_scope_node_id = self.current_scope().node_id();
                     let enclosing_definition =
                         self.binder.find_definition_by_id(current_scope_node_id);
-                    let enclosing_contract_name =
+                    let enclosing_contract_string_id =
                         if let Some(enclosing_definition) = enclosing_definition {
                             if matches!(enclosing_definition, Definition::Contract(_)) {
-                                Some(enclosing_definition.identifier().unparse())
+                                Some(enclosing_definition.identifier().string_id)
                             } else {
                                 None
                             }
@@ -280,8 +280,8 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                             None
                         };
 
-                    if enclosing_contract_name
-                        .is_some_and(|contract_name| contract_name == name.unparse())
+                    if enclosing_contract_string_id
+                        .is_some_and(|contract_id| contract_id == name.string_id)
                     {
                         // TODO(validation): there cannot be a function with the
                         // same name as the enclosing contract (since Solidity

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -2,7 +2,7 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Definition, FileScope, ParametersScope, Scope, ScopeId};
-use crate::context::SemanticFile;
+use crate::context::{FileId, SemanticFile};
 
 /// In this pass all definitions are collected with their naming identifiers.
 /// Also lexical (and other kinds of) scopes are identified and linked together,
@@ -116,10 +116,8 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
             .insert_definition_in_scope(definition, self.current_scope_id());
     }
 
-    fn resolve_import_path(&self, import_node_id: NodeId) -> Option<String> {
-        self.current_file
-            .resolved_import_by_node_id(import_node_id)
-            .cloned()
+    fn resolve_import_path(&mut self, import_node_id: NodeId) -> Option<FileId> {
+        self.current_file.resolved_import_by_node_id(import_node_id)
 
         // TODO(validation): emit an error/warning if the file cannot be resolved
     }
@@ -173,7 +171,7 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
 
 impl<F: SemanticFile> Visitor for Pass<'_, F> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
-        let scope = Scope::new_file(node.id(), self.current_file.id());
+        let scope = Scope::new_file(node.id(), self.current_file.file_id());
         self.enter_scope(scope);
 
         true
@@ -243,11 +241,8 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
         let imported_file_id = self.resolve_import_path(node.id());
 
         for symbol in &node.symbols {
-            let definition = Definition::new_imported_symbol(
-                symbol,
-                symbol.name.string_id,
-                imported_file_id.clone(),
-            );
+            let definition =
+                Definition::new_imported_symbol(symbol, symbol.name.string_id, imported_file_id);
             self.insert_definition_in_current_scope(definition);
         }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -130,7 +130,10 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
     fn collect_parameters(&mut self, parameters: &ir::Parameters) -> ScopeId {
         let mut scope = ParametersScope::new();
         for parameter in parameters {
-            scope.add_parameter(parameter.name.as_ref().map(|id| &id.text), parameter.id());
+            scope.add_parameter(
+                parameter.name.as_ref().map(|id| id.string_id),
+                parameter.id(),
+            );
             if parameter.name.is_some() {
                 let definition = Definition::new_parameter(parameter);
                 self.binder.insert_definition_no_scope(definition);
@@ -242,7 +245,7 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
         for symbol in &node.symbols {
             let definition = Definition::new_imported_symbol(
                 symbol,
-                symbol.name.unparse().to_owned(),
+                symbol.name.string_id,
                 imported_file_id.clone(),
             );
             self.insert_definition_in_current_scope(definition);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -299,6 +299,7 @@ mod tests {
 
     use num_bigint::ToBigInt;
     use slang_solidity_v2_common::versions::LanguageVersion;
+    use slang_solidity_v2_ir::interner::Interner;
     use slang_solidity_v2_parser::{ParseOutput, Parser};
 
     use super::*;
@@ -331,7 +332,8 @@ mod tests {
 
         assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-        let source_unit = ir::build(&source_unit, &source);
+        let mut interner = Interner::default();
+        let source_unit = ir::build(&source_unit, &source, &mut interner);
         let member = source_unit.members.first().expect("no source unit members");
         match member {
             ir::SourceUnitMember::ConstantDefinition(definition) => definition

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -3,15 +3,16 @@ use std::str::FromStr;
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
 use num_traits::Num;
-use slang_solidity_v2_ir::interner::StringId;
+use slang_solidity_v2_ir::interner::{Interner, StringId};
 use slang_solidity_v2_ir::ir;
 
 pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
+    interner: &Interner,
 ) -> Option<usize> {
-    evaluate_compile_time_constant(expression, start_scope, identifier_resolver)
+    evaluate_compile_time_constant(expression, start_scope, identifier_resolver, interner)
         .and_then(|value| value.as_usize())
 }
 
@@ -19,9 +20,11 @@ fn evaluate_compile_time_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
+    interner: &Interner,
 ) -> Option<ConstantValue> {
     let mut evaluator = CompileConstantEvaluator {
         identifier_resolver,
+        interner,
         scope_stack: Vec::new(),
     };
     evaluator.evaluate_expression_in_scope(expression, start_scope)
@@ -53,6 +56,7 @@ pub(crate) trait ConstantIdentifierResolver<Scope> {
 
 struct CompileConstantEvaluator<'a, Scope> {
     identifier_resolver: &'a dyn ConstantIdentifierResolver<Scope>,
+    interner: &'a Interner,
     scope_stack: Vec<Scope>,
 }
 
@@ -103,10 +107,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 self.evaluate_prefix_expression(prefix_expression)
             }
             ir::Expression::HexNumberExpression(hex_number_expression) => {
-                Self::evaluate_hex_number_expression(hex_number_expression)
+                self.evaluate_hex_number_expression(hex_number_expression)
             }
             ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                Self::evaluate_decimal_number_expression(decimal_number_expression)
+                self.evaluate_decimal_number_expression(decimal_number_expression)
             }
             ir::Expression::Identifier(identifier) => self.evaluate_identifier(identifier),
             ir::Expression::TupleExpression(tuple_expression) => {
@@ -255,9 +259,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     }
 
     fn evaluate_hex_number_expression(
+        &self,
         hex_number_expression: &ir::HexNumberExpression,
     ) -> Option<ConstantValue> {
-        let hex = hex_number_expression.literal.unparse();
+        let hex = hex_number_expression.literal.unparse(self.interner);
         // skip `0x` prefix and parse the hexadecimal number
         BigInt::from_str_radix(&hex[2..], 16)
             .ok()
@@ -265,11 +270,12 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     }
 
     fn evaluate_decimal_number_expression(
+        &self,
         decimal_number_expression: &ir::DecimalNumberExpression,
     ) -> Option<ConstantValue> {
         // TODO: this only handles integers but not rational numbers
         // TODO: handle number units
-        let decimal = decimal_number_expression.literal.unparse();
+        let decimal = decimal_number_expression.literal.unparse(self.interner);
         BigInt::from_str(decimal).ok().map(ConstantValue::Integer)
     }
 
@@ -364,7 +370,12 @@ mod tests {
     fn eval_string(input: &str) -> Option<ConstantValue> {
         let mut interner = Interner::default();
         let expression = parse_expression(input, &mut interner);
-        evaluate_compile_time_constant(&expression, String::new(), &MapResolver::new(&interner))
+        evaluate_compile_time_constant(
+            &expression,
+            String::new(),
+            &MapResolver::new(&interner),
+            &interner,
+        )
     }
 
     // `context` is given as a list of constants defined as:
@@ -395,6 +406,7 @@ mod tests {
             &expression,
             String::new(),
             &MapResolver::new_with_context(&interner, context),
+            &interner,
         )
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
 use num_traits::Num;
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir;
 
 pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
@@ -45,7 +46,7 @@ pub(crate) trait ConstantIdentifierResolver<Scope> {
     /// be resolved to a constant.
     fn resolve_identifier_in_scope(
         &self,
-        identifier: &str,
+        identifier: StringId,
         scope: &Scope,
     ) -> Option<(ir::Expression, Scope)>;
 }
@@ -276,7 +277,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let current_scope = self.scope_stack.last().expect("scope stack is empty");
         let (target_expression, target_scope) = self
             .identifier_resolver
-            .resolve_identifier_in_scope(identifier.unparse(), current_scope)?;
+            .resolve_identifier_in_scope(identifier.string_id, current_scope)?;
         self.evaluate_expression_in_scope(&target_expression, target_scope)
     }
 
@@ -304,24 +305,41 @@ mod tests {
 
     use super::*;
 
-    #[derive(Default)]
-    struct MapResolver {
+    struct MapResolver<'a> {
         // qualified identifier => (target expression, target scope)
         // qualified identifier is the concatenation of the scope and identifier
         context: HashMap<String, (ir::Expression, String)>,
+        interner: &'a Interner,
     }
 
-    impl ConstantIdentifierResolver<String> for MapResolver {
+    impl<'a> MapResolver<'a> {
+        fn new(interner: &'a Interner) -> Self {
+            Self {
+                context: HashMap::new(),
+                interner,
+            }
+        }
+
+        fn new_with_context(
+            interner: &'a Interner,
+            context: HashMap<String, (ir::Expression, String)>,
+        ) -> Self {
+            Self { context, interner }
+        }
+    }
+
+    impl ConstantIdentifierResolver<String> for MapResolver<'_> {
         fn resolve_identifier_in_scope(
             &self,
-            identifier: &str,
+            identifier: StringId,
             scope: &String,
         ) -> Option<(ir::Expression, String)> {
+            let identifier = self.interner.resolve(identifier);
             self.context.get(&format!("{scope}{identifier}")).cloned()
         }
     }
 
-    fn parse_expression(input: &str) -> ir::Expression {
+    fn parse_expression(input: &str, interner: &mut Interner) -> ir::Expression {
         let source = format!("uint constant x = {input};");
         let version = LanguageVersion::V0_8_30;
 
@@ -332,8 +350,7 @@ mod tests {
 
         assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-        let mut interner = Interner::default();
-        let source_unit = ir::build(&source_unit, &source, &mut interner);
+        let source_unit = ir::build(&source_unit, &source, interner);
         let member = source_unit.members.first().expect("no source unit members");
         match member {
             ir::SourceUnitMember::ConstantDefinition(definition) => definition
@@ -345,8 +362,9 @@ mod tests {
     }
 
     fn eval_string(input: &str) -> Option<ConstantValue> {
-        let expression = parse_expression(input);
-        evaluate_compile_time_constant(&expression, String::new(), &MapResolver::default())
+        let mut interner = Interner::default();
+        let expression = parse_expression(input, &mut interner);
+        evaluate_compile_time_constant(&expression, String::new(), &MapResolver::new(&interner))
     }
 
     // `context` is given as a list of constants defined as:
@@ -358,18 +376,26 @@ mod tests {
         input: &str,
         context: &[(&str, &str, &str)],
     ) -> Option<ConstantValue> {
+        let mut interner = Interner::default();
         let context: HashMap<String, (ir::Expression, String)> = context
             .iter()
             .map(|(name, input, target_scope)| {
                 (
                     (*name).to_string(),
-                    (parse_expression(input), (*target_scope).to_string()),
+                    (
+                        parse_expression(input, &mut interner),
+                        (*target_scope).to_string(),
+                    ),
                 )
             })
             .collect();
-        let expression = parse_expression(input);
+        let expression = parse_expression(input, &mut interner);
 
-        evaluate_compile_time_constant(&expression, String::new(), &MapResolver { context })
+        evaluate_compile_time_constant(
+            &expression,
+            String::new(),
+            &MapResolver::new_with_context(&interner, context),
+        )
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,3 +1,4 @@
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
@@ -18,12 +19,17 @@ mod visitor;
 /// Finally, public state variables will be assigned an equivalent getter
 /// function type. This happens after the main typing pass to ensure all types
 /// are already registered.
-pub fn run(files: &[impl SemanticFile], binder: &mut Binder, types: &mut TypeRegistry) {
+pub fn run(
+    files: &[impl SemanticFile],
+    binder: &mut Binder,
+    types: &mut TypeRegistry,
+    interner: &Interner,
+) {
     for file in files {
-        Pass::visit_file(file, binder, types);
+        Pass::visit_file(file, binder, types, interner);
     }
     for file in files {
-        Pass::visit_file_type_getters(file, binder, types);
+        Pass::visit_file_type_getters(file, binder, types, interner);
     }
 }
 
@@ -31,15 +37,22 @@ struct Pass<'a> {
     scope_stack: Vec<ScopeId>,
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
+    interner: &'a Interner,
     current_receiver_type: Option<TypeId>,
 }
 
 impl<'a> Pass<'a> {
-    fn visit_file(file: &impl SemanticFile, binder: &'a mut Binder, types: &'a mut TypeRegistry) {
+    fn visit_file(
+        file: &impl SemanticFile,
+        binder: &'a mut Binder,
+        types: &'a mut TypeRegistry,
+        interner: &'a Interner,
+    ) {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
             types,
+            interner,
             current_receiver_type: None,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
@@ -56,11 +69,13 @@ impl<'a> Pass<'a> {
         file: &impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
+        interner: &'a Interner,
     ) {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
             types,
+            interner,
             current_receiver_type: None,
         };
         pass.type_getters_from(file.ir_root());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -51,6 +51,7 @@ impl Pass<'_> {
                                     size_expression,
                                     self.current_contract_or_file_scope_id(),
                                     self,
+                                    self.interner,
                                 )
                                 .unwrap_or_default();
                                 self.types.register_type(Type::FixedSizeArray {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -1,3 +1,4 @@
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir;
 
 use super::evaluator::{evaluate_compile_time_uint_constant, ConstantIdentifierResolver};
@@ -140,7 +141,7 @@ impl Pass<'_> {
 impl ConstantIdentifierResolver<ScopeId> for Pass<'_> {
     fn resolve_identifier_in_scope(
         &self,
-        identifier: &str,
+        identifier: StringId,
         scope_id: &ScopeId,
     ) -> Option<(ir::Expression, ScopeId)> {
         let resolution = self.binder.resolve_in_scope(*scope_id, identifier);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -90,25 +90,23 @@ impl Pass<'_> {
                 }))
             }
             ir::ElementaryType::BytesKeyword(bytes_keyword) => {
-                Type::from_bytes_keyword(bytes_keyword.unparse(), data_location)
+                Type::from_bytes_keyword(bytes_keyword.unparse(self.interner), data_location)
                     .map(|type_| self.types.register_type(type_))
             }
             ir::ElementaryType::IntKeyword(int_keyword) => Some(
                 self.types
-                    .register_type(Type::from_int_keyword(int_keyword.unparse())),
+                    .register_type(Type::from_int_keyword(int_keyword.unparse(self.interner))),
             ),
             ir::ElementaryType::UintKeyword(uint_keyword) => Some(
                 self.types
-                    .register_type(Type::from_uint_keyword(uint_keyword.unparse())),
+                    .register_type(Type::from_uint_keyword(uint_keyword.unparse(self.interner))),
             ),
-            ir::ElementaryType::FixedKeyword(fixed_keyword) => Some(
-                self.types
-                    .register_type(Type::from_fixed_keyword(fixed_keyword.unparse())),
-            ),
-            ir::ElementaryType::UfixedKeyword(ufixed_keyword) => Some(
-                self.types
-                    .register_type(Type::from_ufixed_keyword(ufixed_keyword.unparse())),
-            ),
+            ir::ElementaryType::FixedKeyword(fixed_keyword) => Some(self.types.register_type(
+                Type::from_fixed_keyword(fixed_keyword.unparse(self.interner)),
+            )),
+            ir::ElementaryType::UfixedKeyword(ufixed_keyword) => Some(self.types.register_type(
+                Type::from_ufixed_keyword(ufixed_keyword.unparse(self.interner)),
+            )),
             ir::ElementaryType::BoolKeyword => Some(self.types.boolean()),
             // No ByteKeyword in v2 (removed since Solidity >= 0.8.0)
             ir::ElementaryType::StringKeyword => data_location.map(|data_location| {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -51,6 +51,7 @@ impl Visitor for Pass<'_> {
                 base_slot_expression,
                 self.current_contract_or_file_scope_id(),
                 self,
+                self.interner,
             ) {
                 let Definition::Contract(contract_definition) =
                     self.binder.get_definition_mut(node.id())
@@ -421,7 +422,7 @@ impl Visitor for Pass<'_> {
 
     fn enter_catch_clause_error(&mut self, node: &ir::CatchClauseError) -> bool {
         if let Some(name) = &node.name {
-            let resolution = match name.unparse() {
+            let resolution = match name.unparse(self.interner) {
                 "Error" | "Panic" => Resolution::BuiltIn(BuiltIn::ErrorOrPanic),
                 _ => Resolution::Unresolved,
             };

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -116,7 +116,7 @@ impl Visitor for Pass<'_> {
             let scope_id = imported_symbol
                 .resolved_file_id
                 .as_ref()
-                .and_then(|file_id| self.binder.scope_id_for_file_id(file_id));
+                .and_then(|file_id| self.binder.scope_id_for_file_id(*file_id));
 
             let resolution = scope_id.map_or(Resolution::Unresolved, |scope_id| {
                 self.binder

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -119,7 +119,7 @@ impl Visitor for Pass<'_> {
 
             let resolution = scope_id.map_or(Resolution::Unresolved, |scope_id| {
                 self.binder
-                    .resolve_in_scope(scope_id, symbol.name.unparse())
+                    .resolve_in_scope(scope_id, symbol.name.string_id)
             });
             let reference = Reference::new(Rc::clone(&symbol.name), resolution);
             self.binder.insert_reference(reference);
@@ -354,10 +354,10 @@ impl Visitor for Pass<'_> {
                                 });
                             // TODO(validation): *all* definitions should point to functions
 
-                            symbols.insert(symbol_name.unparse().to_string(), definition_ids);
+                            symbols.insert(symbol_name.string_id, definition_ids);
 
                             if let Some(operator) = &symbol.alias {
-                                operators.insert(*operator, symbol_name.unparse().to_string());
+                                operators.insert(*operator, symbol_name.string_id);
                             }
                         }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
@@ -1,3 +1,4 @@
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::NodeId;
 
 use super::Pass;
@@ -144,7 +145,7 @@ impl Pass<'_> {
     pub(super) fn lookup_function_matching_named_arguments<'a>(
         &'a self,
         type_ids: &[TypeId],
-        argument_typings: &[(String, Typing)],
+        argument_typings: &[(StringId, Typing)],
         receiver_type_id: Option<TypeId>,
     ) -> Option<&'a FunctionType> {
         // get types and filter non-function types
@@ -202,18 +203,16 @@ impl Pass<'_> {
     fn parameters_match_named_arguments(
         &self,
         parameters: &[ParameterDefinition],
-        argument_typings: &[(String, Typing)],
+        argument_typings: &[(StringId, Typing)],
         external_call: bool,
     ) -> bool {
         argument_typings
             .iter()
             .all(|(argument_name, argument_typing)| {
-                let Some(parameter) = parameters.iter().find(|parameter| {
-                    parameter
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| name == argument_name)
-                }) else {
+                let Some(parameter) = parameters
+                    .iter()
+                    .find(|parameter| parameter.name.is_some_and(|name| name == *argument_name))
+                else {
                     return false;
                 };
                 parameter.type_id.is_some_and(|type_id| {
@@ -267,7 +266,7 @@ impl Pass<'_> {
     pub(super) fn lookup_event_matching_named_arguments(
         &self,
         definition_ids: &[NodeId],
-        argument_typings: &[(String, Typing)],
+        argument_typings: &[(StringId, Typing)],
     ) -> Option<NodeId> {
         for definition_id in definition_ids {
             let Some(parameters) = self.get_event_definition_parameters(*definition_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/mod.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use crate::binder::{Binder, Scope, ScopeId};
@@ -21,9 +22,10 @@ pub fn run(
     binder: &mut Binder,
     types: &mut TypeRegistry,
     language_version: LanguageVersion,
+    interner: &Interner,
 ) {
     for file in files {
-        Pass::visit_file(file, binder, types, language_version);
+        Pass::visit_file(file, binder, types, language_version, interner);
     }
     // update definition->references reverse mapping
     binder.update_definitions_to_references_index();
@@ -42,6 +44,7 @@ struct Pass<'a> {
     scope_stack: Vec<ScopeFrame>,
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
+    interner: &'a Interner,
 }
 
 impl<'a> Pass<'a> {
@@ -50,12 +53,14 @@ impl<'a> Pass<'a> {
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
         language_version: LanguageVersion,
+        interner: &'a Interner,
     ) {
         let mut pass = Self {
             language_version,
             scope_stack: Vec::new(),
             binder,
             types,
+            interner,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
         assert!(pass.scope_stack.is_empty());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -209,7 +209,7 @@ impl Pass<'_> {
                         if let Some(scope_id) = import_definition
                             .resolved_file_id
                             .as_ref()
-                            .and_then(|file_id| self.binder.scope_id_for_file_id(file_id))
+                            .and_then(|file_id| self.binder.scope_id_for_file_id(*file_id))
                         {
                             self.binder.resolve_in_scope(scope_id, symbol)
                         } else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::{Pass, ScopeFrame};
@@ -12,10 +13,17 @@ use crate::types::{FunctionType, Type, TypeId};
 /// Lexical style resolution of symbols
 impl Pass<'_> {
     // This is a "top-level" (ie. not a member access) resolution method
-    pub(super) fn resolve_symbol_in_scope(&self, scope_id: ScopeId, symbol: &str) -> Resolution {
+    pub(super) fn resolve_symbol_in_scope(
+        &self,
+        scope_id: ScopeId,
+        symbol: StringId,
+    ) -> Resolution {
         let resolution = self.binder.resolve_in_scope(scope_id, symbol);
         match &resolution {
-            Resolution::Unresolved => self.built_ins_resolver().lookup_global(symbol).into(),
+            Resolution::Unresolved => self
+                .built_ins_resolver()
+                .lookup_global(self.interner.resolve(symbol))
+                .into(),
             Resolution::Ambiguous(definition_ids) => {
                 // Try to disambiguate known cases
                 let first_id = definition_ids.first().copied().unwrap();
@@ -123,7 +131,7 @@ impl Pass<'_> {
         Resolution::from(filtered_definitions)
     }
 
-    pub(super) fn resolve_symbol_in_typing(&self, typing: &Typing, symbol: &str) -> Resolution {
+    pub(super) fn resolve_symbol_in_typing(&self, typing: &Typing, symbol: StringId) -> Resolution {
         match typing {
             Typing::Unresolved => Resolution::Unresolved,
             Typing::Undetermined(type_ids) => {
@@ -183,7 +191,7 @@ impl Pass<'_> {
             Typing::MetaType(type_) => {
                 if let Some(built_in) = self
                     .built_ins_resolver()
-                    .lookup_member_of_meta_type(type_, symbol)
+                    .lookup_member_of_meta_type(type_, self.interner.resolve(symbol))
                 {
                     Resolution::BuiltIn(built_in)
                 } else {
@@ -221,18 +229,18 @@ impl Pass<'_> {
                     }
                     _ => self
                         .built_ins_resolver()
-                        .lookup_member_of_user_definition(definition, symbol)
+                        .lookup_member_of_user_definition(definition, self.interner.resolve(symbol))
                         .into(),
                 }
             }
             Typing::BuiltIn(built_in) => self
                 .built_ins_resolver()
-                .lookup_member_of(built_in, symbol)
+                .lookup_member_of(built_in, self.interner.resolve(symbol))
                 .into(),
         }
     }
 
-    fn resolve_symbol_in_type(&self, type_id: TypeId, symbol: &str) -> Resolution {
+    fn resolve_symbol_in_type(&self, type_id: TypeId, symbol: StringId) -> Resolution {
         let type_ = self.types.get_type_by_id(type_id);
 
         // Resolve direct members of the type first
@@ -243,7 +251,7 @@ impl Pass<'_> {
                     .resolve_in_contract_scope(scope_id, symbol, ResolveOptions::External)
                     .or_else(|| {
                         self.built_ins_resolver()
-                            .lookup_member_of_type_id(type_id, symbol)
+                            .lookup_member_of_type_id(type_id, self.interner.resolve(symbol))
                             .into()
                     })
             }
@@ -261,7 +269,7 @@ impl Pass<'_> {
         Resolution::from(definition_ids).or_else(|| {
             // If still unresolved, try with a built-in
             self.built_ins_resolver()
-                .lookup_member_of_type_id(type_id, symbol)
+                .lookup_member_of_type_id(type_id, self.interner.resolve(symbol))
                 .into()
         })
     }
@@ -269,7 +277,7 @@ impl Pass<'_> {
     fn add_attached_functions_for_type(
         &self,
         receiver_type_id: TypeId,
-        symbol: &str,
+        symbol: StringId,
         definition_ids: &mut Vec<NodeId>,
     ) {
         let active_directives = self.active_using_directives_for_type(receiver_type_id);
@@ -356,7 +364,7 @@ impl Pass<'_> {
         let mut use_contract_lookup = true;
         for (index, identifier) in identifier_path.iter().enumerate() {
             let resolution = if let Some(scope_id) = scope_id {
-                let symbol = identifier.unparse();
+                let symbol = identifier.string_id;
                 if use_contract_lookup {
                     use_contract_lookup = false;
                     self.resolve_symbol_in_scope(scope_id, symbol)
@@ -407,7 +415,7 @@ impl Pass<'_> {
             let resolution =
                 parameters_scope_id.map_or(Resolution::Unresolved, |parameters_scope_id| {
                     self.binder
-                        .resolve_in_scope_as_namespace(parameters_scope_id, identifier.unparse())
+                        .resolve_in_scope_as_namespace(parameters_scope_id, identifier.string_id)
                 });
             let reference = Reference::new(Rc::clone(identifier), resolution);
             self.binder.insert_reference(reference);
@@ -418,12 +426,14 @@ impl Pass<'_> {
     pub(super) fn resolve_symbol_in_yul_scope(
         &self,
         scope_id: ScopeId,
-        symbol: &str,
+        symbol: StringId,
     ) -> Resolution {
         let resolution =
             self.filter_overriden_definitions(self.binder.resolve_in_scope(scope_id, symbol));
         if resolution == Resolution::Unresolved {
-            self.built_ins_resolver().lookup_yul_global(symbol).into()
+            self.built_ins_resolver()
+                .lookup_yul_global(self.interner.resolve(symbol))
+                .into()
         } else {
             resolution
         }
@@ -431,14 +441,14 @@ impl Pass<'_> {
 
     pub(super) fn resolve_yul_suffix(
         &self,
-        symbol: &str,
+        symbol: StringId,
         parent_resolution: &Resolution,
     ) -> Resolution {
         match parent_resolution {
             Resolution::Definition(node_id) => {
                 if let Some(definition) = self.binder.find_definition_by_id(*node_id) {
                     self.built_ins_resolver()
-                        .lookup_yul_suffix(definition, symbol)
+                        .lookup_yul_suffix(definition, self.interner.resolve(symbol))
                         .into()
                 } else {
                     Resolution::Unresolved

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -82,7 +82,7 @@ impl Pass<'_> {
                 .binder
                 .node_typing(Self::string_expression_node_id(string_expression)),
             ir::Expression::ElementaryType(elementary_type) => {
-                Typing::MetaType(Self::type_of_elementary_type(elementary_type))
+                Typing::MetaType(self.type_of_elementary_type(elementary_type))
             }
             ir::Expression::Identifier(identifier) => self.typing_of_identifier(identifier),
             ir::Expression::PayableKeyword => Typing::MetaType(Type::Address { payable: true }),
@@ -91,23 +91,27 @@ impl Pass<'_> {
         }
     }
 
-    fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
+    fn type_of_elementary_type(&self, elementary_type: &ir::ElementaryType) -> Type {
         match elementary_type {
             ir::ElementaryType::AddressType(address_type) => Type::Address {
                 payable: address_type.payable_keyword,
             },
-            ir::ElementaryType::BytesKeyword(terminal) => {
-                Type::from_bytes_keyword(terminal.unparse(), Some(DataLocation::Memory)).unwrap()
+            ir::ElementaryType::BytesKeyword(terminal) => Type::from_bytes_keyword(
+                terminal.unparse(self.interner),
+                Some(DataLocation::Memory),
+            )
+            .unwrap(),
+            ir::ElementaryType::IntKeyword(terminal) => {
+                Type::from_int_keyword(terminal.unparse(self.interner))
             }
-            ir::ElementaryType::IntKeyword(terminal) => Type::from_int_keyword(terminal.unparse()),
             ir::ElementaryType::UintKeyword(terminal) => {
-                Type::from_uint_keyword(terminal.unparse())
+                Type::from_uint_keyword(terminal.unparse(self.interner))
             }
             ir::ElementaryType::FixedKeyword(terminal) => {
-                Type::from_fixed_keyword(terminal.unparse())
+                Type::from_fixed_keyword(terminal.unparse(self.interner))
             }
             ir::ElementaryType::UfixedKeyword(terminal) => {
-                Type::from_ufixed_keyword(terminal.unparse())
+                Type::from_ufixed_keyword(terminal.unparse(self.interner))
             }
             ir::ElementaryType::BoolKeyword => Type::Boolean,
             ir::ElementaryType::StringKeyword => Type::String {
@@ -543,12 +547,12 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn type_of_string_expression(node: &ir::StringExpression) -> Type {
+    pub(super) fn type_of_string_expression(&self, node: &ir::StringExpression) -> Type {
         let kind = match node {
             ir::StringExpression::StringLiterals(strings) => {
                 let size = strings.iter().fold(0usize, |acc, string| {
                     // TODO: consider escaped characters
-                    acc + string.unparse().len() - 2
+                    acc + string.unparse(self.interner).len() - 2
                 });
                 LiteralKind::String {
                     bytes: u32::try_from(size).unwrap(),
@@ -557,7 +561,7 @@ impl Pass<'_> {
             ir::StringExpression::HexStringLiterals(hex_strings) => {
                 let size = hex_strings.iter().fold(0usize, |acc, hex_string| {
                     // 5 is the length of the `hex` prefix plus the quotes
-                    acc + (hex_string.unparse().len() - 5) / 2
+                    acc + (hex_string.unparse(self.interner).len() - 5) / 2
                 });
                 LiteralKind::String {
                     bytes: u32::try_from(size).unwrap(),
@@ -567,7 +571,7 @@ impl Pass<'_> {
                 let size = unicode_strings.iter().fold(0usize, |acc, unicode_string| {
                     // TODO: actually parse the string
                     // 9 is the length of the `unicode` prefix plus quotes
-                    acc + unicode_string.unparse().len() - 9
+                    acc + unicode_string.unparse(self.interner).len() - 9
                 });
                 LiteralKind::String {
                     bytes: u32::try_from(size).unwrap(),
@@ -578,9 +582,10 @@ impl Pass<'_> {
     }
 
     pub(super) fn hex_number_literal_kind(
+        &self,
         hex_number_expression: &ir::HexNumberExpression,
     ) -> LiteralKind {
-        let hex_number = hex_number_expression.literal.unparse();
+        let hex_number = hex_number_expression.literal.unparse(self.interner);
         if hex_number.len() == 42 {
             // TODO(validation): verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -1,3 +1,4 @@
+use slang_solidity_v2_ir::interner::StringId;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 
 use super::Pass;
@@ -412,12 +413,12 @@ impl Pass<'_> {
     pub(super) fn collect_named_argument_typings(
         &self,
         arguments: &[ir::NamedArgument],
-    ) -> Vec<(String, Typing)> {
+    ) -> Vec<(StringId, Typing)> {
         arguments
             .iter()
             .map(|argument| {
                 (
-                    argument.name.unparse().to_string(),
+                    argument.name.string_id,
                     self.typing_of_expression(&argument.value),
                 )
             })

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -115,8 +115,9 @@ impl Visitor for Pass<'_> {
 
     fn enter_expression(&mut self, node: &ir::Expression) -> bool {
         if let ir::Expression::Identifier(identifier) = node {
-            let symbol = identifier.unparse();
-            let resolution = if symbol == "_" && self.is_in_modifier_scope() {
+            let symbol = identifier.string_id;
+            let resolution = if self.interner.resolve(symbol) == "_" && self.is_in_modifier_scope()
+            {
                 Resolution::BuiltIn(BuiltIn::ModifierUnderscore)
             } else {
                 let scope_id = self.current_scope_id();
@@ -317,7 +318,7 @@ impl Visitor for Pass<'_> {
         // typing information of the operand expression
         let operand_typing = self.typing_of_expression(&node.operand);
         let resolution = self.filter_overriden_definitions(
-            self.resolve_symbol_in_typing(&operand_typing, node.member.unparse()),
+            self.resolve_symbol_in_typing(&operand_typing, node.member.string_id),
         );
 
         // If the operand is either `this` or a contract/interface reference
@@ -477,8 +478,10 @@ impl Visitor for Pass<'_> {
     fn enter_call_options_expression(&mut self, node: &ir::CallOptionsExpression) -> bool {
         for option in &node.options {
             let identifier = &option.name;
-            let resolution =
-                crate::built_ins::BuiltInsResolver::lookup_call_option(identifier.unparse()).into();
+            let resolution = crate::built_ins::BuiltInsResolver::lookup_call_option(
+                self.interner.resolve(identifier.string_id),
+            )
+            .into();
             let reference = Reference::new(Rc::clone(identifier), resolution);
             self.binder.insert_reference(reference);
         }
@@ -497,13 +500,13 @@ impl Visitor for Pass<'_> {
 
         let scope_id = self.current_scope_id();
         let identifier = &items[0];
-        let resolution = self.resolve_symbol_in_yul_scope(scope_id, identifier.unparse());
+        let resolution = self.resolve_symbol_in_yul_scope(scope_id, identifier.string_id);
         let reference = Reference::new(Rc::clone(identifier), resolution.clone());
         self.binder.insert_reference(reference);
 
         if items.len() > 1 {
             let suffix = &items[1];
-            let resolution = self.resolve_yul_suffix(suffix.unparse(), &resolution);
+            let resolution = self.resolve_yul_suffix(suffix.string_id, &resolution);
             let reference = Reference::new(Rc::clone(suffix), resolution);
             self.binder.insert_reference(reference);
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -130,13 +130,13 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_hex_number_expression(&mut self, node: &ir::HexNumberExpression) {
-        let kind = Self::hex_number_literal_kind(node);
+        let kind = self.hex_number_literal_kind(node);
         let type_id = self.types.register_type(Type::Literal(kind));
         self.binder.set_node_type(node.id(), Some(type_id));
     }
 
     fn leave_decimal_number_expression(&mut self, node: &ir::DecimalNumberExpression) {
-        let type_ = if node.unit.is_none() && node.literal.unparse() == "0" {
+        let type_ = if node.unit.is_none() && node.literal.unparse(self.interner) == "0" {
             Type::Literal(LiteralKind::Zero)
         } else {
             Type::Literal(LiteralKind::DecimalInteger)
@@ -148,7 +148,7 @@ impl Visitor for Pass<'_> {
     fn leave_string_expression(&mut self, node: &ir::StringExpression) {
         let type_id = self
             .types
-            .register_type(Self::type_of_string_expression(node));
+            .register_type(self.type_of_string_expression(node));
         let node_id = Self::string_expression_node_id(node);
         self.binder.set_node_type(node_id, Some(type_id));
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -257,7 +257,7 @@ contract Test is Base {
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
     p3_type_definitions::run(&files, &mut binder, &mut types);
-    p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
+    p4_resolve_references::run(&files, &mut binder, &mut types, language_version, &interner);
 
     // Verify that references were created and most are resolved
     let references = binder.references();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -67,14 +67,14 @@ contract Test is Base layout at 0 {}
     assert_eq!(2, binder.linearisations().len());
 }
 
-fn get_contract_to_bases_map(binder: &Binder) -> HashMap<String, Vec<String>> {
+fn get_contract_to_bases_map(binder: &Binder, interner: &Interner) -> HashMap<String, Vec<String>> {
     let mut contract_to_bases = HashMap::new();
     for (key, values) in binder.linearisations() {
         let contract_name = binder
             .find_definition_by_id(*key)
             .unwrap()
             .identifier()
-            .unparse()
+            .unparse(interner)
             .to_string();
 
         let base_names: Vec<String> = values
@@ -84,7 +84,7 @@ fn get_contract_to_bases_map(binder: &Binder) -> HashMap<String, Vec<String>> {
                     .find_definition_by_id(*value)
                     .unwrap()
                     .identifier()
-                    .unparse()
+                    .unparse(interner)
                     .to_string()
             })
             .collect();
@@ -114,7 +114,7 @@ interface A is C {}
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
 
-    let contract_to_bases = get_contract_to_bases_map(&binder);
+    let contract_to_bases = get_contract_to_bases_map(&binder, &interner);
 
     let mut expected = HashMap::new();
     expected.insert(
@@ -154,7 +154,7 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
 
-    let contract_to_bases = get_contract_to_bases_map(&binder);
+    let contract_to_bases = get_contract_to_bases_map(&binder, &interner);
 
     let mut expected = HashMap::new();
     expected.insert("Base".to_string(), vec!["Base".to_string()]);
@@ -204,7 +204,7 @@ contract Test is Base {
     p2_linearise_contracts::run(&files, &mut binder);
 
     let types_before = types.iter_types().count();
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, &interner);
     let types_after = types.iter_types().count();
 
     // The pass registers new types for: contracts, mappings, structs, enums,
@@ -256,7 +256,7 @@ contract Test is Base {
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, &interner);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version, &interner);
 
     // Verify that references were created and most are resolved

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -6,27 +6,27 @@ use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
 use crate::binder::{Binder, Resolution};
-use crate::context::SemanticFile;
+use crate::context::{FileId, SemanticFile};
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
 use crate::types::TypeRegistry;
 
 struct TestFile {
-    id: String,
+    file_id: FileId,
     ir_root: ir::SourceUnit,
 }
 
 impl SemanticFile for TestFile {
-    fn id(&self) -> &str {
-        &self.id
+    fn file_id(&self) -> FileId {
+        self.file_id
     }
 
     fn ir_root(&self) -> &ir::SourceUnit {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&String> {
+    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<FileId> {
         None
     }
 }
@@ -40,10 +40,8 @@ fn build_file(name: &str, contents: &str, interner: &mut Interner) -> TestFile {
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
     let ir_root = ir::build(&source_unit, &contents, interner);
-    TestFile {
-        id: name.to_string(),
-        ir_root,
-    }
+    let file_id = interner.intern(name);
+    TestFile { file_id, ir_root }
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
@@ -30,7 +31,7 @@ impl SemanticFile for TestFile {
     }
 }
 
-fn build_file(name: &str, contents: &str) -> TestFile {
+fn build_file(name: &str, contents: &str, interner: &mut Interner) -> TestFile {
     let ParseOutput {
         source_unit,
         errors,
@@ -38,7 +39,7 @@ fn build_file(name: &str, contents: &str) -> TestFile {
 
     assert!(errors.is_empty(), "Parser errors: {errors:?}");
 
-    let ir_root = ir::build(&source_unit, &contents);
+    let ir_root = ir::build(&source_unit, &contents, interner);
     TestFile {
         id: name.to_string(),
         ir_root,
@@ -52,7 +53,8 @@ contract Base {}
 contract Test is Base layout at 0 {}
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut interner = Interner::default();
+    let file = build_file("test.sol", CONTENTS, &mut interner);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -104,7 +106,8 @@ abstract contract B is C {}
 interface A is C {}
 "#;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut interner = Interner::default();
+    let file = build_file("test.sol", CONTENTS, &mut interner);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -143,7 +146,8 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
 }
 "#;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut interner = Interner::default();
+    let file = build_file("test.sol", CONTENTS, &mut interner);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -189,7 +193,8 @@ contract Test is Base {
 }
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut interner = Interner::default();
+    let file = build_file("test.sol", CONTENTS, &mut interner);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -241,7 +246,8 @@ contract Test is Base {
 }
     "###;
 
-    let file = build_file("test.sol", CONTENTS);
+    let mut interner = Interner::default();
+    let file = build_file("test.sol", CONTENTS, &mut interner);
 
     let files = [file];
     let mut binder = Binder::default();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -75,33 +75,36 @@ impl<E, C: CompilationBuilderConfig<Error = E>> CompilationBuilder<E, C> {
     /// imported or not, to be able to query the definitions there.
     ///
     /// Adding a file that has already been added is a no-op.
-    pub fn add_file(&mut self, file_id: &str) -> Result<(), CompilationBuilderError<E>> {
-        if !self.seen_files.insert(file_id.into()) {
+    pub fn add_file(&mut self, id: &str) -> Result<(), CompilationBuilderError<E>> {
+        if !self.seen_files.insert(id.into()) {
             return Ok(());
         }
 
         let source = self
             .config
-            .read_file(file_id)
+            .read_file(id)
             .map_err(|err| CompilationBuilderError::UserError(err))?;
 
         if let Some(source) = source {
             // TODO(v2): move to a proper diagnostics API (reporter)
-            let AddFileResponse { import_paths } = self
+            let AddFileResponse {
+                file_id,
+                import_paths,
+            } = self
                 .internal
-                .add_file(file_id.into(), &source)
+                .add_file(id, &source)
                 .map_err(|err| CompilationBuilderError::ParserError(err))?;
 
             for (node_id, import_path) in import_paths {
                 let import_id = self
                     .config
-                    .resolve_import(file_id, &import_path)
+                    .resolve_import(id, &import_path)
                     .map_err(|err| CompilationBuilderError::UserError(err))?;
 
                 if let Some(import_id) = &import_id {
                     self.internal
-                        .resolve_import(file_id, node_id, import_id.clone())
-                        .unwrap_or_else(|_| panic!("{file_id} should have been added"));
+                        .resolve_import(file_id, node_id, import_id)
+                        .unwrap_or_else(|_| panic!("{id} should have been added"));
                     self.add_file(import_id)?;
                 }
             }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -1,38 +1,45 @@
 use std::collections::HashMap;
 
 use slang_solidity_v2_ir::ir::{self, NodeId};
-use slang_solidity_v2_semantic::context::SemanticFile;
+use slang_solidity_v2_semantic::context::{FileId, SemanticFile};
 
+#[allow(clippy::struct_field_names)]
 pub struct File {
     id: String,
+    file_id: FileId,
     ir_root: ir::SourceUnit,
-    resolved_imports: HashMap<NodeId, String>,
+    resolved_imports: HashMap<NodeId, FileId>,
 }
 
 impl File {
-    pub(crate) fn new(id: String, ir_root: ir::SourceUnit) -> Self {
+    pub(crate) fn new(id: String, file_id: FileId, ir_root: ir::SourceUnit) -> Self {
         Self {
             id,
+            file_id,
             ir_root,
             resolved_imports: HashMap::new(),
         }
     }
 
-    pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
+    pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: FileId) {
         self.resolved_imports.insert(node_id, target_file_id);
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
     }
 }
 
 impl SemanticFile for File {
-    fn id(&self) -> &str {
-        &self.id
+    fn file_id(&self) -> FileId {
+        self.file_id
     }
 
     fn ir_root(&self) -> &ir::SourceUnit {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String> {
-        self.resolved_imports.get(&node_id)
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<FileId> {
+        self.resolved_imports.get(&node_id).copied()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -5,7 +5,9 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_parser::{ParseOutput, Parser, ParserError};
-use slang_solidity_v2_semantic::context::{extract_import_paths_from_source_unit, SemanticContext};
+use slang_solidity_v2_semantic::context::{
+    extract_import_paths_from_source_unit, FileId, SemanticContext,
+};
 
 use super::file::File;
 use super::unit::CompilationUnit;
@@ -14,7 +16,7 @@ use super::unit::CompilationUnit;
 pub struct InternalCompilationBuilder {
     language_version: LanguageVersion,
     interner: Interner,
-    files: BTreeMap<String, File>,
+    files: BTreeMap<FileId, File>,
 }
 
 impl InternalCompilationBuilder {
@@ -28,12 +30,14 @@ impl InternalCompilationBuilder {
 
     pub fn add_file(
         &mut self,
-        id: String,
+        id: &str,
         contents: &str,
     ) -> Result<AddFileResponse, Vec<ParserError>> {
-        if self.files.contains_key(&id) {
+        let file_id = self.interner.intern(id);
+        if self.files.contains_key(&file_id) {
             // Already added. No need to process it again:
             return Ok(AddFileResponse {
+                file_id,
                 import_paths: vec![],
             });
         }
@@ -46,26 +50,33 @@ impl InternalCompilationBuilder {
         let source_unit = ir::build(&source_unit, &contents, &mut self.interner);
         let import_paths = extract_import_paths_from_source_unit(&source_unit, &self.interner);
 
-        let file = File::new(id.clone(), source_unit);
-        self.files.insert(id, file);
+        let file = File::new(id.to_string(), file_id, source_unit);
+        self.files.insert(file_id, file);
 
         if !errors.is_empty() {
             return Err(errors);
         }
 
-        Ok(AddFileResponse { import_paths })
+        Ok(AddFileResponse {
+            file_id,
+            import_paths,
+        })
     }
 
     pub fn resolve_import(
         &mut self,
-        source_file_id: &str,
+        source_file_id: FileId,
         node_id: NodeId,
-        destination_file_id: String,
+        destination_file: &str,
     ) -> Result<(), ResolveImportError> {
         self.files
-            .get_mut(source_file_id)
-            .ok_or_else(|| ResolveImportError::SourceFileNotFound(source_file_id.to_owned()))?
-            .add_resolved_import(node_id, destination_file_id);
+            .get_mut(&source_file_id)
+            .ok_or_else(|| {
+                ResolveImportError::SourceFileNotFound(
+                    self.interner.resolve(source_file_id).to_owned(),
+                )
+            })?
+            .add_resolved_import(node_id, self.interner.intern(destination_file));
 
         Ok(())
     }
@@ -81,6 +92,7 @@ impl InternalCompilationBuilder {
 
 #[doc(hidden)]
 pub struct AddFileResponse {
+    pub file_id: FileId,
     pub import_paths: Vec<(NodeId, String)>,
 }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -44,7 +44,7 @@ impl InternalCompilationBuilder {
         } = Parser::parse(contents, self.language_version);
 
         let source_unit = ir::build(&source_unit, &contents, &mut self.interner);
-        let import_paths = extract_import_paths_from_source_unit(&source_unit);
+        let import_paths = extract_import_paths_from_source_unit(&source_unit, &self.interner);
 
         let file = File::new(id.clone(), source_unit);
         self.files.insert(id, file);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_parser::{ParseOutput, Parser, ParserError};
 use slang_solidity_v2_semantic::context::{extract_import_paths_from_source_unit, SemanticContext};
@@ -12,6 +13,7 @@ use super::unit::CompilationUnit;
 #[doc(hidden)]
 pub struct InternalCompilationBuilder {
     language_version: LanguageVersion,
+    interner: Interner,
     files: BTreeMap<String, File>,
 }
 
@@ -19,6 +21,7 @@ impl InternalCompilationBuilder {
     pub fn create(language_version: LanguageVersion) -> Self {
         Self {
             language_version,
+            interner: Interner::new(),
             files: BTreeMap::new(),
         }
     }
@@ -40,7 +43,7 @@ impl InternalCompilationBuilder {
             errors,
         } = Parser::parse(contents, self.language_version);
 
-        let source_unit = ir::build(&source_unit, &contents);
+        let source_unit = ir::build(&source_unit, &contents, &mut self.interner);
         let import_paths = extract_import_paths_from_source_unit(&source_unit);
 
         let file = File::new(id.clone(), source_unit);
@@ -71,7 +74,12 @@ impl InternalCompilationBuilder {
         let files: Vec<File> = self.files.into_values().collect();
         let semantic = SemanticContext::build_from(self.language_version, &files);
 
-        CompilationUnit::create(self.language_version, files, Rc::new(semantic))
+        CompilationUnit::create(
+            self.language_version,
+            files,
+            Rc::new(semantic),
+            Rc::new(self.interner),
+        )
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -72,14 +72,10 @@ impl InternalCompilationBuilder {
 
     pub fn build(self) -> CompilationUnit {
         let files: Vec<File> = self.files.into_values().collect();
-        let semantic = SemanticContext::build_from(self.language_version, &files);
+        let interner = Rc::new(self.interner);
+        let semantic = SemanticContext::build_from(self.language_version, &files, &interner);
 
-        CompilationUnit::create(
-            self.language_version,
-            files,
-            Rc::new(semantic),
-            Rc::new(self.interner),
-        )
+        CompilationUnit::create(self.language_version, files, Rc::new(semantic), interner)
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -24,7 +24,7 @@ impl CompilationUnit {
     ) -> Self {
         let files: BTreeMap<String, Rc<File>> = files
             .into_iter()
-            .map(|file| (file.id().to_string(), Rc::new(file)))
+            .map(|file| (interner.resolve(file.file_id()).to_string(), Rc::new(file)))
             .collect();
         Self {
             language_version,

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -3,12 +3,14 @@ use std::rc::Rc;
 
 use slang_solidity_v2_ast::{abi, ast};
 use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
 
 use super::file::File;
 
 pub struct CompilationUnit {
     language_version: LanguageVersion,
+    interner: Rc<Interner>,
     files: BTreeMap<String, Rc<File>>,
     semantic: Rc<SemanticContext>,
 }
@@ -18,6 +20,7 @@ impl CompilationUnit {
         language_version: LanguageVersion,
         files: Vec<File>,
         semantic: Rc<SemanticContext>,
+        interner: Rc<Interner>,
     ) -> Self {
         let files: BTreeMap<String, Rc<File>> = files
             .into_iter()
@@ -25,6 +28,7 @@ impl CompilationUnit {
             .collect();
         Self {
             language_version,
+            interner,
             files,
             semantic,
         }
@@ -43,6 +47,10 @@ impl CompilationUnit {
     /// Returns the file with the specified ID, if it exists.
     pub fn file(&self, id: &str) -> Option<Rc<File>> {
         self.files.get(id).cloned()
+    }
+
+    pub fn interner(&self) -> &Interner {
+        &self.interner
     }
 
     // TODO: this should be semi-public

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
@@ -7,7 +7,7 @@ use ariadne::{Color, Config, Label, Report, ReportBuilder, ReportKind, Source};
 use slang_solidity_v2_ir::ir::NodeId;
 use slang_solidity_v2_parser::ParserError;
 use slang_solidity_v2_semantic::binder::Resolution;
-use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
+use slang_solidity_v2_semantic::context::SemanticContext;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use super::report_data::{

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use std::ops::Range;
 
 use slang_solidity_v2::compilation::unit::CompilationUnit;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2_ir::ir::{Identifier, NodeId};
 use slang_solidity_v2_parser::ParserError;
@@ -84,6 +85,7 @@ impl<'a> ReportData<'a> {
 
 struct IdentifierCollector<'a> {
     identifiers: Vec<CollectedIdentifier>,
+    interner: &'a Interner,
     current_file: Option<(&'a String, &'a String)>,
 }
 
@@ -94,7 +96,7 @@ impl Visitor for IdentifierCollector<'_> {
             file_id: self.current_file_id(),
             node_id: node.id(),
             range: node.range.clone(),
-            text: node.text.clone(),
+            text: node.unparse(self.interner).to_owned(),
             line,
             column,
         });
@@ -140,6 +142,7 @@ fn collect_all_identifiers(
 ) -> Vec<CollectedIdentifier> {
     let mut collector = IdentifierCollector {
         identifiers: Vec::new(),
+        interner: compilation.interner(),
         current_file: None,
     };
 
@@ -421,8 +424,8 @@ impl CollectedDefinitionDisplay<'_> {
             .find_definition_by_id(definition_id)
             .unwrap()
             .identifier()
-            .text
-            .clone()
+            .unparse(self.semantic.interner())
+            .to_string()
     }
 }
 

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -8,6 +8,7 @@ use iai_callgrind::{
 };
 use paste::paste;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
@@ -52,16 +53,16 @@ macro_rules! slang_v2_define_tests {
             #[bench::test(stringify!($prj))]
             // Note: the input CST source units are consumed (dropped) during IR building.
             // This is the intended use case: the CST is replaced by the IR representation.
-            pub fn [< $prj _ir_builder >]((project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>)) -> Vec<ir::SourceUnit> {
+            pub fn [< $prj _ir_builder >]((project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>)) -> (Interner, Vec<ir::SourceUnit>) {
                 black_box(tests::slang_v2::ir_builder::run(black_box(project), black_box(source_units)))
             }
 
             #[library_benchmark(setup = tests::slang_v2::semantic::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _semantic >](
-                (project, input_files): (&'static SolidityProject, Vec<tests::slang_v2::semantic::File>),
+                (project, interner, input_files): (&'static SolidityProject, Interner, Vec<tests::slang_v2::semantic::File>),
             ) -> SemanticContext {
-                black_box(tests::slang_v2::semantic::run(black_box(project), black_box(input_files)))
+                black_box(tests::slang_v2::semantic::run(black_box(project), black_box(interner), black_box(input_files)))
             }
 
             library_benchmark_group!(

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -66,7 +66,8 @@ mod unit_tests {
         fn ir_builder() {
             let (project, source_units) =
                 crate::tests::slang_v2::ir_builder::setup(super::PROJECT_TO_TEST);
-            let ir_source_units = crate::tests::slang_v2::ir_builder::test(project, source_units);
+            let (_, ir_source_units) =
+                crate::tests::slang_v2::ir_builder::test(project, source_units);
             let ir_contract_count =
                 crate::tests::slang_v2::ir_builder::count_contracts(&ir_source_units);
             assert_eq!(ir_contract_count, super::CONTRACT_COUNT);
@@ -74,9 +75,10 @@ mod unit_tests {
 
         #[test]
         fn semantic() {
-            let (project, input_files) =
+            let (project, interner, input_files) =
                 crate::tests::slang_v2::semantic::setup(super::PROJECT_TO_TEST);
-            let semantic_context = crate::tests::slang_v2::semantic::test(project, input_files);
+            let semantic_context =
+                crate::tests::slang_v2::semantic::test(project, interner, input_files);
             let semantic_contract_count =
                 crate::tests::slang_v2::semantic::count_contracts(&semantic_context);
             assert_eq!(semantic_contract_count, super::CONTRACT_COUNT);

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit as InputSourceUnit;
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, SourceUnit, SourceUnitMember};
 
 use crate::dataset::SolidityProject;
@@ -20,6 +21,7 @@ pub fn test(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
 ) -> Vec<SourceUnit> {
+    let mut interner = Interner::new();
     let mut ir_source_units = Vec::new();
     for (name, source) in sources {
         ir_source_units.push(ir::build(
@@ -28,6 +30,7 @@ pub fn test(
                 .sources
                 .get(&name)
                 .expect("Source not found in project"),
+            &mut interner,
         ));
     }
     ir_source_units

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -13,14 +13,14 @@ pub fn setup(project: &str) -> (&'static SolidityProject, Vec<(String, InputSour
 pub fn run(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
-) -> Vec<SourceUnit> {
+) -> (Interner, Vec<SourceUnit>) {
     test(project, sources)
 }
 
 pub fn test(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
-) -> Vec<SourceUnit> {
+) -> (Interner, Vec<SourceUnit>) {
     let mut interner = Interner::new();
     let mut ir_source_units = Vec::new();
     for (name, source) in sources {
@@ -33,7 +33,7 @@ pub fn test(
             &mut interner,
         ));
     }
-    ir_source_units
+    (interner, ir_source_units)
 }
 
 pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::{
@@ -34,11 +35,11 @@ impl SemanticFile for File {
     }
 }
 
-pub fn setup(project: &str) -> (&'static SolidityProject, Vec<File>) {
+pub fn setup(project: &str) -> (&'static SolidityProject, Interner, Vec<File>) {
     let (project, sources) = super::ir_builder::setup(project);
-    let ir_source_units = super::ir_builder::test(project, sources);
+    let (interner, ir_source_units) = super::ir_builder::test(project, sources);
     let files = build_files(project, ir_source_units);
-    (project, files)
+    (project, interner, files)
 }
 
 pub fn build_files(
@@ -68,13 +69,21 @@ pub fn build_files(
         .collect()
 }
 
-pub fn run(project: &'static SolidityProject, files: Vec<File>) -> SemanticContext {
-    test(project, files)
+pub fn run(
+    project: &'static SolidityProject,
+    interner: Interner,
+    files: Vec<File>,
+) -> SemanticContext {
+    test(project, interner, files)
 }
 
-pub fn test(project: &'static SolidityProject, files: Vec<impl SemanticFile>) -> SemanticContext {
+pub fn test(
+    project: &'static SolidityProject,
+    interner: Interner,
+    files: Vec<impl SemanticFile>,
+) -> SemanticContext {
     let language_version = super::parser::parse_version(project);
-    SemanticContext::build_from(language_version, &files)
+    SemanticContext::build_from(language_version, &files, &interner)
 }
 
 pub fn count_contracts(semantic: &SemanticContext) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -5,65 +5,66 @@ use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::{
-    extract_import_paths_from_source_unit, SemanticContext, SemanticFile,
+    extract_import_paths_from_source_unit, FileId, SemanticContext, SemanticFile,
 };
 
 use crate::dataset::SolidityProject;
 
 pub struct File {
-    id: String,
+    id: FileId,
     ir_root: ir::SourceUnit,
-    resolved_imports: HashMap<NodeId, String>,
+    resolved_imports: HashMap<NodeId, FileId>,
 }
 
 impl File {
-    pub fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
+    pub fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: FileId) {
         self.resolved_imports.insert(node_id, target_file_id);
     }
 }
 
 impl SemanticFile for File {
-    fn id(&self) -> &str {
-        &self.id
+    fn file_id(&self) -> FileId {
+        self.id
     }
 
     fn ir_root(&self) -> &ir::SourceUnit {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, node_id: ir::NodeId) -> Option<&String> {
-        self.resolved_imports.get(&node_id)
+    fn resolved_import_by_node_id(&self, node_id: ir::NodeId) -> Option<FileId> {
+        self.resolved_imports.get(&node_id).copied()
     }
 }
 
 pub fn setup(project: &str) -> (&'static SolidityProject, Interner, Vec<File>) {
     let (project, sources) = super::ir_builder::setup(project);
-    let (interner, ir_source_units) = super::ir_builder::test(project, sources);
-    let files = build_files(project, ir_source_units, &interner);
+    let (mut interner, ir_source_units) = super::ir_builder::test(project, sources);
+    let files = build_files(project, ir_source_units, &mut interner);
     (project, interner, files)
 }
 
 pub fn build_files(
     project: &'static SolidityProject,
     ir_source_units: Vec<ir::SourceUnit>,
-    interner: &Interner,
+    interner: &mut Interner,
 ) -> Vec<File> {
     ir_source_units
         .into_iter()
         .zip(project.sources.keys())
-        .map(|(ir_root, file_id)| {
+        .map(|(ir_root, source_id)| {
+            let file_id = interner.intern(source_id);
             let import_paths = extract_import_paths_from_source_unit(&ir_root, interner);
             let resolved_imports = import_paths
                 .iter()
                 .filter_map(|(node_id, import_path)| {
                     let resolved_file_id = project
                         .import_resolver
-                        .resolve_import(file_id, import_path)?;
-                    Some((*node_id, resolved_file_id))
+                        .resolve_import(source_id, import_path)?;
+                    Some((*node_id, interner.intern(&resolved_file_id)))
                 })
                 .collect();
             File {
-                id: file_id.to_owned(),
+                id: file_id,
                 ir_root,
                 resolved_imports,
             }

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use slang_solidity_v2_ir::interner::Interner;
 use slang_solidity_v2_ir::ir::{self, NodeId};
@@ -38,19 +39,20 @@ impl SemanticFile for File {
 pub fn setup(project: &str) -> (&'static SolidityProject, Interner, Vec<File>) {
     let (project, sources) = super::ir_builder::setup(project);
     let (interner, ir_source_units) = super::ir_builder::test(project, sources);
-    let files = build_files(project, ir_source_units);
+    let files = build_files(project, ir_source_units, &interner);
     (project, interner, files)
 }
 
 pub fn build_files(
     project: &'static SolidityProject,
     ir_source_units: Vec<ir::SourceUnit>,
+    interner: &Interner,
 ) -> Vec<File> {
     ir_source_units
         .into_iter()
         .zip(project.sources.keys())
         .map(|(ir_root, file_id)| {
-            let import_paths = extract_import_paths_from_source_unit(&ir_root);
+            let import_paths = extract_import_paths_from_source_unit(&ir_root, interner);
             let resolved_imports = import_paths
                 .iter()
                 .filter_map(|(node_id, import_path)| {
@@ -83,7 +85,7 @@ pub fn test(
     files: Vec<impl SemanticFile>,
 ) -> SemanticContext {
     let language_version = super::parser::parse_version(project);
-    SemanticContext::build_from(language_version, &files, &interner)
+    SemanticContext::build_from(language_version, &files, &Rc::new(interner))
 }
 
 pub fn count_contracts(semantic: &SemanticContext) -> usize {


### PR DESCRIPTION
Applies on top of #1597

This PR implements interning for the strings of terminals and file IDs used inside the semantic crate. This should improve performance of the binder for the small price of adding a field to all identifiers in the IR.
