### PR TITLE
security: bump transitive deps to patch advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,12 +80,15 @@ catalogs:
       version: 5.9.3
 
 overrides:
-  basic-ftp@<5.2.2: ^5.2.2
+  basic-ftp@<5.3.0: ^5.3.0
   flatted@<3.4.0: ^3.4.0
   js-yaml@<3.14.2: ^3.14.2
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=5.0.0 <5.1.8: ^5.1.8
+  picomatch@<2.3.2: ^2.3.2
+  picomatch@>=4.0.0 <4.0.4: ^4.0.4
   tmp@<=0.2.3: ^0.2.4
+  undici@>=7.0.0 <7.24.0: ^7.24.0
 
 importers:
 
@@ -1667,8 +1670,8 @@ packages:
     resolution: {integrity: sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==}
     hasBin: true
 
-  basic-ftp@5.2.2:
-    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   better-path-resolve@1.0.0:
@@ -2183,7 +2186,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3140,13 +3143,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -3603,8 +3602,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.16.0:
-    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
@@ -5166,7 +5165,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@4.1.3:
     optional: true
@@ -5255,7 +5254,7 @@ snapshots:
 
   baseline-browser-mapping@2.8.19: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -5397,7 +5396,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.16.0
+      undici: 7.25.0
       whatwg-mimetype: 4.0.0
 
   ci-info@3.9.0: {}
@@ -5835,9 +5834,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-type@3.9.0: {}
 
@@ -5931,7 +5930,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -6317,7 +6316,7 @@ snapshots:
       jest-regex-util: 30.0.1
       jest-util: 30.3.0
       jest-worker: 30.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -6341,7 +6340,7 @@ snapshots:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       pretty-format: 30.3.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -6481,7 +6480,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-util@30.3.0:
     dependencies:
@@ -6490,7 +6489,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@29.7.0:
     dependencies:
@@ -6883,7 +6882,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-fn@2.1.0: {}
 
@@ -7100,9 +7099,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -7431,8 +7428,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmp@0.2.5: {}
 
@@ -7539,7 +7536,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.16.0: {}
+  undici@7.25.0: {}
 
   universalify@0.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,12 +81,18 @@ catalogs:
 
 overrides:
   basic-ftp@<5.3.0: ^5.3.0
+  brace-expansion@<1.1.13: ^1.1.13
+  brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
+  brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
+  diff@>=4.0.0 <4.0.4: ^4.0.4
   flatted@<3.4.0: ^3.4.0
+  follow-redirects@<1.16.0: ^1.16.0
   js-yaml@<3.14.2: ^3.14.2
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=5.0.0 <5.1.8: ^5.1.8
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
+  smol-toml@<1.6.1: ^1.6.1
   tmp@<=0.2.3: ^0.2.4
   undici@>=7.0.0 <7.24.0: ^7.24.0
 
@@ -1692,15 +1698,11 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2028,8 +2030,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -2223,8 +2225,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3346,10 +3348,6 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
-    engines: {node: '>= 18'}
 
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
@@ -5271,18 +5269,14 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.5:
     dependencies:
@@ -5657,7 +5651,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.2:
+  diff@4.0.4:
     optional: true
 
   dir-glob@3.0.1:
@@ -5857,7 +5851,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -6676,7 +6670,7 @@ snapshots:
       markdownlint: 0.40.0
       minimatch: 10.2.4
       run-con: 1.3.2
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       tinyglobby: 0.2.15
     transitivePeerDependencies:
       - supports-color
@@ -6890,7 +6884,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@10.2.5:
     dependencies:
@@ -6898,11 +6892,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -7274,8 +7268,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.6.0: {}
-
   smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
@@ -7295,7 +7287,7 @@ snapshots:
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2
@@ -7483,7 +7475,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,11 +85,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
   brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
   diff@>=4.0.0 <4.0.4: ^4.0.4
-  flatted@<3.4.0: ^3.4.0
   follow-redirects@<1.16.0: ^1.16.0
-  js-yaml@<3.14.2: ^3.14.2
-  minimatch@<3.1.3: ^3.1.3
-  minimatch@>=5.0.0 <5.1.8: ^5.1.8
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   smol-toml@<1.6.1: ^1.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,15 +41,11 @@ overrides:
   "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3" # GHSA-f886-m6hf-6m8v
   "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5" # GHSA-f886-m6hf-6m8v
   "diff@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-73rr-hh4g-fpgx
-  "flatted@<3.4.0": "^3.4.0" # https://github.com/NomicFoundation/slang/security/dependabot/115
   "follow-redirects@<1.16.0": "^1.16.0" # GHSA-r4q5-vmmm-2653
-  "js-yaml@<3.14.2": "^3.14.2" # https://github.com/NomicFoundation/slang/security/dependabot/101
-  "minimatch@<3.1.3": "^3.1.3" # https://github.com/NomicFoundation/slang/security/dependabot/108
-  "minimatch@>=5.0.0 <5.1.8": "^5.1.8" # https://github.com/NomicFoundation/slang/security/dependabot/108
   "picomatch@<2.3.2": "^2.3.2" # GHSA-c2c7-rcm5-vvqj
   "picomatch@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-c2c7-rcm5-vvqj
   "smol-toml@<1.6.1": "^1.6.1" # GHSA-v3rj-xjv7-4jmq
-  "tmp@<=0.2.3": "^0.2.4" # https://github.com/NomicFoundation/slang/security/dependabot/98
+  "tmp@<=0.2.3": "^0.2.4" # GHSA-52f5-9888-hmc6
   "undici@>=7.0.0 <7.24.0": "^7.24.0" # GHSA-f269-vfmq-vjvj, GHSA-vrm6-8vpv-qv8q, GHSA-v9p9-hfj2-hcw8
 
 # Dependency Resolution

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,17 +36,20 @@ catalog:
 
 overrides:
   # Temporary fixes until our dependencies are updated:
-  "basic-ftp@<5.2.2": "^5.2.2" # https://github.com/NomicFoundation/slang/security/dependabot/159
+  "basic-ftp@<5.3.0": "^5.3.0" # GHSA-rp42-5vxx-qpwr
   "flatted@<3.4.0": "^3.4.0" # https://github.com/NomicFoundation/slang/security/dependabot/115
   "js-yaml@<3.14.2": "^3.14.2" # https://github.com/NomicFoundation/slang/security/dependabot/101
   "minimatch@<3.1.3": "^3.1.3" # https://github.com/NomicFoundation/slang/security/dependabot/108
   "minimatch@>=5.0.0 <5.1.8": "^5.1.8" # https://github.com/NomicFoundation/slang/security/dependabot/108
+  "picomatch@<2.3.2": "^2.3.2" # GHSA-c2c7-rcm5-vvqj
+  "picomatch@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-c2c7-rcm5-vvqj
   "tmp@<=0.2.3": "^0.2.4" # https://github.com/NomicFoundation/slang/security/dependabot/98
+  "undici@>=7.0.0 <7.24.0": "^7.24.0" # GHSA-f269-vfmq-vjvj, GHSA-vrm6-8vpv-qv8q, GHSA-v9p9-hfj2-hcw8
 
 # Dependency Resolution
 minimumReleaseAge: 10080 # 1 week
 minimumReleaseAgeExclude:
-  - "basic-ftp@5.2.2" # security fix GHSA-6v7q-wjvx-w8wg: https://github.com/NomicFoundation/slang/security/dependabot/159
+  - "basic-ftp@5.3.0" # security fix GHSA-rp42-5vxx-qpwr
 
 # Store Settings
 storeDir: ".hermit/.pnpm-store"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,8 +50,6 @@ overrides:
 
 # Dependency Resolution
 minimumReleaseAge: 10080 # 1 week
-minimumReleaseAgeExclude:
-  - "basic-ftp@5.3.0" # security fix GHSA-rp42-5vxx-qpwr
 
 # Store Settings
 storeDir: ".hermit/.pnpm-store"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,12 +37,18 @@ catalog:
 overrides:
   # Temporary fixes until our dependencies are updated:
   "basic-ftp@<5.3.0": "^5.3.0" # GHSA-rp42-5vxx-qpwr
+  "brace-expansion@<1.1.13": "^1.1.13" # GHSA-f886-m6hf-6m8v
+  "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3" # GHSA-f886-m6hf-6m8v
+  "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5" # GHSA-f886-m6hf-6m8v
+  "diff@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-73rr-hh4g-fpgx
   "flatted@<3.4.0": "^3.4.0" # https://github.com/NomicFoundation/slang/security/dependabot/115
+  "follow-redirects@<1.16.0": "^1.16.0" # GHSA-r4q5-vmmm-2653
   "js-yaml@<3.14.2": "^3.14.2" # https://github.com/NomicFoundation/slang/security/dependabot/101
   "minimatch@<3.1.3": "^3.1.3" # https://github.com/NomicFoundation/slang/security/dependabot/108
   "minimatch@>=5.0.0 <5.1.8": "^5.1.8" # https://github.com/NomicFoundation/slang/security/dependabot/108
   "picomatch@<2.3.2": "^2.3.2" # GHSA-c2c7-rcm5-vvqj
   "picomatch@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-c2c7-rcm5-vvqj
+  "smol-toml@<1.6.1": "^1.6.1" # GHSA-v3rj-xjv7-4jmq
   "tmp@<=0.2.3": "^0.2.4" # https://github.com/NomicFoundation/slang/security/dependabot/98
   "undici@>=7.0.0 <7.24.0": "^7.24.0" # GHSA-f269-vfmq-vjvj, GHSA-vrm6-8vpv-qv8q, GHSA-v9p9-hfj2-hcw8
 


### PR DESCRIPTION
Bumps all transitive dependencies flagged by `pnpm audit` (6 high, 5 moderate, 1 low). Done as pins in `pnpm-workspace.yaml` overrides since all direct deps are already on their latest catalog versions.

## High

- `basic-ftp` `<5.3.0` → `^5.3.0` ([GHSA-rp42-5vxx-qpwr](https://github.com/advisories/GHSA-rp42-5vxx-qpwr))
- `picomatch` `<2.3.2` → `^2.3.2`, `>=4.0.0 <4.0.4` → `^4.0.4` ([GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj))
- `undici` `>=7.0.0 <7.24.0` → `^7.24.0` ([GHSA-f269-vfmq-vjvj](https://github.com/advisories/GHSA-f269-vfmq-vjvj), [GHSA-vrm6-8vpv-qv8q](https://github.com/advisories/GHSA-vrm6-8vpv-qv8q), [GHSA-v9p9-hfj2-hcw8](https://github.com/advisories/GHSA-v9p9-hfj2-hcw8))

`minimumReleaseAgeExclude` updated from `basic-ftp@5.2.2` to `basic-ftp@5.3.0` (published 2026-04-16, still inside the 1-week cooldown window).

## Moderate

- `brace-expansion` `<1.1.13` → `^1.1.13`, `>=2.0.0 <2.0.3` → `^2.0.3`, `>=4.0.0 <5.0.5` → `^5.0.5` ([GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v))
- `follow-redirects` `<1.16.0` → `^1.16.0` ([GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653))
- `smol-toml` `<1.6.1` → `^1.6.1` ([GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq))

## Low

- `diff` `>=4.0.0 <4.0.4` → `^4.0.4` ([GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx))

## Audited existing overrides

Dropped the following as redundant (verified by removing each and re-running `pnpm audit`):

- `flatted@<3.4.0` — no audit findings reappear
- `js-yaml@<3.14.2` — no audit findings reappear
- `minimatch@<3.1.3` and `minimatch@>=5.0.0 <5.1.8` — resolved versions are already `3.1.5` and `9.0.9`, outside the override ranges (dead code)

Kept `tmp@<=0.2.3` → `^0.2.4` — [GHSA-52f5-9888-hmc6](https://github.com/advisories/GHSA-52f5-9888-hmc6) still reappears via `solc>tmp` when the override is removed. Comment updated to use the GHSA id for consistency.

## Verification

`pnpm audit` now reports **0 vulnerabilities**. `./scripts/bin/infra check` passes.