### PR TITLE
Fine tune bencher threshold

### DIFF
--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -153,6 +153,10 @@ impl CargoController {
         // so any change reflects a real code change, not noise.
         // We also keep the window small (only 2 measurements), for the same reason.
         let threshold = |measure| BencherThreshold::new(measure, "0.01").with_max_sample_size("2");
+
+        // We don't add thresholds for l1-hits, l2-hits, and ram-hits, since there's not a simple
+        // rule that could catch all cases (ie more l1-hits is better if total bytes read remains the same,
+        // but less l1-hits is also better if it decreases total bytes read)
         run_bench(
             self.dry_run.get(),
             self.pr_benchmark,
@@ -161,9 +165,6 @@ impl CargoController {
             &[
                 threshold("estimated-cycles"),
                 threshold("instructions"),
-                threshold("l1-hits"),
-                threshold("l2-hits"),
-                threshold("ram-hits"),
                 threshold("total-read-write"),
                 threshold("total-bytes"),
                 threshold("total-blocks"),

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -48,14 +48,14 @@ impl NpmController {
             hot = &self.hot,
         );
 
-        // 10% threshold: npm benchmarks use wall-clock duration which has natural variance,
+        // 15% threshold: npm benchmarks use wall-clock duration which has natural variance,
         // so a tighter threshold would produce noisy alerts.
         run_bench(
             self.dry_run.get(),
             self.pr_benchmark,
             DEFAULT_BENCHER_PROJECT,
             "json",
-            &[BencherThreshold::new("duration", "0.10")],
+            &[BencherThreshold::new("duration", "0.15")],
             &test_runner,
         );
     }

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -98,16 +98,20 @@ pub(crate) fn run_bench(
             max_sample_size,
         } in thresholds
         {
+            // Since we have to use the same arguments for every threshold, we always
+            // show them and default to "_" if not set.
+            // Bencher will ignore options specified with "_".
+            fn optional_threshold(arg: Option<&str>) -> &str {
+                arg.unwrap_or("_")
+            }
+
             command = command
                 .property("--threshold-measure", measure)
                 .property("--threshold-test", "percentage")
                 .property("--threshold-upper-boundary", upper_boundary)
-                // Since we have to show it for all or for none of the thresholds, we always
-                // show it and default to "_" if not set.
-                // Bencher will ignore options specified with "_".
                 .property(
                     "--threshold-max-sample-size",
-                    max_sample_size.as_ref().map_or("_", String::as_str),
+                    optional_threshold(max_sample_size.as_deref()),
                 );
         }
 


### PR DESCRIPTION
This PR fine tunes some bencher thresholds:

- npm alerts are set to 15%, since we're seeing a lot of noise in them
- L1 hits, L2 hits, and RAM hits are disabled, since there's no simple rule to correctly catch them

cc @nebasuke since you set the numbers originally