### PR TITLE
Fix black_box on benchmarks

### DIFF
--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -1,12 +1,15 @@
 #![allow(clippy::exit)]
 
 use std::hint::black_box;
+use std::rc::Rc;
 
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, Direction, FlamegraphConfig,
     LibraryBenchmarkConfig, Tool, ValgrindTool,
 };
 use paste::paste;
+use slang_solidity::compilation::CompilationUnit;
+use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -34,8 +37,8 @@ macro_rules! slang_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<slang_ $prj>](project: &SolidityProject) {
-                black_box(tests::slang::parser::run(project));
+            pub fn [<slang_ $prj>](project: &SolidityProject) -> Rc<CompilationUnit> {
+                black_box(tests::slang::parser::run(black_box(project)))
             }
         }
     };
@@ -47,7 +50,7 @@ macro_rules! solar_test {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [<solar_ $prj>](project: &SolidityProject) {
-                black_box(tests::solar::parser::run(project));
+                black_box(tests::solar::parser::run(black_box(project)));
             }
         }
     };
@@ -58,8 +61,8 @@ macro_rules! tree_sitter_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<tree_sitter_ $prj>](project: &SolidityProject) {
-                black_box(tests::tree_sitter::parser::run(project));
+            pub fn [<tree_sitter_ $prj>](project: &SolidityProject) -> Vec<tree_sitter::Tree> {
+                black_box(tests::tree_sitter::parser::run(black_box(project)))
             }
         }
     };
@@ -70,8 +73,8 @@ macro_rules! slang_v2_test {
         paste! {
             #[library_benchmark(setup = tests::setup::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [<slang_v2_ $prj>](project: &SolidityProject) {
-                black_box(tests::slang_v2::parser::run(project));
+            pub fn [<slang_v2_ $prj>](project: &SolidityProject) -> Vec<(String, SourceUnit)> {
+                black_box(tests::slang_v2::parser::run(black_box(project)))
             }
         }
     };

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -47,31 +47,31 @@ macro_rules! slang_define_full_tests {
             #[library_benchmark(setup = tests::slang::parser::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _parser >](project: &SolidityProject) -> Rc<CompilationUnit> {
-                black_box(tests::slang::parser::run(project))
+                black_box(tests::slang::parser::run(black_box(project)))
             }
 
             #[library_benchmark(setup = tests::slang::cursor::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _cursor >](unit: Rc<CompilationUnit>) -> Rc<CompilationUnit> {
-                black_box(tests::slang::cursor::run(unit))
+                black_box(tests::slang::cursor::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::slang::query::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _query >](unit: Rc<CompilationUnit>) -> Rc<CompilationUnit> {
-                black_box(tests::slang::query::run(unit))
+                black_box(tests::slang::query::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::slang::bindings_build::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _bindings_build >](unit: Rc<CompilationUnit>) -> BuiltBindingGraph {
-                black_box(tests::slang::bindings_build::run(unit))
+                black_box(tests::slang::bindings_build::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::slang::bindings_resolve::setup)]
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _bindings_resolve >](unit: BuiltBindingGraph) -> BuiltBindingGraph {
-                black_box(tests::slang::bindings_resolve::run(unit))
+                black_box(tests::slang::bindings_resolve::run(black_box(unit)))
             }
 
             // We add a cleanup phase to measure the destruction of the AST and the binding structures
@@ -84,7 +84,7 @@ macro_rules! slang_define_full_tests {
             #[library_benchmark(setup = tests::slang::binder_v2_run::setup)]
             #[bench::test(stringify!($prj))]
             fn [< $prj _binder_v2_run >](unit: Rc<CompilationUnit>) -> BuiltSemanticAnalysis {
-                black_box(tests::slang::binder_v2_run::run(unit))
+                black_box(tests::slang::binder_v2_run::run(black_box(unit)))
             }
 
             #[library_benchmark(setup = tests::slang::binder_v2_cleanup::setup)]

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -9,6 +9,7 @@ use iai_callgrind::{
 use paste::paste;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
 use slang_solidity_v2_ir::ir;
+use slang_solidity_v2_semantic::context::SemanticContext;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -49,6 +50,8 @@ macro_rules! slang_v2_define_tests {
 
             #[library_benchmark(setup = tests::slang_v2::ir_builder::setup)]
             #[bench::test(stringify!($prj))]
+            // Note: the input CST source units are consumed (dropped) during IR building.
+            // This is the intended use case: the CST is replaced by the IR representation.
             pub fn [< $prj _ir_builder >]((project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>)) -> Vec<ir::SourceUnit> {
                 black_box(tests::slang_v2::ir_builder::run(black_box(project), black_box(source_units)))
             }
@@ -57,8 +60,8 @@ macro_rules! slang_v2_define_tests {
             #[bench::test(stringify!($prj))]
             pub fn [< $prj _semantic >](
                 (project, input_files): (&'static SolidityProject, Vec<tests::slang_v2::semantic::File>),
-            ) {
-                black_box(tests::slang_v2::semantic::run(project, input_files))
+            ) -> SemanticContext {
+                black_box(tests::slang_v2::semantic::run(black_box(project), black_box(input_files)))
             }
 
             library_benchmark_group!(

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -8,6 +8,7 @@ use iai_callgrind::{
 };
 use paste::paste;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
+use slang_solidity_v2_ir::ir;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -42,16 +43,14 @@ macro_rules! slang_v2_define_tests {
         paste! {
             #[library_benchmark(setup = tests::slang_v2::parser::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [< $prj _parser >](project: &SolidityProject) {
-                black_box(tests::slang_v2::parser::run(project))
+            pub fn [< $prj _parser >](project: &SolidityProject) -> Vec<(String, SourceUnit)> {
+                black_box(tests::slang_v2::parser::run(black_box(project)))
             }
 
             #[library_benchmark(setup = tests::slang_v2::ir_builder::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [< $prj _ir_builder >](
-                (project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>),
-            ) {
-                black_box(tests::slang_v2::ir_builder::run(project, source_units))
+            pub fn [< $prj _ir_builder >]((project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>)) -> Vec<ir::SourceUnit> {
+                black_box(tests::slang_v2::ir_builder::run(black_box(project), black_box(source_units)))
             }
 
             #[library_benchmark(setup = tests::slang_v2::semantic::setup)]

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -9,11 +9,7 @@ pub fn setup(project: &str) -> (&'static SolidityProject, Vec<(String, InputSour
     (project, parsed)
 }
 
-pub fn run(project: &'static SolidityProject, sources: Vec<(String, InputSourceUnit)>) {
-    test(project, sources);
-}
-
-pub fn test(
+pub fn run(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
 ) -> Vec<SourceUnit> {
@@ -28,6 +24,13 @@ pub fn test(
         ));
     }
     ir_source_units
+}
+
+pub fn test(
+    project: &'static SolidityProject,
+    sources: Vec<(String, InputSourceUnit)>,
+) -> Vec<SourceUnit> {
+    run(project, sources)
 }
 
 pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -13,6 +13,13 @@ pub fn run(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
 ) -> Vec<SourceUnit> {
+    test(project, sources)
+}
+
+pub fn test(
+    project: &'static SolidityProject,
+    sources: Vec<(String, InputSourceUnit)>,
+) -> Vec<SourceUnit> {
     let mut ir_source_units = Vec::new();
     for (name, source) in sources {
         ir_source_units.push(ir::build(
@@ -24,13 +31,6 @@ pub fn run(
         ));
     }
     ir_source_units
-}
-
-pub fn test(
-    project: &'static SolidityProject,
-    sources: Vec<(String, InputSourceUnit)>,
-) -> Vec<SourceUnit> {
-    run(project, sources)
 }
 
 pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
@@ -9,11 +9,7 @@ pub fn setup(project: &str) -> &'static SolidityProject {
     crate::tests::setup::setup(project)
 }
 
-pub fn run(project: &SolidityProject) {
-    test(project);
-}
-
-pub fn test(project: &SolidityProject) -> Vec<(String, SourceUnit)> {
+pub fn run(project: &SolidityProject) -> Vec<(String, SourceUnit)> {
     let lang_version = parse_version(project);
     let mut source_units = Vec::new();
     for (key, source) in &project.sources {
@@ -23,6 +19,10 @@ pub fn test(project: &SolidityProject) -> Vec<(String, SourceUnit)> {
     assert!(!source_units.is_empty());
 
     source_units
+}
+
+pub fn test(project: &SolidityProject) -> Vec<(String, SourceUnit)> {
+    run(project)
 }
 
 pub fn count_contracts(source_units: &Vec<(String, SourceUnit)>) -> usize {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -68,8 +68,8 @@ pub fn build_files(
         .collect()
 }
 
-pub fn run(project: &'static SolidityProject, files: Vec<File>) {
-    test(project, files);
+pub fn run(project: &'static SolidityProject, files: Vec<File>) -> SemanticContext {
+    test(project, files)
 }
 
 pub fn test(project: &'static SolidityProject, files: Vec<impl SemanticFile>) -> SemanticContext {

--- a/crates/solidity/testing/perf/cargo/src/tests/solar/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/solar/parser.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::path::PathBuf;
 
 use solar::ast::{self};
@@ -35,14 +36,26 @@ fn go(project: &SolidityProject, count: bool) -> usize {
         // Use one arena for the entire parsing
         let arena = ast::Arena::new();
 
+        // For benchmarking, we keep all parsed units alive until the end so that memory
+        // footprint measurements are consistent across different parsers.
+        let mut units = vec![];
+
         for fname in project.sources.keys() {
             let mut parser = Parser::from_file(&sess, &arena, &PathBuf::from(fname))?;
 
             let unit = parser.parse_file().map_err(|e| e.emit())?;
 
-            if count {
+            units.push(unit);
+        }
+
+        if count {
+            for unit in units {
                 result += unit.count_contracts();
             }
+        } else {
+            // Since it's more annoying to recover the parsed tree from the session
+            // we black box it here to prevent the compiler from optimizing it away.
+            black_box(&units);
         }
 
         Ok(())

--- a/crates/solidity/testing/perf/cargo/src/tests/tree_sitter/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/tree_sitter/parser.rs
@@ -3,34 +3,41 @@ use tree_sitter::{Parser, Query, QueryCursor};
 
 use crate::dataset::SolidityProject;
 
-pub fn run(project: &SolidityProject) {
-    go(project, false);
+pub fn run(project: &SolidityProject) -> Vec<tree_sitter::Tree> {
+    go(project, Vec::new(), |mut trees, _source, tree| {
+        trees.push(tree);
+        trees
+    })
 }
 
 pub fn test(project: &SolidityProject) -> usize {
-    go(project, true)
+    go(project, 0, |count, source, tree| {
+        count + count_definitions(source, tree)
+    })
 }
 
-fn go(project: &SolidityProject, count: bool) -> usize {
+fn go<T>(
+    project: &SolidityProject,
+    init: T,
+    mut fold: impl FnMut(T, &String, tree_sitter::Tree) -> T,
+) -> T {
     let mut parser = Parser::new();
     let language = &tree_sitter_solidity::LANGUAGE.into();
     parser
         .set_language(language)
         .expect("Error loading Solidity parser");
 
-    let mut result = 0;
+    let mut acc = init;
     for source in project.sources.values() {
         let tree = parser.parse(source, None).unwrap();
         let root_node = tree.root_node();
         assert!(!root_node.has_error());
         assert_eq!(root_node.kind(), "source_file");
 
-        if count {
-            result += count_definitions(source, tree);
-        }
+        acc = fold(acc, source, tree);
     }
 
-    result
+    acc
 }
 
 fn count_definitions(source: &String, tree: tree_sitter::Tree) -> usize {


### PR DESCRIPTION
This PR addresses this comment https://github.com/NomicFoundation/slang/pull/1572#discussion_r3000471639 (and similar ones). It makes sure that every function being benchmarked has its arguments and its result wrapped around `black_box`, to avoid any optimizations to skew results.

It also makes the comparison benchmark uniform by collecting all the parsed trees and only dropping them at the end of the benchmark. This causes `tree_sitter` to use more memory than before, but this is expected.

## Testing
- [x] `ci:perf` label
