### PR TITLE
Slang/publish dry run and trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,8 +158,11 @@ jobs:
       - name: "infra publish cargo --dry-run"
         run: "./scripts/bin/infra publish cargo --dry-run"
 
-      - name: "Verify mike"
-        run: "./bin/python3 -m pipenv run mike --version"
+      - name: "infra publish mkdocs --dry-run"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          ./scripts/bin/infra publish mkdocs --target main-branch --dry-run
 
       - name: "PR: publish summary"
         if: "github.event_name == 'pull_request'"


### PR DESCRIPTION
Restructure the Slang publish workflow from a single monolithic job into a multi-job DAG with PR dry-run support and an environment approval gate.

I've added a `slang-release` environment to the publish step and added it to GitHub settings accordingly (gated to Slang team, no-self review, 15 minute timer).

Added `PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL` to secrets. This will end up in #publishing-notifications. See the successful test message sent.

Still TODO in a follow up PR:
* upload/download artefact flow to stop the `publish:` part of the workflow from building Rust code.
* Split out build/review into two stages.

### Changes

- **Build & validate on every trigger**: Every PR and push exercises the full build-and-validate pipeline (WASM build, cargo/npm dry-run). PRs additionally get a summary in the GitHub Actions step summary.
- **Environment gate**: Real publishing requires manual approval via the `slang-release` GitHub environment
- **Multi-job workflow**: Split into `repo-check` → `changesets` → `build-and-validate` → `notify-deploy` → `publish`
- **Zero-permission baseline**: `permissions: {}` at the top level, each job declares only what it needs
- **Fork detection**: `repo-check` compares `head.repo.full_name` against `github.repository` (works for PRs, unlike hardcoded repo name)
- **Explicit conditions**: Every job has an explicit `if` — no job relies on implicit skip propagation from `needs`. The one exception is `build-and-validate`, which uses `!cancelled()` to override skip propagation from `changesets` (skipped on PRs)
- **Slack notifications**: "Review requested" fires after build validation (before approval gate), "Deployment starting" fires after approval — both post to #publishing-notifications, matching solx/edr pattern

### Execution paths

```
Trigger          repo-check  changesets        build-and-validate  notify-deploy  publish
───────────────  ──────────  ────────────────  ──────────────────  ─────────────  ───────
PR               ✓ gate      ⊘ skip (no push)  ✓ validate          ⊘ skip          ⊘ skip
push (pending)   ✓ gate      ✓ has changesets   ✓ validate          ⊘ skip          ⊘ skip
push (release)   ✓ gate      ✓ no changesets    ✓ validate          ✓ notify        ✓ publish
```

- `changesets` only runs for push/dispatch; skipped for PRs
- `build-and-validate` runs on every trigger — builds WASM and dry-run publishes npm/cargo. On PRs, also posts a summary to the GitHub Actions step summary.
- `notify-deploy` and `publish` require: not a PR, and no pending changesets (i.e., version-bump PR was merged)
- `publish` sends Slack "Deployment starting" after environment approval, then publishes npm/cargo/GitHub release

### Notes

- The existing changeset stash/pop pattern is unchanged
- Each job runs its own `infra setup`, so the publish path does setup twice (changesets + publish). This is a trade-off of multi-job workflows until we implement download/upload artefacts
- `cargo publish --dry-run` and `pnpm publish --dry-run` skip when the local version matches the already-published version, so on PRs the WASM build is the primary validation
- Done: Requires creating a `slang-release` environment in the GitHub repo settings with required reviewers

### Test plan

- [x] Create a PR → verify build-and-validate runs, summary appears, no publishing
- [x] Ad-hoc: temporarily modify workflow to send a test Slack notification during a PR dry-run