### PR TITLE
[v2] Re-export AST/ABI types in `slang_solidity_v2` and clean up public facing modules

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ir/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod ir;
 
 #[cfg(test)]
-pub mod tests;
+mod tests;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -39,14 +39,14 @@ pub enum Definition {
 #[derive(Debug)]
 pub struct ConstantDefinition {
     pub ir_node: ir::ConstantDefinition,
-    pub scope_id: ScopeId,
+    pub(crate) scope_id: ScopeId,
 }
 
 #[derive(Debug)]
 pub struct ContractDefinition {
     pub ir_node: ir::ContractDefinition,
     pub bases: Option<Vec<NodeId>>,
-    pub constructor_parameters_scope_id: Option<ScopeId>,
+    pub(crate) constructor_parameters_scope_id: Option<ScopeId>,
     pub base_slot: Option<usize>,
 }
 
@@ -63,19 +63,19 @@ pub struct EnumMemberDefinition {
 #[derive(Debug)]
 pub struct ErrorDefinition {
     pub ir_node: ir::ErrorDefinition,
-    pub parameters_scope_id: ScopeId,
+    pub(crate) parameters_scope_id: ScopeId,
 }
 
 #[derive(Debug)]
 pub struct EventDefinition {
     pub ir_node: ir::EventDefinition,
-    pub parameters_scope_id: ScopeId,
+    pub(crate) parameters_scope_id: ScopeId,
 }
 
 #[derive(Debug)]
 pub struct FunctionDefinition {
     pub ir_node: ir::FunctionDefinition,
-    pub parameters_scope_id: ScopeId,
+    pub(crate) parameters_scope_id: ScopeId,
     pub visibility: ir::FunctionVisibility,
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -16,7 +16,7 @@ use scopes::ContractScope;
 pub(crate) use scopes::{FileScope, ParameterDefinition, ParametersScope, Scope, UsingDirective};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ScopeId(usize);
+pub(crate) struct ScopeId(usize);
 
 //////////////////////////////////////////////////////////////////////////////
 // Binder
@@ -221,7 +221,8 @@ impl Binder {
         self.linearisations.get(&node_id)
     }
 
-    pub fn linearisations(&self) -> &HashMap<NodeId, Vec<NodeId>> {
+    #[cfg(test)]
+    pub(crate) fn linearisations(&self) -> &HashMap<NodeId, Vec<NodeId>> {
         &self.linearisations
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
@@ -47,7 +47,7 @@ impl Reference {
 }
 
 impl Resolution {
-    pub fn as_definition_id(&self) -> Option<NodeId> {
+    pub(crate) fn as_definition_id(&self) -> Option<NodeId> {
         if let Resolution::Definition(definition_id) = self {
             Some(*definition_id)
         } else {
@@ -64,16 +64,7 @@ impl Resolution {
     }
 
     #[must_use]
-    pub fn non_ambiguous(self) -> Self {
-        if matches!(self, Self::Ambiguous(_)) {
-            Self::Unresolved
-        } else {
-            self
-        }
-    }
-
-    #[must_use]
-    pub fn or_else<F>(self, f: F) -> Self
+    pub(crate) fn or_else<F>(self, f: F) -> Self
     where
         F: FnOnce() -> Self,
     {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -130,7 +130,7 @@ impl SemanticContext {
         reference.resolution.as_definition_id()
     }
 
-    pub fn definition_canonical_name(&self, definition_id: NodeId) -> String {
+    pub(crate) fn definition_canonical_name(&self, definition_id: NodeId) -> String {
         self.binder
             .find_definition_by_id(definition_id)
             .unwrap()
@@ -276,8 +276,8 @@ impl SemanticContext {
     }
 
     pub const SLOT_SIZE: usize = 32;
-    pub const ADDRESS_BYTE_SIZE: usize = 20;
-    pub const SELECTOR_SIZE: usize = 4;
+    pub(crate) const ADDRESS_BYTE_SIZE: usize = 20;
+    pub(crate) const SELECTOR_SIZE: usize = 4;
 
     pub fn storage_size_of_type_id(&self, type_id: TypeId) -> Option<usize> {
         self.storage_size_of_type_id_impl(type_id, &mut HashSet::new())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -104,7 +104,7 @@ impl FunctionType {
     }
 }
 
-pub trait ImplicitlyConvertible<T> {
+pub(crate) trait ImplicitlyConvertible<T> {
     fn implicitly_convertible_to(&self, target: T) -> bool;
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -89,16 +89,16 @@ impl Default for TypeRegistry {
 }
 
 impl TypeRegistry {
-    pub fn find_type(&self, type_: &Type) -> Option<TypeId> {
+    pub(crate) fn find_type(&self, type_: &Type) -> Option<TypeId> {
         self.types.get_index_of(type_).map(TypeId)
     }
 
-    pub fn register_type(&mut self, type_: Type) -> TypeId {
+    pub(crate) fn register_type(&mut self, type_: Type) -> TypeId {
         let (index, _) = self.types.insert_full(type_);
         TypeId(index)
     }
 
-    pub fn register_super_types(&mut self, type_id: TypeId, super_types: Vec<TypeId>) {
+    pub(crate) fn register_super_types(&mut self, type_id: TypeId, super_types: Vec<TypeId>) {
         self.super_types.insert(type_id, super_types);
     }
 
@@ -107,7 +107,11 @@ impl TypeRegistry {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn implicitly_convertible_to(&self, from_type_id: TypeId, to_type_id: TypeId) -> bool {
+    pub(crate) fn implicitly_convertible_to(
+        &self,
+        from_type_id: TypeId,
+        to_type_id: TypeId,
+    ) -> bool {
         if from_type_id == to_type_id {
             return true;
         }
@@ -288,7 +292,7 @@ impl TypeRegistry {
 
     // Similar to `implicitly_convertible_to` above, but with relaxed rules for
     // data location
-    pub fn implicitly_convertible_to_for_external_call(
+    pub(crate) fn implicitly_convertible_to_for_external_call(
         &self,
         from_type_id: TypeId,
         to_type_id: TypeId,
@@ -349,7 +353,10 @@ impl TypeRegistry {
 
     // Changes a function type to have external visibility and any parameters
     // normalized for that (ie. `calldata` location is changed to `memory`)
-    pub fn externalize_function_type(&mut self, function_type: FunctionType) -> FunctionType {
+    pub(crate) fn externalize_function_type(
+        &mut self,
+        function_type: FunctionType,
+    ) -> FunctionType {
         FunctionType {
             visibility: ir::FunctionVisibility::External,
             parameter_types: function_type
@@ -374,7 +381,7 @@ impl TypeRegistry {
         }
     }
 
-    pub fn find_canonical_type_id(&self, type_id: TypeId) -> Option<TypeId> {
+    pub(crate) fn find_canonical_type_id(&self, type_id: TypeId) -> Option<TypeId> {
         let canonical_type = match self.get_type_by_id(type_id) {
             Type::Array { element_type, .. } => {
                 let element_type = self.find_canonical_type_id(*element_type)?;
@@ -444,7 +451,7 @@ impl TypeRegistry {
         self.register_type_with_data_location(type_, location)
     }
 
-    pub fn register_type_with_data_location(
+    pub(crate) fn register_type_with_data_location(
         &mut self,
         type_: Type,
         location: DataLocation,
@@ -495,7 +502,7 @@ impl TypeRegistry {
 
     // Return a type that can be stored in the EVM. In short, convert literal
     // types into the appropriate "real" type
-    pub fn reified_type(&mut self, type_id: TypeId) -> TypeId {
+    pub(crate) fn reified_type(&mut self, type_id: TypeId) -> TypeId {
         let Type::Literal(kind) = self.get_type_by_id(type_id) else {
             return type_id;
         };
@@ -654,52 +661,53 @@ impl TypeRegistry {
 
 // Convenience accessors for pre-defined types
 impl TypeRegistry {
-    pub fn address(&self) -> TypeId {
+    pub(crate) fn address(&self) -> TypeId {
         self.address_type_id
     }
-    pub fn address_payable(&self) -> TypeId {
+    pub(crate) fn address_payable(&self) -> TypeId {
         self.address_payable_type_id
     }
-    pub fn boolean(&self) -> TypeId {
+    pub(crate) fn boolean(&self) -> TypeId {
         self.boolean_type_id
     }
-    pub fn boolean_bytes_tuple(&self) -> TypeId {
+    pub(crate) fn boolean_bytes_tuple(&self) -> TypeId {
         self.boolean_bytes_tuple_type_id
     }
-    pub fn bytes_calldata(&self) -> TypeId {
+    pub(crate) fn bytes_calldata(&self) -> TypeId {
         self.bytes_calldata_type_id
     }
-    pub fn bytes_memory(&self) -> TypeId {
+    pub(crate) fn bytes_memory(&self) -> TypeId {
         self.bytes_memory_type_id
     }
-    pub fn bytes1(&self) -> TypeId {
+    pub(crate) fn bytes1(&self) -> TypeId {
         self.bytes1_type_id
     }
-    pub fn bytes20(&self) -> TypeId {
+    pub(crate) fn bytes20(&self) -> TypeId {
         self.bytes20_type_id
     }
-    pub fn bytes32(&self) -> TypeId {
+    pub(crate) fn bytes32(&self) -> TypeId {
         self.bytes32_type_id
     }
-    pub fn bytes4(&self) -> TypeId {
+    pub(crate) fn bytes4(&self) -> TypeId {
         self.bytes4_type_id
     }
-    pub fn string(&self) -> TypeId {
+    pub(crate) fn string(&self) -> TypeId {
         self.string_type_id
     }
-    pub fn uint256(&self) -> TypeId {
+    pub(crate) fn uint256(&self) -> TypeId {
         self.uint256_type_id
     }
-    pub fn uint8(&self) -> TypeId {
+    pub(crate) fn uint8(&self) -> TypeId {
         self.uint8_type_id
     }
-    pub fn void(&self) -> TypeId {
+    pub(crate) fn void(&self) -> TypeId {
         self.void_type_id
     }
 }
 
+#[cfg(test)]
 impl TypeRegistry {
-    pub fn iter_types(&self) -> impl Iterator<Item = (TypeId, &Type)> {
+    pub(crate) fn iter_types(&self) -> impl Iterator<Item = (TypeId, &Type)> {
         (0usize..).map(TypeId).zip(self.types.iter())
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -18,6 +18,9 @@ license = "MIT"
 keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
+[features]
+__private_testing_utils = []
+
 [dependencies]
 slang_solidity_v2_ast = { workspace = true }
 slang_solidity_v2_common = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/abi.rs
@@ -1,0 +1,1 @@
+pub use slang_solidity_v2_ast::abi::*;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/ast.rs
@@ -1,0 +1,4 @@
+pub use slang_solidity_v2_ast::ast::*;
+pub use slang_solidity_v2_common::built_ins::BuiltIn;
+pub use slang_solidity_v2_common::nodes::NodeId;
+pub use slang_solidity_v2_semantic::types::{DataLocation, TypeId};

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -22,6 +22,10 @@ impl File {
     pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
         self.resolved_imports.insert(node_id, target_file_id);
     }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
 }
 
 impl SemanticFile for File {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -22,10 +22,6 @@ impl File {
     pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
         self.resolved_imports.insert(node_id, target_file_id);
     }
-
-    pub fn id(&self) -> &str {
-        &self.id
-    }
 }
 
 impl SemanticFile for File {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
@@ -1,4 +1,9 @@
-pub mod builder;
-pub mod file;
+mod builder;
+mod file;
 mod internal_builder;
-pub mod unit;
+mod unit;
+
+pub use builder::{CompilationBuilder, CompilationBuilderConfig, CompilationBuilderError};
+pub use file::File;
+pub use slang_solidity_v2_parser::ParserError;
+pub use unit::CompilationUnit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
@@ -4,6 +4,5 @@ mod internal_builder;
 mod unit;
 
 pub use builder::{CompilationBuilder, CompilationBuilderConfig, CompilationBuilderError};
-pub use file::File;
 pub use slang_solidity_v2_parser::ParserError;
 pub use unit::CompilationUnit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -45,7 +45,8 @@ impl CompilationUnit {
         self.files.get(id).cloned()
     }
 
-    // TODO: this should be semi-public
+    #[cfg(feature = "__private_testing_utils")]
+    #[doc(hidden)]
     pub fn semantic(&self) -> &Rc<SemanticContext> {
         &self.semantic
     }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -35,14 +35,9 @@ impl CompilationUnit {
         self.language_version
     }
 
-    /// Returns a list of all files in the compilation unit.
-    pub fn files(&self) -> Vec<Rc<File>> {
-        self.files.values().cloned().collect()
-    }
-
-    /// Returns the file with the specified ID, if it exists.
-    pub fn file(&self, id: &str) -> Option<Rc<File>> {
-        self.files.get(id).cloned()
+    /// Returns a list of all file IDs in the compilation unit.
+    pub fn file_ids(&self) -> Vec<String> {
+        self.files.keys().cloned().collect()
     }
 
     #[cfg(feature = "__private_testing_utils")]
@@ -55,6 +50,14 @@ impl CompilationUnit {
         self.files
             .get(file_id)
             .map(|file| ast::create_source_unit(file.ir_root(), &self.semantic))
+    }
+
+    #[cfg(feature = "__private_testing_utils")]
+    #[doc(hidden)]
+    pub fn get_file_ir_root(&self, file_id: &str) -> Option<slang_solidity_v2_ir::ir::SourceUnit> {
+        self.files
+            .get(file_id)
+            .map(|file| Rc::clone(file.ir_root()))
     }
 
     pub fn all_definitions(&self) -> impl Iterator<Item = ast::Definition> + use<'_> {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/lib.rs
@@ -1,4 +1,7 @@
+pub mod abi;
+pub mod ast;
 pub mod compilation;
+pub mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use slang_solidity_v2_ast::abi::AbiEntry;
 
 use super::fixtures;
+use crate::abi::AbiEntry;
 
 /// Convenience macro to test equality of tuple components for input/output parameters.
 ///

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use slang_solidity_v2_ast::ast::{self, ContractBase, ContractMember, Definition, FunctionKind};
-use slang_solidity_v2_common::built_ins::BuiltIn;
 
 use super::fixtures;
+use crate::ast::{self, BuiltIn, ContractBase, ContractMember, Definition, FunctionKind};
 
 #[derive(Default)]
 struct IdentifierCounter {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -1,12 +1,11 @@
 use std::rc::Rc;
 
 use anyhow::Result;
-use slang_solidity_v2_common::versions::LanguageVersion;
 
-use crate::compilation::builder::{
-    CompilationBuilder, CompilationBuilderConfig, CompilationBuilderError,
+use crate::compilation::{
+    CompilationBuilder, CompilationBuilderConfig, CompilationBuilderError, CompilationUnit,
 };
-use crate::compilation::unit::CompilationUnit;
+use crate::utils::LanguageVersion;
 
 mod abi_with_tuples;
 mod chained_imports;
@@ -44,7 +43,7 @@ macro_rules! define_fixture {
 
         impl $name {
             pub(crate) fn build_compilation_unit(
-            ) -> anyhow::Result<std::rc::Rc<$crate::compilation::unit::CompilationUnit>> {
+            ) -> anyhow::Result<std::rc::Rc<$crate::compilation::CompilationUnit>> {
                 $crate::tests::fixtures::build_compilation_unit_from_fixture(FILES)
             }
         }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -105,41 +105,41 @@ pub(super) fn build_compilation_unit_from_fixture(
 #[test]
 fn test_build_abi_with_tuples_fixture() -> Result<()> {
     let unit = AbiWithTuples::build_compilation_unit()?;
-    assert_eq!(1, unit.files().len());
+    assert_eq!(1, unit.file_ids().len());
     Ok(())
 }
 
 #[test]
 fn test_build_chained_imports_fixture() -> Result<()> {
     let unit = ChainedImports::build_compilation_unit()?;
-    assert_eq!(3, unit.files().len());
+    assert_eq!(3, unit.file_ids().len());
     Ok(())
 }
 
 #[test]
 fn test_build_counter_fixture() -> Result<()> {
     let unit = Counter::build_compilation_unit()?;
-    assert_eq!(3, unit.files().len());
+    assert_eq!(3, unit.file_ids().len());
     Ok(())
 }
 
 #[test]
 fn test_build_full_abi_fixture() -> Result<()> {
     let unit = FullAbi::build_compilation_unit()?;
-    assert_eq!(1, unit.files().len());
+    assert_eq!(1, unit.file_ids().len());
     Ok(())
 }
 
 #[test]
 fn test_build_overrides_fixture() -> Result<()> {
     let unit = Overrides::build_compilation_unit()?;
-    assert_eq!(1, unit.files().len());
+    assert_eq!(1, unit.file_ids().len());
     Ok(())
 }
 
 #[test]
 fn test_build_storage_layout_fixture() -> Result<()> {
     let unit = StorageLayout::build_compilation_unit()?;
-    assert_eq!(1, unit.files().len());
+    assert_eq!(1, unit.file_ids().len());
     Ok(())
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use slang_solidity_v2_ast::ast::Definition;
 
 use super::fixtures;
+use crate::ast::Definition;
 
 #[test]
 fn test_get_file_ast_root() -> Result<()> {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -7,7 +7,7 @@ use crate::ast::Definition;
 fn test_get_file_ast_root() -> Result<()> {
     let unit = fixtures::Counter::build_compilation_unit()?;
 
-    assert_eq!(unit.files().len(), 3);
+    assert_eq!(unit.file_ids().len(), 3);
 
     let main_ast = unit
         .get_file_ast_root("main.sol")

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/utils.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/utils.rs
@@ -1,0 +1,3 @@
+pub use slang_solidity_v2_common::versions::{
+    FromSemverError, LanguageVersion, LanguageVersionSpecifier,
+};

--- a/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
@@ -11,7 +11,7 @@ ariadne = { workspace = true }
 indoc = { workspace = true }
 infra_utils = { workspace = true }
 regex = { workspace = true }
-slang_solidity_v2 = { workspace = true }
+slang_solidity_v2 = { workspace = true, features = ["__private_testing_utils"] }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
@@ -7,7 +7,7 @@ use ariadne::{Color, Config, Label, Report, ReportBuilder, ReportKind, Source};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_parser::ParserError;
 use slang_solidity_v2_semantic::binder::Resolution;
-use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
+use slang_solidity_v2_semantic::context::SemanticContext;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use super::report_data::{

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report.rs
@@ -48,10 +48,9 @@ pub(crate) fn binder_report(report_data: &'_ ReportData<'_>) -> Result<String> {
 
     report_unbound_identifiers(&mut report, unbound_identifiers)?;
 
-    for file in &compilation.files() {
+    for file_id in &compilation.file_ids() {
         writeln!(report, "{SEPARATOR}")?;
 
-        let file_id = file.id();
         if let Some(contents) = files.get(file_id) {
             render_bindings_for_file(
                 &mut report,

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::ops::Range;
 
-use slang_solidity_v2::compilation::unit::CompilationUnit;
+use slang_solidity_v2::compilation::CompilationUnit;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2_ir::ir::Identifier;

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/report_data.rs
@@ -8,7 +8,7 @@ use slang_solidity_v2_ir::ir::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2_ir::ir::Identifier;
 use slang_solidity_v2_parser::ParserError;
 use slang_solidity_v2_semantic::binder::{Definition, Resolution, Typing};
-use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
+use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{DataLocation, FunctionType, LiteralKind, Type, TypeId};
 
 // Types
@@ -144,9 +144,14 @@ fn collect_all_identifiers(
         current_file: None,
     };
 
-    for file in &compilation.files() {
-        collector.current_file = files.get_key_value(file.id());
-        accept_source_unit(file.ir_root(), &mut collector);
+    for file_id in &compilation.file_ids() {
+        collector.current_file = files.get_key_value(file_id);
+        accept_source_unit(
+            &compilation
+                .get_file_ir_root(file_id)
+                .expect("file has IR root"),
+            &mut collector,
+        );
     }
 
     collector.identifiers

--- a/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/semantic/semantic_output/runner.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
-use slang_solidity_v2::compilation::builder::{
+use slang_solidity_v2::compilation::{
     CompilationBuilder, CompilationBuilderConfig, CompilationBuilderError,
 };
 use slang_solidity_v2_common::versions::LanguageVersion;


### PR DESCRIPTION
This prepares `slang_solidity_v2` to be the only public facing crate users of Slang would have to depend on. Re-export AST and ABI types and adjust the public compilation modules. 

Finally, it narrows down the visibility of a lot of types and functions that we not being accessed from outside the crate, in particular in the semantic crate.
