### PR TITLE
fix(.npmrc): remove orphaned auth line, add script/engine safety flags

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-//registry.npmjs.org/
+ignore-scripts=true
+engine-strict=true


### PR DESCRIPTION
The bare `//registry.npmjs.org/` line was left over from commit a1e4bca58 (NPM trusted publishing migration) after the `_authToken=...` value was removed; npm now warns "Unknown project config". Replace it with `ignore-scripts=true` and `engine-strict=true` to mirror the pnpm-workspace settings for non-pnpm invocations (e.g. bare `npm` commands).