### PR TITLE
ci: add dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "cargo"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "github-actions"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -29,7 +29,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "npm"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -40,7 +40,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "pip"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7


### PR DESCRIPTION
Based on existing Dependabot config in solx, see https://github.com/NomicFoundation/solx/blob/main/.github/dependabot.yml

Enable Dependabot version updates for cargo, github-actions, and npm ecosystems.

Should wait with merging until https://github.com/NomicFoundation/slang/pull/1544 is in.

We probably want to wait until CI dry-runs are implemented, see:
* https://github.com/NomicFoundation/slang/pull/1583 
* https://github.com/NomicFoundation/slang/pull/1571 
* https://github.com/NomicFoundation/slang/pull/1591

This should make dependabot PR testing much easier.