### PR TITLE
npm: bump basic-ftp to 5.2.2 for GHSA-6v7q-wjvx-w8wg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ catalogs:
       version: 5.8.3
 
 overrides:
-  basic-ftp@<5.2.0: ^5.2.0
+  basic-ftp@<5.2.2: ^5.2.2
   flatted@<3.4.0: ^3.4.0
   js-yaml@<3.14.2: ^3.14.2
   minimatch@<3.1.3: ^3.1.3
@@ -1667,10 +1667,9 @@ packages:
     resolution: {integrity: sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -5240,7 +5239,7 @@ snapshots:
 
   baseline-browser-mapping@2.8.19: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.2: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -5912,7 +5911,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
 
 overrides:
   # Temporary fixes until our dependencies are updated:
-  "basic-ftp@<5.2.0": "^5.2.0" # https://github.com/NomicFoundation/slang/security/dependabot/113
+  "basic-ftp@<5.2.2": "^5.2.2" # https://github.com/NomicFoundation/slang/security/dependabot/159
   "flatted@<3.4.0": "^3.4.0" # https://github.com/NomicFoundation/slang/security/dependabot/115
   "js-yaml@<3.14.2": "^3.14.2" # https://github.com/NomicFoundation/slang/security/dependabot/101
   "minimatch@<3.1.3": "^3.1.3" # https://github.com/NomicFoundation/slang/security/dependabot/108
@@ -45,6 +45,8 @@ overrides:
 
 # Dependency Resolution
 minimumReleaseAge: 10080 # 1 week
+minimumReleaseAgeExclude:
+  - "basic-ftp@5.2.2" # security fix GHSA-6v7q-wjvx-w8wg: https://github.com/NomicFoundation/slang/security/dependabot/159
 
 # Store Settings
 storeDir: ".hermit/.pnpm-store"


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/slang/security/dependabot/159