### PR TITLE
ci: add workflow-level permissions to all workflow files

### DIFF
--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: "read"
+
 # Queue up benchmark workflows for the same branch, so that results are reported in order:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: "read"
+
 # Queue up benchmark workflows for the same branch, so that results are reported in order:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: "read"
+
 # Queue up benchmark workflows for the same branch, so that results are reported in order:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: "read"
+
 # In the event that there is a new push to the ref, cancel any running jobs because they are now obsolete, wasting resources.
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref_name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: "read"
+
 # Wait for any other publish workflows in-progress to complete, before starting a new one:
 concurrency:
   group: "${{ github.workflow }}"

--- a/.github/workflows/sourcify_all_chains.yml
+++ b/.github/workflows/sourcify_all_chains.yml
@@ -18,6 +18,10 @@ on:
           - "v1"
           - "v2"
           - "compare"
+
+permissions:
+  contents: "read"
+
 jobs:
   run_tests:
     uses: "./.github/workflows/sourcify_single_chain.yml"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -42,6 +42,10 @@ on:
         type: "string"
         required: false
         default: null
+
+permissions:
+  contents: "read"
+
 jobs:
   buildSlang:
     runs-on: "ubuntu-22.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)


### PR DESCRIPTION
Restrict default token permissions to contents: read across all 7 workflow files, following the principle of least privilege. Job-level permissions (e.g. in publish.yml) override where broader access is needed.