### PR TITLE
ci: free disk space on Ubuntu runners before cargo cache restore

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -10,38 +10,24 @@ description: |
 runs:
   using: "composite"
   steps:
-    - name: "Report disk usage and per-directory sizes"
-      shell: "bash"
-      run: |
-        echo "--- df before ---"
-        df -h /
-        echo "--- per-directory sizes ---"
-        sudo du -sh \
-          /usr/share/dotnet \
-          /usr/local/lib/android \
-          /opt/ghc \
-          /usr/local/.ghcup \
-          /opt/hostedtoolcache/CodeQL \
-          /usr/local/share/boost \
-          2>/dev/null || true
-
     # Remove pre-installed tooling slang doesn't use:
     #   - .NET SDK                          (~1.6  GB)
     #   - Android SDK + NDK                 (~11-14 GB, largest single item)
     #   - Haskell (system GHC + ghcup)      (~5-6  GB)
     #   - CodeQL bundles                    (~5.4  GB)
     #   - Boost C++ headers + prebuilt libs (~0.35 GB)
+    #
+    # The five subtrees are independent, so we background each `rm` and
+    # `wait` at the end — `rm` is I/O-bound on inode unlinks, and running
+    # them in parallel roughly halves wall time on the runner's SSD.
     - name: "Remove unused pre-installed tooling"
       shell: "bash"
       run: |
-        sudo rm -rf \
-          /usr/share/dotnet \
-          /usr/local/lib/android \
-          /opt/ghc \
-          /usr/local/.ghcup \
-          /opt/hostedtoolcache/CodeQL \
-          /usr/local/share/boost
-
-    - name: "Report disk usage after cleanup"
-      shell: "bash"
-      run: "df -h /"
+        df -h /
+        sudo rm -rf /usr/share/dotnet           &
+        sudo rm -rf /usr/local/lib/android      &
+        sudo rm -rf /opt/ghc /usr/local/.ghcup  &
+        sudo rm -rf /opt/hostedtoolcache/CodeQL &
+        sudo rm -rf /usr/local/share/boost      &
+        wait
+        df -h /

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,45 @@
+name: "free-disk-space"
+
+description: |
+  Reclaims ~25-30 GB of disk space on GitHub-hosted Ubuntu runners by
+  removing pre-installed tooling that slang does not use.
+
+  Reference: https://github.com/actions/runner-images (the ubuntu-24.04
+  README lists everything pre-installed).
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Report initial disk usage"
+      shell: "bash"
+      run: "df -h /"
+
+    # .NET SDK (~1.6 GB).
+    - name: "Remove .NET SDK"
+      shell: "bash"
+      run: "sudo rm -rf /usr/share/dotnet"
+
+    # Android SDK + NDK (~11-14 GB, the single largest item on ubuntu-24.04).
+    - name: "Remove Android SDK and NDK"
+      shell: "bash"
+      run: "sudo rm -rf /usr/local/lib/android"
+
+    # Haskell toolchain (~5-6 GB): both the system GHC under `/opt/ghc`
+    # and the user-installed `ghcup` toolchain under `/usr/local/.ghcup`.
+    - name: "Remove Haskell (GHC + ghcup)"
+      shell: "bash"
+      run: "sudo rm -rf /opt/ghc /usr/local/.ghcup"
+
+    # CodeQL bundles (~5.4 GB).
+    - name: "Remove CodeQL bundles"
+      shell: "bash"
+      run: "sudo rm -rf /opt/hostedtoolcache/CodeQL"
+
+    # Boost C++ headers and prebuilt libraries (~350 MB).
+    - name: "Remove Boost"
+      shell: "bash"
+      run: "sudo rm -rf /usr/local/share/boost"
+
+    - name: "Report final disk usage"
+      shell: "bash"
+      run: "df -h /"

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -10,36 +10,38 @@ description: |
 runs:
   using: "composite"
   steps:
-    - name: "Report initial disk usage"
+    - name: "Report disk usage and per-directory sizes"
       shell: "bash"
-      run: "df -h /"
+      run: |
+        echo "--- df before ---"
+        df -h /
+        echo "--- per-directory sizes ---"
+        sudo du -sh \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost \
+          2>/dev/null || true
 
-    # .NET SDK (~1.6 GB).
-    - name: "Remove .NET SDK"
+    # Remove pre-installed tooling slang doesn't use:
+    #   - .NET SDK                          (~1.6  GB)
+    #   - Android SDK + NDK                 (~11-14 GB, largest single item)
+    #   - Haskell (system GHC + ghcup)      (~5-6  GB)
+    #   - CodeQL bundles                    (~5.4  GB)
+    #   - Boost C++ headers + prebuilt libs (~0.35 GB)
+    - name: "Remove unused pre-installed tooling"
       shell: "bash"
-      run: "sudo rm -rf /usr/share/dotnet"
+      run: |
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost
 
-    # Android SDK + NDK (~11-14 GB, the single largest item on ubuntu-24.04).
-    - name: "Remove Android SDK and NDK"
-      shell: "bash"
-      run: "sudo rm -rf /usr/local/lib/android"
-
-    # Haskell toolchain (~5-6 GB): both the system GHC under `/opt/ghc`
-    # and the user-installed `ghcup` toolchain under `/usr/local/.ghcup`.
-    - name: "Remove Haskell (GHC + ghcup)"
-      shell: "bash"
-      run: "sudo rm -rf /opt/ghc /usr/local/.ghcup"
-
-    # CodeQL bundles (~5.4 GB).
-    - name: "Remove CodeQL bundles"
-      shell: "bash"
-      run: "sudo rm -rf /opt/hostedtoolcache/CodeQL"
-
-    # Boost C++ headers and prebuilt libraries (~350 MB).
-    - name: "Remove Boost"
-      shell: "bash"
-      run: "sudo rm -rf /usr/local/share/boost"
-
-    - name: "Report final disk usage"
+    - name: "Report disk usage after cleanup"
       shell: "bash"
       run: "df -h /"

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -24,6 +24,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -57,6 +57,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -57,6 +57,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -57,6 +57,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -57,6 +57,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 
@@ -91,6 +94,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 
@@ -120,6 +126,9 @@ jobs:
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
         with:
           persist-credentials: false
+
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
 
       - name: "infra setup pipenv"
         uses: "./.github/actions/devcontainer/run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
-      - name: "Free up disk space"
-        uses: "./.github/actions/free-disk-space"
-
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 
@@ -113,8 +110,10 @@ jobs:
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/save"
 
-  # We cannot run the full CI in devcontainers, as we will run out of disk space in GitHub Actions.
-  # Instead, we just validate the devcontainer is built correctly by running a minimal check below.
+  # The full CI runs on the bare runner so it can reuse the cargo-target cache;
+  # reproducing that cache-mount setup inside a devcontainer would slow CI down
+  # rather than speed it up. This job is kept as a minimal smoke test that the
+  # devcontainer image still builds and can run the tooling it's expected to.
   validate-devcontainer:
     runs-on: "ubuntu-24.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
 
@@ -127,6 +126,9 @@ jobs:
         with:
           persist-credentials: false
 
+      # The devcontainers/ci action pulls and/or builds the devcontainer image
+      # below, which is tight on the stock ubuntu-24.04 runner; freeing unused
+      # pre-installed tooling first keeps the image build from failing on space.
       - name: "Free up disk space"
         uses: "./.github/actions/free-disk-space"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 
@@ -161,6 +164,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
+
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
 
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
@@ -318,6 +324,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
+
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
 
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -59,6 +59,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 

--- a/.github/workflows/sourcify_smoke.yml
+++ b/.github/workflows/sourcify_smoke.yml
@@ -26,6 +26,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Full history is needed by 'git/restore-mtime' to find each file's last commit time.
 
+      - name: "Free up disk space"
+        uses: "./.github/actions/free-disk-space"
+
       - name: "Restore file mtimes from git"
         uses: "./.github/actions/git/restore-mtime"
 


### PR DESCRIPTION
The cargo-target cache sometimes can't be restored on a stock ubuntu-24.04 runner, causing benchmark jobs to fail with "No space left on device" (runs [24459466398](https://github.com/NomicFoundation/slang/actions/runs/24459466398), [24458399749](https://github.com/NomicFoundation/slang/actions/runs/24458399749)).

Add a reusable free-disk-space composite action that removes pre-installed tooling slang doesn't use (.NET, Android SDK, Haskell, CodeQL, Boost), and wire it into every workflow that restores the cargo-target cache.