### PR TITLE
[v2] Migrate `StringExpression::value()` and `compute_canonical_signature()` from v1

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -1,6 +1,7 @@
 mod node_extensions;
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use sha3::{Digest, Keccak256};
@@ -381,13 +382,28 @@ pub(crate) fn type_as_abi_parameter(
     semantic: &Rc<SemanticContext>,
     type_id: TypeId,
 ) -> Option<(String, Vec<ParameterComponent>)> {
+    type_as_abi_parameter_impl(semantic, type_id, &mut HashSet::new())
+}
+
+fn type_as_abi_parameter_impl(
+    semantic: &Rc<SemanticContext>,
+    type_id: TypeId,
+    visited_structs: &mut HashSet<NodeId>,
+) -> Option<(String, Vec<ParameterComponent>)> {
     match semantic.types().get_type_by_id(type_id) {
         Type::Array { element_type, .. } => {
             let (element_type_name, element_components) =
-                type_as_abi_parameter(semantic, *element_type)?;
+                type_as_abi_parameter_impl(semantic, *element_type, visited_structs)?;
             Some((format!("{element_type_name}[]"), element_components))
         }
         Type::Struct { definition_id, .. } => {
+            // Recursive structs are not valid Solidity, but guard against cycles
+            // to avoid unbounded recursion if malformed types reach this point.
+            // TODO(validation): The recursion should be detected in the
+            // `type_definition` pass.
+            if !visited_structs.insert(*definition_id) {
+                return None;
+            }
             // We need to recursively expand the struct fields as components
             let Definition::Struct(definition) = semantic
                 .binder()
@@ -400,13 +416,15 @@ pub(crate) fn type_as_abi_parameter(
             for member in &definition.ir_node.members {
                 let name = member.name.unparse().to_string();
                 let member_type_id = semantic.binder().node_typing(member.id()).as_type_id()?;
-                let (type_name, subcomponents) = type_as_abi_parameter(semantic, member_type_id)?;
+                let (type_name, subcomponents) =
+                    type_as_abi_parameter_impl(semantic, member_type_id, visited_structs)?;
                 components.push(ParameterComponent {
                     name,
                     type_name,
                     components: subcomponents,
                 });
             }
+            visited_structs.remove(definition_id);
             Some(("tuple".to_string(), components))
         }
         _ => Some((semantic.type_canonical_name(type_id)?, Vec::new())),

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
@@ -8,6 +8,12 @@ impl ErrorDefinitionStruct {
         Some(format!("{name}({parameters})"))
     }
 
+    pub fn compute_internal_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.unparse();
+        let parameters = self.parameters().compute_internal_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
     pub fn compute_abi_entry(&self) -> Option<AbiEntry> {
         let inputs = self.parameters().compute_abi_parameters()?;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
@@ -2,6 +2,12 @@ use crate::abi::{AbiEntry, AbiError};
 use crate::ast::ErrorDefinitionStruct;
 
 impl ErrorDefinitionStruct {
+    pub fn compute_canonical_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.unparse();
+        let parameters = self.parameters().compute_canonical_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
     pub fn compute_abi_entry(&self) -> Option<AbiEntry> {
         let inputs = self.parameters().compute_abi_parameters()?;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/errors.rs
@@ -1,4 +1,4 @@
-use crate::abi::{AbiEntry, AbiError};
+use crate::abi::{selector_from_signature, AbiEntry, AbiError};
 use crate::ast::ErrorDefinitionStruct;
 
 impl ErrorDefinitionStruct {
@@ -22,5 +22,10 @@ impl ErrorDefinitionStruct {
             name: self.ir_node.name.unparse().to_string(),
             inputs,
         }))
+    }
+
+    pub fn compute_selector(&self) -> Option<u32> {
+        self.compute_canonical_signature()
+            .map(|sig| selector_from_signature(&sig))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
@@ -1,4 +1,4 @@
-use crate::abi::{AbiEntry, AbiEvent};
+use crate::abi::{selector_from_signature, AbiEntry, AbiEvent};
 use crate::ast::EventDefinitionStruct;
 
 impl EventDefinitionStruct {
@@ -23,5 +23,10 @@ impl EventDefinitionStruct {
             inputs,
             anonymous: self.ir_node.anonymous_keyword,
         }))
+    }
+
+    pub fn compute_selector(&self) -> Option<u32> {
+        self.compute_canonical_signature()
+            .map(|sig| selector_from_signature(&sig))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
@@ -8,6 +8,12 @@ impl EventDefinitionStruct {
         Some(format!("{name}({parameters})"))
     }
 
+    pub fn compute_internal_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.unparse();
+        let parameters = self.parameters().compute_internal_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
     pub fn compute_abi_entry(&self) -> Option<AbiEntry> {
         let inputs = self.parameters().compute_abi_parameters()?;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/events.rs
@@ -2,6 +2,12 @@ use crate::abi::{AbiEntry, AbiEvent};
 use crate::ast::EventDefinitionStruct;
 
 impl EventDefinitionStruct {
+    pub fn compute_canonical_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.unparse();
+        let parameters = self.parameters().compute_canonical_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
     pub fn compute_abi_entry(&self) -> Option<AbiEntry> {
         let inputs = self.parameters().compute_abi_parameters()?;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
@@ -58,17 +58,20 @@ impl FunctionDefinitionStruct {
         }
     }
 
+    pub fn compute_canonical_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.as_ref()?.unparse();
+        let parameters = self.parameters().compute_canonical_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
     pub fn compute_selector(&self) -> Option<u32> {
         if !self.is_externally_visible() {
             return None;
         }
-        let name = self.ir_node.name.as_ref()?.unparse();
-        let signature = format!(
-            "{name}({parameters})",
-            parameters = self.parameters().compute_canonical_signature()?,
-        );
-
-        Some(selector_from_signature(&signature))
+        // TODO: derive the selector from a dedicated external-signature variant
+        // instead of the generic canonical signature.
+        self.compute_canonical_signature()
+            .map(|sig| selector_from_signature(&sig))
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_ir::ir;
+use slang_solidity_v2_semantic::types::TypeId;
 
 use crate::abi::{
     selector_from_signature, type_as_abi_parameter, AbiConstructor, AbiEntry, AbiFallback,
@@ -58,9 +59,24 @@ impl FunctionDefinitionStruct {
         }
     }
 
+    /// Returns the external signature for this function, suitable for ABI encoding.
+    ///
+    /// This is only guaranteed for external functions in valid Solidity, as
+    /// internal functions may contain parameter types that cannot be
+    /// ABI-encoded.
     pub fn compute_canonical_signature(&self) -> Option<String> {
         let name = self.ir_node.name.as_ref()?.unparse();
         let parameters = self.parameters().compute_canonical_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
+    /// Returns the signature for this function using internal type names for
+    /// parameters. Unlike [`Self::compute_canonical_signature`], this form is
+    /// well-defined for any function, including internal ones with parameter
+    /// types that cannot be ABI-encoded.
+    pub fn compute_internal_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.as_ref()?.unparse();
+        let parameters = self.parameters().compute_internal_signature()?;
         Some(format!("{name}({parameters})"))
     }
 
@@ -68,8 +84,6 @@ impl FunctionDefinitionStruct {
         if !self.is_externally_visible() {
             return None;
         }
-        // TODO: derive the selector from a dedicated external-signature variant
-        // instead of the generic canonical signature.
         self.compute_canonical_signature()
             .map(|sig| selector_from_signature(&sig))
     }
@@ -99,13 +113,24 @@ impl ParametersStruct {
         Some(result)
     }
 
+    fn parameter_types_iter(&self) -> impl Iterator<Item = Option<TypeId>> + '_ {
+        self.ir_nodes.iter().map(|parameter| {
+            self.semantic.binder().node_typing(parameter.id()).as_type_id()
+        })
+    }
+
     pub(crate) fn compute_canonical_signature(&self) -> Option<String> {
         let mut result = Vec::new();
-        for parameter in &self.ir_nodes {
-            let node_id = parameter.id();
-            // Bail out with `None` if any of the parameters fails typing
-            let type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;
-            result.push(self.semantic.type_canonical_name(type_id)?);
+        for type_id in self.parameter_types_iter() {
+            result.push(self.semantic.type_canonical_name(type_id?)?);
+        }
+        Some(result.join(","))
+    }
+
+    pub(crate) fn compute_internal_signature(&self) -> Option<String> {
+        let mut result = Vec::new();
+        for type_id in self.parameter_types_iter() {
+            result.push(self.semantic.type_internal_name(type_id?));
         }
         Some(result.join(","))
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/functions.rs
@@ -115,7 +115,10 @@ impl ParametersStruct {
 
     fn parameter_types_iter(&self) -> impl Iterator<Item = Option<TypeId>> + '_ {
         self.ir_nodes.iter().map(|parameter| {
-            self.semantic.binder().node_typing(parameter.id()).as_type_id()
+            self.semantic
+                .binder()
+                .node_typing(parameter.id())
+                .as_type_id()
         })
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
@@ -37,22 +37,26 @@ impl StateVariableDefinitionStruct {
         }))
     }
 
+    pub fn compute_canonical_signature(&self) -> Option<String> {
+        let (inputs, _) = self.extract_getter_type_parameters_abi()?;
+        let parameters = inputs
+            .into_iter()
+            .map(|parameter| parameter.type_name().to_owned())
+            .collect::<Vec<_>>()
+            .join(",");
+        Some(format!(
+            "{name}({parameters})",
+            name = self.ir_node.name.unparse(),
+        ))
+    }
+
     pub fn compute_selector(&self) -> Option<u32> {
         if !self.is_externally_visible() {
             return None;
         }
-        let (inputs, _) = self.extract_getter_type_parameters_abi()?;
-
-        let signature = format!(
-            "{name}({parameters})",
-            name = self.ir_node.name.unparse(),
-            parameters = inputs
-                .into_iter()
-                .map(|parameter| parameter.type_name().to_owned())
-                .collect::<Vec<_>>()
-                .join(","),
-        );
-
-        Some(selector_from_signature(&signature))
+        // TODO: derive the selector from a dedicated external-signature variant
+        // instead of the generic canonical signature.
+        self.compute_canonical_signature()
+            .map(|sig| selector_from_signature(&sig))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/state_variables.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_semantic::binder;
+use slang_solidity_v2_semantic::types::Type;
 
 use crate::abi::{
     extract_function_type_parameters_abi, selector_from_signature, AbiEntry, AbiFunction,
@@ -50,12 +51,41 @@ impl StateVariableDefinitionStruct {
         ))
     }
 
+    pub fn compute_internal_signature(&self) -> Option<String> {
+        if !self.is_externally_visible() {
+            // There is no getter defined if the variable is not public
+            return None;
+        }
+        let binder::Definition::StateVariable(definition) = self
+            .semantic
+            .binder()
+            .find_definition_by_id(self.ir_node.id())?
+        else {
+            unreachable!("definition is not a state variable");
+        };
+        let Type::Function(function_type) = self
+            .semantic
+            .types()
+            .get_type_by_id(definition.getter_type_id?)
+        else {
+            unreachable!("getter type is not a function");
+        };
+        let parameters = function_type
+            .parameter_types
+            .iter()
+            .map(|type_id| self.semantic.type_internal_name(*type_id))
+            .collect::<Vec<_>>()
+            .join(",");
+        Some(format!(
+            "{name}({parameters})",
+            name = self.ir_node.name.unparse(),
+        ))
+    }
+
     pub fn compute_selector(&self) -> Option<u32> {
         if !self.is_externally_visible() {
             return None;
         }
-        // TODO: derive the selector from a dedicated external-signature variant
-        // instead of the generic canonical signature.
         self.compute_canonical_signature()
             .map(|sig| selector_from_signature(&sig))
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
@@ -1,7 +1,63 @@
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::binder::Typing;
 
-use super::super::FunctionCallExpressionStruct;
+use super::super::{FunctionCallExpressionStruct, StringExpression};
+
+impl StringExpression {
+    /// Returns the concatenated decoded string value as bytes.
+    ///
+    /// Handles all three variants:
+    /// - `StringLiterals` — strips quotes, returns UTF-8 bytes
+    /// - `HexStringLiterals` — strips `hex"..."`, decodes hex pairs to bytes
+    /// - `UnicodeStringLiterals` — strips `unicode"..."`, returns UTF-8 bytes
+    ///
+    /// TODO(v2): Escape sequences (`\n`, `\xNN`, `\uNNNN`, etc.) are not yet
+    /// decoded — the raw escape text is returned as-is for regular and unicode
+    /// strings.
+    pub fn value(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        match self {
+            StringExpression::StringLiterals(terminals) => {
+                for terminal in terminals {
+                    let content = Self::strip_prefix_and_quotes(&terminal.text, "");
+                    result.extend_from_slice(content.as_bytes());
+                }
+            }
+            StringExpression::HexStringLiterals(terminals) => {
+                for terminal in terminals {
+                    let content = Self::strip_prefix_and_quotes(&terminal.text, "hex");
+                    result.extend(
+                        (0..content.len())
+                            .step_by(2)
+                            .map(|i| u8::from_str_radix(&content[i..i + 2], 16).unwrap()),
+                    );
+                }
+            }
+            StringExpression::UnicodeStringLiterals(terminals) => {
+                for terminal in terminals {
+                    let content = Self::strip_prefix_and_quotes(&terminal.text, "unicode");
+                    result.extend_from_slice(content.as_bytes());
+                }
+            }
+        }
+        result
+    }
+
+    fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
+        text.strip_prefix(prefix)
+            .and_then(|stripped| {
+                stripped
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .or_else(|| {
+                        stripped
+                            .strip_prefix('\'')
+                            .and_then(|s| s.strip_suffix('\''))
+                    })
+            })
+            .unwrap_or(text)
+    }
+}
 
 impl FunctionCallExpressionStruct {
     /// Returns `true` if this call is a type conversion (e.g. `uint256(x)`,

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
@@ -7,25 +7,31 @@ impl StringExpression {
     /// Returns the concatenated decoded string value as bytes.
     ///
     /// Handles all three variants:
-    /// - `StringLiterals` — strips quotes, returns UTF-8 bytes
+    /// - `StringLiterals` — strips quotes, decodes escape sequences, returns
+    ///   the decoded bytes
     /// - `HexStringLiterals` — strips `hex"..."`, decodes hex pairs to bytes
-    /// - `UnicodeStringLiterals` — strips `unicode"..."`, returns UTF-8 bytes
+    /// - `UnicodeStringLiterals` — strips `unicode"..."`, decodes escape
+    ///   sequences, returns UTF-8 bytes
     ///
-    /// TODO(v2): Escape sequences (`\n`, `\xNN`, `\uNNNN`, etc.) are not yet
-    /// decoded — the raw escape text is returned as-is for regular and unicode
-    /// strings.
+    /// Escape sequences decoded for string and unicode-string variants:
+    /// `\n`, `\r`, `\t`, `\'`, `\"`, `\\`, line continuations (`\<LF>`,
+    /// `\<CR>`, `\<CRLF>`), `\xNN` (hex byte), and `\uNNNN` (Unicode code
+    /// point, UTF-8 encoded).
     pub fn value(&self) -> Vec<u8> {
+        // TODO: this implementation should live in the semantic crate to be
+        // used by the typing pass. This is required for example to check for
+        // valid implicit conversion of a string into a bytesXX array.
         let mut result = Vec::new();
         match self {
             StringExpression::StringLiterals(terminals) => {
                 for terminal in terminals {
-                    let content = Self::strip_prefix_and_quotes(&terminal.text, "");
-                    result.extend_from_slice(content.as_bytes());
+                    let content = strip_prefix_and_quotes(&terminal.text, "");
+                    result.extend(decode_escape_sequences(content));
                 }
             }
             StringExpression::HexStringLiterals(terminals) => {
                 for terminal in terminals {
-                    let content = Self::strip_prefix_and_quotes(&terminal.text, "hex");
+                    let content = strip_prefix_and_quotes(&terminal.text, "hex");
                     result.extend(
                         (0..content.len())
                             .step_by(2)
@@ -35,28 +41,85 @@ impl StringExpression {
             }
             StringExpression::UnicodeStringLiterals(terminals) => {
                 for terminal in terminals {
-                    let content = Self::strip_prefix_and_quotes(&terminal.text, "unicode");
-                    result.extend_from_slice(content.as_bytes());
+                    let content = strip_prefix_and_quotes(&terminal.text, "unicode");
+                    result.extend(decode_escape_sequences(content));
                 }
             }
         }
         result
     }
+}
 
-    fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
-        text.strip_prefix(prefix)
-            .and_then(|stripped| {
-                stripped
-                    .strip_prefix('"')
-                    .and_then(|s| s.strip_suffix('"'))
-                    .or_else(|| {
-                        stripped
-                            .strip_prefix('\'')
-                            .and_then(|s| s.strip_suffix('\''))
-                    })
-            })
-            .unwrap_or(text)
+fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
+    text.strip_prefix(prefix)
+        .and_then(|stripped| {
+            stripped
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .or_else(|| {
+                    stripped
+                        .strip_prefix('\'')
+                        .and_then(|s| s.strip_suffix('\''))
+                })
+        })
+        .unwrap_or(text)
+}
+
+fn decode_escape_sequences(content: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(content.len());
+    let mut buf = [0u8; 4];
+    let mut chars = content.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            continue;
+        }
+        // Grammar guarantees at least one char after backslash; if input
+        // is malformed we just stop.
+        let Some(next) = chars.next() else { break };
+        match next {
+            'n' => out.push(b'\n'),
+            'r' => out.push(b'\r'),
+            't' => out.push(b'\t'),
+            '\'' => out.push(b'\''),
+            '"' => out.push(b'"'),
+            '\\' => out.push(b'\\'),
+            // Line continuation: `\<CR>`, `\<CRLF>`, `\<LF>` all decode to empty.
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+            }
+            '\n' => {}
+            'x' => {
+                let h1 = chars.next().unwrap();
+                let h2 = chars.next().unwrap();
+                let hex: String = [h1, h2].iter().collect();
+                out.push(u8::from_str_radix(&hex, 16).unwrap());
+            }
+            'u' => {
+                let h1 = chars.next().unwrap();
+                let h2 = chars.next().unwrap();
+                let h3 = chars.next().unwrap();
+                let h4 = chars.next().unwrap();
+                let hex: String = [h1, h2, h3, h4].iter().collect();
+                let code_point = u32::from_str_radix(&hex, 16).unwrap();
+                // `\uNNNN` code points in the surrogate range (0xD800..=0xDFFF)
+                // are not valid Unicode scalars; skip them silently.
+                if let Some(ch) = char::from_u32(code_point) {
+                    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                }
+                // TODO(validation): emit an error/warning if the unicode scalar
+                // is not valid
+            }
+            other => {
+                // Grammar should prevent unknown escape chars, but pass
+                // them through verbatim as a defensive fallback.
+                out.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
+            }
+        }
     }
+    out
 }
 
 impl FunctionCallExpressionStruct {
@@ -75,5 +138,130 @@ impl FunctionCallExpressionStruct {
             ),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_escape_sequences, strip_prefix_and_quotes};
+
+    // ----- decode_escape_sequences -----
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(decode_escape_sequences(""), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn decode_no_escapes() {
+        assert_eq!(decode_escape_sequences("hello"), b"hello");
+    }
+
+    #[test]
+    fn decode_ascii_escapes() {
+        assert_eq!(decode_escape_sequences(r"\n"), b"\n");
+        assert_eq!(decode_escape_sequences(r"\r"), b"\r");
+        assert_eq!(decode_escape_sequences(r"\t"), b"\t");
+        assert_eq!(decode_escape_sequences(r"\'"), b"'");
+        assert_eq!(decode_escape_sequences(r#"\""#), b"\"");
+        assert_eq!(decode_escape_sequences(r"\\"), b"\\");
+    }
+
+    #[test]
+    fn decode_mixed_text_and_escapes() {
+        assert_eq!(
+            decode_escape_sequences(r"hello\tworld\n"),
+            b"hello\tworld\n",
+        );
+    }
+
+    #[test]
+    fn decode_line_continuation_lf() {
+        // Backslash followed by raw LF → empty.
+        assert_eq!(decode_escape_sequences("a\\\nb"), b"ab");
+    }
+
+    #[test]
+    fn decode_line_continuation_cr() {
+        // Backslash followed by raw CR → empty.
+        assert_eq!(decode_escape_sequences("a\\\rb"), b"ab");
+    }
+
+    #[test]
+    fn decode_line_continuation_crlf() {
+        // Backslash followed by raw CRLF → empty (CR and LF both consumed).
+        assert_eq!(decode_escape_sequences("a\\\r\nb"), b"ab");
+    }
+
+    #[test]
+    fn decode_hex_byte_escape() {
+        assert_eq!(decode_escape_sequences(r"\x41"), b"A");
+        assert_eq!(decode_escape_sequences(r"\xff"), &[0xffu8]);
+        assert_eq!(decode_escape_sequences(r"\x00"), &[0x00u8]);
+    }
+
+    #[test]
+    fn decode_unicode_escape_ascii() {
+        // U+0041 → 'A' (single UTF-8 byte).
+        assert_eq!(decode_escape_sequences(r"\u0041"), b"A");
+    }
+
+    #[test]
+    fn decode_unicode_escape_multibyte() {
+        // U+00E9 é → 0xC3 0xA9.
+        assert_eq!(decode_escape_sequences(r"\u00e9"), &[0xC3, 0xA9]);
+        // U+2713 ✓ → 0xE2 0x9C 0x93.
+        assert_eq!(decode_escape_sequences(r"\u2713"), &[0xE2, 0x9C, 0x93]);
+    }
+
+    #[test]
+    fn decode_unicode_escape_surrogate_skipped() {
+        // Lone surrogate 0xD800 is not a valid Unicode scalar → skipped.
+        assert_eq!(decode_escape_sequences(r"\ud800"), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn decode_raw_non_ascii_passthrough() {
+        // Raw multibyte input (legal in unicode strings) passes through as
+        // its UTF-8 encoding.
+        assert_eq!(decode_escape_sequences("ñ"), &[0xC3, 0xB1]);
+    }
+
+    // ----- strip_prefix_and_quotes -----
+
+    #[test]
+    fn strip_double_quotes_no_prefix() {
+        assert_eq!(strip_prefix_and_quotes(r#""hello""#, ""), "hello");
+    }
+
+    #[test]
+    fn strip_single_quotes_no_prefix() {
+        assert_eq!(strip_prefix_and_quotes("'hello'", ""), "hello");
+    }
+
+    #[test]
+    fn strip_hex_prefix_double_quotes() {
+        assert_eq!(strip_prefix_and_quotes(r#"hex"414243""#, "hex"), "414243");
+    }
+
+    #[test]
+    fn strip_hex_prefix_single_quotes() {
+        assert_eq!(strip_prefix_and_quotes("hex'414243'", "hex"), "414243");
+    }
+
+    #[test]
+    fn strip_unicode_prefix() {
+        assert_eq!(strip_prefix_and_quotes(r#"unicode"ñ""#, "unicode"), "ñ");
+    }
+
+    #[test]
+    fn strip_empty_content() {
+        assert_eq!(strip_prefix_and_quotes(r#""""#, ""), "");
+    }
+
+    #[test]
+    fn strip_falls_back_when_no_match() {
+        // Malformed / unexpected input is returned unchanged.
+        assert_eq!(strip_prefix_and_quotes("unquoted", ""), "unquoted");
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
@@ -32,11 +32,7 @@ impl StringExpression {
             StringExpression::HexStringLiterals(terminals) => {
                 for terminal in terminals {
                     let content = strip_prefix_and_quotes(&terminal.text, "hex");
-                    result.extend(
-                        (0..content.len())
-                            .step_by(2)
-                            .map(|i| u8::from_str_radix(&content[i..i + 2], 16).unwrap()),
-                    );
+                    result.extend(decode_hex_string(content));
                 }
             }
             StringExpression::UnicodeStringLiterals(terminals) => {
@@ -63,6 +59,21 @@ fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
                 })
         })
         .unwrap_or(text)
+}
+
+fn decode_hex_string(content: &str) -> Vec<u8> {
+    let mut result = Vec::with_capacity(content.len() / 2);
+    let mut i = 0usize;
+    while i < content.len() {
+        // Decode pairs of hex digits skipping over underscore separators
+        if content.as_bytes()[i] == b'_' {
+            i += 1;
+        }
+        // Parser grammar guarantees that we have at least 2 more digits
+        result.push(u8::from_str_radix(&content[i..i + 2], 16).unwrap());
+        i += 2;
+    }
+    result
 }
 
 fn decode_escape_sequences(content: &str) -> Vec<u8> {
@@ -143,7 +154,19 @@ impl FunctionCallExpressionStruct {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_escape_sequences, strip_prefix_and_quotes};
+    use super::{decode_escape_sequences, decode_hex_string, strip_prefix_and_quotes};
+
+    // ----- decode_hex_string ------
+
+    #[test]
+    fn decode_hex_string_no_underscores() {
+        assert_eq!(decode_hex_string("303132"), b"012");
+    }
+
+    #[test]
+    fn decode_hex_string_with_underscores() {
+        assert_eq!(decode_hex_string("30_31_32"), b"012");
+    }
 
     // ----- decode_escape_sequences -----
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
@@ -58,7 +58,7 @@ fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
                         .and_then(|s| s.strip_suffix('\''))
                 })
         })
-        .unwrap_or(text)
+        .expect("string prefix mismatch or not quoted")
 }
 
 fn decode_hex_string(content: &str) -> Vec<u8> {
@@ -87,7 +87,7 @@ fn decode_escape_sequences(content: &str) -> Vec<u8> {
         }
         // Grammar guarantees at least one char after backslash; if input
         // is malformed we just stop.
-        let Some(next) = chars.next() else { break };
+        let next = chars.next().expect("unterminated escape sequence");
         match next {
             'n' => out.push(b'\n'),
             'r' => out.push(b'\r'),
@@ -309,8 +309,14 @@ mod tests {
     }
 
     #[test]
-    fn strip_falls_back_when_no_match() {
-        // Malformed / unexpected input is returned unchanged.
-        assert_eq!(strip_prefix_and_quotes("unquoted", ""), "unquoted");
+    #[should_panic(expected = "string prefix mismatch or not quoted")]
+    fn strip_panics_when_not_quoted() {
+        strip_prefix_and_quotes("unquoted", "");
+    }
+
+    #[test]
+    #[should_panic(expected = "string prefix mismatch or not quoted")]
+    fn strip_panics_on_prefix_mismatch() {
+        strip_prefix_and_quotes("hex'1234'", "unicode");
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expressions.rs
@@ -199,6 +199,14 @@ mod tests {
     }
 
     #[test]
+    fn decode_multiple_ascii_escapes() {
+        assert_eq!(
+            decode_escape_sequences(r#"\t\n\r\'\"\\"#),
+            &[0x09, 0x0a, 0x0d, 0x27, 0x22, 0x5c]
+        );
+    }
+
+    #[test]
     fn decode_line_continuation_lf() {
         // Backslash followed by raw LF → empty.
         assert_eq!(decode_escape_sequences("a\\\nb"), b"ab");
@@ -235,6 +243,24 @@ mod tests {
         assert_eq!(decode_escape_sequences(r"\u00e9"), &[0xC3, 0xA9]);
         // U+2713 ✓ → 0xE2 0x9C 0x93.
         assert_eq!(decode_escape_sequences(r"\u2713"), &[0xE2, 0x9C, 0x93]);
+    }
+
+    #[test]
+    fn decode_unicode_escape_combined_multibyte() {
+        // Dollar sign
+        assert_eq!(decode_escape_sequences(r"aaa\u0024aaa"), b"aaa$aaa");
+        // Cent
+        assert_eq!(decode_escape_sequences(r"aaa\u00A2aaa"), b"aaa\xc2\xa2aaa");
+        // Euro
+        assert_eq!(
+            decode_escape_sequences(r"aaa\u20ACaaa"),
+            b"aaa\xe2\x82\xacaaa"
+        );
+        // All combined
+        assert_eq!(
+            decode_escape_sequences(r"\u0024\u00A2\u20AC"),
+            b"$\xc2\xa2\xe2\x82\xac"
+        );
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -194,6 +195,14 @@ impl SemanticContext {
     }
 
     pub fn type_canonical_name(&self, type_id: TypeId) -> Option<String> {
+        self.type_canonical_name_impl(type_id, &mut HashSet::new())
+    }
+
+    fn type_canonical_name_impl(
+        &self,
+        type_id: TypeId,
+        visited_structs: &mut HashSet<NodeId>,
+    ) -> Option<String> {
         match self.types.get_type_by_id(type_id) {
             Type::Address { .. }
             | Type::Boolean
@@ -205,12 +214,12 @@ impl SemanticContext {
             | Type::String { .. } => Some(self.type_internal_name(type_id)),
 
             Type::Array { element_type, .. } => self
-                .type_canonical_name(*element_type)
+                .type_canonical_name_impl(*element_type, visited_structs)
                 .map(|element| format!("{element}[]",)),
             Type::FixedSizeArray {
                 element_type, size, ..
             } => self
-                .type_canonical_name(*element_type)
+                .type_canonical_name_impl(*element_type, visited_structs)
                 .map(|element| format!("{element}[{size}]",)),
 
             Type::Contract { .. } | Type::Interface { .. } => Some("address".to_string()),
@@ -218,6 +227,13 @@ impl SemanticContext {
             Type::Enum { .. } => Some("uint8".to_string()),
 
             Type::Struct { definition_id, .. } => {
+                // Recursive structs are not valid Solidity, but guard against cycles
+                // to avoid unbounded recursion if malformed types reach this point.
+                // TODO(validation): The recursion should be detected in the
+                // `type_definition` pass.
+                if !visited_structs.insert(*definition_id) {
+                    return None;
+                }
                 let Definition::Struct(struct_) = self
                     .binder
                     .find_definition_by_id(*definition_id)
@@ -228,9 +244,11 @@ impl SemanticContext {
                 let mut fields = Vec::new();
                 for member in &struct_.ir_node.members {
                     let member_type_id = self.binder.node_typing(member.id()).as_type_id()?;
-                    let field_type = self.type_canonical_name(member_type_id)?;
+                    let field_type =
+                        self.type_canonical_name_impl(member_type_id, visited_structs)?;
                     fields.push(field_type);
                 }
+                visited_structs.remove(definition_id);
                 Some(format!("({fields})", fields = fields.join(",")))
             }
 
@@ -243,7 +261,7 @@ impl SemanticContext {
                     unreachable!("definition in user defined value type is not a UDVT");
                 };
                 udvt.target_type_id
-                    .and_then(|type_id| self.type_canonical_name(type_id))
+                    .and_then(|type_id| self.type_canonical_name_impl(type_id, visited_structs))
             }
 
             Type::Literal(_) | Type::Mapping { .. } | Type::Tuple { .. } | Type::Void => None,
@@ -255,6 +273,14 @@ impl SemanticContext {
     pub const SELECTOR_SIZE: usize = 4;
 
     pub fn storage_size_of_type_id(&self, type_id: TypeId) -> Option<usize> {
+        self.storage_size_of_type_id_impl(type_id, &mut HashSet::new())
+    }
+
+    fn storage_size_of_type_id_impl(
+        &self,
+        type_id: TypeId,
+        visited_structs: &mut HashSet<NodeId>,
+    ) -> Option<usize> {
         match self.types.get_type_by_id(type_id) {
             Type::Address { .. } | Type::Contract { .. } | Type::Interface { .. } => {
                 Some(Self::ADDRESS_BYTE_SIZE)
@@ -272,7 +298,8 @@ impl SemanticContext {
             Type::FixedSizeArray {
                 element_type, size, ..
             } => {
-                let element_size = self.storage_size_of_type_id(*element_type)?;
+                let element_size =
+                    self.storage_size_of_type_id_impl(*element_type, visited_structs)?;
                 if element_size > Self::SLOT_SIZE {
                     let slots_per_element = element_size.div_ceil(Self::SLOT_SIZE);
                     Some(slots_per_element * size * Self::SLOT_SIZE)
@@ -293,6 +320,13 @@ impl SemanticContext {
                 }
             }
             Type::Struct { definition_id, .. } => {
+                // Recursive structs are not valid Solidity, but guard against cycles
+                // to avoid unbounded recursion if malformed types reach this point.
+                // TODO(validation): The recursion should be detected in the
+                // `type_definition` pass.
+                if !visited_structs.insert(*definition_id) {
+                    return None;
+                }
                 let Definition::Struct(struct_definition) =
                     self.binder.find_definition_by_id(*definition_id)?
                 else {
@@ -301,13 +335,15 @@ impl SemanticContext {
                 let mut ptr: usize = 0;
                 for member in &struct_definition.ir_node.members {
                     let member_type_id = self.binder.node_typing(member.id()).as_type_id()?;
-                    let member_size = self.storage_size_of_type_id(member_type_id)?;
+                    let member_size =
+                        self.storage_size_of_type_id_impl(member_type_id, visited_structs)?;
                     let remaining_bytes = Self::SLOT_SIZE - (ptr % Self::SLOT_SIZE);
                     if remaining_bytes < Self::SLOT_SIZE && member_size >= remaining_bytes {
                         ptr += remaining_bytes;
                     }
                     ptr += member_size;
                 }
+                visited_structs.remove(definition_id);
                 // round up the final allocation to a full slot, because the
                 // next variable needs to start at the next slot anyway
                 ptr = ptr.div_ceil(Self::SLOT_SIZE) * Self::SLOT_SIZE;
@@ -319,7 +355,10 @@ impl SemanticContext {
                 else {
                     return None;
                 };
-                self.storage_size_of_type_id(user_defined_value.target_type_id?)
+                self.storage_size_of_type_id_impl(
+                    user_defined_value.target_type_id?,
+                    visited_structs,
+                )
             }
 
             Type::Literal(_) => None,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -278,6 +278,7 @@ impl Visitor for Pass<'_> {
     fn leave_struct_member(&mut self, node: &ir::StructMember) {
         let type_id = self.resolve_type_name(&node.type_name, Some(DataLocation::Inherited));
         self.binder.set_node_type(node.id(), type_id);
+        // TODO(validation): check that the struct definition is not recursive
     }
 
     fn leave_enum_definition(&mut self, node: &ir::EnumDefinition) {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -171,6 +171,25 @@ fn test_function_selector() -> Result<()> {
 }
 
 #[test]
+fn test_events_and_errors_selectors() -> Result<()> {
+    let unit = fixtures::FullAbi::build_compilation_unit()?;
+
+    let test_contract = unit
+        .find_contract_by_name("Test")
+        .expect("Test contract can be found");
+
+    let events = test_contract.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].compute_selector(), Some(0xb9b1_0fa6)); // Event(uint256,bytes)
+
+    let errors = test_contract.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].compute_selector(), Some(0xcf47_9181)); // InsufficientBalance(uint256,uint256)
+
+    Ok(())
+}
+
+#[test]
 fn test_full_abi_with_events_and_errors() -> Result<()> {
     let unit = fixtures::FullAbi::build_compilation_unit()?;
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/abi/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/abi/mod.rs
@@ -405,8 +405,6 @@ impl FunctionDefinitionStruct {
         if !self.is_externally_visible() {
             return None;
         }
-        // TODO: derive the selector from a dedicated external-signature variant
-        // instead of the generic canonical signature.
         self.compute_canonical_signature()
             .map(|sig| selector_from_signature(&sig))
     }
@@ -494,8 +492,6 @@ impl StateVariableDefinitionStruct {
         if !self.is_externally_visible() {
             return None;
         }
-        // TODO: derive the selector from a dedicated external-signature variant
-        // instead of the generic canonical signature.
         self.compute_canonical_signature()
             .map(|sig| selector_from_signature(&sig))
     }


### PR DESCRIPTION
Migrates the AST API additions from #1710 and #1712 to the v2 codebase.

Additionally
- For `StringExpression::value()` we now handle escape sequences. This implementation should eventually be moved to the semantic crate and used in the type resolution pass to collect literal values and enrich `Type::Literal` types.
- Add `compute_internal_signature()` for AST types, analogous to `compute_canonical_signature()` but it doesn't do struct->tuple expansion and is well-defined for functions that have parameters that cannot be ABI encoded.
- Add some guard rails in ABI-related functions to handle recursive `struct` definitions. These are forbidden in Solidity, but we don't perform the validation checks to stop them from getting registered in the `TypeRegistry`.
