### PR TITLE
ci: add Rust build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,12 @@ jobs:
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
           persist-credentials: false
+          # Full history is needed by git-restore-mtime below to find each file's last commit time.
           fetch-depth: 0
 
+      # git checkout sets all file mtimes to "now", which invalidates cached cargo fingerprints
+      # and causes unnecessary recompilation. This restores mtimes to each file's last commit time,
+      # so unchanged files match the cached fingerprints and cargo skips recompilation.
       - name: "Restore file mtimes from git"
         uses: "chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3" # v2.3
 


### PR DESCRIPTION
I've also increased Slang repo cache to 30GB for now. Can probably decrease it later, but let's leave some space to assess how the cache actually grows. 


## Summary

  - Cache compiled Rust `target/` artifacts across CI runs using `actions/cache`
  - Restore file mtimes after checkout using `git-restore-mtime-action` so cargo fingerprints match cached artifacts
  - Cache is saved on `main` only, restored on PR branches via `restore-keys` prefix matching

  ## How it works

  `actions/checkout` sets all file mtimes to "now", which invalidates cargo's fingerprint cache and forces full
  recompilation on every run. `git-restore-mtime-action` walks git history and resets each file's mtime to its last
  commit time, so unchanged files match the cached fingerprints.

  The cache uses `Cargo.lock` hash as the primary key with a prefix fallback, so lock file changes get a fresh cache
  while still benefiting from partial hits.

  Requires `fetch-depth: 0` (full clone) so the mtime action has enough history to work with.


  ### Why not rust-cache?

  We evaluated Swatinem/rust-cache across 8 commits on this branch and couldn't get it to meaningfully cache compiled
  artifacts:

  - cache-targets: true (default) — aggressively cleans target/, stripping dependency artifacts. All 464 crates still
  recompiled on every cache hit.
  - cache-targets: false — despite the name, this excludes target/ from the cache entirely rather than disabling
  cleanup. So nothing was cached at all.
  - Missing await bug — rust-cache's cleanup tries to opendir paths like target/tests/target, but the async call is
  missing an await, so the ENOENT escapes the try-catch and produces ##[error] annotations on every run. Required a
  mkdir -p workaround.
  - Hermit overlap — rust-cache's registry/git caching is redundant since the existing Hermit cache already handles
  ~/.cargo/registry/ and ~/.cargo/git/.

  ## Results

  Comparison of a typical PR run before and after this change:

  | Step | Before | After | Reduction |
  |------|--------|-------|-----------|
  | **infra check** | 464 crates / ~5m 13s | 5 crates / ~45s | 99% fewer compilations |
  | **infra test** | 331 crates / ~9m 25s | 17 crates / ~4m | 95% fewer compilations |
  | **infra lint** | 68 crates / ~2m 22s | 1 crate / ~1m 45s | 99% fewer compilations |
  | **Total** | ~18m 42s | ~8m 19s | **~10 min faster** |

  Before: [run 23431644468](https://github.com/NomicFoundation/slang/actions/runs/23431644468)
  After: [run 23440692140](https://github.com/NomicFoundation/slang/actions/runs/23440692140/job/68190486131?pr=1565)

  ## Test plan

 - [x] First run: check "Save Cargo Target Cache" step saves successfully (expect 500 MB–2 GB compressed) -> 3.2GB
  - [x] Verified cache restore + mtime fix reduces recompilation from ~863 to ~23 crates
  - [x] Cache is only saved on `main` pushes, not on PR branches
  - [x] Both `target/` and `crates/infra/cli/target/` are cached