### PR TITLE
[WIP]Fix black_box on benchmarks

### DIFF
--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -1,12 +1,15 @@
 #![allow(clippy::exit)]
 
 use std::hint::black_box;
+use std::rc::Rc;
 
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, Direction, FlamegraphConfig,
     LibraryBenchmarkConfig, Tool, ValgrindTool,
 };
 use paste::paste;
+use slang_solidity::compilation::CompilationUnit;
+use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::{tests, tests_v2};
 
@@ -25,8 +28,8 @@ macro_rules! slang_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<slang_ $prj>](project: &SolidityProject) {
-                black_box(tests::parser::run(project));
+            pub fn [<slang_ $prj>](project: &SolidityProject) -> Rc<CompilationUnit> {
+                black_box(tests::parser::run(black_box(project)))
             }
         }
     };
@@ -38,7 +41,7 @@ macro_rules! solar_test {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [<solar_ $prj>](project: &SolidityProject) {
-                black_box(tests::solar_parser::run(project));
+                black_box(tests::solar_parser::run(black_box(project)));
             }
         }
     };
@@ -49,8 +52,8 @@ macro_rules! tree_sitter_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<tree_sitter_ $prj>](project: &SolidityProject) {
-                black_box(tests::tree_sitter_parser::run(project));
+            pub fn [<tree_sitter_ $prj>](project: &SolidityProject) -> Vec<tree_sitter::Tree> {
+                black_box(tests::tree_sitter_parser::run(black_box(project)))
             }
         }
     };
@@ -61,8 +64,8 @@ macro_rules! slang_v2_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<slang_v2_ $prj>](project: &SolidityProject) {
-                black_box(tests_v2::parser::run(project));
+            pub fn [<slang_v2_ $prj>](project: &SolidityProject) -> Vec<SourceUnit> {
+                black_box(tests_v2::parser::run(black_box(project)))
             }
         }
     };

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -38,31 +38,31 @@ macro_rules! slang_define_full_tests {
             #[library_benchmark(setup = tests::parser::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _parser >](project: &SolidityProject) -> Rc<CompilationUnit> {
-                black_box(tests::parser::run(project))
+                black_box(tests::parser::run(black_box(project)))
             }
 
             #[library_benchmark(setup = tests::cursor::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _cursor >](unit: Rc<CompilationUnit>) -> Rc<CompilationUnit> {
-                black_box(tests::cursor::run(unit))
+                black_box(tests::cursor::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::query::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _query >](unit: Rc<CompilationUnit>) -> Rc<CompilationUnit> {
-                black_box(tests::query::run(unit))
+                black_box(tests::query::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::bindings_build::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _bindings_build >](unit: Rc<CompilationUnit>) -> BuiltBindingGraph {
-                black_box(tests::bindings_build::run(unit))
+                black_box(tests::bindings_build::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::bindings_resolve::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _bindings_resolve >](unit: BuiltBindingGraph) -> BuiltBindingGraph {
-                black_box(tests::bindings_resolve::run(unit))
+                black_box(tests::bindings_resolve::run(black_box(unit)))
             }
 
             // We add a cleanup phase to measure the destruction of the AST and the binding structures
@@ -75,7 +75,7 @@ macro_rules! slang_define_full_tests {
             #[library_benchmark(setup = tests::binder_v2_run::setup)]
             #[bench::test(stringify!($prj))]
             fn [< $prj _binder_v2_run >](unit: Rc<CompilationUnit>) -> BuiltSemanticAnalysis {
-                black_box(tests::binder_v2_run::run(unit))
+                black_box(tests::binder_v2_run::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::binder_v2_cleanup::setup)]

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -8,6 +8,7 @@ use iai_callgrind::{
 };
 use paste::paste;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
+use slang_solidity_v2_semantic::ir;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests_v2;
 
@@ -33,14 +34,14 @@ macro_rules! slang_v2_define_tests {
         paste! {
             #[library_benchmark(setup = tests_v2::parser::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [< $prj _parser >](project: &SolidityProject) {
-                black_box(tests_v2::parser::run(project))
+            pub fn [< $prj _parser >](project: &SolidityProject) -> Vec<SourceUnit> {
+                black_box(tests_v2::parser::run(black_box(project)))
             }
 
             #[library_benchmark(setup = tests_v2::ir_builder::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [< $prj _ir_builder >](source_units: Vec<SourceUnit>) {
-                black_box(tests_v2::ir_builder::run(source_units))
+            pub fn [< $prj _ir_builder >](source_units: Vec<SourceUnit>) -> Vec<ir::SourceUnit> {
+                black_box(tests_v2::ir_builder::run(black_box(source_units)))
             }
 
 

--- a/crates/solidity/testing/perf/cargo/src/tests/solar_parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/solar_parser.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::path::PathBuf;
 
 use solar::ast::{self};
@@ -42,6 +43,10 @@ fn go(project: &SolidityProject, count: bool) -> usize {
 
             if count {
                 result += unit.count_contracts();
+            } else {
+                // Since it's more annoying to recover the parsed tree from the session
+                // we black box it here to prevent the compiler from optimizing it away.
+                black_box(&unit);
             }
         }
 

--- a/crates/solidity/testing/perf/cargo/src/tests/tree_sitter_parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/tree_sitter_parser.rs
@@ -3,34 +3,41 @@ use tree_sitter::{Parser, Query, QueryCursor};
 
 use crate::dataset::SolidityProject;
 
-pub fn run(project: &SolidityProject) {
-    go(project, false);
+pub fn run(project: &SolidityProject) -> Vec<tree_sitter::Tree> {
+    go(project, Vec::new(), |mut trees, _source, tree| {
+        trees.push(tree);
+        trees
+    })
 }
 
 pub fn test(project: &SolidityProject) -> usize {
-    go(project, true)
+    go(project, 0, |count, source, tree| {
+        count + count_definitions(source, tree)
+    })
 }
 
-fn go(project: &SolidityProject, count: bool) -> usize {
+fn go<T>(
+    project: &SolidityProject,
+    init: T,
+    mut fold: impl FnMut(T, &String, tree_sitter::Tree) -> T,
+) -> T {
     let mut parser = Parser::new();
     let language = &tree_sitter_solidity::LANGUAGE.into();
     parser
         .set_language(language)
         .expect("Error loading Solidity parser");
 
-    let mut result = 0;
+    let mut acc = init;
     for source in project.sources.values() {
         let tree = parser.parse(source, None).unwrap();
         let root_node = tree.root_node();
         assert!(!root_node.has_error());
         assert_eq!(root_node.kind(), "source_file");
 
-        if count {
-            result += count_definitions(source, tree);
-        }
+        acc = fold(acc, source, tree);
     }
 
-    result
+    acc
 }
 
 fn count_definitions(source: &String, tree: tree_sitter::Tree) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests_v2/ir_builder.rs
@@ -5,16 +5,16 @@ pub fn setup(project: &str) -> Vec<InputSourceUnit> {
     super::parser::test(super::parser::setup(project))
 }
 
-pub fn run(input: Vec<InputSourceUnit>) {
-    test(input);
-}
-
-pub fn test(input: Vec<InputSourceUnit>) -> Vec<SourceUnit> {
+pub fn run(input: Vec<InputSourceUnit>) -> Vec<SourceUnit> {
     let mut ir_source_units = Vec::new();
     for source in input {
         ir_source_units.push(ir::build(&source));
     }
     ir_source_units
+}
+
+pub fn test(input: Vec<InputSourceUnit>) -> Vec<SourceUnit> {
+    run(input)
 }
 
 pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests_v2/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests_v2/parser.rs
@@ -9,11 +9,7 @@ pub fn setup(project: &str) -> &'static SolidityProject {
     crate::tests::setup::setup(project)
 }
 
-pub fn run(project: &SolidityProject) {
-    test(project);
-}
-
-pub fn test(project: &SolidityProject) -> Vec<SourceUnit> {
+pub fn run(project: &SolidityProject) -> Vec<SourceUnit> {
     let lang_version = parse_version(project);
     let mut source_units = Vec::new();
     for source in project.sources.values() {
@@ -23,6 +19,10 @@ pub fn test(project: &SolidityProject) -> Vec<SourceUnit> {
     assert!(!source_units.is_empty());
 
     source_units
+}
+
+pub fn test(project: &SolidityProject) -> Vec<SourceUnit> {
+    run(project)
 }
 
 pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {


### PR DESCRIPTION
This PR addresses this comment https://github.com/NomicFoundation/slang/pull/1572#discussion_r3000471639 (and similar ones). It makes sure that every function being benchmarked has its arguments and its result wrapped around `black_box`, to avoid any optimizations to skew results.

## Testing
- [ ] comparison benchmark run https://github.com/NomicFoundation/slang/actions/runs/23648845399
- [ ] slang benchmark run https://github.com/NomicFoundation/slang/actions/runs/23648873848