### PR TITLE
Improve verbatim code in definition

### DIFF
--- a/crates/codegen-v2/parser/src/parser/parser_builder.rs
+++ b/crates/codegen-v2/parser/src/parser/parser_builder.rs
@@ -75,7 +75,7 @@ impl<'a> ParserBuilder<'a> {
         }) = parser_options
         {
             // If there's a verbatim rule, then skip generating the rules
-            return LALRPOPItem::Verbatim(verbatim.to_string());
+            return LALRPOPItem::Verbatim(verbatim.value.clone());
         }
 
         // Translate the LanguageItem into LALRPOP items

--- a/crates/codegen-v2/parser/src/parser/parser_builder.rs
+++ b/crates/codegen-v2/parser/src/parser/parser_builder.rs
@@ -75,7 +75,7 @@ impl<'a> ParserBuilder<'a> {
         }) = parser_options
         {
             // If there's a verbatim rule, then skip generating the rules
-            return LALRPOPItem::Verbatim(verbatim.clone());
+            return LALRPOPItem::Verbatim(verbatim.to_string());
         }
 
         // Translate the LanguageItem into LALRPOP items

--- a/crates/codegen-v2/semantic/src/built_ins.rs
+++ b/crates/codegen-v2/semantic/src/built_ins.rs
@@ -37,7 +37,10 @@ pub fn build_built_ins_model(language: &Language) -> Vec<BuiltInContextModel> {
                         .map(|def| BuiltInDefinitionModel {
                             name: def.name.to_string(),
                             enabled: def.enabled.clone().unwrap_or(VersionSpecifier::Always),
-                            internal_parameter: def.internal_parameter.clone(),
+                            internal_parameter: def
+                                .internal_parameter
+                                .as_ref()
+                                .map(|x| x.value.clone()),
                         })
                         .collect(),
                 })

--- a/crates/language-v2/definition/src/model/built_ins.rs
+++ b/crates/language-v2/definition/src/model/built_ins.rs
@@ -1,7 +1,7 @@
 use language_v2_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{Identifier, VersionSpecifier};
+use crate::model::{Code, Identifier, VersionSpecifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
@@ -29,5 +29,5 @@ pub struct BuiltInDefinition {
     /// A verbatim Rust type to use in the definition of the variant in the
     /// internal enum if required for correct resolution or typing.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub internal_parameter: Option<String>,
+    pub internal_parameter: Option<Code>,
 }

--- a/crates/language-v2/definition/src/model/utils/code.rs
+++ b/crates/language-v2/definition/src/model/utils/code.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use language_v2_internal_macros::WriteOutputTokens;
 use proc_macro2::{Delimiter, Group, TokenStream};
 use serde::{Deserialize, Serialize};
@@ -15,22 +13,14 @@ use crate::internals::{Error, ErrorsCollection, ParseHelpers, ParseInputTokens, 
 /// verbatim and stores the result as a `String`.
 ///
 /// The body must tokenize as valid Rust (balanced delimiters, etc.), but is otherwise
-/// free-form. `//` comments are stripped by the Rust lexer before the proc-macro sees
-/// them and are not preserved in the captured string.
+/// free-form. Comments are stripped by the Rust lexer before the proc-macro sees them,
+/// so they are not preserved in the captured string.
 #[derive(
     Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, WriteOutputTokens,
 )]
 #[serde(transparent)]
 pub struct Code {
     pub value: String,
-}
-
-impl Deref for Code {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
 }
 
 impl ParseInputTokens for Code {
@@ -41,7 +31,7 @@ impl ParseInputTokens for Code {
     /// source-level formatting — turning `Foo<T>` into `Foo < T >`, which
     /// LALRPOP rejects when the captured string is embedded into a generated
     /// `.lalrpop` grammar.
-    /// 
+    ///
     /// Note: If you find a valid reason to support it, do it and comment the reason.
     fn parse_value(input: ParseStream<'_>, _: &mut ErrorsCollection) -> Result<Self> {
         let tokens: TokenStream = ParseHelpers::syn(input)?;

--- a/crates/language-v2/definition/src/model/utils/code.rs
+++ b/crates/language-v2/definition/src/model/utils/code.rs
@@ -1,0 +1,92 @@
+use std::ops::Deref;
+
+use language_v2_internal_macros::WriteOutputTokens;
+use proc_macro2::{Delimiter, Group, TokenStream};
+use serde::{Deserialize, Serialize};
+use syn::parse::ParseStream;
+
+use crate::internals::{Error, ErrorsCollection, ParseHelpers, ParseInputTokens, Result};
+
+/// A wrapper type for embedding free-form code inside the DSL.
+///
+/// Syntactically, `Code(...)` is just another DSL node — the same shape as
+/// `Struct(...)`, `Topic(...)`, or `ParserOptions(...)` — but instead of parsing its
+/// body as structured fields, the DSL parser captures every token inside the parens
+/// verbatim and stores the result as a `String`.
+///
+/// The body must tokenize as valid Rust (balanced delimiters, etc.), but is otherwise
+/// free-form. `//` comments are stripped by the Rust lexer before the proc-macro sees
+/// them and are not preserved in the captured string.
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, WriteOutputTokens,
+)]
+#[serde(transparent)]
+pub struct Code {
+    pub value: String,
+}
+
+impl Deref for Code {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl ParseInputTokens for Code {
+    /// `Code` must always be invoked as a named value (`Code(...)`), handled by
+    /// [`Self::parse_named_value`]. This direct path is unsupported: it would
+    /// route the body through a nested `ParseStream`, which rebuilds the
+    /// `TokenStream` and loses the original
+    /// source-level formatting — turning `Foo<T>` into `Foo < T >`, which
+    /// LALRPOP rejects when the captured string is embedded into a generated
+    /// `.lalrpop` grammar.
+    /// 
+    /// Note: If you find a valid reason to support it, do it and comment the reason.
+    fn parse_value(input: ParseStream<'_>, _: &mut ErrorsCollection) -> Result<Self> {
+        let tokens: TokenStream = ParseHelpers::syn(input)?;
+        Error::fatal(&tokens, &Errors::UnsupportedDirectCall)
+    }
+
+    /// Parse `Code(...)` at a named-value position and capture the parenthesized
+    /// body verbatim.
+    ///
+    /// ## Why we parse a `Group` directly instead of using `ParseHelpers::delimited`
+    ///
+    /// `ParseHelpers::delimited` descends into the body via syn's `parenthesized!`,
+    /// which creates a nested `ParseStream` backed by a fresh `TokenBuffer` over
+    /// the group's contents. Pulling a `TokenStream` back out of that buffer
+    /// rebuilds a new stream token-by-token; the reconstructed stream no longer
+    /// has the compiler-side source-level backing, and its `Display` falls back
+    /// to per-token `Spacing`-based formatting — not sufficient to reproduce
+    /// `Foo<T>`.
+    ///
+    /// Grabbing the body as a `proc_macro2::Group` and calling `group.stream()`
+    /// returns the original `TokenStream` handle untouched, so `to_string()`
+    /// produces `Foo<T>` exactly as written — what LALRPOP expects.
+    fn parse_named_value(input: ParseStream<'_>, _: &mut ErrorsCollection) -> Result<Self> {
+        let name = ParseHelpers::syn::<syn::Ident>(input)?;
+        if name != "Code" {
+            return Error::fatal(&name, &Errors::ExpectedCode);
+        }
+
+        let group = ParseHelpers::syn::<Group>(input)?;
+        if group.delimiter() != Delimiter::Parenthesis {
+            return Error::fatal(&group, &Errors::ExpectedParens);
+        }
+
+        Ok(Self {
+            value: group.stream().to_string(),
+        })
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Errors {
+    #[error("Expected `Code(...)` DSL node.")]
+    ExpectedCode,
+    #[error("`Code` body must be delimited with `(...)`.")]
+    ExpectedParens,
+    #[error("`Code` must be parsed via `parse_named_value` to preserve source-level formatting.")]
+    UnsupportedDirectCall,
+}

--- a/crates/language-v2/definition/src/model/utils/mod.rs
+++ b/crates/language-v2/definition/src/model/utils/mod.rs
@@ -1,7 +1,9 @@
+mod code;
 mod identifier;
 mod parser_options;
 mod version_specifier;
 
+pub use code::*;
 pub use identifier::*;
 pub use parser_options::*;
 pub use version_specifier::*;

--- a/crates/language-v2/definition/src/model/utils/parser_options.rs
+++ b/crates/language-v2/definition/src/model/utils/parser_options.rs
@@ -1,6 +1,8 @@
 use language_v2_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use serde::{Deserialize, Serialize};
 
+use crate::model::utils::Code;
+
 /// Options that are used during parser generation.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[derive_spanned_type(Clone, Debug, ParseInputTokens, WriteOutputTokens)]
@@ -13,5 +15,5 @@ pub struct ParserOptions {
     ///
     /// Helpful to solve complex parsing situations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verbatim: Option<String>,
+    pub verbatim: Option<Code>,
 }

--- a/crates/language-v2/internal_macros/src/derive/spanned.rs
+++ b/crates/language-v2/internal_macros/src/derive/spanned.rs
@@ -152,7 +152,7 @@ fn get_spanned_type(input: Type) -> Type {
 
         // These are model Types that don't have a derived 'SpannedXXX' type.
         // Let's just wrap it in 'Spanned<T>':
-        "Identifier" => {
+        "Code" | "Identifier" => {
             parse_quote! {
                 crate::internals::Spanned<#input>
             }

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.rs
@@ -1,0 +1,26 @@
+#![allow(unused_crate_dependencies)]
+
+language_v2_macros::compile!(Language(
+    name = Foo,
+    root_item = Bar,
+    versions = ["1.0.0"],
+    contexts = [LexicalContext(
+        name = Foo,
+        sections = [Section(
+            title = "S",
+            topics = [Topic(
+                title = "T",
+                items = [
+                    Struct(
+                        name = Bar,
+                        fields = (baz = Required(Baz)),
+                        parser_options = ParserOptions(inline = false, verbatim = "raw string not accepted")
+                    ),
+                    Token(name = Baz, scanner = Atom("baz"))
+                ]
+            )]
+        )]
+    )]
+));
+
+fn main() {}

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.rs
@@ -20,7 +20,8 @@ language_v2_macros::compile!(Language(
                 ]
             )]
         )]
-    )]
+    )],
+    built_ins = []
 ));
 
 fn main() {}

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_string_literal/test.stderr
@@ -1,0 +1,5 @@
+error: expected identifier
+  --> src/fail/p0_parsing/code_string_literal/test.rs:17:83
+   |
+17 |                         parser_options = ParserOptions(inline = false, verbatim = "raw string not accepted")
+   |                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.rs
@@ -1,0 +1,26 @@
+#![allow(unused_crate_dependencies)]
+
+language_v2_macros::compile!(Language(
+    name = Foo,
+    root_item = Bar,
+    versions = ["1.0.0"],
+    contexts = [LexicalContext(
+        name = Foo,
+        sections = [Section(
+            title = "S",
+            topics = [Topic(
+                title = "T",
+                items = [
+                    Struct(
+                        name = Bar,
+                        fields = (baz = Required(Baz)),
+                        parser_options = ParserOptions(inline = false, verbatim = NotCode(body))
+                    ),
+                    Token(name = Baz, scanner = Atom("baz"))
+                ]
+            )]
+        )]
+    )]
+));
+
+fn main() {}

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.rs
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.rs
@@ -20,7 +20,8 @@ language_v2_macros::compile!(Language(
                 ]
             )]
         )]
-    )]
+    )],
+    built_ins = []
 ));
 
 fn main() {}

--- a/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.stderr
+++ b/crates/language-v2/tests/src/fail/p0_parsing/code_wrong_ident/test.stderr
@@ -1,0 +1,5 @@
+error: Expected `Code(...)` DSL node.
+  --> src/fail/p0_parsing/code_wrong_ident/test.rs:17:83
+   |
+17 |                         parser_options = ParserOptions(inline = false, verbatim = NotCode(body))
+   |                                                                                   ^^^^^^^

--- a/crates/language-v2/tests/src/pass/code.rs
+++ b/crates/language-v2/tests/src/pass/code.rs
@@ -1,0 +1,64 @@
+use language_v2_definition::model::{Item, ParserOptions};
+
+language_v2_macros::compile!(Language(
+    name = CodeTest,
+    root_item = Foo,
+    versions = ["1.0.0"],
+    contexts = [LexicalContext(
+        name = CodeTest,
+        sections = [Section(
+            title = "S",
+            topics = [Topic(
+                title = "T",
+                items = [
+                    Struct(
+                        name = Foo,
+                        fields = (bar = Required(Bar)),
+                        parser_options = ParserOptions(
+                            inline = false,
+                            verbatim = Code(
+                                Foo: Foo = {
+                                    <bar: Bar> => new_foo(bar),
+                                };
+                            )
+                        )
+                    ),
+                    Token(name = Bar, scanner = Atom("bar"))
+                ]
+            )]
+        )]
+    )]
+));
+
+#[test]
+fn captures_body_tokens() {
+    let lang = code_test::CodeTestDefinition::create();
+
+    // Navigate to Foo's parser_options.verbatim. Foo is the first item of the first topic.
+    let Item::Struct { item } = &lang.contexts[0].sections[0].topics[0].items[0] else {
+        panic!("expected first item to be a Struct");
+    };
+    let Some(ParserOptions {
+        verbatim: Some(code),
+        ..
+    }) = &item.parser_options
+    else {
+        panic!("expected parser_options.verbatim to be Some");
+    };
+    let text = code.to_string();
+
+    // Body tokens round-trip (whitespace is normalized by TokenStream::to_string, so
+    // spacing between individual tokens is not guaranteed — we just check key fragments
+    // appear in the body).
+    for fragment in ["Foo", "Bar", "new_foo", "bar"] {
+        assert!(
+            text.contains(fragment),
+            "missing {fragment:?} in body, got: {text:?}",
+        );
+    }
+
+    // Outer delimiter chars are not in the captured string (they are the DSL delimiters,
+    // consumed by `parse_named_value` before the body parser runs).
+    assert!(!text.starts_with('('));
+    assert!(!text.trim_end().ends_with(')'));
+}

--- a/crates/language-v2/tests/src/pass/code.rs
+++ b/crates/language-v2/tests/src/pass/code.rs
@@ -17,7 +17,7 @@ language_v2_macros::compile!(Language(
                         parser_options = ParserOptions(
                             inline = false,
                             verbatim = Code(
-                                Foo: Foo = {
+                                Foo: Foo<T> = {
                                     <bar: Bar> => new_foo(bar),
                                 };
                             )
@@ -45,7 +45,7 @@ fn captures_body_tokens() {
     else {
         panic!("expected parser_options.verbatim to be Some");
     };
-    let text = code.to_string();
+    let text = code.value.clone();
 
     // Body tokens round-trip (whitespace is normalized by TokenStream::to_string, so
     // spacing between individual tokens is not guaranteed — we just check key fragments
@@ -56,6 +56,18 @@ fn captures_body_tokens() {
             "missing {fragment:?} in body, got: {text:?}",
         );
     }
+
+    // Make sure spaces are kept as they were originally (e.g. no extra spaces around angle brackets).
+    //
+    // This could be an issue for tools like LALRPOP
+    assert!(
+        text.contains("Foo<T>"),
+        "generic angle brackets lost Joint spacing (expected `Foo<T>`), got: {text:?}",
+    );
+    assert!(
+        !text.contains("Foo < T >"),
+        "generic angle brackets were rendered with spaces (`Foo < T >`), got: {text:?}",
+    );
 
     // Outer delimiter chars are not in the captured string (they are the DSL delimiters,
     // consumed by `parse_named_value` before the body parser runs).

--- a/crates/language-v2/tests/src/pass/code.rs
+++ b/crates/language-v2/tests/src/pass/code.rs
@@ -27,7 +27,8 @@ language_v2_macros::compile!(Language(
                 ]
             )]
         )]
-    )]
+    )],
+    built_ins = []
 ));
 
 #[test]

--- a/crates/language-v2/tests/src/pass/mod.rs
+++ b/crates/language-v2/tests/src/pass/mod.rs
@@ -1,1 +1,2 @@
+mod code;
 mod tiny_language;

--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -4549,7 +4549,7 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                 BuiltInScope(
                     name = Type,
                     definitions = [
-                        BuiltInDefinition(name = Type, internal_parameter = "TypeId"),
+                        BuiltInDefinition(name = Type, internal_parameter = Code(TypeId)),
                         BuiltInDefinition(name = TypeName),
                         BuiltInDefinition(name = TypeCreationCode),
                         BuiltInDefinition(name = TypeRuntimeCode),
@@ -4557,22 +4557,22 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                         BuiltInDefinition(
                             name = TypeEnumMin,
                             enabled = From("0.8.8"),
-                            internal_parameter = "TypeId"
+                            internal_parameter = Code(TypeId)
                         ),
                         BuiltInDefinition(
                             name = TypeEnumMax,
                             enabled = From("0.8.8"),
-                            internal_parameter = "TypeId"
+                            internal_parameter = Code(TypeId)
                         ),
-                        BuiltInDefinition(name = TypeMin, internal_parameter = "TypeId"),
-                        BuiltInDefinition(name = TypeMax, internal_parameter = "TypeId")
+                        BuiltInDefinition(name = TypeMin, internal_parameter = Code(TypeId)),
+                        BuiltInDefinition(name = TypeMax, internal_parameter = Code(TypeId))
                     ]
                 ),
                 BuiltInScope(
                     name = Contextual,
                     definitions = [
                         BuiltInDefinition(name = ArrayPop),
-                        BuiltInDefinition(name = ArrayPush, internal_parameter = "TypeId"),
+                        BuiltInDefinition(name = ArrayPush, internal_parameter = Code(TypeId)),
                         BuiltInDefinition(name = BytesConcat),
                         BuiltInDefinition(name = CallOptionGas),
                         BuiltInDefinition(name = CallOptionSalt),
@@ -4588,12 +4588,12 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                         BuiltInDefinition(
                             name = Unwrap,
                             enabled = From("0.8.8"),
-                            internal_parameter = "NodeId"
+                            internal_parameter = Code(NodeId)
                         ),
                         BuiltInDefinition(
                             name = Wrap,
                             enabled = From("0.8.8"),
-                            internal_parameter = "NodeId"
+                            internal_parameter = Code(NodeId)
                         )
                     ]
                 )
@@ -4644,7 +4644,7 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                         BuiltInDefinition(name = YulInvalid),
                         BuiltInDefinition(name = YulIszero),
                         BuiltInDefinition(name = YulKeccak256),
-                        BuiltInDefinition(name = YulLog, internal_parameter = "u8"),
+                        BuiltInDefinition(name = YulLog, internal_parameter = Code(u8)),
                         BuiltInDefinition(name = YulLt),
                         BuiltInDefinition(name = YulMcopy, enabled = From("0.8.24")),
                         BuiltInDefinition(name = YulMload),

--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -1580,7 +1580,9 @@ language_v2_macros::compile!(Language(
                                         members = Required(ContractMembers),
                                         close_brace = Required(CloseBrace)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = "
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // Contracts are syntactically complex (for an LR parser) since the storage layout specifier
 // has a trailing expression, which can have a trailing option call (`{ ... }`), which conflicts
 // with the contract members block.
@@ -1598,13 +1600,16 @@ ContractDefinition: ContractDefinition = {
         new_contract_definition(abstract_keyword, contract_keyword, name, specifiers, open_brace, members, close_brace)
     },
 };
-")
+                                        )
+                                    )
                                 ),
                                 Repeated(
                                     name = ContractSpecifiers,
                                     reference = ContractSpecifier,
                                     allow_empty = true,
-                                    parser_options = ParserOptions(inline = false, verbatim = "
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // In this case, we require at least one specifier, the case with zero is handled above.
 // Note that the return type now includes the trailing members
 ContractSpecifiersTrailingMembers: (ContractSpecifiers, (OpenBrace, ContractMembers, CloseBrace)) = {
@@ -1641,11 +1646,10 @@ ExpressionTrailingMembers: (Expression, (OpenBrace, ContractMembers, CloseBrace)
         <expression: Expression19<BracedContractMembers>>  => <>,
 };
 BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
-    <open_brace: OpenBrace>  <members: ContractMembers>  <close_brace: CloseBrace>  => {
-        (open_brace, members, close_brace)
-    },
+    <open_brace: OpenBrace>  <members: ContractMembers>  <close_brace: CloseBrace>  => (open_brace, members, close_brace),
 };
-")
+                                        )
+                                    )
                                 ),
                                 Enum(
                                     name = ContractSpecifier,
@@ -1831,7 +1835,9 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
                                         value = Optional(reference = StateVariableDefinitionValue),
                                         semicolon = Required(Semicolon)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // State variable definitions have a conflict when used with function types, since some attributes
 // can be both function type attributes and state variable attributes.
 // For example in `function (uint a) internal internal foo;`, the first `internal` is a function type attribute,
@@ -1840,7 +1846,7 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
 // To disambiguate in these cases we need to count, everything from the second attribute onwards
 // belongs to the state variable. This is very hard to do in LR(1) grammars, so we resort to letting
 // the function type capture all compatible attributes, and then extract the trailing ones to use them in the state variable.
-// 
+//
 // This is done by splitting the state variable rules into two cases, one where any type is allowed, except function types
 // that do not specify a return; and one where only function types without return are allowed.
 //
@@ -1895,7 +1901,8 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
         <transient_keyword: TransientKeyword>  => new_state_variable_attribute_transient_keyword(<>),
         <constant_keyword: ConstantKeyword>  => new_state_variable_attribute_constant_keyword(<>),
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = StateVariableDefinitionValue,
@@ -2253,7 +2260,9 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
                                         PrimaryExpression(reference = ElementaryType),
                                         PrimaryExpression(reference = IdentifierPath)
                                     ],
-                                    parser_options = ParserOptions(inline = false, verbatim = "
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // TypeName has two peculiarities:
 // 1. We need to parametrize the FunctionRule to allow StateVariableDefinition to disable FunctionTypes without returns.
 //    Note that the ArrayTypeName doesn't respect this; most of these manual cases care about trailing constructs, as
@@ -2287,7 +2296,8 @@ ArrayTypeName: ArrayTypeName = {
 
 // An empty rule to disable IAPs
 NoIndexAccessPath: parser_helpers::IndexAccessPath = {};
-")
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = FunctionType,
@@ -2297,7 +2307,9 @@ NoIndexAccessPath: parser_helpers::IndexAccessPath = {};
                                         attributes = Required(FunctionTypeAttributes),
                                         returns = Optional(reference = ReturnsDeclaration)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = "
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // The only reason to split FunctionType into two rules is to allow StateVariableDefinition
 // to choose whether to allow FunctionTypes without returns or not.
 // Note: This could be solved with macros, but is short enough to be explicit
@@ -2311,9 +2323,10 @@ FunctionTypeInternalNoReturn: FunctionType = {
 };
 FunctionTypeInternalReturn: FunctionType = {
     <function_keyword: FunctionKeyword>  <parameters: ParametersDeclaration>  <attributes: FunctionTypeAttributes>  <returns: ReturnsDeclaration>  => new_function_type(function_keyword, parameters, attributes, Some(returns)),
-    
+
 };
-")
+                                        )
+                                    )
                                 ),
                                 Repeated(
                                     name = FunctionTypeAttributes,
@@ -2442,7 +2455,9 @@ FunctionTypeInternalReturn: FunctionType = {
                                         EnumVariant(reference = VariableDeclarationStatement),
                                         EnumVariant(reference = ExpressionStatement)
                                     ],
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // There's two issues with `Statement`:
 //
 // This is a common problem in grammars[1]. To not reinvent the wheel we follow advice from
@@ -2524,7 +2539,8 @@ IdentifierPathNoRevert: IdentifierPath = {
     // or a single identifier that is not `revert`
     <head: SomeIdentifier<"RevertKeyword_Unreserved">>  => new_identifier_path(vec![new_identifier_path_element_identifier(<>)]),
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = UncheckedBlock,
@@ -2600,7 +2616,9 @@ IdentifierPathNoRevert: IdentifierPath = {
                                     name = MultiTypedDeclarationElements,
                                     reference = MultiTypedDeclarationElement,
                                     separator = Comma,
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // MultiTypedDeclaration conflict with tuple expression, for example, the following is ambiguous:
 //
 // |--------|  => Assignment expression
@@ -2619,7 +2637,7 @@ MultiTypedDeclarationElements: MultiTypedDeclarationElements = {
         elements.extend(typed_tuple_deconstruction_element.unwrap_or(vec![]));
         new_multi_typed_declaration_elements(elements)
     },
-    
+
 };
 
 // TuplePrefix counts how many leading commas we have in a tuple deconstruction or
@@ -2629,7 +2647,8 @@ TuplePrefix: usize = {
     Comma  <rest: TuplePrefix>  => 1 + rest,
     => 0,
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = MultiTypedDeclarationElement,
@@ -2665,14 +2684,17 @@ TuplePrefix: usize = {
                                         body = Required(Statement),
                                         else_branch = Optional(reference = ElseBranch)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // As explained in the `Statement` rule, this solves the dangling else problem
 IfStatement<TrailingElse>: IfStatement = {
     // IfStatement only allows `if`s without an else if TrailingElse == "True"
     <if_keyword: IfKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<"True">> if TrailingElse == "True"  => new_if_statement(<>, None),
     <if_keyword: IfKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<"False">>  <else_keyword: ElseKeyword>  <else_branch: _Statement<TrailingElse>>  => new_if_statement(if_keyword, open_paren, condition, close_paren, body, Some(new_else_branch(else_keyword, else_branch))),
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = ElseBranch,
@@ -2692,13 +2714,17 @@ IfStatement<TrailingElse>: IfStatement = {
                                         close_paren = Required(CloseParen),
                                         body = Required(Statement)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // As explained in the `Statement` rule, this solves the dangling else problem
 //
 // Since a `ForStatement` can have a trailing `Statement` we need to parametrize it as well
 ForStatement<TrailingElse>: ForStatement = {
         <for_keyword: ForKeyword>  <open_paren: OpenParen>  <initialization: ForStatementInitialization>  <condition: ForStatementCondition>  <iterator: (Expression)?>  <close_paren: CloseParen>  <body: _Statement<TrailingElse>>  => new_for_statement(<>),
-};"#)
+};
+                                        )
+                                    )
                                 ),
                                 Enum(
                                     name = ForStatementInitialization,
@@ -2724,13 +2750,17 @@ ForStatement<TrailingElse>: ForStatement = {
                                         close_paren = Required(CloseParen),
                                         body = Required(Statement)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // As explained in the `Statement` rule, this solves the dangling else problem
 //
 // Since a `WhileStatement` can have a trailing `Statement` we need to parametrize it as well
 WhileStatement<TrailingElse>: WhileStatement = {
         <while_keyword: WhileKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<TrailingElse>>  => new_while_statement(<>),
-};"#)
+};
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = DoWhileStatement,
@@ -2789,7 +2819,9 @@ WhileStatement<TrailingElse>: WhileStatement = {
                                         body = Required(Block),
                                         catch_clauses = Required(CatchClauses)
                                     ),
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // A try statement conflicts with expressions since an expression can have named arguments (similar to a block)
 // at the end. For example, if the parser sees `try foo { a` it doesn't know whether foo is an expression and it should
 // start parsing a block (a reduce) or whether it should keep parsing a call options expression (a shift).
@@ -2810,7 +2842,8 @@ TryStatement: TryStatement = {
 ExpressionTrailingBlock: (Expression, Block) = {
         <expression: Expression19<Block>>  => <>,
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Repeated(
                                     name = CatchClauses,
@@ -3162,7 +3195,7 @@ ExpressionTrailingBlock: (Expression, Block) = {
                                     ],
                                     parser_options = ParserOptions(
                                         inline = false,
-                                        verbatim = r#"
+                                        verbatim = Code(
 // Expression has a lot of tricky cases:
 // 1. There's conflicts with `TypeName`, for example `a.b[c]` can be either a member access over an identifier path, or
 //    an array type, depending on what comes next. As explained on the `TypeName` rule, we need to delay reduction of
@@ -3228,7 +3261,7 @@ Expression1<IndexAccessPathRule, NewExpressionRule>: Expression = {
     <expression: Expression0<IndexAccessPathRule, NewExpressionRule>>  => <>,
 };
 
-// A Matcher for an empty NewExpression 
+// A Matcher for an empty NewExpression
 NoNewExpression: NewExpression = {};
 
 // Tail is a rule identifying what comes after the expression, whatever is captured is added to the tuple result
@@ -3237,11 +3270,9 @@ Expression5<Tail>: (Expression, Tail) = {
         let (expr, tail) = expression;
         (new_expression_prefix_expression(new_prefix_expression(expression_prefix_expression_operator, expr)), tail)
     },
-    
+
     // A tail can appear just after a postfix or primary expression
-    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>> <tail: Tail> => {
-        (expression, tail)
-    },
+    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>> <tail: Tail> => (expression, tail),
 };
 Expression6<Tail>: (Expression, Tail) = {
     // This is the only other postfix expression that can overwrite a trailing element
@@ -3252,7 +3283,7 @@ Expression6<Tail>: (Expression, Tail) = {
         let (expr, _) = expression;
         (new_expression_postfix_expression(new_postfix_expression(expr, expression_postfix_expression_operator)), tail)
     },
-    
+
     <expression: Expression5<Tail>>  => <>,
 };
 Expression7<Tail>: (Expression, Tail) = {
@@ -3263,7 +3294,7 @@ Expression7<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_exponentiation_expression(new_exponentiation_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression6<Tail>>  => <>,
 };
 Expression8<Tail>: (Expression, Tail) = {
@@ -3273,7 +3304,7 @@ Expression8<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_multiplicative_expression(new_multiplicative_expression(e, expression_multiplicative_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression7<Tail>>  => <>,
 };
 Expression9<Tail>: (Expression, Tail) = {
@@ -3283,7 +3314,7 @@ Expression9<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_additive_expression(new_additive_expression(e, expression_additive_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression8<Tail>>  => <>,
 };
 Expression10<Tail>: (Expression, Tail) = {
@@ -3293,7 +3324,7 @@ Expression10<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_shift_expression(new_shift_expression(e, expression_shift_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression9<Tail>>  => <>,
 };
 Expression11<Tail>: (Expression, Tail) = {
@@ -3303,7 +3334,7 @@ Expression11<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_bitwise_and_expression(new_bitwise_and_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression10<Tail>>  => <>,
 };
 Expression12<Tail>: (Expression, Tail) = {
@@ -3313,7 +3344,7 @@ Expression12<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_bitwise_xor_expression(new_bitwise_xor_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression11<Tail>>  => <>,
 };
 Expression13<Tail>: (Expression, Tail) = {
@@ -3323,7 +3354,7 @@ Expression13<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_bitwise_or_expression(new_bitwise_or_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression12<Tail>>  => <>,
 };
 Expression14<Tail>: (Expression, Tail) = {
@@ -3333,7 +3364,7 @@ Expression14<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_inequality_expression(new_inequality_expression(e, expression_inequality_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression13<Tail>>  => <>,
 };
 Expression15<Tail>: (Expression, Tail) = {
@@ -3343,7 +3374,7 @@ Expression15<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_equality_expression(new_equality_expression(e, expression_equality_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression14<Tail>>  => <>,
 };
 Expression16<Tail>: (Expression, Tail) = {
@@ -3353,7 +3384,7 @@ Expression16<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_and_expression(new_and_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression15<Tail>>  => <>,
 };
 Expression17<Tail>: (Expression, Tail) = {
@@ -3363,7 +3394,7 @@ Expression17<Tail>: (Expression, Tail) = {
         let (e2, tail) = expression_2;
         (new_expression_or_expression(new_or_expression(e, operator, e2)), tail)
     },
-    
+
     <expression: Expression16<Tail>>  => <>,
 };
 Expression19<Tail>: (Expression, Tail) = {
@@ -3375,14 +3406,14 @@ Expression19<Tail>: (Expression, Tail) = {
         let (false_expr, tail) = false_expression;
         (new_expression_conditional_expression(new_conditional_expression(cond_expr, question_mark, true_expr, colon, false_expr)), tail)
     },
-    
+
     <expression: Expression17<EmptyTail>>  <expression_assignment_expression_operator: Expression_AssignmentExpression_Operator>  <expression_2: Expression19<Tail>>  => {
         #[allow(clippy::ignored_unit_patterns)]
         let (e, _) = expression;
         let (e2, tail) = expression_2;
         (new_expression_assignment_expression(new_assignment_expression(e, expression_assignment_expression_operator, e2)), tail)
     },
-    
+
     <expression: Expression17<Tail>>  => <>,
 };
 
@@ -3461,8 +3492,8 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
     <identifier: IdentPathRule> => parser_helpers::new_index_access_path_from_identifier_path(<>),
     <elementary_type: ElementaryType>  => parser_helpers::new_index_access_path_from_elementary_type(<>),
 };
-"#
-                            )
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = IndexAccessEnd,
@@ -3556,7 +3587,7 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
                                     ),
                                     parser_options = ParserOptions(
                                         inline = false,
-                                        verbatim = r#"
+                                        verbatim = Code(
 // We avoid function types entirely in new expressions, this is ok since they're not allowed
 // in Solidity, but the error will be syntactic rather than semantic, which may be confusing.
 //
@@ -3564,11 +3595,12 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
 // parsed either as part of the function type or as part of a try statement.
 NewExpression: NewExpression = {
     <new_keyword: NewKeyword>  <type_name: TypeName1<NoFunctionType, IndexAccessPath<IdentifierPath>>>  => new_new_expression(<>),
-    
+
 };
 
 NoFunctionType: FunctionType = {};
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = TupleExpression,
@@ -3584,7 +3616,7 @@ NoFunctionType: FunctionType = {};
                                     separator = Comma,
                                     parser_options = ParserOptions(
                                         inline = false,
-                                        verbatim = r#"
+                                        verbatim = Code(
 // See the comment around TupleDeconstructionStatement for an explanation of this rule.
 #[inline]
 TupleValues: TupleValues = {
@@ -3600,9 +3632,10 @@ TupleValues: TupleValues = {
         elements.extend(tuple_value.unwrap_or(vec![]));
         new_tuple_values(elements)
     },
-    
+
 };
-"#)
+                                        )
+                                    )
                                 ),
                                 Struct(
                                     name = TupleValue,
@@ -3881,7 +3914,9 @@ TupleValues: TupleValues = {
                                     name = IdentifierPath,
                                     reference = IdentifierPathElement,
                                     separator = Period,
-                                    parser_options = ParserOptions(inline = false, verbatim = r#"
+                                    parser_options = ParserOptions(
+                                        inline = false,
+                                        verbatim = Code(
 // We need to force this to differentiate the first element from not being
 // an `AddressKeyword`
 IdentifierPath: IdentifierPath = {
@@ -3894,18 +3929,18 @@ IdentifierPath: IdentifierPath = {
             None => new_identifier_path(vec![new_identifier_path_element_identifier(head)]),
         }
     },
-    
+
 };
 IdentifierPathTail: Vec<IdentifierPathElement> = {
     Period  <elements: IdentifierPathTailElements>  => <>,
-    
+
 };
 IdentifierPathTailElements: Vec<IdentifierPathElement> = {
     <member_access_identifier: Separated<Period, <IdentifierPathElement>>>  => <>,
-    
-};
-"#)
 
+};
+                                        )
+                                    )
                                 ),
                                 Enum(
                                     // An element of an identifier path can be either an identifier or the reserved `address` keyword

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/grammar.generated.lalrpop
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/grammar.generated.lalrpop
@@ -263,68 +263,64 @@ Repeated<T>: Vec<T> = {
 
 // Rules for topic Contracts
     
-    
-// Contracts are syntactically complex (for an LR parser) since the storage layout specifier
-// has a trailing expression, which can have a trailing option call (`{ ... }`), which conflicts
-// with the contract members block.
-//
-// In order to solve this we use a trailing expression that captures both the expression and the members,
-// and then extract the members from it.
-ContractDefinition: ContractDefinition = {
-    // If no specifiers are present, we simply capture the members directly
-    <abstract_keyword: (AbstractKeyword)?>  <contract_keyword: ContractKeyword>  <name: Identifier>  <open_brace: OpenBrace>  <members: ContractMembers>  <close_brace: CloseBrace>  => {
-        new_contract_definition(abstract_keyword, contract_keyword, name, new_contract_specifiers(vec![]), open_brace, members, close_brace)
-    },
-    // If specifiers are present, we extract the trailing members from them
-    <abstract_keyword: (AbstractKeyword)?>  <contract_keyword: ContractKeyword>  <name: Identifier>  <specifiers: ContractSpecifiersTrailingMembers>  => {
+    ContractDefinition: ContractDefinition =
+{
+    <abstract_keyword: (AbstractKeyword)?> <contract_keyword: ContractKeyword>
+    <name: Identifier> <open_brace: OpenBrace> <members: ContractMembers>
+    <close_brace: CloseBrace> =>
+    {
+        new_contract_definition(abstract_keyword, contract_keyword, name,
+        new_contract_specifiers(vec![]), open_brace, members, close_brace)
+    }, <abstract_keyword: (AbstractKeyword)?> <contract_keyword:
+    ContractKeyword> <name: Identifier> <specifiers:
+    ContractSpecifiersTrailingMembers> =>
+    {
         let (specifiers, (open_brace, members, close_brace)) = specifiers;
-        new_contract_definition(abstract_keyword, contract_keyword, name, specifiers, open_brace, members, close_brace)
+        new_contract_definition(abstract_keyword, contract_keyword, name,
+        specifiers, open_brace, members, close_brace)
     },
 };
-
     
-    
-// In this case, we require at least one specifier, the case with zero is handled above.
-// Note that the return type now includes the trailing members
-ContractSpecifiersTrailingMembers: (ContractSpecifiers, (OpenBrace, ContractMembers, CloseBrace)) = {
-    <mut contract_specifier: RepeatedAllowEmpty<<ContractSpecifier>>> <tail: ContractSpecifierTrailingMembers>  => {
-        let (specifier, tail) = tail;
-        contract_specifier.push(specifier);
+    ContractSpecifiersTrailingMembers:
+(ContractSpecifiers, (OpenBrace, ContractMembers, CloseBrace)) =
+{
+    <mut contract_specifier: RepeatedAllowEmpty<<ContractSpecifier>>> <tail:
+    ContractSpecifierTrailingMembers> =>
+    {
+        let (specifier, tail) = tail; contract_specifier.push(specifier);
         (new_contract_specifiers(contract_specifier), tail)
     },
-};
-ContractSpecifierTrailingMembers: (ContractSpecifier, (OpenBrace, ContractMembers, CloseBrace)) = {
-    // Since there's no conflict with inheritance specifiers, we can parse them directly and
-    // then parse the members
-    <inheritance_specifier: InheritanceSpecifier> <open_brace: OpenBrace>  <members: ContractMembers>  <close_brace: CloseBrace>  => {
-        (new_contract_specifier_inheritance_specifier(inheritance_specifier), (open_brace, members, close_brace))
-    },
-    // For storage layout specifiers, we need to extract the trailing members from them
-    <storage_layout_specifier: StorageLayoutSpecifierTrailingMembers>  => {
+}; ContractSpecifierTrailingMembers:
+(ContractSpecifier, (OpenBrace, ContractMembers, CloseBrace)) =
+{
+    <inheritance_specifier: InheritanceSpecifier> <open_brace: OpenBrace>
+    <members: ContractMembers> <close_brace: CloseBrace> =>
+    {
+        (new_contract_specifier_inheritance_specifier(inheritance_specifier),
+        (open_brace, members, close_brace))
+    }, <storage_layout_specifier: StorageLayoutSpecifierTrailingMembers> =>
+    {
         let (storage_layout_specifier, tail) = storage_layout_specifier;
-        (new_contract_specifier_storage_layout_specifier(storage_layout_specifier), tail)
+        (new_contract_specifier_storage_layout_specifier(storage_layout_specifier),
+        tail)
     },
-};
-
-StorageLayoutSpecifierTrailingMembers: (StorageLayoutSpecifier, (OpenBrace, ContractMembers, CloseBrace)) = {
-    // Instead of parsing a regular Expression, we parse one that captures the trailing members
-    <layout_keyword: LayoutKeyword>  <at_keyword: AtKeyword>  <expression: ExpressionTrailingMembers>  => {
+}; StorageLayoutSpecifierTrailingMembers:
+(StorageLayoutSpecifier, (OpenBrace, ContractMembers, CloseBrace)) =
+{
+    <layout_keyword: LayoutKeyword> <at_keyword: AtKeyword> <expression:
+    ExpressionTrailingMembers> =>
+    {
         let (expr, tail) = expression;
         (new_storage_layout_specifier(layout_keyword, at_keyword, expr), tail)
     },
+}; ExpressionTrailingMembers:
+(Expression, (OpenBrace, ContractMembers, CloseBrace)) =
+{ <expression: Expression19<BracedContractMembers>> => <>, };
+BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) =
+{
+    <open_brace: OpenBrace> <members: ContractMembers> <close_brace:
+    CloseBrace> => (open_brace, members, close_brace),
 };
-
-// An expression followed by contract members
-// See the Expression rule for details
-ExpressionTrailingMembers: (Expression, (OpenBrace, ContractMembers, CloseBrace)) = {
-        <expression: Expression19<BracedContractMembers>>  => <>,
-};
-BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
-    <open_brace: OpenBrace>  <members: ContractMembers>  <close_brace: CloseBrace>  => {
-        (open_brace, members, close_brace)
-    },
-};
-
     ContractSpecifier: ContractSpecifier = {
         <inheritance_specifier: InheritanceSpecifier>  => new_contract_specifier_inheritance_specifier(<>),
         <storage_layout_specifier: StorageLayoutSpecifier>  => new_contract_specifier_storage_layout_specifier(<>),
@@ -424,71 +420,54 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) = {
 
 // Rules for topic State Variables
     
-    
-// State variable definitions have a conflict when used with function types, since some attributes
-// can be both function type attributes and state variable attributes.
-// For example in `function (uint a) internal internal foo;`, the first `internal` is a function type attribute,
-// while the second `internal` is a state variable attribute.
-//
-// To disambiguate in these cases we need to count, everything from the second attribute onwards
-// belongs to the state variable. This is very hard to do in LR(1) grammars, so we resort to letting
-// the function type capture all compatible attributes, and then extract the trailing ones to use them in the state variable.
-// 
-// This is done by splitting the state variable rules into two cases, one where any type is allowed, except function types
-// that do not specify a return; and one where only function types without return are allowed.
-//
-// Another issue comes from the `error` keyword, since it's not reserved it can also be used as an identifier.
-// This conflicts with state variables since `error foo...` could be the beginning of either an
-// error definition or a state variable definition.
-//
-// To solve this we match against state variables where the type is exactly `error` as a special case.
-StateVariableDefinition: StateVariableDefinition = {
-    // When allowing any type except function types without return, we can parse normally.
-    // Note the `IdentifierPathNoError`, it avoids matching against `error` as an identifier.
-    <type_name: TypeName1<FunctionTypeInternalReturn, IndexAccessPath<IdentifierPathNoError>>>  <attributes: StateVariableAttributes>  <name: Identifier>  <value: (StateVariableDefinitionValue)?>  <semicolon: Semicolon>  => new_state_variable_definition(<>),
-
-    // Special case for `error` type
-    <l:@L> L_ErrorKeyword_Unreserved <r:@R>  <attributes: StateVariableAttributes>  <name: Identifier>  <value: (StateVariableDefinitionValue)?>  <semicolon: Semicolon> => {
-        let identifier = new_identifier(l..r, source);
-        let iap = parser_helpers::new_index_access_path_from_identifier_path(new_identifier_path(vec![new_identifier_path_element_identifier(identifier)]));
+    StateVariableDefinition: StateVariableDefinition =
+{
+    <type_name: TypeName1<FunctionTypeInternalReturn,
+    IndexAccessPath<IdentifierPathNoError>>> <attributes:
+    StateVariableAttributes> <name: Identifier> <value:
+    (StateVariableDefinitionValue)?> <semicolon: Semicolon> =>
+    new_state_variable_definition(<>), <l:@L> L_ErrorKeyword_Unreserved <r:@R>
+    <attributes: StateVariableAttributes> <name: Identifier> <value:
+    (StateVariableDefinitionValue)?> <semicolon: Semicolon> =>
+    {
+        let identifier = new_identifier(l..r, source); let iap =
+        parser_helpers::new_index_access_path_from_identifier_path(new_identifier_path(vec![new_identifier_path_element_identifier(identifier)]));
         let type_name = parser_helpers::new_type_name_index_access_path(iap);
-
-        new_state_variable_definition(type_name, attributes, name, value, semicolon)
-    },
-
-
-    // If the function type has no return, then we don't directly parse state variable attributes, we only do it if
-    // we see a special one (one that can be a state variable attribute but not a function type attribute).
-    <type_name: FunctionTypeInternalNoReturn> <special_attributes: (<SpecialStateVariableAttribute> <StateVariableAttributes>)?> <name: Identifier>  <value: (StateVariableDefinitionValue)?>  <semicolon: Semicolon>  => {
-        let (function_type, mut extra_attributes) = parser_helpers::extract_extra_attributes(type_name);
-        if let Some(special_attributes) = special_attributes {
+        new_state_variable_definition(type_name, attributes, name, value,
+        semicolon)
+    }, <type_name: FunctionTypeInternalNoReturn> <special_attributes:
+    (<SpecialStateVariableAttribute> <StateVariableAttributes>)?> <name:
+    Identifier> <value: (StateVariableDefinitionValue)?> <semicolon:
+    Semicolon> =>
+    {
+        let (function_type, mut extra_attributes) =
+        parser_helpers::extract_extra_attributes(type_name); if let
+        Some(special_attributes) = special_attributes
+        {
             extra_attributes.push(special_attributes.0);
             extra_attributes.extend(special_attributes.1.elements);
         }
-        new_state_variable_definition(new_type_name_function_type(function_type), new_state_variable_attributes(extra_attributes), name, value, semicolon)
+        new_state_variable_definition(new_type_name_function_type(function_type),
+        new_state_variable_attributes(extra_attributes), name, value,
+        semicolon)
     },
-};
-
-// Match an identifier path that, if it's a single element, is not `error`
-IdentifierPathNoError: IdentifierPath = {
-    // We either have any identifier with a tail (ie a period)
-    <head: Identifier>  <mut tail: IdentifierPathTail>  => {
+}; IdentifierPathNoError: IdentifierPath =
+{
+    <head: Identifier> <mut tail: IdentifierPathTail> =>
+    {
         tail.insert(0, new_identifier_path_element_identifier(head));
         new_identifier_path(tail)
-    },
-    // or a single identifier that is not `error`
-    <head: SomeIdentifier<"ErrorKeyword_Unreserved">>  => new_identifier_path(vec![new_identifier_path_element_identifier(<>)]),
+    }, <head: SomeIdentifier<"ErrorKeyword_Unreserved">> =>
+    new_identifier_path(vec![new_identifier_path_element_identifier(<>)]),
+}; SpecialStateVariableAttribute: StateVariableAttribute =
+{
+    <override_specifier: OverrideSpecifier> =>
+    new_state_variable_attribute_override_specifier(<>), <immutable_keyword:
+    ImmutableKeyword> => new_state_variable_attribute_immutable_keyword(<>),
+    <transient_keyword: TransientKeyword> =>
+    new_state_variable_attribute_transient_keyword(<>), <constant_keyword:
+    ConstantKeyword> => new_state_variable_attribute_constant_keyword(<>),
 };
-
-// These are the attributes that can appear in a state variable but not a function,
-// they can work as a limit between these definitions.
-SpecialStateVariableAttribute: StateVariableAttribute = {
-        <override_specifier: OverrideSpecifier>  => new_state_variable_attribute_override_specifier(<>),
-        <immutable_keyword: ImmutableKeyword>  => new_state_variable_attribute_immutable_keyword(<>),
-        <transient_keyword: TransientKeyword>  => new_state_variable_attribute_transient_keyword(<>),
-        <constant_keyword: ConstantKeyword>  => new_state_variable_attribute_constant_keyword(<>),
-};
-
     StateVariableDefinitionValue: StateVariableDefinitionValue = {
         <equal: Equal>  <value: Expression>  => new_state_variable_definition_value(<>),
         
@@ -695,59 +674,41 @@ SpecialStateVariableAttribute: StateVariableAttribute = {
 
 // Rules for topic Advanced Types
     
-    
-// TypeName has two peculiarities:
-// 1. We need to parametrize the FunctionRule to allow StateVariableDefinition to disable FunctionTypes without returns.
-//    Note that the ArrayTypeName doesn't respect this; most of these manual cases care about trailing constructs, as
-//    soon as an extra `[]` is added, the ambiguities disappear.
-// 2. A TypeName that can be represented as an `IndexAccessPath` can conflict with a `MemberAccess`, for example
-//    `a.b[c]` can be either a member access over an identifier path, or array type, depending on what comes next.
-//    This means we need to treat these constructs as IAPs for as long as possible, and only convert them to TypeNames
-//    when it's certainly a type. `new_type_name_index_access_path` transforms an IAP into a TypeName.
-//    However, since a IAP and an array type conflict, we need to make sure that array types are only matched against
-//    base types that are not IAPs, hence the parametric IAPRule.
-TypeName0<FunctionRule, IAPRule>: TypeName = {
+    TypeName0<FunctionRule, IAPRule>: TypeName =
+{
     <function_type: FunctionRule> => new_type_name_function_type(<>),
-    <mapping_type: MappingType>  => new_type_name_mapping_type(<>),
-    <index_access_path: IAPRule> => parser_helpers::new_type_name_index_access_path(<>),
-};
-TypeName1<FunctionRule, IAPRule>: TypeName = {
-    <type_name: ArrayTypeName>  => new_type_name_array_type_name(<>),
-    <type_name: TypeName0<FunctionRule, IAPRule>>  => <>,
-};
-TypeName: TypeName = {
-    // A regular type can have any function type and an IAP
-    <type_name: TypeName1<FunctionType, IndexAccessPath<IdentifierPath>>>  => <>,
-};
-
-#[inline]
-ArrayTypeName: ArrayTypeName = {
-    // The base expression shouldn't end in a trailing IAP, if it does (like `a.b[c]`) it will be
-    // handled by `new_type_name_index_access_path` above
-    <type_name: TypeName1<FunctionType, NoIndexAccessPath>>  <open_bracket: OpenBracket>  <index: (Expression)?>  <close_bracket: CloseBracket>  => new_array_type_name(<>),
-};
-
-// An empty rule to disable IAPs
-NoIndexAccessPath: parser_helpers::IndexAccessPath = {};
-
+    <mapping_type: MappingType> => new_type_name_mapping_type(<>),
+    <index_access_path: IAPRule> =>
+    parser_helpers::new_type_name_index_access_path(<>),
+}; TypeName1<FunctionRule, IAPRule>: TypeName =
+{
+    <type_name: ArrayTypeName> => new_type_name_array_type_name(<>),
+    <type_name: TypeName0<FunctionRule, IAPRule>> => <>,
+}; TypeName: TypeName =
+{
+    <type_name: TypeName1<FunctionType, IndexAccessPath<IdentifierPath>>> =>
+    <>,
+}; #[inline] ArrayTypeName: ArrayTypeName =
+{
+    <type_name: TypeName1<FunctionType, NoIndexAccessPath>> <open_bracket:
+    OpenBracket> <index: (Expression)?> <close_bracket: CloseBracket> =>
+    new_array_type_name(<>),
+}; NoIndexAccessPath: parser_helpers::IndexAccessPath = {};
     
-    
-// The only reason to split FunctionType into two rules is to allow StateVariableDefinition
-// to choose whether to allow FunctionTypes without returns or not.
-// Note: This could be solved with macros, but is short enough to be explicit
-FunctionType: FunctionType = {
-    FunctionTypeInternalNoReturn => <>,
-    FunctionTypeInternalReturn => <>,
+    FunctionType: FunctionType =
+{ FunctionTypeInternalNoReturn => <>, FunctionTypeInternalReturn => <>, };
+FunctionTypeInternalNoReturn: FunctionType =
+{
+    <function_keyword: FunctionKeyword> <parameters: ParametersDeclaration>
+    <attributes: FunctionTypeAttributes> =>
+    new_function_type(function_keyword, parameters, attributes, None),
+}; FunctionTypeInternalReturn: FunctionType =
+{
+    <function_keyword: FunctionKeyword> <parameters: ParametersDeclaration>
+    <attributes: FunctionTypeAttributes> <returns: ReturnsDeclaration> =>
+    new_function_type(function_keyword, parameters, attributes,
+    Some(returns)),
 };
-
-FunctionTypeInternalNoReturn: FunctionType = {
-    <function_keyword: FunctionKeyword>  <parameters: ParametersDeclaration>  <attributes: FunctionTypeAttributes>   => new_function_type(function_keyword, parameters, attributes, None),
-};
-FunctionTypeInternalReturn: FunctionType = {
-    <function_keyword: FunctionKeyword>  <parameters: ParametersDeclaration>  <attributes: FunctionTypeAttributes>  <returns: ReturnsDeclaration>  => new_function_type(function_keyword, parameters, attributes, Some(returns)),
-    
-};
-
     FunctionTypeAttributes: FunctionTypeAttributes = {
         <function_type_attribute: RepeatedAllowEmpty<<FunctionTypeAttribute>>>  => new_function_type_attributes(<>),
         
@@ -814,89 +775,65 @@ FunctionTypeInternalReturn: FunctionType = {
         
     };
     
-    
-// There's two issues with `Statement`:
-//
-// This is a common problem in grammars[1]. To not reinvent the wheel we follow advice from
-// LALRPOP community[2].
-// Briefly, we parametrize statements on whether they allow a trailing else or not, forcing `else`s to attach to
-// the innermost `if`` possible.
-//
-// [1]: https://en.wikipedia.org/wiki/Dangling_else
-// [2]: https://github.com/lalrpop/lalrpop/issues/67#issuecomment-188951041
-//
-// On top of that, the `revert` keyword is unreserved, meaning that a variable declaration like
-// `revert x = ...;` is valid.
-// From the perspective of the parser there's an ambiguity when looking at a statement starting with `revert x ...`
-//
-// To solve it we introduce a special `VariableDeclarationStatement` that handles this case specifically,
-// since both this and `RevertStatement` are inlined, the parser doesn't need to reduce until it has seen the
-// entire statement.
-_Statement<TrailingElse>: Statement = {
-    <if_statement: IfStatement<TrailingElse>>  => new_statement_if_statement(<>),
-    <for_statement: ForStatement<TrailingElse>>  => new_statement_for_statement(<>),
-    <while_statement: WhileStatement<TrailingElse>>  => new_statement_while_statement(<>),
-    <do_while_statement: DoWhileStatement>  => new_statement_do_while_statement(<>),
-    <continue_statement: ContinueStatement>  => new_statement_continue_statement(<>),
-    <break_statement: BreakStatement>  => new_statement_break_statement(<>),
-    <return_statement: ReturnStatement>  => new_statement_return_statement(<>),
-    <emit_statement: EmitStatement>  => new_statement_emit_statement(<>),
-    <try_statement: TryStatement>  => new_statement_try_statement(<>),
-    <revert_statement: RevertStatement>  => new_statement_revert_statement(<>),
-    <assembly_statement: AssemblyStatement>  => new_statement_assembly_statement(<>),
-    <block: Block>  => new_statement_block(<>),
-    <unchecked_block: UncheckedBlock>  => new_statement_unchecked_block(<>),
-    <variable_declaration_statement: VariableDeclarationStatementSpecialRevert>  => new_statement_variable_declaration_statement(<>),
-    <expression_statement: ExpressionStatement>  => new_statement_expression_statement(<>),
-};
-
-// By default statements allow dangling `else`s
-Statement = _Statement<"True">;
-
-// A VariableDeclarationStatement that has a `revert` type as a special case, this allows
-// to disambiguate between a revert statement and a variable declaration with type `revert`
-//
-// Note: They need to be inline together with `RevertStatement` to actually avoid shift/reduce conflicts
-#[inline]
-VariableDeclarationStatementSpecialRevert: VariableDeclarationStatement = {
-    <target: VariableDeclarationTargetSpecialRevert>  <semicolon: Semicolon>  => new_variable_declaration_statement(<>),
-};
-#[inline]
-VariableDeclarationTargetSpecialRevert: VariableDeclarationTarget = {
-    <single_typed_declaration: SingleTypedDeclarationSpecialRevert>  => new_variable_declaration_target_single_typed_declaration(<>),
-    <multi_typed_declaration: MultiTypedDeclaration>  => new_variable_declaration_target_multi_typed_declaration(<>),
-};
-#[inline]
-SingleTypedDeclarationSpecialRevert: SingleTypedDeclaration = {
-    <declaration: VariableDeclarationSpecialRevert>  <value: (VariableDeclarationValue)?>  => new_single_typed_declaration(<>),
-};
-#[inline]
-VariableDeclarationSpecialRevert: VariableDeclaration = {
-    // A regular type that is not `revert`
-    //
-    // Note: we're tempted to inline TypeNames, but they are recursive, that's why we extract the special case
-    <type_name: TypeName1<FunctionType, IndexAccessPath<IdentifierPathNoRevert>>>  <storage_location: (StorageLocation)?>  <name: Identifier>  => new_variable_declaration(<>),
-    // The special `revert` type
-    <l:@L> L_RevertKeyword_Unreserved <r:@R>  <storage_location: (StorageLocation)?>  <name: Identifier>  => {
-        let identifier = new_identifier(l..r, source);
-        let iap = parser_helpers::new_index_access_path_from_identifier_path(new_identifier_path(vec![new_identifier_path_element_identifier(identifier)]));
+    _Statement<TrailingElse>: Statement =
+{
+    <if_statement: IfStatement<TrailingElse>> =>
+    new_statement_if_statement(<>), <for_statement:
+    ForStatement<TrailingElse>> => new_statement_for_statement(<>),
+    <while_statement: WhileStatement<TrailingElse>> =>
+    new_statement_while_statement(<>), <do_while_statement: DoWhileStatement>
+    => new_statement_do_while_statement(<>), <continue_statement:
+    ContinueStatement> => new_statement_continue_statement(<>),
+    <break_statement: BreakStatement> => new_statement_break_statement(<>),
+    <return_statement: ReturnStatement> => new_statement_return_statement(<>),
+    <emit_statement: EmitStatement> => new_statement_emit_statement(<>),
+    <try_statement: TryStatement> => new_statement_try_statement(<>),
+    <revert_statement: RevertStatement> => new_statement_revert_statement(<>),
+    <assembly_statement: AssemblyStatement> =>
+    new_statement_assembly_statement(<>), <block: Block> =>
+    new_statement_block(<>), <unchecked_block: UncheckedBlock> =>
+    new_statement_unchecked_block(<>), <variable_declaration_statement:
+    VariableDeclarationStatementSpecialRevert> =>
+    new_statement_variable_declaration_statement(<>), <expression_statement:
+    ExpressionStatement> => new_statement_expression_statement(<>),
+}; Statement = _Statement<"True">; #[inline]
+VariableDeclarationStatementSpecialRevert: VariableDeclarationStatement =
+{
+    <target: VariableDeclarationTargetSpecialRevert> <semicolon: Semicolon> =>
+    new_variable_declaration_statement(<>),
+}; #[inline] VariableDeclarationTargetSpecialRevert: VariableDeclarationTarget
+=
+{
+    <single_typed_declaration: SingleTypedDeclarationSpecialRevert> =>
+    new_variable_declaration_target_single_typed_declaration(<>),
+    <multi_typed_declaration: MultiTypedDeclaration> =>
+    new_variable_declaration_target_multi_typed_declaration(<>),
+}; #[inline] SingleTypedDeclarationSpecialRevert: SingleTypedDeclaration =
+{
+    <declaration: VariableDeclarationSpecialRevert> <value:
+    (VariableDeclarationValue)?> => new_single_typed_declaration(<>),
+}; #[inline] VariableDeclarationSpecialRevert: VariableDeclaration =
+{
+    <type_name: TypeName1<FunctionType,
+    IndexAccessPath<IdentifierPathNoRevert>>> <storage_location:
+    (StorageLocation)?> <name: Identifier> => new_variable_declaration(<>),
+    <l:@L> L_RevertKeyword_Unreserved <r:@R> <storage_location:
+    (StorageLocation)?> <name: Identifier> =>
+    {
+        let identifier = new_identifier(l..r, source); let iap =
+        parser_helpers::new_index_access_path_from_identifier_path(new_identifier_path(vec![new_identifier_path_element_identifier(identifier)]));
         let type_name = parser_helpers::new_type_name_index_access_path(iap);
         new_variable_declaration(type_name, storage_location, name)
     }
-};
-
-// An IdentifierPath that cannot be `revert`, used to disambiguate from the `revert` type
-#[inline]
-IdentifierPathNoRevert: IdentifierPath = {
-    // We either have any identifier with a tail (ie a period)
-    <head: Identifier> <mut tail: IdentifierPathTail>  => {
+}; #[inline] IdentifierPathNoRevert: IdentifierPath =
+{
+    <head: Identifier> <mut tail: IdentifierPathTail> =>
+    {
         tail.insert(0, new_identifier_path_element_identifier(head));
         new_identifier_path(tail)
-    },
-    // or a single identifier that is not `revert`
-    <head: SomeIdentifier<"RevertKeyword_Unreserved">>  => new_identifier_path(vec![new_identifier_path_element_identifier(<>)]),
+    }, <head: SomeIdentifier<"RevertKeyword_Unreserved">> =>
+    new_identifier_path(vec![new_identifier_path_element_identifier(<>)]),
 };
-
     UncheckedBlock: UncheckedBlock = {
         <unchecked_keyword: UncheckedKeyword>  <block: Block>  => new_unchecked_block(<>),
         
@@ -934,36 +871,19 @@ IdentifierPathNoRevert: IdentifierPath = {
         
     };
     
-    
-// MultiTypedDeclaration conflict with tuple expression, for example, the following is ambiguous:
-//
-// |--------|  => Assignment expression
-// |--|        => Tuple expression
-// (,,) = foo;
-// |--------|  => MultiTypedDeclaration
-//
-// In order to fix that, we give priority to assignment expressions, except an actual declaration (`uint bar`)
-// is seen.
-//
-// Since they also share a prefix (`(,,,`) we need to have a common prefix rule to avoid reduce/reduce conflicts.
-MultiTypedDeclarationElements: MultiTypedDeclarationElements = {
-    <prefix: TuplePrefix> <differentiator: VariableDeclaration> <typed_tuple_deconstruction_element: (Comma <Separated<Comma, <MultiTypedDeclarationElement>>>)?>  => {
-        let mut elements = vec![new_multi_typed_declaration_element(None); prefix];
+    MultiTypedDeclarationElements: MultiTypedDeclarationElements =
+{
+    <prefix: TuplePrefix> <differentiator: VariableDeclaration>
+    <typed_tuple_deconstruction_element:
+    (Comma <Separated<Comma, <MultiTypedDeclarationElement>>>)?> =>
+    {
+        let mut elements =
+        vec![new_multi_typed_declaration_element(None); prefix];
         elements.push(new_multi_typed_declaration_element(Some(differentiator)));
         elements.extend(typed_tuple_deconstruction_element.unwrap_or(vec![]));
         new_multi_typed_declaration_elements(elements)
     },
-    
-};
-
-// TuplePrefix counts how many leading commas we have in a tuple deconstruction or
-// in a tuple expression, this helps avoid reduce/reduce conflicts
-TuplePrefix: usize = {
-    // Count how many commas we have at the start, each comma represents an unnamed element
-    Comma  <rest: TuplePrefix>  => 1 + rest,
-    => 0,
-};
-
+}; TuplePrefix: usize = { Comma <rest: TuplePrefix> => 1 + rest, => 0, };
     MultiTypedDeclarationElement: MultiTypedDeclarationElement = {
         <member: (VariableDeclaration)?>  => new_multi_typed_declaration_element(<>),
         
@@ -982,25 +902,28 @@ TuplePrefix: usize = {
 
 // Rules for topic Control Statements
     
-    
-// As explained in the `Statement` rule, this solves the dangling else problem
-IfStatement<TrailingElse>: IfStatement = {
-    // IfStatement only allows `if`s without an else if TrailingElse == "True"
-    <if_keyword: IfKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<"True">> if TrailingElse == "True"  => new_if_statement(<>, None),
-    <if_keyword: IfKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<"False">>  <else_keyword: ElseKeyword>  <else_branch: _Statement<TrailingElse>>  => new_if_statement(if_keyword, open_paren, condition, close_paren, body, Some(new_else_branch(else_keyword, else_branch))),
+    IfStatement<TrailingElse>: IfStatement =
+{
+    <if_keyword: IfKeyword> <open_paren: OpenParen> <condition: Expression>
+    <close_paren: CloseParen> <body: _Statement<"True">> if TrailingElse ==
+    "True" => new_if_statement(<>, None), <if_keyword: IfKeyword> <open_paren:
+    OpenParen> <condition: Expression> <close_paren: CloseParen> <body:
+    _Statement<"False">> <else_keyword: ElseKeyword> <else_branch:
+    _Statement<TrailingElse>> =>
+    new_if_statement(if_keyword, open_paren, condition, close_paren, body,
+    Some(new_else_branch(else_keyword, else_branch))),
 };
-
     ElseBranch: ElseBranch = {
         <else_keyword: ElseKeyword>  <body: Statement>  => new_else_branch(<>),
         
     };
     
-    
-// As explained in the `Statement` rule, this solves the dangling else problem
-//
-// Since a `ForStatement` can have a trailing `Statement` we need to parametrize it as well
-ForStatement<TrailingElse>: ForStatement = {
-        <for_keyword: ForKeyword>  <open_paren: OpenParen>  <initialization: ForStatementInitialization>  <condition: ForStatementCondition>  <iterator: (Expression)?>  <close_paren: CloseParen>  <body: _Statement<TrailingElse>>  => new_for_statement(<>),
+    ForStatement<TrailingElse>: ForStatement =
+{
+    <for_keyword: ForKeyword> <open_paren: OpenParen> <initialization:
+    ForStatementInitialization> <condition: ForStatementCondition> <iterator:
+    (Expression)?> <close_paren: CloseParen> <body: _Statement<TrailingElse>>
+    => new_for_statement(<>),
 };
     ForStatementInitialization: ForStatementInitialization = {
         <variable_declaration_statement: VariableDeclarationStatement>  => new_for_statement_initialization_variable_declaration_statement(<>),
@@ -1014,12 +937,11 @@ ForStatement<TrailingElse>: ForStatement = {
         
     };
     
-    
-// As explained in the `Statement` rule, this solves the dangling else problem
-//
-// Since a `WhileStatement` can have a trailing `Statement` we need to parametrize it as well
-WhileStatement<TrailingElse>: WhileStatement = {
-        <while_keyword: WhileKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <body: _Statement<TrailingElse>>  => new_while_statement(<>),
+    WhileStatement<TrailingElse>: WhileStatement =
+{
+    <while_keyword: WhileKeyword> <open_paren: OpenParen> <condition:
+    Expression> <close_paren: CloseParen> <body: _Statement<TrailingElse>> =>
+    new_while_statement(<>),
 };
     DoWhileStatement: DoWhileStatement = {
         <do_keyword: DoKeyword>  <body: Statement>  <while_keyword: WhileKeyword>  <open_paren: OpenParen>  <condition: Expression>  <close_paren: CloseParen>  <semicolon: Semicolon>  => new_do_while_statement(<>),
@@ -1045,28 +967,21 @@ WhileStatement<TrailingElse>: WhileStatement = {
 
 // Rules for topic Error Handling
     
-    
-// A try statement conflicts with expressions since an expression can have named arguments (similar to a block)
-// at the end. For example, if the parser sees `try foo { a` it doesn't know whether foo is an expression and it should
-// start parsing a block (a reduce) or whether it should keep parsing a call options expression (a shift).
-//
-// We use expressions with a trailing block to solve this, and steal the block from there.
-TryStatement: TryStatement = {
-    // a `ReturnsDeclaration` acts as a disambiguator
-    <try_keyword: TryKeyword>  <expression: Expression>  <returns: ReturnsDeclaration>  <body: Block>  <catch_clauses: CatchClauses>  => {
-        new_try_statement(try_keyword, expression, Some(returns), body, catch_clauses)
-    },
-    <try_keyword: TryKeyword>  <expression: ExpressionTrailingBlock>   <catch_clauses: CatchClauses>  => {
+    TryStatement: TryStatement =
+{
+    <try_keyword: TryKeyword> <expression: Expression> <returns:
+    ReturnsDeclaration> <body: Block> <catch_clauses: CatchClauses> =>
+    {
+        new_try_statement(try_keyword, expression, Some(returns), body,
+        catch_clauses)
+    }, <try_keyword: TryKeyword> <expression: ExpressionTrailingBlock>
+    <catch_clauses: CatchClauses> =>
+    {
         let (expr, body) = expression;
         new_try_statement(try_keyword, expr, None, body, catch_clauses)
     },
-};
-
-// An expression followed by a block
-ExpressionTrailingBlock: (Expression, Block) = {
-        <expression: Expression19<Block>>  => <>,
-};
-
+}; ExpressionTrailingBlock: (Expression, Block) =
+{ <expression: Expression19<Block>> => <>, };
     CatchClauses: CatchClauses = {
         <catch_clause: Repeated<<CatchClause>>>  => new_catch_clauses(<>),
         
@@ -1093,306 +1008,301 @@ ExpressionTrailingBlock: (Expression, Block) = {
 
 // Rules for topic Base Expressions
     
-    
-// Expression has a lot of tricky cases:
-// 1. There's conflicts with `TypeName`, for example `a.b[c]` can be either a member access over an identifier path, or
-//    an array type, depending on what comes next. As explained on the `TypeName` rule, we need to delay reduction of
-//    these constructs as long as possible, only converting them to `Expression` at new_expression_index_access_path.
-//    Note: That there's no `ElementaryType` rule, it's handled as an IAP
-// 2. But this creates another problem, since we still want to have `MemberAccess` and `IndexAccess` as expressions,
-//    but now they conflict with IAP; for example, `a.b` can be either a member access or an IAP, therefore we have to
-//    disable member access and index access over IAPs that can be types, we do this by parametrizing the
-//    `IndexAccessPathRule`
-// 3. Also, new expressions are problematic, since they have a trailing `TypeName`, allowing this example to be parsed
-//    in two different ambiguous ways:
-//
-//        |--------| => IndexAccessExpression
-//        |-----|    => NewExpression
-//            |-|    => TypeName
-//        new foo[]
-//            |---|  => TypeName (an array type)
-//        |-------|  => NewExpression
-//
-//    We want to fix this by giving priority to the internal typename, therefore we parametrize over `NewExpressionRule`
-//    disallowing `MemberAccess` and `IndexAccess` over new expressions.
-// 4. `Expression` are often at a trailing position, for example in storage layout specifiers,
-//    to facilitate fixing ambiguities in those cases, we allow `Expression` to be parametrized over a trailing element,
-//    that will be matched against when possible, and lifted up through the recursion.
-//    This seems to not have any effect, but it allows the parser to postpone reductions.
-// 5. Finally, expressions have multiple precedence levels and associativity, we handle this explicitely here.
-Expression0<IndexAccessPathRule, NewExpressionRule>: Expression = {
-    // The Rule used here is parametric
-    <index_access_path: IndexAccessPathRule> => parser_helpers::new_expression_index_access_path(<>),
-    // The Rule used here is parametric
-    <new_expression: NewExpressionRule> => new_expression_new_expression(<>),
-    <tuple_expression: TupleExpression>  => new_expression_tuple_expression(<>),
-    <type_expression: TypeExpression>  => new_expression_type_expression(<>),
-    <array_expression: ArrayExpression>  => new_expression_array_expression(<>),
-    <hex_number_expression: HexNumberExpression>  => new_expression_hex_number_expression(<>),
-    <decimal_number_expression: DecimalNumberExpression>  => new_expression_decimal_number_expression(<>),
-    <string_expression: StringExpression>  => new_expression_string_expression(<>),
-    <payable_keyword: PayableKeyword>  => new_expression_payable_keyword(<>),
-    <this_keyword: ThisKeyword>  => new_expression_this_keyword(<>),
-    <super_keyword: SuperKeyword>  => new_expression_super_keyword(<>),
-    <true_keyword: TrueKeyword>  => new_expression_true_keyword(<>),
-    <false_keyword: FalseKeyword>  => new_expression_false_keyword(<>),
-};
-
-// An IAP that doesn't match anything
-NoIndexAccessPath_Expr: parser_helpers::IndexAccessPath = {};
-
-// We simplifiy all these levels of expressions into a single one, there's no need
-// for precedence here
-Expression1<IndexAccessPathRule, NewExpressionRule>: Expression = {
-    // When parsing an index acces expression, the sub expression shouldn't trail in an index access path
-    // Nor should it trail on a NewExpression
-    <expression: Expression1<NoIndexAccessPath_Expr, NoNewExpression>>  <open_bracket: OpenBracket>  <start: (Expression)?>  <end: (IndexAccessEnd)?>  <close_bracket: CloseBracket>  => new_expression_index_access_expression(new_index_access_expression(<>)),
-    // When parsing a member access expression, the sub expression shouldn't trail in a path
-    // Nor should it trail on a NewExpression
-    <expression: Expression1<IndexAccessPath<NoIdentPath>, NoNewExpression>>  <period: Period>  <member: IdentifierPathElement>  => new_expression_member_access_expression(new_member_access_expression(<>)),
-
-    // Both the braces and the arguments declaration serve as markers for disambiguation, therefore
-    // resetting the parametric rules.
-    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>>  <open_brace: OpenBrace>  <options: CallOptions>  <close_brace: CloseBrace>  => new_expression_call_options_expression(new_call_options_expression(<>)),
-    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>>  <arguments: ArgumentsDeclaration>  => new_expression_function_call_expression(new_function_call_expression(<>)),
-
-    <expression: Expression0<IndexAccessPathRule, NewExpressionRule>>  => <>,
-};
-
-// A Matcher for an empty NewExpression 
-NoNewExpression: NewExpression = {};
-
-// Tail is a rule identifying what comes after the expression, whatever is captured is added to the tuple result
-Expression5<Tail>: (Expression, Tail) = {
-    <expression_prefix_expression_operator: Expression_PrefixExpression_Operator>  <expression: Expression5<Tail>>  => {
+    Expression0<IndexAccessPathRule, NewExpressionRule>: Expression =
+{
+    <index_access_path: IndexAccessPathRule> =>
+    parser_helpers::new_expression_index_access_path(<>), <new_expression:
+    NewExpressionRule> => new_expression_new_expression(<>),
+    <tuple_expression: TupleExpression> =>
+    new_expression_tuple_expression(<>), <type_expression: TypeExpression> =>
+    new_expression_type_expression(<>), <array_expression: ArrayExpression> =>
+    new_expression_array_expression(<>), <hex_number_expression:
+    HexNumberExpression> => new_expression_hex_number_expression(<>),
+    <decimal_number_expression: DecimalNumberExpression> =>
+    new_expression_decimal_number_expression(<>), <string_expression:
+    StringExpression> => new_expression_string_expression(<>),
+    <payable_keyword: PayableKeyword> => new_expression_payable_keyword(<>),
+    <this_keyword: ThisKeyword> => new_expression_this_keyword(<>),
+    <super_keyword: SuperKeyword> => new_expression_super_keyword(<>),
+    <true_keyword: TrueKeyword> => new_expression_true_keyword(<>),
+    <false_keyword: FalseKeyword> => new_expression_false_keyword(<>),
+}; NoIndexAccessPath_Expr: parser_helpers::IndexAccessPath = {};
+Expression1<IndexAccessPathRule, NewExpressionRule>: Expression =
+{
+    <expression: Expression1<NoIndexAccessPath_Expr, NoNewExpression>>
+    <open_bracket: OpenBracket> <start: (Expression)?> <end:
+    (IndexAccessEnd)?> <close_bracket: CloseBracket> =>
+    new_expression_index_access_expression(new_index_access_expression(<>)),
+    <expression: Expression1<IndexAccessPath<NoIdentPath>, NoNewExpression>>
+    <period: Period> <member: IdentifierPathElement> =>
+    new_expression_member_access_expression(new_member_access_expression(<>)),
+    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>>
+    <open_brace: OpenBrace> <options: CallOptions> <close_brace: CloseBrace>
+    =>
+    new_expression_call_options_expression(new_call_options_expression(<>)),
+    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>>
+    <arguments: ArgumentsDeclaration> =>
+    new_expression_function_call_expression(new_function_call_expression(<>)),
+    <expression: Expression0<IndexAccessPathRule, NewExpressionRule>> => <>,
+}; NoNewExpression: NewExpression = {}; Expression5<Tail>: (Expression, Tail)
+=
+{
+    <expression_prefix_expression_operator:
+    Expression_PrefixExpression_Operator> <expression: Expression5<Tail>> =>
+    {
         let (expr, tail) = expression;
-        (new_expression_prefix_expression(new_prefix_expression(expression_prefix_expression_operator, expr)), tail)
-    },
-    
-    // A tail can appear just after a postfix or primary expression
-    <expression: Expression1<IndexAccessPath<IdentifierPath>, NewExpression>> <tail: Tail> => {
-        (expression, tail)
-    },
+        (new_expression_prefix_expression(new_prefix_expression(expression_prefix_expression_operator,
+        expr)), tail)
+    }, <expression: Expression1<IndexAccessPath<IdentifierPath>,
+    NewExpression>> <tail: Tail> => (expression, tail),
+}; Expression6<Tail>: (Expression, Tail) =
+{
+    <expression: Expression6<EmptyTail>>
+    <expression_postfix_expression_operator:
+    Expression_PostfixExpression_Operator> <tail: Tail> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (expr, _) = expression;
+        (new_expression_postfix_expression(new_postfix_expression(expr,
+        expression_postfix_expression_operator)), tail)
+    }, <expression: Expression5<Tail>> => <>,
+}; Expression7<Tail>: (Expression, Tail) =
+{
+    <expression: Expression6<EmptyTail>> <operator: AsteriskAsterisk>
+    <expression_2: Expression7<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_exponentiation_expression(new_exponentiation_expression(e,
+        operator, e2)), tail)
+    }, <expression: Expression6<Tail>> => <>,
+}; Expression8<Tail>: (Expression, Tail) =
+{
+    <expression: Expression8<EmptyTail>>
+    <expression_multiplicative_expression_operator:
+    Expression_MultiplicativeExpression_Operator> <expression_2:
+    Expression7<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_multiplicative_expression(new_multiplicative_expression(e,
+        expression_multiplicative_expression_operator, e2)), tail)
+    }, <expression: Expression7<Tail>> => <>,
+}; Expression9<Tail>: (Expression, Tail) =
+{
+    <expression: Expression9<EmptyTail>>
+    <expression_additive_expression_operator:
+    Expression_AdditiveExpression_Operator> <expression_2: Expression8<Tail>>
+    =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_additive_expression(new_additive_expression(e,
+        expression_additive_expression_operator, e2)), tail)
+    }, <expression: Expression8<Tail>> => <>,
+}; Expression10<Tail>: (Expression, Tail) =
+{
+    <expression: Expression10<EmptyTail>>
+    <expression_shift_expression_operator:
+    Expression_ShiftExpression_Operator> <expression_2: Expression9<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_shift_expression(new_shift_expression(e,
+        expression_shift_expression_operator, e2)), tail)
+    }, <expression: Expression9<Tail>> => <>,
+}; Expression11<Tail>: (Expression, Tail) =
+{
+    <expression: Expression11<EmptyTail>> <operator: Ampersand> <expression_2:
+    Expression10<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_bitwise_and_expression(new_bitwise_and_expression(e,
+        operator, e2)), tail)
+    }, <expression: Expression10<Tail>> => <>,
+}; Expression12<Tail>: (Expression, Tail) =
+{
+    <expression: Expression12<EmptyTail>> <operator: Caret> <expression_2:
+    Expression11<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_bitwise_xor_expression(new_bitwise_xor_expression(e,
+        operator, e2)), tail)
+    }, <expression: Expression11<Tail>> => <>,
+}; Expression13<Tail>: (Expression, Tail) =
+{
+    <expression: Expression13<EmptyTail>> <operator: Bar> <expression_2:
+    Expression12<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_bitwise_or_expression(new_bitwise_or_expression(e,
+        operator, e2)), tail)
+    }, <expression: Expression12<Tail>> => <>,
+}; Expression14<Tail>: (Expression, Tail) =
+{
+    <expression: Expression14<EmptyTail>>
+    <expression_inequality_expression_operator:
+    Expression_InequalityExpression_Operator> <expression_2:
+    Expression13<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_inequality_expression(new_inequality_expression(e,
+        expression_inequality_expression_operator, e2)), tail)
+    }, <expression: Expression13<Tail>> => <>,
+}; Expression15<Tail>: (Expression, Tail) =
+{
+    <expression: Expression15<EmptyTail>>
+    <expression_equality_expression_operator:
+    Expression_EqualityExpression_Operator> <expression_2: Expression14<Tail>>
+    =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_equality_expression(new_equality_expression(e,
+        expression_equality_expression_operator, e2)), tail)
+    }, <expression: Expression14<Tail>> => <>,
+}; Expression16<Tail>: (Expression, Tail) =
+{
+    <expression: Expression16<EmptyTail>> <operator: AmpersandAmpersand>
+    <expression_2: Expression15<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_and_expression(new_and_expression(e, operator, e2)),
+        tail)
+    }, <expression: Expression15<Tail>> => <>,
+}; Expression17<Tail>: (Expression, Tail) =
+{
+    <expression: Expression17<EmptyTail>> <operator: BarBar> <expression_2:
+    Expression16<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_or_expression(new_or_expression(e, operator, e2)),
+        tail)
+    }, <expression: Expression16<Tail>> => <>,
+}; Expression19<Tail>: (Expression, Tail) =
+{
+    <expression: Expression17<EmptyTail>> <question_mark: QuestionMark>
+    <true_expression: Expression19<EmptyTail>> <colon: Colon>
+    <false_expression: Expression19<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (cond_expr, _) =
+        expression; #[allow(clippy::ignored_unit_patterns)] let (true_expr, _)
+        = true_expression; let (false_expr, tail) = false_expression;
+        (new_expression_conditional_expression(new_conditional_expression(cond_expr,
+        question_mark, true_expr, colon, false_expr)), tail)
+    }, <expression: Expression17<EmptyTail>>
+    <expression_assignment_expression_operator:
+    Expression_AssignmentExpression_Operator> <expression_2:
+    Expression19<Tail>> =>
+    {
+        #[allow(clippy::ignored_unit_patterns)] let (e, _) = expression; let
+        (e2, tail) = expression_2;
+        (new_expression_assignment_expression(new_assignment_expression(e,
+        expression_assignment_expression_operator, e2)), tail)
+    }, <expression: Expression17<Tail>> => <>,
+}; Expression: Expression =
+{ <expression: Expression19<EmptyTail>> => expression.0, }; EmptyTail: () =
+{ () => (), }; Expression_PrefixExpression_Operator:
+Expression_PrefixExpression_Operator =
+{
+    <operator: PlusPlus> =>
+    new_expression_prefix_expression_operator_plus_plus(<>), <operator:
+    MinusMinus> => new_expression_prefix_expression_operator_minus_minus(<>),
+    <operator: Tilde> => new_expression_prefix_expression_operator_tilde(<>),
+    <operator: Bang> => new_expression_prefix_expression_operator_bang(<>),
+    <operator: Minus> => new_expression_prefix_expression_operator_minus(<>),
+    <operator: DeleteKeyword> =>
+    new_expression_prefix_expression_operator_delete_keyword(<>),
+}; Expression_PostfixExpression_Operator:
+Expression_PostfixExpression_Operator =
+{
+    <operator: PlusPlus> =>
+    new_expression_postfix_expression_operator_plus_plus(<>), <operator:
+    MinusMinus> => new_expression_postfix_expression_operator_minus_minus(<>),
+}; Expression_MultiplicativeExpression_Operator:
+Expression_MultiplicativeExpression_Operator =
+{
+    <operator: Asterisk> =>
+    new_expression_multiplicative_expression_operator_asterisk(<>), <operator:
+    Slash> => new_expression_multiplicative_expression_operator_slash(<>),
+    <operator: Percent> =>
+    new_expression_multiplicative_expression_operator_percent(<>),
+}; Expression_AdditiveExpression_Operator:
+Expression_AdditiveExpression_Operator =
+{
+    <operator: Plus> => new_expression_additive_expression_operator_plus(<>),
+    <operator: Minus> =>
+    new_expression_additive_expression_operator_minus(<>),
+}; Expression_ShiftExpression_Operator: Expression_ShiftExpression_Operator =
+{
+    <operator: LessThanLessThan> =>
+    new_expression_shift_expression_operator_less_than_less_than(<>),
+    <operator: GreaterThanGreaterThan> =>
+    new_expression_shift_expression_operator_greater_than_greater_than(<>),
+    <operator: GreaterThanGreaterThanGreaterThan> =>
+    new_expression_shift_expression_operator_greater_than_greater_than_greater_than(<>),
+}; Expression_InequalityExpression_Operator:
+Expression_InequalityExpression_Operator =
+{
+    <operator: LessThan> =>
+    new_expression_inequality_expression_operator_less_than(<>), <operator:
+    GreaterThan> =>
+    new_expression_inequality_expression_operator_greater_than(<>), <operator:
+    LessThanEqual> =>
+    new_expression_inequality_expression_operator_less_than_equal(<>),
+    <operator: GreaterThanEqual> =>
+    new_expression_inequality_expression_operator_greater_than_equal(<>),
+}; Expression_EqualityExpression_Operator:
+Expression_EqualityExpression_Operator =
+{
+    <operator: EqualEqual> =>
+    new_expression_equality_expression_operator_equal_equal(<>), <operator:
+    BangEqual> => new_expression_equality_expression_operator_bang_equal(<>),
+}; Expression_AssignmentExpression_Operator:
+Expression_AssignmentExpression_Operator =
+{
+    <operator: Equal> =>
+    new_expression_assignment_expression_operator_equal(<>), <operator:
+    BarEqual> => new_expression_assignment_expression_operator_bar_equal(<>),
+    <operator: PlusEqual> =>
+    new_expression_assignment_expression_operator_plus_equal(<>), <operator:
+    MinusEqual> =>
+    new_expression_assignment_expression_operator_minus_equal(<>), <operator:
+    CaretEqual> =>
+    new_expression_assignment_expression_operator_caret_equal(<>), <operator:
+    SlashEqual> =>
+    new_expression_assignment_expression_operator_slash_equal(<>), <operator:
+    PercentEqual> =>
+    new_expression_assignment_expression_operator_percent_equal(<>),
+    <operator: AsteriskEqual> =>
+    new_expression_assignment_expression_operator_asterisk_equal(<>),
+    <operator: AmpersandEqual> =>
+    new_expression_assignment_expression_operator_ampersand_equal(<>),
+    <operator: LessThanLessThanEqual> =>
+    new_expression_assignment_expression_operator_less_than_less_than_equal(<>),
+    <operator: GreaterThanGreaterThanEqual> =>
+    new_expression_assignment_expression_operator_greater_than_greater_than_equal(<>),
+    <operator: GreaterThanGreaterThanGreaterThanEqual> =>
+    new_expression_assignment_expression_operator_greater_than_greater_than_greater_than_equal(<>),
+}; NoIdentPath: IdentifierPath = {}; IndexAccessPath<IdentPathRule>:
+parser_helpers::IndexAccessPath =
+{
+    <iap: IndexAccessPath<IdentifierPath>> <open_bracket: OpenBracket> <start:
+    (Expression)?> <end: (IndexAccessEnd)?> <close_bracket: CloseBracket> =>
+    parser_helpers::index_access_path_add_index(<>),
+    <IndexAccessPath1<IdentPathRule>> => <>,
+}; IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath =
+{
+    <identifier: IdentPathRule> =>
+    parser_helpers::new_index_access_path_from_identifier_path(<>),
+    <elementary_type: ElementaryType> =>
+    parser_helpers::new_index_access_path_from_elementary_type(<>),
 };
-Expression6<Tail>: (Expression, Tail) = {
-    // This is the only other postfix expression that can overwrite a trailing element
-    // Note that the recursive call expects no tail at all
-    <expression: Expression6<EmptyTail>>  <expression_postfix_expression_operator: Expression_PostfixExpression_Operator> <tail: Tail>  => {
-        // This is monomorphized by LALRPOP, so we can't really fix this
-        #[allow(clippy::ignored_unit_patterns)]
-        let (expr, _) = expression;
-        (new_expression_postfix_expression(new_postfix_expression(expr, expression_postfix_expression_operator)), tail)
-    },
-    
-    <expression: Expression5<Tail>>  => <>,
-};
-Expression7<Tail>: (Expression, Tail) = {
-    // Note that only the right recursive rule matches a tail, the left recursive expects no tail
-    <expression: Expression6<EmptyTail>>  <operator: AsteriskAsterisk>  <expression_2: Expression7<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_exponentiation_expression(new_exponentiation_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression6<Tail>>  => <>,
-};
-Expression8<Tail>: (Expression, Tail) = {
-    <expression: Expression8<EmptyTail>>  <expression_multiplicative_expression_operator: Expression_MultiplicativeExpression_Operator>  <expression_2: Expression7<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_multiplicative_expression(new_multiplicative_expression(e, expression_multiplicative_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression7<Tail>>  => <>,
-};
-Expression9<Tail>: (Expression, Tail) = {
-    <expression: Expression9<EmptyTail>>  <expression_additive_expression_operator: Expression_AdditiveExpression_Operator>  <expression_2: Expression8<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_additive_expression(new_additive_expression(e, expression_additive_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression8<Tail>>  => <>,
-};
-Expression10<Tail>: (Expression, Tail) = {
-    <expression: Expression10<EmptyTail>>  <expression_shift_expression_operator: Expression_ShiftExpression_Operator>  <expression_2: Expression9<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_shift_expression(new_shift_expression(e, expression_shift_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression9<Tail>>  => <>,
-};
-Expression11<Tail>: (Expression, Tail) = {
-    <expression: Expression11<EmptyTail>>  <operator: Ampersand>  <expression_2: Expression10<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_bitwise_and_expression(new_bitwise_and_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression10<Tail>>  => <>,
-};
-Expression12<Tail>: (Expression, Tail) = {
-    <expression: Expression12<EmptyTail>>  <operator: Caret>  <expression_2: Expression11<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_bitwise_xor_expression(new_bitwise_xor_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression11<Tail>>  => <>,
-};
-Expression13<Tail>: (Expression, Tail) = {
-    <expression: Expression13<EmptyTail>>  <operator: Bar>  <expression_2: Expression12<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_bitwise_or_expression(new_bitwise_or_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression12<Tail>>  => <>,
-};
-Expression14<Tail>: (Expression, Tail) = {
-    <expression: Expression14<EmptyTail>>  <expression_inequality_expression_operator: Expression_InequalityExpression_Operator>  <expression_2: Expression13<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_inequality_expression(new_inequality_expression(e, expression_inequality_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression13<Tail>>  => <>,
-};
-Expression15<Tail>: (Expression, Tail) = {
-    <expression: Expression15<EmptyTail>>  <expression_equality_expression_operator: Expression_EqualityExpression_Operator>  <expression_2: Expression14<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_equality_expression(new_equality_expression(e, expression_equality_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression14<Tail>>  => <>,
-};
-Expression16<Tail>: (Expression, Tail) = {
-    <expression: Expression16<EmptyTail>>  <operator: AmpersandAmpersand>  <expression_2: Expression15<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_and_expression(new_and_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression15<Tail>>  => <>,
-};
-Expression17<Tail>: (Expression, Tail) = {
-    <expression: Expression17<EmptyTail>>  <operator: BarBar>  <expression_2: Expression16<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_or_expression(new_or_expression(e, operator, e2)), tail)
-    },
-    
-    <expression: Expression16<Tail>>  => <>,
-};
-Expression19<Tail>: (Expression, Tail) = {
-    <expression: Expression17<EmptyTail>>  <question_mark: QuestionMark>  <true_expression: Expression19<EmptyTail>>  <colon: Colon>  <false_expression: Expression19<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (cond_expr, _) = expression;
-        #[allow(clippy::ignored_unit_patterns)]
-        let (true_expr, _) = true_expression;
-        let (false_expr, tail) = false_expression;
-        (new_expression_conditional_expression(new_conditional_expression(cond_expr, question_mark, true_expr, colon, false_expr)), tail)
-    },
-    
-    <expression: Expression17<EmptyTail>>  <expression_assignment_expression_operator: Expression_AssignmentExpression_Operator>  <expression_2: Expression19<Tail>>  => {
-        #[allow(clippy::ignored_unit_patterns)]
-        let (e, _) = expression;
-        let (e2, tail) = expression_2;
-        (new_expression_assignment_expression(new_assignment_expression(e, expression_assignment_expression_operator, e2)), tail)
-    },
-    
-    <expression: Expression17<Tail>>  => <>,
-};
-
-Expression: Expression = {
-    // By default, we expect no tail
-    <expression: Expression19<EmptyTail>>  => expression.0,
-};
-
-// An empty tail is the default behaviour
-EmptyTail: () = {
-    () => (),
-};
-
-// The different operators are used like choices, and wrapped accordingly
-Expression_PrefixExpression_Operator: Expression_PrefixExpression_Operator = {
-    <operator: PlusPlus>  => new_expression_prefix_expression_operator_plus_plus(<>),
-    <operator: MinusMinus>  => new_expression_prefix_expression_operator_minus_minus(<>),
-    <operator: Tilde>  => new_expression_prefix_expression_operator_tilde(<>),
-    <operator: Bang>  => new_expression_prefix_expression_operator_bang(<>),
-    <operator: Minus>  => new_expression_prefix_expression_operator_minus(<>),
-    <operator: DeleteKeyword>  => new_expression_prefix_expression_operator_delete_keyword(<>),
-};
-Expression_PostfixExpression_Operator: Expression_PostfixExpression_Operator = {
-    <operator: PlusPlus>  => new_expression_postfix_expression_operator_plus_plus(<>),
-    <operator: MinusMinus>  => new_expression_postfix_expression_operator_minus_minus(<>),
-};
-Expression_MultiplicativeExpression_Operator: Expression_MultiplicativeExpression_Operator = {
-    <operator: Asterisk>  => new_expression_multiplicative_expression_operator_asterisk(<>),
-    <operator: Slash>  => new_expression_multiplicative_expression_operator_slash(<>),
-    <operator: Percent>  => new_expression_multiplicative_expression_operator_percent(<>),
-};
-Expression_AdditiveExpression_Operator: Expression_AdditiveExpression_Operator = {
-    <operator: Plus>  => new_expression_additive_expression_operator_plus(<>),
-    <operator: Minus>  => new_expression_additive_expression_operator_minus(<>),
-};
-Expression_ShiftExpression_Operator: Expression_ShiftExpression_Operator = {
-    <operator: LessThanLessThan>  => new_expression_shift_expression_operator_less_than_less_than(<>),
-    <operator: GreaterThanGreaterThan>  => new_expression_shift_expression_operator_greater_than_greater_than(<>),
-    <operator: GreaterThanGreaterThanGreaterThan>  => new_expression_shift_expression_operator_greater_than_greater_than_greater_than(<>),
-};
-Expression_InequalityExpression_Operator: Expression_InequalityExpression_Operator = {
-    <operator: LessThan>  => new_expression_inequality_expression_operator_less_than(<>),
-    <operator: GreaterThan>  => new_expression_inequality_expression_operator_greater_than(<>),
-    <operator: LessThanEqual>  => new_expression_inequality_expression_operator_less_than_equal(<>),
-    <operator: GreaterThanEqual>  => new_expression_inequality_expression_operator_greater_than_equal(<>),
-};
-Expression_EqualityExpression_Operator: Expression_EqualityExpression_Operator = {
-    <operator: EqualEqual>  => new_expression_equality_expression_operator_equal_equal(<>),
-    <operator: BangEqual>  => new_expression_equality_expression_operator_bang_equal(<>),
-};
-Expression_AssignmentExpression_Operator: Expression_AssignmentExpression_Operator = {
-    <operator: Equal>  => new_expression_assignment_expression_operator_equal(<>),
-    <operator: BarEqual>  => new_expression_assignment_expression_operator_bar_equal(<>),
-    <operator: PlusEqual>  => new_expression_assignment_expression_operator_plus_equal(<>),
-    <operator: MinusEqual>  => new_expression_assignment_expression_operator_minus_equal(<>),
-    <operator: CaretEqual>  => new_expression_assignment_expression_operator_caret_equal(<>),
-    <operator: SlashEqual>  => new_expression_assignment_expression_operator_slash_equal(<>),
-    <operator: PercentEqual>  => new_expression_assignment_expression_operator_percent_equal(<>),
-    <operator: AsteriskEqual>  => new_expression_assignment_expression_operator_asterisk_equal(<>),
-    <operator: AmpersandEqual>  => new_expression_assignment_expression_operator_ampersand_equal(<>),
-    <operator: LessThanLessThanEqual>  => new_expression_assignment_expression_operator_less_than_less_than_equal(<>),
-    <operator: GreaterThanGreaterThanEqual>  => new_expression_assignment_expression_operator_greater_than_greater_than_equal(<>),
-    <operator: GreaterThanGreaterThanGreaterThanEqual>  => new_expression_assignment_expression_operator_greater_than_greater_than_greater_than_equal(<>),
-};
-
-// A rule matching en empty `IdentifierPath`
-NoIdentPath: IdentifierPath = {};
-
-// An Index Access Path that is parametric over the IdentifierPath rule used for member access and index access
-IndexAccessPath<IdentPathRule>: parser_helpers::IndexAccessPath = {
-    // As before, we usually care about trailing constructs, so the brackets serve as markers to reset the parametric rule
-    <iap: IndexAccessPath<IdentifierPath>> <open_bracket: OpenBracket>  <start: (Expression)?>  <end: (IndexAccessEnd)?>  <close_bracket: CloseBracket>  => parser_helpers::index_access_path_add_index(<>),
-    <IndexAccessPath1<IdentPathRule>>  => <>,
-};
-IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
-    <identifier: IdentPathRule> => parser_helpers::new_index_access_path_from_identifier_path(<>),
-    <elementary_type: ElementaryType>  => parser_helpers::new_index_access_path_from_elementary_type(<>),
-};
-
     IndexAccessEnd: IndexAccessEnd = {
         <colon: Colon>  <end: (Expression)?>  => new_index_access_end(<>),
         
@@ -1441,43 +1351,31 @@ IndexAccessPath1<IdentPathRule>: parser_helpers::IndexAccessPath = {
         
     };
     
-    
-// We avoid function types entirely in new expressions, this is ok since they're not allowed
-// in Solidity, but the error will be syntactic rather than semantic, which may be confusing.
-//
-// We do this to avoid the amibiguity of `try new function () returns (uint) ...`, where the returns clause may be
-// parsed either as part of the function type or as part of a try statement.
-NewExpression: NewExpression = {
-    <new_keyword: NewKeyword>  <type_name: TypeName1<NoFunctionType, IndexAccessPath<IdentifierPath>>>  => new_new_expression(<>),
-    
-};
-
-NoFunctionType: FunctionType = {};
-
+    NewExpression: NewExpression =
+{
+    <new_keyword: NewKeyword> <type_name: TypeName1<NoFunctionType,
+    IndexAccessPath<IdentifierPath>>> => new_new_expression(<>),
+}; NoFunctionType: FunctionType = {};
     TupleExpression: TupleExpression = {
         <open_paren: OpenParen>  <items: TupleValues>  <close_paren: CloseParen>  => new_tuple_expression(<>),
         
     };
     
-    
-// See the comment around TupleDeconstructionStatement for an explanation of this rule.
-#[inline]
-TupleValues: TupleValues = {
-    <prefix: TuplePrefix> => {
-        // We need to add an extra empty element here, since the trailing comma indicates
-        // an additional empty tuple value.
+    #[inline] TupleValues: TupleValues =
+{
+    <prefix: TuplePrefix> =>
+    {
         let elements = vec![new_tuple_value(None); prefix + 1];
         new_tuple_values(elements)
-    },
-    <prefix: TuplePrefix> <differentiator: Expression> <tuple_value: (Comma <Separated<Comma, <TupleValue>>>)?>  => {
+    }, <prefix: TuplePrefix> <differentiator: Expression> <tuple_value:
+    (Comma <Separated<Comma, <TupleValue>>>)?> =>
+    {
         let mut elements = vec![new_tuple_value(None); prefix];
         elements.push(new_tuple_value(Some(differentiator)));
         elements.extend(tuple_value.unwrap_or(vec![]));
         new_tuple_values(elements)
     },
-    
 };
-
     TupleValue: TupleValue = {
         <expression: (Expression)?>  => new_tuple_value(<>),
         
@@ -1537,30 +1435,27 @@ TupleValues: TupleValues = {
 
 // Rules for topic Identifiers
     
-    
-// We need to force this to differentiate the first element from not being
-// an `AddressKeyword`
-IdentifierPath: IdentifierPath = {
-    <head: Identifier>  <tail: (IdentifierPathTail)?>  => {
-        match tail {
-            Some(mut tail) => {
+    IdentifierPath: IdentifierPath =
+{
+    <head: Identifier> <tail: (IdentifierPathTail)?> =>
+    {
+        match tail
+        {
+            Some(mut tail) =>
+            {
                 tail.insert(0, new_identifier_path_element_identifier(head));
                 new_identifier_path(tail)
-            },
-            None => new_identifier_path(vec![new_identifier_path_element_identifier(head)]),
+            }, None =>
+            new_identifier_path(vec![new_identifier_path_element_identifier(head)]),
         }
     },
-    
+}; IdentifierPathTail: Vec<IdentifierPathElement> =
+{ Period <elements: IdentifierPathTailElements> => <>, };
+IdentifierPathTailElements: Vec<IdentifierPathElement> =
+{
+    <member_access_identifier: Separated<Period, <IdentifierPathElement>>> =>
+    <>,
 };
-IdentifierPathTail: Vec<IdentifierPathElement> = {
-    Period  <elements: IdentifierPathTailElements>  => <>,
-    
-};
-IdentifierPathTailElements: Vec<IdentifierPathElement> = {
-    <member_access_identifier: Separated<Period, <IdentifierPathElement>>>  => <>,
-    
-};
-
     IdentifierPathElement: IdentifierPathElement = {
         <identifier: Identifier>  => new_identifier_path_element_identifier(<>),
         <address_keyword: AddressKeyword>  => new_identifier_path_element_address_keyword(<>),


### PR DESCRIPTION
This PR aims to improve the verbatim code snippets on the language definition, by not having just a regular string we can have some kind of syntax highlighting.

One caveat of this approach is that the code snippet has to be tokenizable to Rust, well parethesized, and `//` comments are lost.

If #1655 is merged before this, I may need to use the new `Code(...)` for some of its changes.