### PR TITLE
chore: disable Renovate lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,10 +102,6 @@
   ],
   "labels": ["dependencies"],
   "configMigration": true,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 9am on Friday"]
-  },
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
The `lockFileMaintenance` option for renovate is a lot heavier than I hoped.  See https://github.com/NomicFoundation/slang/pull/1699 for an example.

I had a look, and while you can split per ecosystem, we would still get too large PRs for it to sense. 