### PR TITLE
feat(backend): narrow literal typing and expose via AST methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "metaslang_bindings",
  "metaslang_cst",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "paste",
  "semver 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ markdown = { version = "0.3.0" }
 nom = { version = "8.0.0" }
 num-bigint = { version = "0.4.6" }
 num-format = { version = "0.4.4" }
+num-integer = { version = "0.1.46" }
 num-traits = { version = "0.2.18" }
 paste = { version = "1.0.15" }
 proc-macro2 = { version = "1.0.106" }

--- a/crates/solidity/outputs/cargo/crate/Cargo.toml
+++ b/crates/solidity/outputs/cargo/crate/Cargo.toml
@@ -31,6 +31,7 @@ __private_backend_api = [
   "dep:indexmap",
   "dep:paste",
   "dep:num-bigint",
+  "dep:num-integer",
   "dep:num-traits",
   "dep:sha3",
 ]
@@ -43,6 +44,7 @@ indexmap = { workspace = true, optional = true }
 metaslang_bindings = { workspace = true }
 metaslang_cst = { workspace = true }
 num-bigint = { workspace = true, optional = true }
+num-integer = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 paste = { workspace = true, optional = true }
 semver = { workspace = true }

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/mod.rs
@@ -5,6 +5,7 @@ pub use nodes::*;
 mod node_extensions;
 pub use node_extensions::*;
 
+pub use super::super::types::LiteralKind;
 use super::ir2_flat_contracts as input;
 
 #[path = "visitor.generated.rs"]

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
@@ -1,6 +1,14 @@
-use super::super::{FunctionCallExpressionStruct, StringExpression};
+use num_bigint::BigInt;
+
+use super::super::{
+    DecimalNumberExpressionStruct, FunctionCallExpressionStruct, HexNumberExpressionStruct,
+    StringExpression,
+};
 use crate::backend::binder::Typing;
 use crate::backend::ir::ir2_flat_contracts as input_ir;
+use crate::backend::passes::p4_type_definitions::evaluator::{
+    evaluate_decimal_number_expression, evaluate_hex_number_expression, ConstantValue,
+};
 
 impl StringExpression {
     /// Returns the concatenated decoded string value as bytes.
@@ -52,6 +60,23 @@ impl StringExpression {
                     })
             })
             .unwrap_or(text)
+    }
+}
+
+impl DecimalNumberExpressionStruct {
+    /// Returns the integer value of this literal, or `None` for rationals
+    /// that do not reduce to an integer after unit multiplication.
+    pub fn value(&self) -> Option<BigInt> {
+        evaluate_decimal_number_expression(&self.ir_node)
+            .map(|ConstantValue::Integer(integer)| integer)
+    }
+}
+
+impl HexNumberExpressionStruct {
+    /// Returns the integer value of this literal, or `None` if the literal
+    /// cannot be evaluated (e.g. a malformed hex digit sequence).
+    pub fn value(&self) -> Option<BigInt> {
+        evaluate_hex_number_expression(&self.ir_node).map(|ConstantValue::Integer(integer)| integer)
     }
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
@@ -6,9 +6,7 @@ use super::super::{
 };
 use crate::backend::binder::Typing;
 use crate::backend::ir::ir2_flat_contracts as input_ir;
-use crate::backend::passes::p4_type_definitions::evaluator::{
-    evaluate_decimal_number_expression, evaluate_hex_number_expression, ConstantValue,
-};
+use crate::backend::types::ConstantValue;
 
 impl StringExpression {
     /// Returns the concatenated decoded string value as bytes.
@@ -66,8 +64,10 @@ impl StringExpression {
 impl DecimalNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` for rationals
     /// that do not reduce to an integer after unit multiplication.
-    pub fn value(&self) -> Option<BigInt> {
-        evaluate_decimal_number_expression(&self.ir_node)
+    // TODO: support returning rational values (numerator/denominator) once
+    // the evaluator exposes them.
+    pub fn integer_value(&self) -> Option<BigInt> {
+        ConstantValue::from_decimal_number(&self.ir_node)
             .map(|ConstantValue::Integer(integer)| integer)
     }
 }
@@ -75,8 +75,9 @@ impl DecimalNumberExpressionStruct {
 impl HexNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` if the literal
     /// cannot be evaluated (e.g. a malformed hex digit sequence).
-    pub fn value(&self) -> Option<BigInt> {
-        evaluate_hex_number_expression(&self.ir_node).map(|ConstantValue::Integer(integer)| integer)
+    // TODO: support returning rational values once the evaluator exposes them.
+    pub fn integer_value(&self) -> Option<BigInt> {
+        ConstantValue::from_hex_number(&self.ir_node).map(|ConstantValue::Integer(integer)| integer)
     }
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use paste::paste;
 
 use super::Definition;
-use crate::backend::types::{self, DataLocation, FunctionTypeKind, TypeId};
+use crate::backend::types::{self, DataLocation, FunctionTypeKind, LiteralKind, TypeId};
 use crate::backend::SemanticAnalysis;
 
 // __SLANG_TYPE_TYPES__ keep in sync with binder types
@@ -309,7 +309,15 @@ impl InterfaceType {
     }
 }
 
-impl LiteralType {}
+impl LiteralType {
+    /// Returns the narrowed kind of this literal type.
+    pub fn kind(&self) -> LiteralKind {
+        let types::Type::Literal(kind) = self.internal_type() else {
+            unreachable!("LiteralType wraps a literal variant by construction")
+        };
+        kind.clone()
+    }
+}
 
 impl MappingType {
     pub fn key_type(&self) -> Type {

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use num_bigint::BigInt;
+use num_integer::Integer;
 use num_traits::cast::ToPrimitive;
 use num_traits::Num;
 
@@ -30,7 +31,7 @@ fn evaluate_compile_time_constant<Scope>(
 }
 
 #[derive(Clone, Debug, PartialEq)]
-enum ConstantValue {
+pub(crate) enum ConstantValue {
     Integer(BigInt),
 }
 
@@ -105,10 +106,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 self.evaluate_prefix_expression(prefix_expression)
             }
             input_ir::Expression::HexNumberExpression(hex_number_expression) => {
-                Self::evaluate_hex_number_expression(hex_number_expression)
+                evaluate_hex_number_expression(hex_number_expression)
             }
             input_ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                Self::evaluate_decimal_number_expression(decimal_number_expression)
+                evaluate_decimal_number_expression(decimal_number_expression)
             }
             input_ir::Expression::Identifier(terminal_node) => {
                 self.evaluate_identifier(terminal_node)
@@ -269,25 +270,6 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         }
     }
 
-    fn evaluate_hex_number_expression(
-        hex_number_expression: &input_ir::HexNumberExpression,
-    ) -> Option<ConstantValue> {
-        let hex = hex_number_expression.literal.unparse();
-        // skip `0x` prefix and parse the hexadecimal number
-        BigInt::from_str_radix(&hex[2..], 16)
-            .ok()
-            .map(ConstantValue::Integer)
-    }
-
-    fn evaluate_decimal_number_expression(
-        decimal_number_expression: &input_ir::DecimalNumberExpression,
-    ) -> Option<ConstantValue> {
-        // TODO: this only handles integers but not rational numbers
-        // TODO: handle number units
-        let decimal = decimal_number_expression.literal.unparse();
-        BigInt::from_str(&decimal).ok().map(ConstantValue::Integer)
-    }
-
     fn evaluate_identifier(&mut self, identifier: &Rc<TerminalNode>) -> Option<ConstantValue> {
         let current_scope = self.scope_stack.last().expect("scope stack is empty");
         let (target_expression, target_scope) = self
@@ -305,6 +287,70 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             self.evaluate_expression(inner_expression)
         } else {
             None
+        }
+    }
+}
+
+pub(crate) fn evaluate_hex_number_expression(
+    hex_number_expression: &input_ir::HexNumberExpression,
+) -> Option<ConstantValue> {
+    let hex = hex_number_expression.literal.unparse();
+    // skip `0x` prefix, strip digit-grouping underscores, and parse the
+    // hexadecimal number
+    let digits: String = hex[2..]
+        .chars()
+        .filter(|character| *character != '_')
+        .collect();
+    let value = BigInt::from_str_radix(&digits, 16).ok()?;
+    let scaled = match &hex_number_expression.unit {
+        None => value,
+        Some(unit) => value * BigInt::from(unit),
+    };
+    Some(ConstantValue::Integer(scaled))
+}
+
+pub(crate) fn evaluate_decimal_number_expression(
+    decimal_number_expression: &input_ir::DecimalNumberExpression,
+) -> Option<ConstantValue> {
+    let decimal = decimal_number_expression.literal.unparse();
+    let cleaned: String = decimal.chars().filter(|c| *c != '_').collect();
+    let (mantissa, exponent) = match cleaned.split_once(['e', 'E']) {
+        Some((m, e)) => (m, e.parse::<i64>().ok()?),
+        None => (cleaned.as_str(), 0),
+    };
+    let (int_part, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let numerator = BigInt::from_str(&format!("{int_part}{fraction}")).ok()?;
+    let unit = decimal_number_expression
+        .unit
+        .as_ref()
+        .map_or(BigInt::from(1u32), BigInt::from);
+    let scaled = numerator * unit;
+    let net_exp = exponent - i64::try_from(fraction.len()).ok()?;
+    let shift = BigInt::from(10u32).pow(u32::try_from(net_exp.unsigned_abs()).ok()?);
+    if net_exp >= 0 {
+        Some(ConstantValue::Integer(scaled * shift))
+    } else {
+        scaled
+            .is_multiple_of(&shift)
+            .then(|| ConstantValue::Integer(scaled / shift))
+    }
+}
+
+impl From<&input_ir::NumberUnit> for BigInt {
+    fn from(value: &input_ir::NumberUnit) -> Self {
+        match value {
+            input_ir::NumberUnit::WeiKeyword | input_ir::NumberUnit::SecondsKeyword => {
+                Self::from(1u32)
+            }
+            input_ir::NumberUnit::GweiKeyword => Self::from(10u64.pow(9)),
+            input_ir::NumberUnit::SzaboKeyword => Self::from(10u64.pow(12)),
+            input_ir::NumberUnit::FinneyKeyword => Self::from(10u64.pow(15)),
+            input_ir::NumberUnit::EtherKeyword => Self::from(10u64.pow(18)),
+            input_ir::NumberUnit::MinutesKeyword => Self::from(60u32),
+            input_ir::NumberUnit::HoursKeyword => Self::from(60u32 * 60),
+            input_ir::NumberUnit::DaysKeyword => Self::from(60u32 * 60 * 24),
+            input_ir::NumberUnit::WeeksKeyword => Self::from(60u32 * 60 * 24 * 7),
+            input_ir::NumberUnit::YearsKeyword => Self::from(60u64 * 60 * 24 * 365),
         }
     }
 }
@@ -392,6 +438,82 @@ mod tests {
             .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
         assert!(eval_string("0xa0")
             .is_some_and(|value| value == ConstantValue::Integer(160.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_literals_with_digit_separators() {
+        assert!(eval_string("1_000")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
+        assert!(eval_string("1_000_000")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000_000.to_bigint().unwrap())));
+        assert!(eval_string("0xdead_beef").is_some_and(
+            |value| value == ConstantValue::Integer(0xdead_beef_u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("0x1234_5678").is_some_and(
+            |value| value == ConstantValue::Integer(0x1234_5678_u64.to_bigint().unwrap())
+        ));
+    }
+
+    #[test]
+    fn test_literals_with_number_units() {
+        assert!(eval_string("1 wei")
+            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+        assert!(eval_string("1 gwei").is_some_and(
+            |value| value == ConstantValue::Integer(1_000_000_000u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("1 ether").is_some_and(|value| value
+            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("2 ether").is_some_and(|value| value
+            == ConstantValue::Integer(2_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1 seconds")
+            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+        assert!(eval_string("1 minutes")
+            .is_some_and(|value| value == ConstantValue::Integer(60.to_bigint().unwrap())));
+        assert!(eval_string("1 hours")
+            .is_some_and(|value| value == ConstantValue::Integer(3_600.to_bigint().unwrap())));
+        assert!(eval_string("1 days")
+            .is_some_and(|value| value == ConstantValue::Integer(86_400.to_bigint().unwrap())));
+        assert!(eval_string("1 weeks")
+            .is_some_and(|value| value == ConstantValue::Integer(604_800.to_bigint().unwrap())));
+        assert!(
+            eval_string_in_version("1 szabo", &VERSION_0_4_26)
+                .is_some_and(|value| value
+                    == ConstantValue::Integer(1_000_000_000_000u64.to_bigint().unwrap()))
+        );
+        assert!(eval_string_in_version("1 finney", &VERSION_0_4_26)
+            .is_some_and(|value| value
+                == ConstantValue::Integer(1_000_000_000_000_000u64.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_literals_with_scientific_notation() {
+        assert!(eval_string("1e3")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
+        assert!(eval_string("2e10").is_some_and(
+            |value| value == ConstantValue::Integer(20_000_000_000u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("1e18").is_some_and(|value| value
+            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1.5e3")
+            .is_some_and(|value| value == ConstantValue::Integer(1_500.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_reducible_rational_literals() {
+        assert!(eval_string("1.5 ether").is_some_and(|value| value
+            == ConstantValue::Integer(1_500_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("0.5 ether").is_some_and(|value| value
+            == ConstantValue::Integer(500_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("0.5 gwei").is_some_and(
+            |value| value == ConstantValue::Integer(500_000_000u64.to_bigint().unwrap())
+        ));
+    }
+
+    #[test]
+    fn test_non_reducible_rational_literals() {
+        assert!(eval_string("0.5").is_none());
+        assert!(eval_string("3.14").is_none());
+        assert!(eval_string("1e-1").is_none());
     }
 
     #[test]

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/evaluator.rs
@@ -1,12 +1,10 @@
 use std::rc::Rc;
-use std::str::FromStr;
 
 use num_bigint::BigInt;
-use num_integer::Integer;
 use num_traits::cast::ToPrimitive;
-use num_traits::Num;
 
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
+use crate::backend::types::ConstantValue;
 use crate::cst::{TerminalKind, TerminalNode};
 
 pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
@@ -28,18 +26,6 @@ fn evaluate_compile_time_constant<Scope>(
         scope_stack: Vec::new(),
     };
     evaluator.evaluate_expression_in_scope(expression, start_scope)
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum ConstantValue {
-    Integer(BigInt),
-}
-
-impl ConstantValue {
-    fn as_usize(&self) -> Option<usize> {
-        let Self::Integer(value) = self;
-        value.to_usize()
-    }
 }
 
 pub(crate) trait ConstantIdentifierResolver<Scope> {
@@ -106,10 +92,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 self.evaluate_prefix_expression(prefix_expression)
             }
             input_ir::Expression::HexNumberExpression(hex_number_expression) => {
-                evaluate_hex_number_expression(hex_number_expression)
+                ConstantValue::from_hex_number(hex_number_expression)
             }
             input_ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                evaluate_decimal_number_expression(decimal_number_expression)
+                ConstantValue::from_decimal_number(decimal_number_expression)
             }
             input_ir::Expression::Identifier(terminal_node) => {
                 self.evaluate_identifier(terminal_node)
@@ -287,70 +273,6 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             self.evaluate_expression(inner_expression)
         } else {
             None
-        }
-    }
-}
-
-pub(crate) fn evaluate_hex_number_expression(
-    hex_number_expression: &input_ir::HexNumberExpression,
-) -> Option<ConstantValue> {
-    let hex = hex_number_expression.literal.unparse();
-    // skip `0x` prefix, strip digit-grouping underscores, and parse the
-    // hexadecimal number
-    let digits: String = hex[2..]
-        .chars()
-        .filter(|character| *character != '_')
-        .collect();
-    let value = BigInt::from_str_radix(&digits, 16).ok()?;
-    let scaled = match &hex_number_expression.unit {
-        None => value,
-        Some(unit) => value * BigInt::from(unit),
-    };
-    Some(ConstantValue::Integer(scaled))
-}
-
-pub(crate) fn evaluate_decimal_number_expression(
-    decimal_number_expression: &input_ir::DecimalNumberExpression,
-) -> Option<ConstantValue> {
-    let decimal = decimal_number_expression.literal.unparse();
-    let cleaned: String = decimal.chars().filter(|c| *c != '_').collect();
-    let (mantissa, exponent) = match cleaned.split_once(['e', 'E']) {
-        Some((m, e)) => (m, e.parse::<i64>().ok()?),
-        None => (cleaned.as_str(), 0),
-    };
-    let (int_part, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
-    let numerator = BigInt::from_str(&format!("{int_part}{fraction}")).ok()?;
-    let unit = decimal_number_expression
-        .unit
-        .as_ref()
-        .map_or(BigInt::from(1u32), BigInt::from);
-    let scaled = numerator * unit;
-    let net_exp = exponent - i64::try_from(fraction.len()).ok()?;
-    let shift = BigInt::from(10u32).pow(u32::try_from(net_exp.unsigned_abs()).ok()?);
-    if net_exp >= 0 {
-        Some(ConstantValue::Integer(scaled * shift))
-    } else {
-        scaled
-            .is_multiple_of(&shift)
-            .then(|| ConstantValue::Integer(scaled / shift))
-    }
-}
-
-impl From<&input_ir::NumberUnit> for BigInt {
-    fn from(value: &input_ir::NumberUnit) -> Self {
-        match value {
-            input_ir::NumberUnit::WeiKeyword | input_ir::NumberUnit::SecondsKeyword => {
-                Self::from(1u32)
-            }
-            input_ir::NumberUnit::GweiKeyword => Self::from(10u64.pow(9)),
-            input_ir::NumberUnit::SzaboKeyword => Self::from(10u64.pow(12)),
-            input_ir::NumberUnit::FinneyKeyword => Self::from(10u64.pow(15)),
-            input_ir::NumberUnit::EtherKeyword => Self::from(10u64.pow(18)),
-            input_ir::NumberUnit::MinutesKeyword => Self::from(60u32),
-            input_ir::NumberUnit::HoursKeyword => Self::from(60u32 * 60),
-            input_ir::NumberUnit::DaysKeyword => Self::from(60u32 * 60 * 24),
-            input_ir::NumberUnit::WeeksKeyword => Self::from(60u32 * 60 * 24 * 7),
-            input_ir::NumberUnit::YearsKeyword => Self::from(60u64 * 60 * 24 * 365),
         }
     }
 }

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/mod.rs
@@ -6,7 +6,7 @@ use crate::backend::semantic::SemanticAnalysis;
 use crate::backend::types::{Type, TypeId, TypeRegistry};
 use crate::cst::NodeId;
 
-pub(crate) mod evaluator;
+mod evaluator;
 mod resolution;
 mod typing;
 mod visitor;

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p4_type_definitions/mod.rs
@@ -6,7 +6,7 @@ use crate::backend::semantic::SemanticAnalysis;
 use crate::backend::types::{Type, TypeId, TypeRegistry};
 use crate::cst::NodeId;
 
-mod evaluator;
+pub(crate) mod evaluator;
 mod resolution;
 mod typing;
 mod visitor;

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/typing.rs
@@ -4,8 +4,11 @@ use super::Pass;
 use crate::backend::binder::{Definition, Resolution, Typing};
 use crate::backend::built_ins::BuiltIn;
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
+use crate::backend::passes::p4_type_definitions::evaluator::{
+    evaluate_decimal_number_expression, evaluate_hex_number_expression, ConstantValue,
+};
 use crate::backend::types::{DataLocation, FunctionType, LiteralKind, Type, TypeId};
-use crate::cst::{NodeId, TerminalNode};
+use crate::cst::{NodeId, TerminalKind, TerminalNode};
 use crate::utils::versions::{VERSION_0_5_0, VERSION_0_8_0};
 
 impl Pass<'_> {
@@ -176,6 +179,55 @@ impl Pass<'_> {
             }
         } else {
             None
+        }
+    }
+
+    pub(super) fn type_of_prefix_expression(
+        &mut self,
+        node: &input_ir::PrefixExpression,
+    ) -> Option<TypeId> {
+        match node.operator.kind {
+            TerminalKind::Minus => {
+                // `-literal` folds into a signed literal kind carrying the
+                // two's-complement width of the negated value, matching
+                // solc's `RationalNumberType::integerType()` behaviour for
+                // negated rational-number literals.
+                let folded = match &node.operand {
+                    input_ir::Expression::DecimalNumberExpression(decimal_number) => {
+                        evaluate_decimal_number_expression(decimal_number)
+                    }
+                    input_ir::Expression::HexNumberExpression(hex_number) => {
+                        evaluate_hex_number_expression(hex_number)
+                    }
+                    _ => None,
+                };
+                if let Some(ConstantValue::Integer(magnitude)) = folded {
+                    if magnitude.sign() != num_bigint::Sign::NoSign {
+                        let negated_bits = (magnitude - 1u32).bits() + 1;
+                        let bytes = u32::try_from(negated_bits.div_ceil(8)).unwrap().max(1);
+                        return Some(self.types.register_type(Type::Literal(
+                            LiteralKind::DecimalInteger {
+                                bytes,
+                                signed: true,
+                            },
+                        )));
+                    }
+                }
+                self.typing_of_expression(&node.operand).as_type_id()
+            }
+            TerminalKind::PlusPlus
+            | TerminalKind::Plus
+            | TerminalKind::MinusMinus
+            | TerminalKind::Tilde => {
+                // TODO(validation): check that the operand is integer
+                self.typing_of_expression(&node.operand).as_type_id()
+            }
+            TerminalKind::Bang => {
+                // TODO(validation): check that the operand is boolean
+                Some(self.types.boolean())
+            }
+            TerminalKind::DeleteKeyword => Some(self.types.void()),
+            _ => None,
         }
     }
 
@@ -580,9 +632,17 @@ impl Pass<'_> {
     ) -> LiteralKind {
         if hex_number_expression.unit.is_some() {
             // this is deprecated in Solidity >= 0.5.0 anyway
-            return LiteralKind::DecimalInteger;
+            return LiteralKind::DecimalInteger {
+                bytes: 32,
+                signed: false,
+            };
         }
-        let hex_number = hex_number_expression.literal.unparse();
+        let hex_number: String = hex_number_expression
+            .literal
+            .unparse()
+            .chars()
+            .filter(|character| *character != '_')
+            .collect();
         if hex_number.len() == 42 {
             // TODO(validation): verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/typing.rs
@@ -4,10 +4,7 @@ use super::Pass;
 use crate::backend::binder::{Definition, Resolution, Typing};
 use crate::backend::built_ins::BuiltIn;
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
-use crate::backend::passes::p4_type_definitions::evaluator::{
-    evaluate_decimal_number_expression, evaluate_hex_number_expression, ConstantValue,
-};
-use crate::backend::types::{DataLocation, FunctionType, LiteralKind, Type, TypeId};
+use crate::backend::types::{ConstantValue, DataLocation, FunctionType, LiteralKind, Type, TypeId};
 use crate::cst::{NodeId, TerminalKind, TerminalNode};
 use crate::utils::versions::{VERSION_0_5_0, VERSION_0_8_0};
 
@@ -194,23 +191,20 @@ impl Pass<'_> {
                 // negated rational-number literals.
                 let folded = match &node.operand {
                     input_ir::Expression::DecimalNumberExpression(decimal_number) => {
-                        evaluate_decimal_number_expression(decimal_number)
+                        ConstantValue::from_decimal_number(decimal_number)
                     }
                     input_ir::Expression::HexNumberExpression(hex_number) => {
-                        evaluate_hex_number_expression(hex_number)
+                        ConstantValue::from_hex_number(hex_number)
                     }
                     _ => None,
                 };
-                if let Some(ConstantValue::Integer(magnitude)) = folded {
+                if let Some(constant) = &folded {
+                    let ConstantValue::Integer(magnitude) = constant;
                     if magnitude.sign() != num_bigint::Sign::NoSign {
-                        let negated_bits = (magnitude - 1u32).bits() + 1;
-                        let bytes = u32::try_from(negated_bits.div_ceil(8)).unwrap().max(1);
-                        return Some(self.types.register_type(Type::Literal(
-                            LiteralKind::DecimalInteger {
-                                bytes,
-                                signed: true,
-                            },
-                        )));
+                        return Some(
+                            self.types
+                                .register_type(Type::Literal(constant.get_signed_literal_kind())),
+                        );
                     }
                 }
                 self.typing_of_expression(&node.operand).as_type_id()
@@ -637,12 +631,8 @@ impl Pass<'_> {
                 signed: false,
             };
         }
-        let hex_number: String = hex_number_expression
-            .literal
-            .unparse()
-            .chars()
-            .filter(|character| *character != '_')
-            .collect();
+        let mut hex_number = hex_number_expression.literal.unparse();
+        hex_number.retain(|character| character != '_');
         if hex_number.len() == 42 {
             // TODO(validation): verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/visitor.rs
@@ -4,10 +4,7 @@ use super::Pass;
 use crate::backend::binder::{Reference, Resolution, Typing};
 use crate::backend::ir::ir2_flat_contracts::visitor::Visitor;
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
-use crate::backend::passes::p4_type_definitions::evaluator::{
-    evaluate_decimal_number_expression, ConstantValue,
-};
-use crate::backend::types::{DataLocation, LiteralKind, Type};
+use crate::backend::types::{ConstantValue, DataLocation, LiteralKind, Type};
 use crate::utils::versions::{VERSION_0_5_0, VERSION_0_7_0};
 
 impl Visitor for Pass<'_> {
@@ -144,14 +141,8 @@ impl Visitor for Pass<'_> {
         let type_ = if node.unit.is_none() && node.literal.unparse() == "0" {
             Type::Literal(LiteralKind::Zero)
         } else {
-            match evaluate_decimal_number_expression(node) {
-                Some(ConstantValue::Integer(value)) => {
-                    let bytes = u32::try_from(value.bits().div_ceil(8)).unwrap().max(1);
-                    Type::Literal(LiteralKind::DecimalInteger {
-                        bytes,
-                        signed: false,
-                    })
-                }
+            match ConstantValue::from_decimal_number(node) {
+                Some(constant) => Type::Literal(constant.get_literal_kind()),
                 None => Type::Literal(LiteralKind::Rational),
             }
         };

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p5_resolve_references/visitor.rs
@@ -4,8 +4,10 @@ use super::Pass;
 use crate::backend::binder::{Reference, Resolution, Typing};
 use crate::backend::ir::ir2_flat_contracts::visitor::Visitor;
 use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
+use crate::backend::passes::p4_type_definitions::evaluator::{
+    evaluate_decimal_number_expression, ConstantValue,
+};
 use crate::backend::types::{DataLocation, LiteralKind, Type};
-use crate::cst::TerminalKind;
 use crate::utils::versions::{VERSION_0_5_0, VERSION_0_7_0};
 
 impl Visitor for Pass<'_> {
@@ -142,7 +144,16 @@ impl Visitor for Pass<'_> {
         let type_ = if node.unit.is_none() && node.literal.unparse() == "0" {
             Type::Literal(LiteralKind::Zero)
         } else {
-            Type::Literal(LiteralKind::DecimalInteger)
+            match evaluate_decimal_number_expression(node) {
+                Some(ConstantValue::Integer(value)) => {
+                    let bytes = u32::try_from(value.bits().div_ceil(8)).unwrap().max(1);
+                    Type::Literal(LiteralKind::DecimalInteger {
+                        bytes,
+                        signed: false,
+                    })
+                }
+                None => Type::Literal(LiteralKind::Rational),
+            }
         };
         let type_id = self.types.register_type(type_);
         self.binder.set_node_type(node.node_id, Some(type_id));
@@ -273,22 +284,7 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_prefix_expression(&mut self, node: &input_ir::PrefixExpression) {
-        let type_id = match node.operator.kind {
-            TerminalKind::PlusPlus
-            | TerminalKind::Plus
-            | TerminalKind::MinusMinus
-            | TerminalKind::Minus
-            | TerminalKind::Tilde => {
-                // TODO(validation): check that the operand is integer
-                self.typing_of_expression(&node.operand).as_type_id()
-            }
-            TerminalKind::Bang => {
-                // TODO(validation): check that the operand is boolean
-                Some(self.types.boolean())
-            }
-            TerminalKind::DeleteKeyword => Some(self.types.void()),
-            _ => None,
-        };
+        let type_id = self.type_of_prefix_expression(node);
         self.binder.set_node_type(node.node_id, type_id);
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/constants.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/constants.rs
@@ -1,0 +1,101 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::cast::ToPrimitive;
+use num_traits::Num;
+
+use super::LiteralKind;
+use crate::backend::ir::ir2_flat_contracts::{self as input_ir};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ConstantValue {
+    Integer(BigInt),
+}
+
+impl ConstantValue {
+    pub(crate) fn from_hex_number(
+        hex_number_expression: &input_ir::HexNumberExpression,
+    ) -> Option<Self> {
+        let hex = hex_number_expression.literal.unparse();
+        let value = BigInt::from_str_radix(&hex[2..], 16).ok()?;
+        let scaled = match &hex_number_expression.unit {
+            None => value,
+            Some(unit) => value * BigInt::from(unit),
+        };
+        Some(Self::Integer(scaled))
+    }
+
+    pub(crate) fn from_decimal_number(
+        decimal_number_expression: &input_ir::DecimalNumberExpression,
+    ) -> Option<Self> {
+        let mut decimal = decimal_number_expression.literal.unparse();
+        decimal.retain(|c| c != '_');
+        let (mantissa, exponent) = match decimal.split_once(['e', 'E']) {
+            Some((m, e)) => (m, e.parse::<i64>().ok()?),
+            None => (decimal.as_str(), 0),
+        };
+        let (int_part, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+        let numerator = BigInt::from_str(&format!("{int_part}{fraction}")).ok()?;
+        let unit = decimal_number_expression
+            .unit
+            .as_ref()
+            .map_or(BigInt::from(1u32), BigInt::from);
+        let scaled_numerator = numerator * unit;
+        let decimal_shift = exponent - i64::try_from(fraction.len()).ok()?;
+        let denominator =
+            BigInt::from(10u32).pow(u32::try_from(decimal_shift.unsigned_abs()).ok()?);
+        if decimal_shift >= 0 {
+            Some(Self::Integer(scaled_numerator * denominator))
+        } else {
+            // TODO: support returning a rational value (numerator/denominator)
+            // when the literal does not reduce to an integer.
+            scaled_numerator
+                .is_multiple_of(&denominator)
+                .then(|| Self::Integer(scaled_numerator / denominator))
+        }
+    }
+
+    pub(crate) fn as_usize(&self) -> Option<usize> {
+        let Self::Integer(value) = self;
+        value.to_usize()
+    }
+
+    pub(crate) fn get_literal_kind(&self) -> LiteralKind {
+        let Self::Integer(value) = self;
+        let bytes = u32::try_from(value.bits().div_ceil(8)).unwrap().max(1);
+        LiteralKind::DecimalInteger {
+            bytes,
+            signed: false,
+        }
+    }
+
+    pub(crate) fn get_signed_literal_kind(&self) -> LiteralKind {
+        let Self::Integer(magnitude) = self;
+        let negated_bits = (magnitude - 1u32).bits() + 1;
+        let bytes = u32::try_from(negated_bits.div_ceil(8)).unwrap().max(1);
+        LiteralKind::DecimalInteger {
+            bytes,
+            signed: true,
+        }
+    }
+}
+
+impl From<&input_ir::NumberUnit> for BigInt {
+    fn from(value: &input_ir::NumberUnit) -> Self {
+        match value {
+            input_ir::NumberUnit::WeiKeyword | input_ir::NumberUnit::SecondsKeyword => {
+                Self::from(1u32)
+            }
+            input_ir::NumberUnit::GweiKeyword => Self::from(10u64.pow(9)),
+            input_ir::NumberUnit::SzaboKeyword => Self::from(10u64.pow(12)),
+            input_ir::NumberUnit::FinneyKeyword => Self::from(10u64.pow(15)),
+            input_ir::NumberUnit::EtherKeyword => Self::from(10u64.pow(18)),
+            input_ir::NumberUnit::MinutesKeyword => Self::from(60u32),
+            input_ir::NumberUnit::HoursKeyword => Self::from(60u32 * 60),
+            input_ir::NumberUnit::DaysKeyword => Self::from(60u32 * 60 * 24),
+            input_ir::NumberUnit::WeeksKeyword => Self::from(60u32 * 60 * 24 * 7),
+            input_ir::NumberUnit::YearsKeyword => Self::from(60u64 * 60 * 24 * 365),
+        }
+    }
+}

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/mod.rs
@@ -75,9 +75,10 @@ pub enum Type {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum LiteralKind {
     Zero,
-    // TODO: collect and store more information about literal numbers
+    // TODO: model rational values as part of compile-time constant folding,
+    // so that expressions like `1.5 * 2` can reduce to an integer literal.
     Rational,
-    DecimalInteger,
+    DecimalInteger { bytes: u32, signed: bool },
     HexInteger { bytes: u32 },
     HexString { bytes: u32 },
     String { bytes: u32 },
@@ -201,7 +202,7 @@ impl Type {
             self,
             Type::Literal(
                 LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { .. }
                     | LiteralKind::HexInteger { .. }
                     | LiteralKind::Rational
             )

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/mod.rs
@@ -1,8 +1,10 @@
 use crate::cst::NodeId;
 
+mod constants;
 mod parsing;
 mod registry;
 
+pub(crate) use constants::ConstantValue;
 pub use registry::TypeRegistry;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
@@ -145,26 +145,39 @@ impl TypeRegistry {
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger { signed: false, .. }
                     // TODO: rationals cannot be always converted to integers,
                     // unless their fractional part is zero. But for now and
                     // without further information about the literal number
                     // itself, assume it can.
-                    | LiteralKind::Rational
-                    | LiteralKind::HexInteger { .. },
+                    | LiteralKind::Rational,
                 ),
                 Type::Integer { .. },
-            ) => {
-                // TODO(validation): check that the rational can fit in the given integer type
-                true
-            }
+            ) => true,
+
+            // TODO: verify against solc's RationalNumberType::isImplicitlyConvertibleTo.
+            (
+                Type::Literal(
+                    LiteralKind::DecimalInteger {
+                        bytes,
+                        signed: false,
+                    }
+                    | LiteralKind::HexInteger { bytes },
+                ),
+                Type::Integer { bits: to_bits, .. },
+            ) => bytes * 8 <= *to_bits,
 
             // A signed decimal literal (produced by `-literal`) may only
             // implicitly convert to a signed integer type.
             (
-                Type::Literal(LiteralKind::DecimalInteger { signed: true, .. }),
-                Type::Integer { signed: true, .. },
-            ) => true,
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: true,
+                }),
+                Type::Integer {
+                    signed: true,
+                    bits: to_bits,
+                },
+            ) => bytes * 8 <= *to_bits,
 
             (
                 Type::Literal(
@@ -174,22 +187,35 @@ impl TypeRegistry {
                     | LiteralKind::HexInteger { .. },
                 ),
                 Type::Literal(LiteralKind::Rational),
-            ) |
-            (
-                Type::Literal(
-                    LiteralKind::Zero
-                    | LiteralKind::DecimalInteger { .. }
-                    | LiteralKind::HexInteger { .. },
-                ),
-                Type::Literal(LiteralKind::DecimalInteger { .. }),
-            ) |
-            (
-                Type::Literal(
-                    LiteralKind::Zero
-                    | LiteralKind::HexInteger { .. },
-                ),
-                Type::Literal(LiteralKind::HexInteger { .. }),
             ) => true,
+
+            (
+                Type::Literal(LiteralKind::Zero),
+                Type::Literal(
+                    LiteralKind::DecimalInteger { .. } | LiteralKind::HexInteger { .. },
+                ),
+            ) => true,
+
+            (
+                Type::Literal(LiteralKind::HexInteger { bytes: from_bytes }),
+                Type::Literal(
+                    LiteralKind::HexInteger { bytes: to_bytes }
+                    | LiteralKind::DecimalInteger { bytes: to_bytes, .. },
+                ),
+            ) => from_bytes <= to_bytes,
+
+            // A signed decimal literal (produced by `-literal`) only
+            // implicitly converts to a signed `DecimalInteger` target.
+            (
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes: from_bytes,
+                    signed: from_signed,
+                }),
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes: to_bytes,
+                    signed: to_signed,
+                }),
+            ) if !*from_signed || *to_signed => from_bytes <= to_bytes,
 
             (Type::Integer { .. }, Type::Literal(_)) => false,
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
@@ -152,7 +152,10 @@ impl TypeRegistry {
                     | LiteralKind::Rational,
                 ),
                 Type::Integer { .. },
-            ) => true,
+            ) => {
+                // TODO(validation): check that the rational can fit in the given integer type
+                true
+            }
 
             // TODO: verify against solc's RationalNumberType::isImplicitlyConvertibleTo.
             (

--- a/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/types/registry.rs
@@ -145,7 +145,7 @@ impl TypeRegistry {
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { signed: false, .. }
                     // TODO: rationals cannot be always converted to integers,
                     // unless their fractional part is zero. But for now and
                     // without further information about the literal number
@@ -159,10 +159,17 @@ impl TypeRegistry {
                 true
             }
 
+            // A signed decimal literal (produced by `-literal`) may only
+            // implicitly convert to a signed integer type.
+            (
+                Type::Literal(LiteralKind::DecimalInteger { signed: true, .. }),
+                Type::Integer { signed: true, .. },
+            ) => true,
+
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { .. }
                     | LiteralKind::Rational
                     | LiteralKind::HexInteger { .. },
                 ),
@@ -171,10 +178,10 @@ impl TypeRegistry {
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { .. }
                     | LiteralKind::HexInteger { .. },
                 ),
-                Type::Literal(LiteralKind::DecimalInteger),
+                Type::Literal(LiteralKind::DecimalInteger { .. }),
             ) |
             (
                 Type::Literal(
@@ -483,7 +490,7 @@ impl TypeRegistry {
             // will convert 1, 2, 3, etc into uint8 and 1.2 into ufixed8x1
             LiteralKind::Zero
             | LiteralKind::Rational
-            | LiteralKind::DecimalInteger
+            | LiteralKind::DecimalInteger { .. }
             | LiteralKind::HexInteger { .. } => self.uint256(),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => self.string(),
             LiteralKind::Address => self.address(),

--- a/crates/solidity/outputs/cargo/tests/src/binder/report_data.rs
+++ b/crates/solidity/outputs/cargo/tests/src/binder/report_data.rs
@@ -308,7 +308,14 @@ impl CollectedDefinitionDisplay<'_> {
             Type::Literal(kind) => match kind {
                 LiteralKind::Zero => "lit-zero".to_string(),
                 LiteralKind::Rational => "rational".to_string(),
-                LiteralKind::DecimalInteger => "lit-integer".to_string(),
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: false,
+                } => format!("lit-integer({bytes})"),
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: true,
+                } => format!("lit-integer({bytes}, signed)"),
                 LiteralKind::HexInteger { bytes } => format!("lit-hex({bytes})"),
                 LiteralKind::HexString { bytes } => format!("lit-hexstring({bytes})"),
                 LiteralKind::String { bytes } => format!("lit-string({bytes})"),


### PR DESCRIPTION
Narrows the types assigned to integer literals and exposes them via two small methods on existing AST wrappers — no internals leak.

### New API

- `ast::DecimalNumberExpression::value() -> Option<BigInt>`
- `ast::HexNumberExpression::value() -> Option<BigInt>`
- `ast::LiteralType::kind() -> LiteralKind`
- `ast::LiteralKind` re-exported for ergonomics

### Evaluator

`evaluate_decimal_number_expression` now handles:

- Digit separators (`1_000_000`, `0xde_ad_be_ef`)
- Unit multipliers (`1 ether`, `1 days`)
- Fractional reductions (`1.5 ether`, `0.5 gwei`)
- Scientific notation (`1e18`, `2.5e10`, `5e-3`)

### Typing

- `LiteralKind::DecimalInteger` gains `bytes: u32` and `signed: bool`
- `LiteralKind::HexInteger { bytes: u32 }` parallel
- `type_of_prefix_expression` in p5 folds `-literal` into a signed narrowed kind, matching solc's `RationalNumberType::integerType()`

### Internals stay private

`CompileConstantEvaluator`, `ConstantValue`, the `evaluator` module, `internal_type()`, and the `ir_node` / `semantic` AST struct fields all remain `pub(crate)`. `evaluate_{hex,decimal}_number_expression` hoisted to `pub(crate)` free functions.

### Out of scope

Non-reducible rationals still map to `LiteralKind::Rational`. Full rational arithmetic at compile time is a separate scope.
