### PR TITLE
fix renovate bencher cli in Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,29 @@ jobs:
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/save"
 
+  renovate-config-check:
+    runs-on: "ubuntu-24.04" # _SLANG_DEV_CONTAINER_BASE_IMAGE_ (keep in sync)
+
+    permissions:
+      contents: "read"
+
+    steps:
+      - name: "Checkout Repository"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Renovate schema check"
+        run: "./bin/npx --yes --package renovate -- renovate-config-validator renovate.json"
+
+      - name: "Renovate extraction dry-run"
+        env:
+          # Without a token, github-tags/github-releases lookups (e.g. bencher_cli) hit the
+          # anonymous 60 req/hr rate limit shared across the runner IP.
+          GITHUB_COM_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          LOG_LEVEL: "debug"
+        run: "./bin/npx --yes renovate --platform=local --dry-run=full"
+
   # The full CI runs on the bare runner so it can reuse the cargo-target cache;
   # reproducing that cache-mount setup inside a devcontainer would slow CI down
   # rather than speed it up. This job is kept as a minimal smoke test that the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,13 @@ Whenever you see this annotation, it means all occurrences of that marker must b
 grep -r "__MARKER_NAME__" .
 ```
 
+## Renovate Config
+
+When editing `renovate.json` (or any `Cargo.toml` line paired with its custom regex manager via a [sync marker](#sync-markers)), validate locally before pushing:
+
+- **Schema check:** `npx --yes --package renovate -- renovate-config-validator renovate.json`
+- **Full extraction dry-run:** `LOG_LEVEL=debug npx --yes renovate --platform=local --dry-run=full` — confirms each dep shows the expected `skipReason` / `updates`. Catches gotchas like `matchPackageNames` failing to match git-source cargo deps (where `packageName` is the git URL, not the `Cargo.toml` key — use `matchDepNames` for those).
+
 ## Snapshot Tests
 
 For testing, we maintain snapshots checked into the repo:

--- a/renovate.json
+++ b/renovate.json
@@ -100,8 +100,8 @@
       "labels": ["ci:perf"]
     },
     {
-      "description": "bencher_cli: handled by customManagers entry below that tracks release tags — disable built-in cargo digest updates so the two don't fight.",
-      "matchPackageNames": ["bencher_cli"],
+      "description": "bencher_cli: handled by customManagers entry below that tracks release tags — disable built-in cargo digest updates so the two don't fight. Note: matches on depName (Cargo.toml key), not packageName (which is the git URL for git-source deps).",
+      "matchDepNames": ["bencher_cli"],
       "matchManagers": ["cargo"],
       "enabled": false
     }


### PR DESCRIPTION
Small follow-up from https://github.com/NomicFoundation/slang/pull/1702. While I did test locally to see if the config would pass, I now discovered renovate doesn't always match on package name. I've added some info to `AGENTS.md` to make it obvious how to test when making this kind of change in the future. 