### PR TITLE
ci: group Dependabot minor/patch updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,17 +51,10 @@ updates:
       default-days: 7
       semver-major-days: 30
     groups:
-      npm-types:
-        patterns:
-          - "@types/*"
-        # Includes majors: @types/* are type definitions, historically
-        # safe across majors (e.g. @types/node 12→24 merged cleanly).
       npm-minor-patch:
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "@types/*"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,39 +6,68 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "cargo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
       semver-major-days: 30
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      # Major updates are left as individual PRs: they often need code
+      # changes (e.g. nom 7→8, ariadne 0.2→0.6) which would block a group.
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "github-actions"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
+        # Includes majors: the SHA-pin comment adjustment is identical
+        # regardless of version, so one grouped PR amortizes that fix.
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "npm"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
       semver-major-days: 30
+    groups:
+      npm-types:
+        patterns:
+          - "@types/*"
+        # Includes majors: @types/* are type definitions, historically
+        # safe across majors (e.g. @types/node 12→24 merged cleanly).
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "@types/*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "pip"
     open-pull-requests-limit: 5
@@ -53,3 +82,8 @@ updates:
       - dependency-name: "mkdocs-minify-plugin"
       - dependency-name: "mkdocs-pymdownx-material-extras"
       - dependency-name: "mike"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,7 @@ updates:
       github-actions-all:
         patterns:
           - "*"
-        # Includes majors: the SHA-pin comment adjustment is identical
-        # regardless of version, so one grouped PR amortizes that fix.
+        # Includes majors.
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Will likely be replaced by https://github.com/NomicFoundation/slang/pull/1693

See complete analysis here: https://www.notion.so/nomicfoundation/Slang-dependency-update-activity-2026-03-16-2026-04-15-343578cdeaf580e28578dc342fa9c7c8

This includes a bunch of follow-ups (including things like `strum` ↔︎ `strum_macros` coordination). 


## Summary

Group Dependabot's minor/patch updates per ecosystem to reduce weekly PR volume, while keeping major bumps as individual PRs since they frequently need code changes that would block a grouped rollup.

## Why

Based on analysis of the last ~4 weeks of Dependabot activity:

| Week | cargo | npm | pip | github-actions |
|---|---|---|---|---|
| 04-06 | ❌ ariadne + nom needed rewrites | ❌ prettier 2→3 needed rewrite | ✅ with `ignore` for MkDocs (already in config) | ✅ with 4 SHA-pin commits |
| 04-13 | ⏳ (in progress) | ✅ | ✅ | — |

Across the completed weeks, both cargo and npm rollups each failed once, in each case caused by major-version bumps (nom 7→8, ariadne 0.2→0.6, prettier 2→3). Patch/minor updates consistently merge cleanly or with small in-PR fixes (e.g. public_api snapshot regens).

This config isolates that failure mode: majors stay individual (where they belong), and minor/patch get bundled.

## Config changes

- **Schedule:** daily → weekly (Monday) for all ecosystems.
- **cargo / npm / pip:** minor+patch grouped per ecosystem; majors remain individual.
- **github-actions:** single group, including majors.
- **pip:** MkDocs `ignore` list unchanged.
- **`open-pull-requests-limit`:** 5 → 10 for cargo and npm to leave headroom for individual major PRs alongside group PRs.

## Residual risks (known, accepted)

1. **Transitive cargo-cooldown violations** — if a grouped PR pulls in a fresh transitive, the whole group's CI fails. Mitigation: `@dependabot recreate` or manually split.
2. **Closed-without-merge deps in a group** — if a specific dep is unwanted (e.g. the recent tree-sitter-solidity / toml closures), use `@dependabot ignore <dep>@<ver>` on the group PR.
3. **Security advisories** — bypass grouping automatically; no change.

## Test plan

- [ ] Merge and wait for next Monday's Dependabot run
- [ ] Confirm group PRs are created per ecosystem
- [ ] Confirm any major-version bumps arrive as individual PRs