### PR TITLE
[v2] Minor type registry fixes

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -1340,7 +1340,7 @@ impl YulVariableDeclarationValueStruct {
 // Choices
 //
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AbicoderVersion {
     AbicoderV1Keyword,
     AbicoderV2Keyword,
@@ -1421,13 +1421,13 @@ pub enum Expression {
     FalseKeyword,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_AdditiveExpression_Operator {
     Minus,
     Plus,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_AssignmentExpression_Operator {
     AmpersandEqual,
     AsteriskEqual,
@@ -1443,13 +1443,13 @@ pub enum Expression_AssignmentExpression_Operator {
     SlashEqual,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_EqualityExpression_Operator {
     BangEqual,
     EqualEqual,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_InequalityExpression_Operator {
     GreaterThan,
     GreaterThanEqual,
@@ -1457,20 +1457,20 @@ pub enum Expression_InequalityExpression_Operator {
     LessThanEqual,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_MultiplicativeExpression_Operator {
     Asterisk,
     Percent,
     Slash,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_PostfixExpression_Operator {
     MinusMinus,
     PlusPlus,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_PrefixExpression_Operator {
     Bang,
     DeleteKeyword,
@@ -1480,7 +1480,7 @@ pub enum Expression_PrefixExpression_Operator {
     Tilde,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Expression_ShiftExpression_Operator {
     GreaterThanGreaterThan,
     GreaterThanGreaterThanGreaterThan,
@@ -1500,7 +1500,7 @@ pub enum ForStatementInitialization {
     Semicolon,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FunctionKind {
     Regular,
     Constructor,
@@ -1509,7 +1509,7 @@ pub enum FunctionKind {
     Modifier,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FunctionMutability {
     Pure,
     View,
@@ -1517,7 +1517,7 @@ pub enum FunctionMutability {
     Payable,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FunctionVisibility {
     Public,
     Private,
@@ -1531,7 +1531,7 @@ pub enum ImportClause {
     ImportDeconstruction(ImportDeconstruction),
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum NumberUnit {
     WeiKeyword,
     GweiKeyword,
@@ -1567,7 +1567,7 @@ pub enum SourceUnitMember {
     ConstantDefinition(ConstantDefinition),
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum StateVariableMutability {
     Mutable,
     Constant,
@@ -1575,7 +1575,7 @@ pub enum StateVariableMutability {
     Transient,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum StateVariableVisibility {
     Public,
     Private,
@@ -1601,7 +1601,7 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum StorageLocation {
     MemoryKeyword,
     StorageKeyword,
@@ -1630,7 +1630,7 @@ pub enum UsingClause {
     UsingDeconstruction(UsingDeconstruction),
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UsingOperator {
     Ampersand,
     Asterisk,
@@ -1673,7 +1673,7 @@ pub enum VersionLiteral {
     StringLiteral(StringLiteral),
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum VersionOperator {
     PragmaCaret,
     PragmaTilde,

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -56,7 +56,7 @@ pub struct NodeId(usize);
     {% endif %}
   {% endfor %}
   {% if all_unique_terminals -%}
-    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
   {%- else -%}
     #[derive(Clone, Debug)]
   {%- endif %}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -511,7 +511,7 @@ impl<'a> BuiltInsResolver<'a> {
                 _ => None,
             },
             Type::Function(ftype) => {
-                if ftype.is_external() {
+                if ftype.is_externally_visible() {
                     match symbol {
                         "address" if self.language_version >= LanguageVersion::V0_8_2 => {
                             Some(BuiltIn::Address)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -2,7 +2,7 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::NodeId;
 
 use super::binder::{Binder, Definition, Typing};
-use super::types::{DataLocation, FunctionType, LiteralKind, Type, TypeId, TypeRegistry};
+use super::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BuiltIn {
@@ -510,9 +510,8 @@ impl<'a> BuiltInsResolver<'a> {
                 "length" => Some(BuiltIn::Length),
                 _ => None,
             },
-            Type::Function(FunctionType { external, .. }) => {
-                // Solidity < 0.5.0 didn't require explicit visibility attributes
-                if *external {
+            Type::Function(ftype) => {
+                if ftype.is_external() {
                     match symbol {
                         "address" if self.language_version >= LanguageVersion::V0_8_2 => {
                             Some(BuiltIn::Address)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -260,11 +260,8 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                 let parameters_scope_id = self.collect_parameters(&node.parameters);
 
                 if let Some(name) = &node.name {
-                    let definition = Definition::new_function(
-                        node,
-                        parameters_scope_id,
-                        node.visibility.clone(),
-                    );
+                    let definition =
+                        Definition::new_function(node, parameters_scope_id, node.visibility);
 
                     let current_scope_node_id = self.current_scope().node_id();
                     let enclosing_definition =
@@ -370,7 +367,7 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
     }
 
     fn enter_state_variable_definition(&mut self, node: &ir::StateVariableDefinition) -> bool {
-        let definition = Definition::new_state_variable(node, node.visibility.clone());
+        let definition = Definition::new_state_variable(node, node.visibility);
         self.insert_definition_in_current_scope(definition);
 
         // there may be more definitions in the type of the state variable (eg.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -81,18 +81,14 @@ impl Pass<'_> {
                 } else {
                     self.types.void()
                 };
-                let kind = (&function_type.mutability).into();
-                let external = matches!(
-                    function_type.visibility,
-                    ir::FunctionVisibility::External | ir::FunctionVisibility::Public
-                );
                 Some(self.types.register_type(Type::Function(FunctionType {
                     definition_id: None,
                     implicit_receiver_type: None,
                     parameter_types,
                     return_type,
-                    external,
-                    kind,
+                    // TODO(validation): function types can only be internal or external
+                    visibility: function_type.visibility,
+                    mutability: function_type.mutability,
                 })))
             }
             ir::TypeName::MappingType(mapping_type) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -3,7 +3,7 @@ use slang_solidity_v2_ir::ir::NodeId;
 
 use super::Pass;
 use crate::binder::{Definition, Scope};
-use crate::types::{DataLocation, FunctionType, FunctionTypeKind, Type, TypeId};
+use crate::types::{DataLocation, FunctionType, Type, TypeId};
 
 impl Pass<'_> {
     pub(super) fn type_of_identifier_path(
@@ -141,18 +141,13 @@ impl Pass<'_> {
         } else {
             self.types.void()
         };
-        let kind = (&function_definition.mutability).into();
-        let external = matches!(
-            function_definition.visibility,
-            ir::FunctionVisibility::External | ir::FunctionVisibility::Public
-        );
         Some(self.types.register_type(Type::Function(FunctionType {
             definition_id: Some(function_definition.id()),
             implicit_receiver_type,
             parameter_types,
             return_type,
-            external,
-            kind,
+            visibility: function_definition.visibility,
+            mutability: function_definition.mutability,
         })))
     }
 
@@ -243,8 +238,8 @@ impl Pass<'_> {
             implicit_receiver_type: Some(receiver_type_id),
             parameter_types,
             return_type,
-            external: true,
-            kind: FunctionTypeKind::View,
+            visibility: ir::FunctionVisibility::Public,
+            mutability: ir::FunctionMutability::View,
         });
         Some(self.types.register_type(getter_type))
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -357,8 +357,7 @@ impl Visitor for Pass<'_> {
                             symbols.insert(symbol_name.unparse().to_string(), definition_ids);
 
                             if let Some(operator) = &symbol.alias {
-                                operators
-                                    .insert(operator.clone(), symbol_name.unparse().to_string());
+                                operators.insert(*operator, symbol_name.unparse().to_string());
                             }
                         }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
@@ -63,7 +63,7 @@ impl Pass<'_> {
                     self.parameters_match_positional_arguments(
                         parameters,
                         argument_typings,
-                        function_type.external,
+                        function_type.is_external(),
                     )
                 } else if parameters.len() == argument_typings.len() + 1
                     && function_type.implicit_receiver_type.is_none()
@@ -80,7 +80,7 @@ impl Pass<'_> {
                     self.parameters_match_positional_arguments(
                         &parameters[1..],
                         argument_typings,
-                        function_type.external,
+                        function_type.is_external(),
                     )
                 } else {
                     false
@@ -90,7 +90,7 @@ impl Pass<'_> {
                 self.parameters_match_positional_arguments(
                     parameters,
                     argument_typings,
-                    function_type.external,
+                    function_type.is_external(),
                 )
             } else {
                 false
@@ -172,7 +172,7 @@ impl Pass<'_> {
                 self.parameters_match_named_arguments(
                     parameters,
                     argument_typings,
-                    function_type.external,
+                    function_type.is_external(),
                 )
             } else if let Some(receiver_type_id) = receiver_type_id {
                 // we have a receiver type, so check the first parameter type
@@ -188,7 +188,7 @@ impl Pass<'_> {
                     self.parameters_match_named_arguments(
                         &parameters[1..],
                         argument_typings,
-                        function_type.external,
+                        function_type.is_external(),
                     )
                 } else {
                     false

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/disambiguation.rs
@@ -63,7 +63,7 @@ impl Pass<'_> {
                     self.parameters_match_positional_arguments(
                         parameters,
                         argument_typings,
-                        function_type.is_external(),
+                        function_type.is_externally_visible(),
                     )
                 } else if parameters.len() == argument_typings.len() + 1
                     && function_type.implicit_receiver_type.is_none()
@@ -80,7 +80,7 @@ impl Pass<'_> {
                     self.parameters_match_positional_arguments(
                         &parameters[1..],
                         argument_typings,
-                        function_type.is_external(),
+                        function_type.is_externally_visible(),
                     )
                 } else {
                     false
@@ -90,7 +90,7 @@ impl Pass<'_> {
                 self.parameters_match_positional_arguments(
                     parameters,
                     argument_typings,
-                    function_type.is_external(),
+                    function_type.is_externally_visible(),
                 )
             } else {
                 false
@@ -172,7 +172,7 @@ impl Pass<'_> {
                 self.parameters_match_named_arguments(
                     parameters,
                     argument_typings,
-                    function_type.is_external(),
+                    function_type.is_externally_visible(),
                 )
             } else if let Some(receiver_type_id) = receiver_type_id {
                 // we have a receiver type, so check the first parameter type
@@ -188,7 +188,7 @@ impl Pass<'_> {
                     self.parameters_match_named_arguments(
                         &parameters[1..],
                         argument_typings,
-                        function_type.is_external(),
+                        function_type.is_externally_visible(),
                     )
                 } else {
                     false

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -225,8 +225,9 @@ impl Pass<'_> {
             // used as an external function. If the member is a *public*
             // function, change the expression typing to indicate the
             // external access.
-            if function_type.visibility == ir::FunctionVisibility::Public {
-                let external_function_type = function_type.with_external_visibility();
+            if function_type.is_externally_visible() {
+                let external_function_type =
+                    self.types.externalize_function_type(function_type.clone());
                 let type_id_with_external_visibility = self
                     .types
                     .register_type(Type::Function(external_function_type));

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -199,7 +199,11 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn typing_of_resolution_as_getter(&self, resolution: &Resolution) -> Typing {
+    pub(super) fn typing_of_resolution_as_contract_member(
+        &mut self,
+        resolution: &Resolution,
+    ) -> Typing {
+        // Check if the target is a state variable, and if it has a getter
         if let Resolution::Definition(definition_id) = resolution {
             if let Definition::StateVariable(state_var_definition) =
                 self.binder.find_definition_by_id(*definition_id).unwrap()
@@ -209,7 +213,28 @@ impl Pass<'_> {
                 }
             }
         }
-        self.typing_of_resolution(resolution)
+
+        let mut typing = self.typing_of_resolution(resolution);
+        let resolved_type = typing
+            .as_type_id()
+            .map(|type_id| self.types.get_type_by_id(type_id));
+
+        if let Some(Type::Function(function_type)) = resolved_type {
+            // If the resolved type is a function and the operand is either
+            // `this` or something of an address type, the function is being
+            // used as an external function. If the member is a *public*
+            // function, change the expression typing to indicate the
+            // external access.
+            if function_type.visibility == ir::FunctionVisibility::Public {
+                let external_function_type = function_type.with_external_visibility();
+                let type_id_with_external_visibility = self
+                    .types
+                    .register_type(Type::Function(external_function_type));
+                typing = Typing::Resolved(type_id_with_external_visibility);
+            }
+        }
+
+        typing
     }
 
     fn type_id_of_receiver(&self, operand: &ir::Expression) -> Option<TypeId> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -320,19 +320,21 @@ impl Visitor for Pass<'_> {
             self.resolve_symbol_in_typing(&operand_typing, node.member.unparse()),
         );
 
-        // Special case: if the operand is either `this` or a contract/interface
-        // reference type, then try to type the member as a getter
+        // If the operand is either `this` or a contract/interface reference
+        // type, then resolve the member typing as a contract member. This
+        // handles public getters and visibility changes for public methods.
         let mut typing = if self.typing_is_contract_reference(&operand_typing) {
-            self.typing_of_resolution_as_getter(&resolution)
+            self.typing_of_resolution_as_contract_member(&resolution)
         } else {
             self.typing_of_resolution(&resolution)
         };
 
-        // Special case: If the type is a reference type with location
-        // "inherited", we use the operand's location for the resulting typing
+        // Special cases
         if let Some(type_id) = typing.as_type_id() {
             let type_ = self.types.get_type_by_id(type_id);
             if type_.is_inherited_location() {
+                // If the type is a reference type with location "inherited", we
+                // use the operand's location for the resulting typing
                 if let Some(operand_location) = operand_typing
                     .as_type_id()
                     .and_then(|type_id| self.types.get_type_by_id(type_id).data_location())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -115,8 +115,15 @@ impl DataLocation {
         }
     }
 
-    pub fn overrides(&self, target: Self) -> bool {
-        *self == target || (*self == Self::Memory && target == Self::Calldata)
+    // When calling external functions, it is irrelevant if the data location of
+    // the parameters is ``calldata`` or ``memory``, the encoding of the data
+    // does not change. Because of that, changing the data location when
+    // overriding external functions is allowed.
+    // See https://github.com/argotorg/solidity/pull/12850
+    pub fn overrides_in_external_function(&self, target: Self) -> bool {
+        *self == target
+            || (*self == Self::Memory && target == Self::Calldata)
+            || (*self == Self::Calldata && target == Self::Memory)
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,4 +1,4 @@
-use slang_solidity_v2_ir::ir::{self, NodeId};
+use slang_solidity_v2_ir::ir::{self, FunctionMutability, FunctionVisibility, NodeId};
 
 mod parsing;
 mod registry;
@@ -90,10 +90,70 @@ pub struct FunctionType {
     pub implicit_receiver_type: Option<TypeId>,
     pub parameter_types: Vec<TypeId>,
     pub return_type: TypeId,
-    // TODO: a bool is not sufficient in some corner cases and we need to
-    // distinguish between public and external
-    pub external: bool,
-    pub kind: FunctionTypeKind,
+    pub visibility: FunctionVisibility,
+    pub mutability: FunctionMutability,
+}
+
+impl FunctionType {
+    pub fn is_external(&self) -> bool {
+        matches!(
+            self.visibility,
+            FunctionVisibility::External | FunctionVisibility::Public
+        )
+    }
+}
+
+pub trait ImplicitlyConvertible<T> {
+    fn implicitly_convertible_to(&self, target: T) -> bool;
+}
+
+impl ImplicitlyConvertible<FunctionVisibility> for FunctionVisibility {
+    fn implicitly_convertible_to(&self, target: Self) -> bool {
+        matches!(
+            (self, target),
+            // public can convert to public, external or internal (if called
+            // internally)
+            (
+                FunctionVisibility::Public,
+                FunctionVisibility::Public
+                    | FunctionVisibility::Internal
+                    | FunctionVisibility::External,
+            )
+                // private converts to private or internal
+                | (
+                    FunctionVisibility::Private,
+                    FunctionVisibility::Private | FunctionVisibility::Internal,
+                )
+                // internal and external only convert to themselves
+                | (FunctionVisibility::Internal, FunctionVisibility::Internal)
+                | (FunctionVisibility::External, FunctionVisibility::External)
+        )
+    }
+}
+
+impl ImplicitlyConvertible<FunctionMutability> for FunctionMutability {
+    fn implicitly_convertible_to(&self, target: Self) -> bool {
+        matches!(
+            (self, target),
+            // pure converts to view or non-payable
+            (
+                FunctionMutability::Pure,
+                FunctionMutability::Pure | FunctionMutability::View | FunctionMutability::NonPayable,
+            )
+                // view converts to non-payable
+                | (
+                FunctionMutability::View,
+                FunctionMutability::View | FunctionMutability::NonPayable
+            )
+                // non-payable does not implicitly convert to any other kind
+                | (FunctionMutability::NonPayable, FunctionMutability::NonPayable)
+                // payable converts to non-payable
+                | (
+                    FunctionMutability::Payable,
+                    FunctionMutability::Payable | FunctionMutability::NonPayable,
+                )
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -107,14 +167,6 @@ pub enum DataLocation {
 }
 
 impl DataLocation {
-    pub fn implicitly_convertible_to(&self, target: Self) -> bool {
-        match (self, target) {
-            (from, to) if *from == to => true,
-            (DataLocation::Storage | DataLocation::Calldata, DataLocation::Memory) => true,
-            _ => false,
-        }
-    }
-
     // When calling external functions, it is irrelevant if the data location of
     // the parameters is ``calldata`` or ``memory``, the encoding of the data
     // does not change. Because of that, changing the data location when
@@ -137,46 +189,12 @@ impl From<&ir::StorageLocation> for DataLocation {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum FunctionTypeKind {
-    Pure,
-    View,
-    NonPayable,
-    Payable,
-}
-
-impl FunctionTypeKind {
-    pub fn implicitly_convertible_to(&self, target: Self) -> bool {
-        matches!(
-            (self, target),
-            // pure converts to view or non-payable
-            (
-                FunctionTypeKind::Pure,
-                FunctionTypeKind::Pure | FunctionTypeKind::View | FunctionTypeKind::NonPayable,
-            )
-                // view converts to non-payable
-                | (
-                FunctionTypeKind::View,
-                FunctionTypeKind::View | FunctionTypeKind::NonPayable
-            )
-                // non-payable does not implicitly convert to any other kind
-                | (FunctionTypeKind::NonPayable, FunctionTypeKind::NonPayable)
-                // payable converts to non-payable
-                | (
-                    FunctionTypeKind::Payable,
-                    FunctionTypeKind::Payable | FunctionTypeKind::NonPayable,
-                )
-        )
-    }
-}
-
-impl From<&ir::FunctionMutability> for FunctionTypeKind {
-    fn from(value: &ir::FunctionMutability) -> Self {
-        match value {
-            ir::FunctionMutability::Pure => Self::Pure,
-            ir::FunctionMutability::View => Self::View,
-            ir::FunctionMutability::NonPayable => Self::NonPayable,
-            ir::FunctionMutability::Payable => Self::Payable,
+impl ImplicitlyConvertible<DataLocation> for DataLocation {
+    fn implicitly_convertible_to(&self, target: Self) -> bool {
+        match (self, target) {
+            (from, to) if *from == to => true,
+            (DataLocation::Storage | DataLocation::Calldata, DataLocation::Memory) => true,
+            _ => false,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -101,6 +101,18 @@ impl FunctionType {
             FunctionVisibility::External | FunctionVisibility::Public
         )
     }
+
+    #[must_use]
+    pub fn with_external_visibility(&self) -> Self {
+        Self {
+            definition_id: self.definition_id,
+            implicit_receiver_type: self.implicit_receiver_type,
+            parameter_types: self.parameter_types.clone(),
+            return_type: self.return_type,
+            visibility: FunctionVisibility::External,
+            mutability: self.mutability,
+        }
+    }
 }
 
 pub trait ImplicitlyConvertible<T> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -95,7 +95,7 @@ pub struct FunctionType {
 }
 
 impl FunctionType {
-    pub fn is_external(&self) -> bool {
+    pub fn is_externally_visible(&self) -> bool {
         matches!(
             self.visibility,
             FunctionVisibility::External | FunctionVisibility::Public

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -101,18 +101,6 @@ impl FunctionType {
             FunctionVisibility::External | FunctionVisibility::Public
         )
     }
-
-    #[must_use]
-    pub fn with_external_visibility(&self) -> Self {
-        Self {
-            definition_id: self.definition_id,
-            implicit_receiver_type: self.implicit_receiver_type,
-            parameter_types: self.parameter_types.clone(),
-            return_type: self.return_type,
-            visibility: FunctionVisibility::External,
-            mutability: self.mutability,
-        }
-    }
 }
 
 pub trait ImplicitlyConvertible<T> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -498,84 +498,103 @@ impl TypeRegistry {
         }
         // TODO(validation): check that return parameters match
 
-        // check if all parameter types are equal except maybe in the data
-        // location: memory can override calldata as the location of a parameter
-        ftype
-            .parameter_types
-            .iter()
-            .zip(other.parameter_types.iter())
-            .all(|(ptype_left, ptype_right)| {
-                if ptype_left == ptype_right {
-                    return true;
-                }
-                let type_left = self.get_type_by_id(*ptype_left);
-                let type_right = self.get_type_by_id(*ptype_right);
-                match (type_left, type_right) {
-                    (
-                        Type::Array {
-                            element_type: element_type_left,
-                            location: location_left,
-                        },
-                        Type::Array {
-                            element_type: element_type_right,
-                            location: location_right,
-                        },
-                    ) => {
-                        element_type_left == element_type_right
-                            && location_left.overrides(*location_right)
-                    }
-                    (
-                        Type::FixedSizeArray {
-                            element_type: element_type_left,
-                            size: size_left,
-                            location: location_left,
-                        },
-                        Type::FixedSizeArray {
-                            element_type: element_type_right,
-                            size: size_right,
-                            location: location_right,
-                        },
-                    ) => {
-                        element_type_left == element_type_right
-                            && size_left == size_right
-                            && location_left.overrides(*location_right)
-                    }
-                    (
-                        Type::Bytes {
-                            location: location_left,
-                        },
-                        Type::Bytes {
-                            location: location_right,
-                        },
-                    )
-                    | (
-                        Type::String {
-                            location: location_left,
-                        },
-                        Type::String {
-                            location: location_right,
-                        },
-                    ) => location_left.overrides(*location_right),
-                    (
-                        Type::Struct {
-                            definition_id: definition_id_left,
-                            location: location_left,
-                        },
-                        Type::Struct {
-                            definition_id: definition_id_right,
-                            location: location_right,
-                        },
-                    ) => {
-                        definition_id_left == definition_id_right
-                            && location_left.overrides(*location_right)
-                    }
-                    _ => {
-                        // anything else is not compatible because it should have
-                        // the same type_id, or is not a valid type for a parameter
-                        false
-                    }
-                }
-            })
+        // If the `other` function is external, allow changing the data location
+        // of parameters from `memory` to `calldata` (or viceversa) if our
+        // visibility is external or public.
+        if other.external && ftype.external {
+            ftype
+                .parameter_types
+                .iter()
+                .zip(other.parameter_types.iter())
+                .all(|(ptype_left, ptype_right)| {
+                    self.parameter_type_overrides_in_external_function(*ptype_left, *ptype_right)
+                })
+        } else {
+            // parameter types don't match, so this is not an override
+            false
+        }
+    }
+
+    // Returns true if a the `left` type can override the `right` type in an
+    // external function signature. External functions allow changing data
+    // location from `memory` to `calldata` and viceversa.
+    fn parameter_type_overrides_in_external_function(&self, left: TypeId, right: TypeId) -> bool {
+        if left == right {
+            return true;
+        }
+        let type_left = self.get_type_by_id(left);
+        let type_right = self.get_type_by_id(right);
+        match (type_left, type_right) {
+            (
+                Type::Array {
+                    element_type: element_type_left,
+                    location: location_left,
+                },
+                Type::Array {
+                    element_type: element_type_right,
+                    location: location_right,
+                },
+            ) => {
+                //element_type_left == element_type_right
+                self.parameter_type_overrides_in_external_function(
+                    *element_type_left,
+                    *element_type_right,
+                ) && location_left.overrides_in_external_function(*location_right)
+            }
+            (
+                Type::FixedSizeArray {
+                    element_type: element_type_left,
+                    size: size_left,
+                    location: location_left,
+                },
+                Type::FixedSizeArray {
+                    element_type: element_type_right,
+                    size: size_right,
+                    location: location_right,
+                },
+            ) => {
+                //element_type_left == element_type_right
+                self.parameter_type_overrides_in_external_function(
+                    *element_type_left,
+                    *element_type_right,
+                ) && size_left == size_right
+                    && location_left.overrides_in_external_function(*location_right)
+            }
+            (
+                Type::Bytes {
+                    location: location_left,
+                },
+                Type::Bytes {
+                    location: location_right,
+                },
+            )
+            | (
+                Type::String {
+                    location: location_left,
+                },
+                Type::String {
+                    location: location_right,
+                },
+            ) => location_left.overrides_in_external_function(*location_right),
+            (
+                Type::Struct {
+                    definition_id: definition_id_left,
+                    location: location_left,
+                },
+                Type::Struct {
+                    definition_id: definition_id_right,
+                    location: location_right,
+                },
+            ) => {
+                definition_id_left == definition_id_right
+                    && location_left.overrides_in_external_function(*location_right)
+            }
+            _ => {
+                // anything else is not compatible because it should have
+                // the same type_id, or is not a valid type for a parameter
+                false
+            }
+        }
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
 use indexmap::IndexSet;
+use slang_solidity_v2_ir::ir;
 
 use super::{DataLocation, FunctionType, LiteralKind, Type, TypeId};
+use crate::types::ImplicitlyConvertible;
 
 /// The `TypeRegistry` stores an index of registered types, both elementary
 /// types and user defined types. Each type is given a `TypeId` for efficient
@@ -264,10 +266,10 @@ impl TypeRegistry {
 
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
                 // This is full equality except for definition_id which can differ
-                from_function_type.external == to_function_type.external
+                from_function_type.visibility.implicitly_convertible_to(to_function_type.visibility)
                     && from_function_type
-                        .kind
-                        .implicitly_convertible_to(to_function_type.kind)
+                        .mutability
+                        .implicitly_convertible_to(to_function_type.mutability)
                     && from_function_type.parameter_types == to_function_type.parameter_types
                     && from_function_type.return_type == to_function_type.return_type
             }
@@ -376,16 +378,16 @@ impl TypeRegistry {
             Type::Function(FunctionType {
                 parameter_types,
                 return_type,
-                external,
-                kind,
+                visibility,
+                mutability,
                 ..
             }) => Type::Function(FunctionType {
                 definition_id: None,
                 implicit_receiver_type: None,
                 parameter_types: parameter_types.clone(),
                 return_type: *return_type,
-                external: *external,
-                kind: *kind,
+                visibility: *visibility,
+                mutability: *mutability,
             }),
 
             Type::Address { .. }
@@ -501,7 +503,12 @@ impl TypeRegistry {
         // If the `other` function is external, allow changing the data location
         // of parameters from `memory` to `calldata` (or viceversa) if our
         // visibility is external or public.
-        if other.external && ftype.external {
+        if matches!(other.visibility, ir::FunctionVisibility::External)
+            && matches!(
+                ftype.visibility,
+                ir::FunctionVisibility::External | ir::FunctionVisibility::Public
+            )
+        {
             ftype
                 .parameter_types
                 .iter()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -495,15 +495,16 @@ impl TypeRegistry {
         {
             return false;
         }
-        if ftype.parameter_types == other.parameter_types {
-            return true;
-        }
-        // TODO(validation): check that return parameters match
 
-        // If the `other` function is external, allow changing the data location
-        // of parameters from `memory` to `calldata` (or viceversa) if our
-        // visibility is external or public.
-        if matches!(other.visibility, ir::FunctionVisibility::External)
+        // In general, parameter types must match exactly for functions to
+        // override others.
+        if ftype.parameter_types == other.parameter_types {
+            true
+
+        // The exception is if the `other` function is external which allows
+        // changing the data location of parameters from `memory` to `calldata`
+        // (or viceversa) if the visibility of `ftype` is external or public.
+        } else if matches!(other.visibility, ir::FunctionVisibility::External)
             && matches!(
                 ftype.visibility,
                 ir::FunctionVisibility::External | ir::FunctionVisibility::Public
@@ -517,7 +518,7 @@ impl TypeRegistry {
                     self.parameter_type_overrides_in_external_function(*ptype_left, *ptype_right)
                 })
         } else {
-            // parameter types don't match, so this is not an override
+            // Parameter types don't match: `ftype` *does not* override `other`.
             false
         }
     }
@@ -542,11 +543,11 @@ impl TypeRegistry {
                     location: location_right,
                 },
             ) => {
-                //element_type_left == element_type_right
-                self.parameter_type_overrides_in_external_function(
-                    *element_type_left,
-                    *element_type_right,
-                ) && location_left.overrides_in_external_function(*location_right)
+                location_left.overrides_in_external_function(*location_right)
+                    && self.parameter_type_overrides_in_external_function(
+                        *element_type_left,
+                        *element_type_right,
+                    )
             }
             (
                 Type::FixedSizeArray {
@@ -560,12 +561,12 @@ impl TypeRegistry {
                     location: location_right,
                 },
             ) => {
-                //element_type_left == element_type_right
-                self.parameter_type_overrides_in_external_function(
-                    *element_type_left,
-                    *element_type_right,
-                ) && size_left == size_right
+                size_left == size_right
                     && location_left.overrides_in_external_function(*location_right)
+                    && self.parameter_type_overrides_in_external_function(
+                        *element_type_left,
+                        *element_type_right,
+                    )
             }
             (
                 Type::Bytes {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -265,7 +265,8 @@ impl TypeRegistry {
             ) => from_location.implicitly_convertible_to(*to_location),
 
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
-                // This is full equality except for definition_id which can differ
+                // This is full equality except for visibility and mutability
+                // which can be converted to, and definition_id which can differ
                 from_function_type.visibility.implicitly_convertible_to(to_function_type.visibility)
                     && from_function_type
                         .mutability
@@ -343,6 +344,33 @@ impl TypeRegistry {
             | (Type::String { .. }, Type::String { .. }) => true,
 
             _ => self.implicitly_convertible_to(from_type_id, to_type_id),
+        }
+    }
+
+    // Changes a function type to have external visibility and any parameters
+    // normalized for that (ie. `calldata` location is changed to `memory`)
+    pub fn externalize_function_type(&mut self, function_type: FunctionType) -> FunctionType {
+        FunctionType {
+            visibility: ir::FunctionVisibility::External,
+            parameter_types: function_type
+                .parameter_types
+                .into_iter()
+                .map(|parameter_type_id| {
+                    let parameter_type = self.get_type_by_id(parameter_type_id);
+                    if parameter_type
+                        .data_location()
+                        .is_some_and(|location| location == DataLocation::Calldata)
+                    {
+                        self.register_type_with_data_location(
+                            parameter_type.clone(),
+                            DataLocation::Memory,
+                        )
+                    } else {
+                        parameter_type_id
+                    }
+                })
+                .collect(),
+            ..function_type
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/generated/contracts.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/generated/contracts.rs
@@ -37,6 +37,11 @@ fn diamond() -> Result<()> {
 }
 
 #[test]
+fn external_functions_overrides() -> Result<()> {
+    run(T, "external_functions_overrides")
+}
+
+#[test]
 fn fallback_receive() -> Result<()> {
     run(T, "fallback_receive")
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/generated/function_types.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/generated/function_types.rs
@@ -22,6 +22,11 @@ fn externals() -> Result<()> {
 }
 
 #[test]
+fn implicit_conversion() -> Result<()> {
+    run(T, "implicit_conversion")
+}
+
+#[test]
 fn reference() -> Result<()> {
     run(T, "reference")
 }

--- a/crates/solidity-v2/testing/snapshots/semantic_output/contracts/external_functions_overrides/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/contracts/external_functions_overrides/generated/0.8.0-success.txt
@@ -1,0 +1,141 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (21):
+- Def: #1 ["Base" @ input.sol:1:10] (contract)
+- Def: #2 ["Data" @ input.sol:2:12] (struct)
+- Def: #3 ["x" @ input.sol:3:14] (struct member, type: uint256)
+- Def: #4 ["foo" @ input.sol:5:14] (function, type: function (Data memory[] memory) returns void)
+- Def: #5 ["d" @ input.sol:5:32] (parameter, type: Data memory[] memory)
+- Def: #6 ["bar" @ input.sol:6:14] (function, type: function (Data calldata[] calldata) returns void)
+- Def: #7 ["d" @ input.sol:6:34] (parameter, type: Data calldata[] calldata)
+- Def: #8 ["foo2" @ input.sol:7:14] (function, type: function (Data memory[] memory) returns void)
+- Def: #9 ["d" @ input.sol:7:33] (parameter, type: Data memory[] memory)
+- Def: #10 ["bar2" @ input.sol:8:14] (function, type: function (Data calldata[] calldata) returns void)
+- Def: #11 ["d" @ input.sol:8:35] (parameter, type: Data calldata[] calldata)
+- Def: #12 ["Foo" @ input.sol:11:10] (contract)
+- Def: #13 ["foo" @ input.sol:14:14] (function, type: function (Data calldata[] calldata) returns void)
+- Def: #14 ["d" @ input.sol:14:34] (parameter, type: Data calldata[] calldata)
+- Def: #15 ["bar" @ input.sol:15:14] (function, type: function (Data memory[] memory) returns void)
+- Def: #16 ["d" @ input.sol:15:32] (parameter, type: Data memory[] memory)
+- Def: #17 ["foo2" @ input.sol:16:14] (function, type: function (Data calldata[] calldata) returns void)
+- Def: #18 ["d" @ input.sol:16:35] (parameter, type: Data calldata[] calldata)
+- Def: #19 ["bar2" @ input.sol:17:14] (function, type: function (Data memory[] memory) returns void)
+- Def: #20 ["d" @ input.sol:17:33] (parameter, type: Data memory[] memory)
+- Def: #21 ["test" @ input.sol:19:14] (function, type: function () returns void)
+
+------------------------------------------------------------------------
+
+References (13):
+- Ref: ["Data" @ input.sol:5:18] -> #2
+- Ref: ["Data" @ input.sol:6:18] -> #2
+- Ref: ["Data" @ input.sol:7:19] -> #2
+- Ref: ["Data" @ input.sol:8:19] -> #2
+- Ref: ["Base" @ input.sol:11:17] -> #1
+- Ref: ["Data" @ input.sol:14:18] -> #2
+- Ref: ["Data" @ input.sol:15:18] -> #2
+- Ref: ["Data" @ input.sol:16:19] -> #2
+- Ref: ["Data" @ input.sol:17:19] -> #2
+- Ref: ["foo" @ input.sol:20:14] -> #13
+- Ref: ["bar" @ input.sol:21:14] -> #15
+- Ref: ["foo2" @ input.sol:22:14] -> #17
+- Ref: ["bar2" @ input.sol:23:14] -> #19
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Base {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     struct Data {
+    │            ──┬─  
+    │              ╰─── name: 2
+  3 │         uint x;
+    │              ┬  
+    │              ╰── name: 3
+    │ 
+  5 │     function foo(Data[] memory d) virtual external {}
+    │              ─┬─ ──┬─          ┬  
+    │               ╰─────────────────── name: 4
+    │                    │           │  
+    │                    ╰────────────── ref: 2
+    │                                │  
+    │                                ╰── name: 5
+  6 │     function bar(Data[] calldata d) virtual external {}
+    │              ─┬─ ──┬─            ┬  
+    │               ╰───────────────────── name: 6
+    │                    │             │  
+    │                    ╰──────────────── ref: 2
+    │                                  │  
+    │                                  ╰── name: 7
+  7 │     function foo2(Data[] memory d) virtual external {}
+    │              ──┬─ ──┬─          ┬  
+    │                ╰─────────────────── name: 8
+    │                     │           │  
+    │                     ╰────────────── ref: 2
+    │                                 │  
+    │                                 ╰── name: 9
+  8 │     function bar2(Data[] calldata d) virtual external {}
+    │              ──┬─ ──┬─            ┬  
+    │                ╰───────────────────── name: 10
+    │                     │             │  
+    │                     ╰──────────────── ref: 2
+    │                                   │  
+    │                                   ╰── name: 11
+    │ 
+ 11 │ contract Foo is Base {
+    │          ─┬─    ──┬─  
+    │           ╰─────────── name: 12
+    │                   │   
+    │                   ╰─── ref: 1
+    │ 
+ 14 │     function foo(Data[] calldata d) override external {}
+    │              ─┬─ ──┬─            ┬  
+    │               ╰───────────────────── name: 13
+    │                    │             │  
+    │                    ╰──────────────── ref: 2
+    │                                  │  
+    │                                  ╰── name: 14
+ 15 │     function bar(Data[] memory d) override external {}
+    │              ─┬─ ──┬─          ┬  
+    │               ╰─────────────────── name: 15
+    │                    │           │  
+    │                    ╰────────────── ref: 2
+    │                                │  
+    │                                ╰── name: 16
+ 16 │     function foo2(Data[] calldata d) override public {}
+    │              ──┬─ ──┬─            ┬  
+    │                ╰───────────────────── name: 17
+    │                     │             │  
+    │                     ╰──────────────── ref: 2
+    │                                   │  
+    │                                   ╰── name: 18
+ 17 │     function bar2(Data[] memory d) override public {}
+    │              ──┬─ ──┬─          ┬  
+    │                ╰─────────────────── name: 19
+    │                     │           │  
+    │                     ╰────────────── ref: 2
+    │                                 │  
+    │                                 ╰── name: 20
+    │ 
+ 19 │     function test() internal view {
+    │              ──┬─  
+    │                ╰─── name: 21
+ 20 │         this.foo;
+    │              ─┬─  
+    │               ╰─── ref: 13
+ 21 │         this.bar;
+    │              ─┬─  
+    │               ╰─── ref: 15
+ 22 │         this.foo2;
+    │              ──┬─  
+    │                ╰─── ref: 17
+ 23 │         this.bar2;
+    │              ──┬─  
+    │                ╰─── ref: 19
+────╯

--- a/crates/solidity-v2/testing/snapshots/semantic_output/contracts/external_functions_overrides/input.sol
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/contracts/external_functions_overrides/input.sol
@@ -1,0 +1,25 @@
+contract Base {
+    struct Data {
+        uint x;
+    }
+    function foo(Data[] memory d) virtual external {}
+    function bar(Data[] calldata d) virtual external {}
+    function foo2(Data[] memory d) virtual external {}
+    function bar2(Data[] calldata d) virtual external {}
+}
+
+contract Foo is Base {
+    // All these changes in memory location are valid because the base function
+    // is external.
+    function foo(Data[] calldata d) override external {}
+    function bar(Data[] memory d) override external {}
+    function foo2(Data[] calldata d) override public {}
+    function bar2(Data[] memory d) override public {}
+
+    function test() internal view {
+        this.foo;
+        this.bar;
+        this.foo2;
+        this.bar2;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/generated/0.8.0-success.txt
@@ -1,0 +1,87 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (8):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["intern" @ input.sol:2:14] (function, type: function () returns void)
+- Def: #3 ["extern" @ input.sol:3:14] (function, type: function () returns void)
+- Def: #4 ["privat" @ input.sol:4:14] (function, type: function () returns void)
+- Def: #5 ["publi" @ input.sol:5:14] (function, type: function () returns void)
+- Def: #6 ["callback" @ input.sol:7:14] (function, type: function (function () returns void) returns void)
+- Def: #7 ["callback" @ input.sol:8:14] (function, type: function (function () returns void) returns void)
+- Def: #8 ["test" @ input.sol:10:14] (function, type: function () returns void)
+
+------------------------------------------------------------------------
+
+References (10):
+- Ref: ["callback" @ input.sol:11:9] -> #6
+- Ref: ["intern" @ input.sol:11:18] -> #2
+- Ref: ["callback" @ input.sol:12:9] -> #7
+- Ref: ["extern" @ input.sol:12:23] -> #3
+- Ref: ["callback" @ input.sol:13:9] -> #6
+- Ref: ["privat" @ input.sol:13:18] -> #4
+- Ref: ["callback" @ input.sol:14:9] -> #6
+- Ref: ["publi" @ input.sol:14:18] -> #5
+- Ref: ["callback" @ input.sol:15:9] -> #7
+- Ref: ["publi" @ input.sol:15:23] -> #5
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 1
+  2 │     function intern() internal {}
+    │              ───┬──  
+    │                 ╰──── name: 2
+  3 │     function extern() external {}
+    │              ───┬──  
+    │                 ╰──── name: 3
+  4 │     function privat() private {}
+    │              ───┬──  
+    │                 ╰──── name: 4
+  5 │     function publi() public {}
+    │              ──┬──  
+    │                ╰──── name: 5
+    │ 
+  7 │     function callback(function() internal) private pure {}
+    │              ────┬───  
+    │                  ╰───── name: 6
+  8 │     function callback(function() external) private pure {}
+    │              ────┬───  
+    │                  ╰───── name: 7
+    │ 
+ 10 │     function test() internal view {
+    │              ──┬─  
+    │                ╰─── name: 8
+ 11 │         callback(intern);       // internal
+    │         ────┬─── ───┬──  
+    │             ╰──────────── ref: 6
+    │                     │    
+    │                     ╰──── ref: 2
+ 12 │         callback(this.extern);  // external
+    │         ────┬───      ───┬──  
+    │             ╰───────────────── ref: 7
+    │                          │    
+    │                          ╰──── ref: 3
+ 13 │         callback(privat);       // internal
+    │         ────┬─── ───┬──  
+    │             ╰──────────── ref: 6
+    │                     │    
+    │                     ╰──── ref: 4
+ 14 │         callback(publi);        // internal
+    │         ────┬─── ──┬──  
+    │             ╰─────────── ref: 6
+    │                    │    
+    │                    ╰──── ref: 5
+ 15 │         callback(this.publi);   // external
+    │         ────┬───      ──┬──  
+    │             ╰──────────────── ref: 7
+    │                         │    
+    │                         ╰──── ref: 5
+────╯

--- a/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/generated/0.8.0-success.txt
@@ -1,28 +1,44 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Definitions (8):
+Definitions (14):
 - Def: #1 ["Test" @ input.sol:1:10] (contract)
-- Def: #2 ["intern" @ input.sol:2:14] (function, type: function () returns void)
-- Def: #3 ["extern" @ input.sol:3:14] (function, type: function () returns void)
-- Def: #4 ["privat" @ input.sol:4:14] (function, type: function () returns void)
-- Def: #5 ["publi" @ input.sol:5:14] (function, type: function () returns void)
-- Def: #6 ["callback" @ input.sol:7:14] (function, type: function (function () returns void) returns void)
-- Def: #7 ["callback" @ input.sol:8:14] (function, type: function (function () returns void) returns void)
-- Def: #8 ["test" @ input.sol:10:14] (function, type: function () returns void)
+- Def: #2 ["memory_internal" @ input.sol:2:14] (function, type: function (bytes memory) returns void)
+- Def: #3 ["memory_external" @ input.sol:3:14] (function, type: function (bytes memory) returns void)
+- Def: #4 ["memory_private" @ input.sol:4:14] (function, type: function (bytes memory) returns void)
+- Def: #5 ["memory_public" @ input.sol:5:14] (function, type: function (bytes memory) returns void)
+- Def: #6 ["calldata_internal" @ input.sol:7:14] (function, type: function (bytes calldata) returns void)
+- Def: #7 ["calldata_external" @ input.sol:8:14] (function, type: function (bytes calldata) returns void)
+- Def: #8 ["calldata_private" @ input.sol:9:14] (function, type: function (bytes calldata) returns void)
+- Def: #9 ["calldata_public" @ input.sol:10:14] (function, type: function (bytes calldata) returns void)
+- Def: #10 ["memory_callback" @ input.sol:12:14] (function, type: function (function (bytes memory) returns void) returns void)
+- Def: #11 ["memory_callback" @ input.sol:13:14] (function, type: function (function (bytes memory) returns void) returns void)
+- Def: #12 ["calldata_callback" @ input.sol:15:14] (function, type: function (function (bytes calldata) returns void) returns void)
+- Def: #13 ["calldata_callback" @ input.sol:17:14] (function, type: function (function (bytes calldata) returns void) returns void)
+- Def: #14 ["test" @ input.sol:19:14] (function, type: function () returns void)
 
 ------------------------------------------------------------------------
 
-References (10):
-- Ref: ["callback" @ input.sol:11:9] -> #6
-- Ref: ["intern" @ input.sol:11:18] -> #2
-- Ref: ["callback" @ input.sol:12:9] -> #7
-- Ref: ["extern" @ input.sol:12:23] -> #3
-- Ref: ["callback" @ input.sol:13:9] -> #6
-- Ref: ["privat" @ input.sol:13:18] -> #4
-- Ref: ["callback" @ input.sol:14:9] -> #6
-- Ref: ["publi" @ input.sol:14:18] -> #5
-- Ref: ["callback" @ input.sol:15:9] -> #7
-- Ref: ["publi" @ input.sol:15:23] -> #5
+References (20):
+- Ref: ["memory_callback" @ input.sol:20:9] -> #10
+- Ref: ["memory_internal" @ input.sol:20:25] -> #2
+- Ref: ["memory_callback" @ input.sol:21:9] -> #11
+- Ref: ["memory_external" @ input.sol:21:30] -> #3
+- Ref: ["memory_callback" @ input.sol:22:9] -> #10
+- Ref: ["memory_private" @ input.sol:22:25] -> #4
+- Ref: ["memory_callback" @ input.sol:23:9] -> #10
+- Ref: ["memory_public" @ input.sol:23:25] -> #5
+- Ref: ["memory_callback" @ input.sol:24:9] -> #11
+- Ref: ["memory_public" @ input.sol:24:30] -> #5
+- Ref: ["memory_callback" @ input.sol:26:9] -> #11
+- Ref: ["calldata_external" @ input.sol:26:30] -> #7
+- Ref: ["memory_callback" @ input.sol:27:9] -> #11
+- Ref: ["calldata_public" @ input.sol:27:30] -> #9
+- Ref: ["calldata_callback" @ input.sol:33:9] -> #12
+- Ref: ["calldata_internal" @ input.sol:33:27] -> #6
+- Ref: ["calldata_callback" @ input.sol:34:9] -> #12
+- Ref: ["calldata_private" @ input.sol:34:27] -> #8
+- Ref: ["calldata_callback" @ input.sol:35:9] -> #12
+- Ref: ["calldata_public" @ input.sol:35:27] -> #9
 
 ------------------------------------------------------------------------
 
@@ -36,52 +52,100 @@ Bindings:
   1 │ contract Test {
     │          ──┬─  
     │            ╰─── name: 1
-  2 │     function intern() internal {}
-    │              ───┬──  
-    │                 ╰──── name: 2
-  3 │     function extern() external {}
-    │              ───┬──  
-    │                 ╰──── name: 3
-  4 │     function privat() private {}
-    │              ───┬──  
-    │                 ╰──── name: 4
-  5 │     function publi() public {}
-    │              ──┬──  
-    │                ╰──── name: 5
+  2 │     function memory_internal(bytes memory) internal {}
+    │              ───────┬───────  
+    │                     ╰───────── name: 2
+  3 │     function memory_external(bytes memory) external {}
+    │              ───────┬───────  
+    │                     ╰───────── name: 3
+  4 │     function memory_private(bytes memory) private {}
+    │              ───────┬──────  
+    │                     ╰──────── name: 4
+  5 │     function memory_public(bytes memory) public {}
+    │              ──────┬──────  
+    │                    ╰──────── name: 5
     │ 
-  7 │     function callback(function() internal) private pure {}
-    │              ────┬───  
-    │                  ╰───── name: 6
-  8 │     function callback(function() external) private pure {}
-    │              ────┬───  
-    │                  ╰───── name: 7
+  7 │     function calldata_internal(bytes calldata) internal {}
+    │              ────────┬────────  
+    │                      ╰────────── name: 6
+  8 │     function calldata_external(bytes calldata) external {}
+    │              ────────┬────────  
+    │                      ╰────────── name: 7
+  9 │     function calldata_private(bytes calldata) private {}
+    │              ────────┬───────  
+    │                      ╰───────── name: 8
+ 10 │     function calldata_public(bytes calldata) public {}
+    │              ───────┬───────  
+    │                     ╰───────── name: 9
     │ 
- 10 │     function test() internal view {
+ 12 │     function memory_callback(function(bytes memory) internal) private pure {}
+    │              ───────┬───────  
+    │                     ╰───────── name: 10
+ 13 │     function memory_callback(function(bytes memory) external) private pure {}
+    │              ───────┬───────  
+    │                     ╰───────── name: 11
+    │ 
+ 15 │     function calldata_callback(function(bytes calldata) internal) private pure {}
+    │              ────────┬────────  
+    │                      ╰────────── name: 12
+    │ 
+ 17 │     function calldata_callback(function(bytes calldata) external) private pure {}
+    │              ────────┬────────  
+    │                      ╰────────── name: 13
+    │ 
+ 19 │     function test() internal view {
     │              ──┬─  
-    │                ╰─── name: 8
- 11 │         callback(intern);       // internal
-    │         ────┬─── ───┬──  
-    │             ╰──────────── ref: 6
-    │                     │    
-    │                     ╰──── ref: 2
- 12 │         callback(this.extern);  // external
-    │         ────┬───      ───┬──  
-    │             ╰───────────────── ref: 7
-    │                          │    
-    │                          ╰──── ref: 3
- 13 │         callback(privat);       // internal
-    │         ────┬─── ───┬──  
-    │             ╰──────────── ref: 6
-    │                     │    
-    │                     ╰──── ref: 4
- 14 │         callback(publi);        // internal
-    │         ────┬─── ──┬──  
-    │             ╰─────────── ref: 6
-    │                    │    
-    │                    ╰──── ref: 5
- 15 │         callback(this.publi);   // external
-    │         ────┬───      ──┬──  
-    │             ╰──────────────── ref: 7
-    │                         │    
-    │                         ╰──── ref: 5
+    │                ╰─── name: 14
+ 20 │         memory_callback(memory_internal);
+    │         ───────┬─────── ───────┬───────  
+    │                ╰───────────────────────── ref: 10
+    │                                │         
+    │                                ╰───────── ref: 2
+ 21 │         memory_callback(this.memory_external);  // resolves to the external variant
+    │         ───────┬───────      ───────┬───────  
+    │                ╰────────────────────────────── ref: 11
+    │                                     │         
+    │                                     ╰───────── ref: 3
+ 22 │         memory_callback(memory_private);
+    │         ───────┬─────── ───────┬──────  
+    │                ╰──────────────────────── ref: 10
+    │                                │        
+    │                                ╰──────── ref: 4
+ 23 │         memory_callback(memory_public);
+    │         ───────┬─────── ──────┬──────  
+    │                ╰─────────────────────── ref: 10
+    │                               │        
+    │                               ╰──────── ref: 5
+ 24 │         memory_callback(this.memory_public);    // resolves to the external variant
+    │         ───────┬───────      ──────┬──────  
+    │                ╰──────────────────────────── ref: 11
+    │                                    │        
+    │                                    ╰──────── ref: 5
+    │ 
+ 26 │         memory_callback(this.calldata_external);
+    │         ───────┬───────      ────────┬────────  
+    │                ╰──────────────────────────────── ref: 11
+    │                                      │          
+    │                                      ╰────────── ref: 7
+ 27 │         memory_callback(this.calldata_public);
+    │         ───────┬───────      ───────┬───────  
+    │                ╰────────────────────────────── ref: 11
+    │                                     │         
+    │                                     ╰───────── ref: 9
+    │ 
+ 33 │         calldata_callback(calldata_internal);
+    │         ────────┬──────── ────────┬────────  
+    │                 ╰──────────────────────────── ref: 12
+    │                                   │          
+    │                                   ╰────────── ref: 6
+ 34 │         calldata_callback(calldata_private);
+    │         ────────┬──────── ────────┬───────  
+    │                 ╰─────────────────────────── ref: 12
+    │                                   │         
+    │                                   ╰───────── ref: 8
+ 35 │         calldata_callback(calldata_public);
+    │         ────────┬──────── ───────┬───────  
+    │                 ╰────────────────────────── ref: 12
+    │                                  │         
+    │                                  ╰───────── ref: 9
 ────╯

--- a/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/input.sol
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/input.sol
@@ -1,0 +1,17 @@
+contract Test {
+    function intern() internal {}
+    function extern() external {}
+    function privat() private {}
+    function publi() public {}
+
+    function callback(function() internal) private pure {}
+    function callback(function() external) private pure {}
+
+    function test() internal view {
+        callback(intern);       // internal
+        callback(this.extern);  // external
+        callback(privat);       // internal
+        callback(publi);        // internal
+        callback(this.publi);   // external
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/input.sol
+++ b/crates/solidity-v2/testing/snapshots/semantic_output/function_types/implicit_conversion/input.sol
@@ -1,17 +1,37 @@
 contract Test {
-    function intern() internal {}
-    function extern() external {}
-    function privat() private {}
-    function publi() public {}
+    function memory_internal(bytes memory) internal {}
+    function memory_external(bytes memory) external {}
+    function memory_private(bytes memory) private {}
+    function memory_public(bytes memory) public {}
 
-    function callback(function() internal) private pure {}
-    function callback(function() external) private pure {}
+    function calldata_internal(bytes calldata) internal {}
+    function calldata_external(bytes calldata) external {}
+    function calldata_private(bytes calldata) private {}
+    function calldata_public(bytes calldata) public {}
+
+    function memory_callback(function(bytes memory) internal) private pure {}
+    function memory_callback(function(bytes memory) external) private pure {}
+
+    function calldata_callback(function(bytes calldata) internal) private pure {}
+    // This is not referenced because calling an external function with calldata parameters makes no sense
+    function calldata_callback(function(bytes calldata) external) private pure {}
 
     function test() internal view {
-        callback(intern);       // internal
-        callback(this.extern);  // external
-        callback(privat);       // internal
-        callback(publi);        // internal
-        callback(this.publi);   // external
+        memory_callback(memory_internal);
+        memory_callback(this.memory_external);  // resolves to the external variant
+        memory_callback(memory_private);
+        memory_callback(memory_public);
+        memory_callback(this.memory_public);    // resolves to the external variant
+
+        memory_callback(this.calldata_external);
+        memory_callback(this.calldata_public);
+        // Calls with other variants of calldata_* functions are not valid
+
+        // calldata_callback cannot be called with any of the memory_* functions
+
+        // All of these resolve to the internal parameter variant
+        calldata_callback(calldata_internal);
+        calldata_callback(calldata_private);
+        calldata_callback(calldata_public);
     }
 }


### PR DESCRIPTION
This spawned while resolving [one of the pending comments](https://github.com/NomicFoundation/slang/pull/1577#discussion_r3009333429) from #1577. Turns out that overriding rules a bit more complicated in Solidity. Data location can change in overridden functions, but only if they are external. There was [a bug](https://github.com/ethereum/solidity/issues/10900) in `solc` which was fixed in 0.8.14. There is an accompanying [blog post](https://blog.soliditylang.org/2022/05/17/data-location-inheritance-bug/) explaining the issue.

This made me uncover another subtle bug in the binder regarding the typing of public functions when called externally. I also realized that we don't need a `FunctionTypeKind` and we can use `ir::FunctionMutability` directly now that the IR is unique across the semantic passes.
