### PR TITLE
[v2] Add performance tests for semantic passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
  "slang_solidity_v2_cst",
  "slang_solidity_v2_ir",
  "slang_solidity_v2_parser",
+ "slang_solidity_v2_semantic",
  "solar-compiler",
  "solidity_testing_utils",
  "streaming-iterator",

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -19,6 +19,29 @@ pub trait SemanticFile {
     fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String>;
 }
 
+pub fn extract_import_paths_from_source_unit(
+    source_unit: &ir::SourceUnit,
+) -> Vec<(NodeId, String)> {
+    let mut import_paths = Vec::new();
+
+    for member in &source_unit.members {
+        let ir::SourceUnitMember::ImportClause(import_clause) = member else {
+            continue;
+        };
+        let (node_id, path) = match import_clause {
+            ir::ImportClause::PathImport(path_import) => {
+                (path_import.id(), path_import.path.unparse().to_owned())
+            }
+            ir::ImportClause::ImportDeconstruction(import_deconstruction) => (
+                import_deconstruction.id(),
+                import_deconstruction.path.unparse().to_owned(),
+            ),
+        };
+        import_paths.push((node_id, path));
+    }
+    import_paths
+}
+
 pub struct SemanticContext {
     binder: Binder,
     types: TypeRegistry,

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/internal_builder.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeId};
 use slang_solidity_v2_parser::{Parser, ParserError};
-use slang_solidity_v2_semantic::context::SemanticContext;
+use slang_solidity_v2_semantic::context::{extract_import_paths_from_source_unit, SemanticContext};
 
 use super::file::File;
 use super::unit::CompilationUnit;
@@ -33,7 +33,7 @@ impl InternalCompilationBuilder {
 
         let source_unit_cst = Parser::parse(contents, self.language_version)?;
         let source_unit = ir::build(&source_unit_cst, &contents);
-        let import_paths = Self::extract_imports_path(&source_unit);
+        let import_paths = extract_import_paths_from_source_unit(&source_unit);
 
         let file = File::new(id.clone(), source_unit);
         self.files.insert(id, file);
@@ -53,27 +53,6 @@ impl InternalCompilationBuilder {
             .add_resolved_import(node_id, destination_file_id);
 
         Ok(())
-    }
-
-    fn extract_imports_path(source_unit: &ir::SourceUnit) -> Vec<(NodeId, String)> {
-        let mut import_paths = Vec::new();
-
-        for member in &source_unit.members {
-            let ir::SourceUnitMember::ImportClause(import_clause) = member else {
-                continue;
-            };
-            let (node_id, path) = match import_clause {
-                ir::ImportClause::PathImport(path_import) => {
-                    (path_import.id(), path_import.path.unparse().to_owned())
-                }
-                ir::ImportClause::ImportDeconstruction(import_deconstruction) => (
-                    import_deconstruction.id(),
-                    import_deconstruction.path.unparse().to_owned(),
-                ),
-            };
-            import_paths.push((node_id, path));
-        }
-        import_paths
     }
 
     pub fn build(self) -> CompilationUnit {

--- a/crates/solidity/testing/perf/cargo/Cargo.toml
+++ b/crates/solidity/testing/perf/cargo/Cargo.toml
@@ -18,6 +18,7 @@ slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }
 slang_solidity_v2_parser = { workspace = true }
+slang_solidity_v2_semantic = { workspace = true }
 solar = { workspace = true }
 solidity_testing_utils = { workspace = true }
 streaming-iterator = { workspace = true }

--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -21,6 +21,7 @@ mod __dependencies_used_in_lib__ {
     use slang_solidity_v2_cst as _;
     use slang_solidity_v2_ir as _;
     use slang_solidity_v2_parser as _;
+    use slang_solidity_v2_semantic as _;
     use solar as _;
     use solidity_testing_utils as _;
     use streaming_iterator as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -25,6 +25,7 @@ mod __dependencies_used_in_lib__ {
     use slang_solidity_v2_cst as _;
     use slang_solidity_v2_ir as _;
     use slang_solidity_v2_parser as _;
+    use slang_solidity_v2_semantic as _;
     use solar as _;
     use solidity_testing_utils as _;
     use streaming_iterator as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -21,6 +21,7 @@ mod __dependencies_used_in_lib__ {
     use slang_solidity_v2_common as _;
     use slang_solidity_v2_ir as _;
     use slang_solidity_v2_parser as _;
+    use slang_solidity_v2_semantic as _;
     use solar as _;
     use solidity_testing_utils as _;
     use streaming_iterator as _;
@@ -47,10 +48,19 @@ macro_rules! slang_v2_define_tests {
 
             #[library_benchmark(setup = tests::slang_v2::ir_builder::setup)]
             #[bench::test(stringify!($prj))]
-            pub fn [< $prj _ir_builder >]((project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>)) {
+            pub fn [< $prj _ir_builder >](
+                (project, source_units): (&'static SolidityProject, Vec<(String, SourceUnit)>),
+            ) {
                 black_box(tests::slang_v2::ir_builder::run(project, source_units))
             }
 
+            #[library_benchmark(setup = tests::slang_v2::semantic::setup)]
+            #[bench::test(stringify!($prj))]
+            pub fn [< $prj _semantic >](
+                (project, input_files): (&'static SolidityProject, Vec<tests::slang_v2::semantic::File>),
+            ) {
+                black_box(tests::slang_v2::semantic::run(project, input_files))
+            }
 
             library_benchmark_group!(
                 name = [< $prj _full_v2 >];
@@ -59,6 +69,7 @@ macro_rules! slang_v2_define_tests {
                 benchmarks =
                 [< $prj _parser >],
                 [< $prj _ir_builder >],
+                [< $prj _semantic >],
             );
         }
     };

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -52,19 +52,34 @@ mod unit_tests {
     }
 
     mod slang_v2 {
+        // __SLANG_V2_INFRA_BENCHMARKS_LIST__ (keep in sync)
+
         #[test]
         fn parser() {
-            // __SLANG_V2_INFRA_BENCHMARKS_LIST__ (keep in sync)
-
-            let payload = crate::tests::setup::setup(super::PROJECT_TO_TEST);
-            let source_units = crate::tests::slang_v2::parser::test(payload);
+            let project = crate::tests::slang_v2::parser::setup(super::PROJECT_TO_TEST);
+            let source_units = crate::tests::slang_v2::parser::test(project);
             let contract_count = crate::tests::slang_v2::parser::count_contracts(&source_units);
             assert_eq!(contract_count, super::CONTRACT_COUNT);
+        }
 
-            let ir_source_units = crate::tests::slang_v2::ir_builder::test(payload, source_units);
+        #[test]
+        fn ir_builder() {
+            let (project, source_units) =
+                crate::tests::slang_v2::ir_builder::setup(super::PROJECT_TO_TEST);
+            let ir_source_units = crate::tests::slang_v2::ir_builder::test(project, source_units);
             let ir_contract_count =
                 crate::tests::slang_v2::ir_builder::count_contracts(&ir_source_units);
             assert_eq!(ir_contract_count, super::CONTRACT_COUNT);
+        }
+
+        #[test]
+        fn semantic() {
+            let (project, input_files) =
+                crate::tests::slang_v2::semantic::setup(super::PROJECT_TO_TEST);
+            let semantic_context = crate::tests::slang_v2::semantic::test(project, input_files);
+            let semantic_contract_count =
+                crate::tests::slang_v2::semantic::count_contracts(&semantic_context);
+            assert_eq!(semantic_contract_count, super::CONTRACT_COUNT);
         }
     }
 

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/mod.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/mod.rs
@@ -1,2 +1,3 @@
 pub mod ir_builder;
 pub mod parser;
+pub mod semantic;

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
@@ -40,7 +40,7 @@ pub fn count_contracts(source_units: &Vec<(String, SourceUnit)>) -> usize {
     contract_count
 }
 
-fn parse_version(project: &SolidityProject) -> LanguageVersion {
+pub fn parse_version(project: &SolidityProject) -> LanguageVersion {
     let mut version = semver::Version::parse(&project.compiler_version).unwrap();
     version.pre = Prerelease::EMPTY;
     version.build = BuildMetadata::EMPTY;

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_semantic::binder;
+use slang_solidity_v2_semantic::context::{
+    extract_import_paths_from_source_unit, SemanticContext, SemanticFile,
+};
+
+use crate::dataset::SolidityProject;
+
+pub struct File {
+    id: String,
+    ir_root: ir::SourceUnit,
+    resolved_imports: HashMap<NodeId, String>,
+}
+
+impl File {
+    pub fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
+        self.resolved_imports.insert(node_id, target_file_id);
+    }
+}
+
+impl SemanticFile for File {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn ir_root(&self) -> &ir::SourceUnit {
+        &self.ir_root
+    }
+
+    fn resolved_import_by_node_id(&self, node_id: ir::NodeId) -> Option<&String> {
+        self.resolved_imports.get(&node_id)
+    }
+}
+
+pub fn setup(project: &str) -> (&'static SolidityProject, Vec<File>) {
+    let (project, sources) = super::ir_builder::setup(project);
+    let ir_source_units = super::ir_builder::test(project, sources);
+    let files = build_files(project, ir_source_units);
+    (project, files)
+}
+
+pub fn build_files(
+    project: &'static SolidityProject,
+    ir_source_units: Vec<ir::SourceUnit>,
+) -> Vec<File> {
+    ir_source_units
+        .into_iter()
+        .zip(project.sources.keys())
+        .map(|(ir_root, file_id)| {
+            let import_paths = extract_import_paths_from_source_unit(&ir_root);
+            let resolved_imports = import_paths
+                .iter()
+                .filter_map(|(node_id, import_path)| {
+                    let resolved_file_id = project
+                        .import_resolver
+                        .resolve_import(file_id, import_path)?;
+                    Some((*node_id, resolved_file_id))
+                })
+                .collect();
+            File {
+                id: file_id.to_owned(),
+                ir_root,
+                resolved_imports,
+            }
+        })
+        .collect()
+}
+
+pub fn run(project: &'static SolidityProject, files: Vec<File>) {
+    test(project, files);
+}
+
+pub fn test(project: &'static SolidityProject, files: Vec<impl SemanticFile>) -> SemanticContext {
+    let language_version = super::parser::parse_version(project);
+    SemanticContext::build_from(language_version, &files)
+}
+
+pub fn count_contracts(semantic: &SemanticContext) -> usize {
+    semantic
+        .binder()
+        .definitions()
+        .values()
+        .filter(|definition| {
+            matches!(
+                definition,
+                binder::Definition::Contract(_)
+                    | binder::Definition::Interface(_)
+                    | binder::Definition::Library(_)
+            )
+        })
+        .count()
+}


### PR DESCRIPTION
This adds a test to the `slang-v2` bench for the semantic passes in v2, as well as the associated unit test.

To make this easier without using `CompilationUnit`, also the `extract_import_paths` was moved into `semantic`. This makes sense as that (along with the user-provided import resolver) is needed to build a complete `SemanticFile` implementation.
