### PR TITLE
[v2] Add location information for AST nodes

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
@@ -10,7 +10,7 @@ impl SourceUnitStruct {
                 if contract.abstract_keyword() {
                     None
                 } else {
-                    contract.compute_abi_with_file_id(file_id.clone())
+                    contract.compute_abi_with_file_id(file_id.to_string())
                 }
             })
             .collect()

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
@@ -2,7 +2,7 @@ use super::super::{ContractDefinition, SourceUnitMember, SourceUnitStruct};
 
 impl SourceUnitStruct {
     pub fn file_id(&self) -> String {
-        self.semantic.node_id_to_file_id(self.ir_node.id()).unwrap()
+        self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
     pub fn contracts(&self) -> Vec<ContractDefinition> {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
@@ -1,7 +1,7 @@
 use super::super::{ContractDefinition, SourceUnitMember, SourceUnitStruct};
 
 impl SourceUnitStruct {
-    pub fn file_id(&self) -> String {
+    pub fn file_id(&self) -> &str {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused)]
 #![allow(non_camel_case_types)]
+use std::ops::Range;
 use std::rc::Rc;
 
 use slang_solidity_v2_common::nodes::NodeId;
@@ -9,6 +10,21 @@ use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 
 use super::types::Type;
+
+pub struct NodeLocation {
+    file_id: String,
+    text_range: Range<usize>,
+}
+
+impl NodeLocation {
+    pub fn file_id(&self) -> &str {
+        &self.file_id
+    }
+
+    pub fn text_range(&self) -> &Range<usize> {
+        &self.text_range
+    }
+}
 
 //
 // Sequences
@@ -42,6 +58,13 @@ impl AbicoderPragmaStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -87,6 +110,13 @@ impl AdditiveExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type AddressType = Rc<AddressTypeStruct>;
@@ -117,6 +147,13 @@ impl AddressTypeStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -153,6 +190,13 @@ impl AndExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ArrayExpression = Rc<ArrayExpressionStruct>;
@@ -183,6 +227,13 @@ impl ArrayExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -222,6 +273,13 @@ impl ArrayTypeNameStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type AssemblyStatement = Rc<AssemblyStatementStruct>;
@@ -260,6 +318,13 @@ impl AssemblyStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -305,6 +370,13 @@ impl AssignmentExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type BitwiseAndExpression = Rc<BitwiseAndExpressionStruct>;
@@ -339,6 +411,13 @@ impl BitwiseAndExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -375,6 +454,13 @@ impl BitwiseOrExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type BitwiseXorExpression = Rc<BitwiseXorExpressionStruct>;
@@ -410,6 +496,13 @@ impl BitwiseXorExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type Block = Rc<BlockStruct>;
@@ -438,6 +531,13 @@ impl BlockStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type BreakStatement = Rc<BreakStatementStruct>;
@@ -464,6 +564,13 @@ impl BreakStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -499,6 +606,13 @@ impl CallOptionsExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -538,6 +652,13 @@ impl CatchClauseStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type CatchClauseError = Rc<CatchClauseErrorStruct>;
@@ -575,6 +696,13 @@ impl CatchClauseErrorStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -614,6 +742,13 @@ impl ConditionalExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -664,6 +799,13 @@ impl ConstantDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ContinueStatement = Rc<ContinueStatementStruct>;
@@ -690,6 +832,13 @@ impl ContinueStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -741,6 +890,13 @@ impl ContractDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
@@ -779,6 +935,13 @@ impl DecimalNumberExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type DoWhileStatement = Rc<DoWhileStatementStruct>;
@@ -813,6 +976,13 @@ impl DoWhileStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -849,6 +1019,13 @@ impl EmitStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type EnumDefinition = Rc<EnumDefinitionStruct>;
@@ -883,6 +1060,13 @@ impl EnumDefinitionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -928,6 +1112,13 @@ impl EqualityExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ErrorDefinition = Rc<ErrorDefinitionStruct>;
@@ -962,6 +1153,13 @@ impl ErrorDefinitionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1002,6 +1200,13 @@ impl EventDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ExperimentalPragma = Rc<ExperimentalPragmaStruct>;
@@ -1032,6 +1237,13 @@ impl ExperimentalPragmaStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1068,6 +1280,13 @@ impl ExponentiationExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ExpressionStatement = Rc<ExpressionStatementStruct>;
@@ -1098,6 +1317,13 @@ impl ExpressionStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1145,6 +1371,13 @@ impl ForStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type FunctionCallExpression = Rc<FunctionCallExpressionStruct>;
@@ -1179,6 +1412,13 @@ impl FunctionCallExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1259,6 +1499,13 @@ impl FunctionDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type FunctionType = Rc<FunctionTypeStruct>;
@@ -1305,6 +1552,13 @@ impl FunctionTypeStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
@@ -1335,6 +1589,13 @@ impl HexNumberExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1378,6 +1639,13 @@ impl IfStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ImportDeconstruction = Rc<ImportDeconstructionStruct>;
@@ -1412,6 +1680,13 @@ impl ImportDeconstructionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1450,6 +1725,13 @@ impl ImportDeconstructionSymbolStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1496,6 +1778,13 @@ impl IndexAccessExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type InequalityExpression = Rc<InequalityExpressionStruct>;
@@ -1540,6 +1829,13 @@ impl InequalityExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type InheritanceType = Rc<InheritanceTypeStruct>;
@@ -1577,6 +1873,13 @@ impl InheritanceTypeStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1620,6 +1923,13 @@ impl InterfaceDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type LibraryDefinition = Rc<LibraryDefinitionStruct>;
@@ -1654,6 +1964,13 @@ impl LibraryDefinitionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1690,6 +2007,13 @@ impl MappingTypeStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type MemberAccessExpression = Rc<MemberAccessExpressionStruct>;
@@ -1724,6 +2048,13 @@ impl MemberAccessExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1763,6 +2094,13 @@ impl ModifierInvocationStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type MultiTypedDeclaration = Rc<MultiTypedDeclarationStruct>;
@@ -1798,6 +2136,13 @@ impl MultiTypedDeclarationStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type MultiTypedDeclarationElement = Rc<MultiTypedDeclarationElementStruct>;
@@ -1831,6 +2176,13 @@ impl MultiTypedDeclarationElementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1876,6 +2228,13 @@ impl MultiplicativeExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type NamedArgument = Rc<NamedArgumentStruct>;
@@ -1911,6 +2270,13 @@ impl NamedArgumentStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type NewExpression = Rc<NewExpressionStruct>;
@@ -1941,6 +2307,13 @@ impl NewExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -1976,6 +2349,13 @@ impl OrExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2023,6 +2403,13 @@ impl ParameterStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type PathImport = Rc<PathImportStruct>;
@@ -2057,6 +2444,13 @@ impl PathImportStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2096,6 +2490,13 @@ impl PostfixExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type PragmaDirective = Rc<PragmaDirectiveStruct>;
@@ -2126,6 +2527,13 @@ impl PragmaDirectiveStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2165,6 +2573,13 @@ impl PrefixExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type ReturnStatement = Rc<ReturnStatementStruct>;
@@ -2198,6 +2613,13 @@ impl ReturnStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2233,6 +2655,13 @@ impl RevertStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2276,6 +2705,13 @@ impl ShiftExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type SingleTypedDeclaration = Rc<SingleTypedDeclarationStruct>;
@@ -2314,6 +2750,13 @@ impl SingleTypedDeclarationStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type SourceUnit = Rc<SourceUnitStruct>;
@@ -2341,6 +2784,13 @@ impl SourceUnitStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2399,6 +2849,13 @@ impl StateVariableDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type StructDefinition = Rc<StructDefinitionStruct>;
@@ -2434,6 +2891,13 @@ impl StructDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type StructMember = Rc<StructMemberStruct>;
@@ -2468,6 +2932,13 @@ impl StructMemberStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2515,6 +2986,13 @@ impl TryStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type TupleExpression = Rc<TupleExpressionStruct>;
@@ -2545,6 +3023,13 @@ impl TupleExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2577,6 +3062,13 @@ impl TupleValueStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type TypeExpression = Rc<TypeExpressionStruct>;
@@ -2608,6 +3100,13 @@ impl TypeExpressionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type UncheckedBlock = Rc<UncheckedBlockStruct>;
@@ -2638,6 +3137,13 @@ impl UncheckedBlockStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2674,6 +3180,13 @@ impl UserDefinedValueTypeDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type UsingDeconstruction = Rc<UsingDeconstructionStruct>;
@@ -2704,6 +3217,13 @@ impl UsingDeconstructionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2743,6 +3263,13 @@ impl UsingDeconstructionSymbolStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type UsingDirective = Rc<UsingDirectiveStruct>;
@@ -2781,6 +3308,13 @@ impl UsingDirectiveStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2824,6 +3358,13 @@ impl VariableDeclarationStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type VariableDeclarationStatement = Rc<VariableDeclarationStatementStruct>;
@@ -2855,6 +3396,13 @@ impl VariableDeclarationStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type VersionPragma = Rc<VersionPragmaStruct>;
@@ -2885,6 +3433,13 @@ impl VersionPragmaStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2920,6 +3475,13 @@ impl VersionRangeStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -2959,6 +3521,13 @@ impl VersionTermStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type WhileStatement = Rc<WhileStatementStruct>;
@@ -2994,6 +3563,13 @@ impl WhileStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulBlock = Rc<YulBlockStruct>;
@@ -3022,6 +3598,13 @@ impl YulBlockStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulBreakStatement = Rc<YulBreakStatementStruct>;
@@ -3049,6 +3632,13 @@ impl YulBreakStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
@@ -3075,6 +3665,13 @@ impl YulContinueStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -3106,6 +3703,13 @@ impl YulDefaultCaseStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -3150,6 +3754,13 @@ impl YulForStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
@@ -3184,6 +3795,13 @@ impl YulFunctionCallExpressionStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -3231,6 +3849,13 @@ impl YulFunctionDefinitionStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulIfStatement = Rc<YulIfStatementStruct>;
@@ -3266,6 +3891,13 @@ impl YulIfStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulLeaveStatement = Rc<YulLeaveStatementStruct>;
@@ -3292,6 +3924,13 @@ impl YulLeaveStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -3328,6 +3967,13 @@ impl YulSwitchStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulValueCase = Rc<YulValueCaseStruct>;
@@ -3363,6 +4009,13 @@ impl YulValueCaseStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulVariableAssignmentStatement = Rc<YulVariableAssignmentStatementStruct>;
@@ -3397,6 +4050,13 @@ impl YulVariableAssignmentStatementStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -3436,6 +4096,13 @@ impl YulVariableDeclarationStatementStruct {
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
+    }
 }
 
 pub type YulVariableDeclarationValue = Rc<YulVariableDeclarationValueStruct>;
@@ -3466,6 +4133,13 @@ impl YulVariableDeclarationValueStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }
 
@@ -5714,5 +6388,12 @@ impl IdentifierStruct {
 
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+            text_range: self.ir_node.range.clone(),
+        }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -11,21 +11,6 @@ use slang_solidity_v2_semantic::context::SemanticContext;
 
 use super::types::Type;
 
-pub struct NodeLocation {
-    file_id: String,
-    text_range: Range<usize>,
-}
-
-impl NodeLocation {
-    pub fn file_id(&self) -> &str {
-        &self.file_id
-    }
-
-    pub fn text_range(&self) -> &Range<usize> {
-        &self.text_range
-    }
-}
-
 //
 // Sequences
 //
@@ -60,11 +45,12 @@ impl AbicoderPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -111,11 +97,12 @@ impl AdditiveExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -149,11 +136,12 @@ impl AddressTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -191,11 +179,12 @@ impl AndExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -229,11 +218,12 @@ impl ArrayExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -274,11 +264,12 @@ impl ArrayTypeNameStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -320,11 +311,12 @@ impl AssemblyStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -371,11 +363,12 @@ impl AssignmentExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -413,11 +406,12 @@ impl BitwiseAndExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -455,11 +449,12 @@ impl BitwiseOrExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -497,11 +492,12 @@ impl BitwiseXorExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -532,11 +528,12 @@ impl BlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -566,11 +563,12 @@ impl BreakStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -608,11 +606,12 @@ impl CallOptionsExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -653,11 +652,12 @@ impl CatchClauseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -698,11 +698,12 @@ impl CatchClauseErrorStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -744,11 +745,12 @@ impl ConditionalExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -800,11 +802,12 @@ impl ConstantDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -834,11 +837,12 @@ impl ContinueStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -891,11 +895,12 @@ impl ContractDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -936,11 +941,12 @@ impl DecimalNumberExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -978,11 +984,12 @@ impl DoWhileStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1020,11 +1027,12 @@ impl EmitStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1062,11 +1070,12 @@ impl EnumDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1113,11 +1122,12 @@ impl EqualityExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1155,11 +1165,12 @@ impl ErrorDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1201,11 +1212,12 @@ impl EventDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1239,11 +1251,12 @@ impl ExperimentalPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1281,11 +1294,12 @@ impl ExponentiationExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1319,11 +1333,12 @@ impl ExpressionStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1372,11 +1387,12 @@ impl ForStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1414,11 +1430,12 @@ impl FunctionCallExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1500,11 +1517,12 @@ impl FunctionDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1553,11 +1571,12 @@ impl FunctionTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1591,11 +1610,12 @@ impl HexNumberExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1640,11 +1660,12 @@ impl IfStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1682,11 +1703,12 @@ impl ImportDeconstructionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1727,11 +1749,12 @@ impl ImportDeconstructionSymbolStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1779,11 +1802,12 @@ impl IndexAccessExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1830,11 +1854,12 @@ impl InequalityExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1875,11 +1900,12 @@ impl InheritanceTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1924,11 +1950,12 @@ impl InterfaceDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -1966,11 +1993,12 @@ impl LibraryDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2008,11 +2036,12 @@ impl MappingTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2050,11 +2079,12 @@ impl MemberAccessExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2095,11 +2125,12 @@ impl ModifierInvocationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2137,11 +2168,12 @@ impl MultiTypedDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2178,11 +2210,12 @@ impl MultiTypedDeclarationElementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2229,11 +2262,12 @@ impl MultiplicativeExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2271,11 +2305,12 @@ impl NamedArgumentStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2309,11 +2344,12 @@ impl NewExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2351,11 +2387,12 @@ impl OrExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2404,11 +2441,12 @@ impl ParameterStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2446,11 +2484,12 @@ impl PathImportStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2491,11 +2530,12 @@ impl PostfixExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2529,11 +2569,12 @@ impl PragmaDirectiveStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2574,11 +2615,12 @@ impl PrefixExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2615,11 +2657,12 @@ impl ReturnStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2657,11 +2700,12 @@ impl RevertStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2706,11 +2750,12 @@ impl ShiftExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2751,11 +2796,12 @@ impl SingleTypedDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2786,11 +2832,12 @@ impl SourceUnitStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2850,11 +2897,12 @@ impl StateVariableDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2892,11 +2940,12 @@ impl StructDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2934,11 +2983,12 @@ impl StructMemberStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -2987,11 +3037,12 @@ impl TryStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3025,11 +3076,12 @@ impl TupleExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3063,11 +3115,12 @@ impl TupleValueStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3101,11 +3154,12 @@ impl TypeExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3139,11 +3193,12 @@ impl UncheckedBlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3181,11 +3236,12 @@ impl UserDefinedValueTypeDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3219,11 +3275,12 @@ impl UsingDeconstructionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3264,11 +3321,12 @@ impl UsingDeconstructionSymbolStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3310,11 +3368,12 @@ impl UsingDirectiveStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3359,11 +3418,12 @@ impl VariableDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3397,11 +3457,12 @@ impl VariableDeclarationStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3435,11 +3496,12 @@ impl VersionPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3477,11 +3539,12 @@ impl VersionRangeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3522,11 +3585,12 @@ impl VersionTermStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3564,11 +3628,12 @@ impl WhileStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3599,11 +3664,12 @@ impl YulBlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3633,11 +3699,12 @@ impl YulBreakStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3667,11 +3734,12 @@ impl YulContinueStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3705,11 +3773,12 @@ impl YulDefaultCaseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3755,11 +3824,12 @@ impl YulForStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3797,11 +3867,12 @@ impl YulFunctionCallExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3850,11 +3921,12 @@ impl YulFunctionDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3892,11 +3964,12 @@ impl YulIfStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3926,11 +3999,12 @@ impl YulLeaveStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -3968,11 +4042,12 @@ impl YulSwitchStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -4010,11 +4085,12 @@ impl YulValueCaseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -4052,11 +4128,12 @@ impl YulVariableAssignmentStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -4097,11 +4174,12 @@ impl YulVariableDeclarationStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -4135,11 +4213,12 @@ impl YulVariableDeclarationValueStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }
 
@@ -6390,10 +6469,11 @@ impl IdentifierStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-            file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-            text_range: self.ir_node.range.clone(),
-        }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -9,21 +9,6 @@ use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use super::types::Type;
 
-pub struct NodeLocation {
-    file_id: String,
-    text_range: Range<usize>,
-}
-
-impl NodeLocation {
-    pub fn file_id(&self) -> &str {
-        &self.file_id
-    }
-
-    pub fn text_range(&self) -> &Range<usize> {
-        &self.text_range
-    }
-}
-
 //
 // Sequences
 //
@@ -120,11 +105,12 @@ impl NodeLocation {
       Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_location(&self) -> NodeLocation {
-      NodeLocation {
-        file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-        text_range: self.ir_node.range.clone(),
-      }
+    pub fn get_file_id(&self) -> &str {
+        self.semantic.file_id_from_node_id(self.ir_node.id())
+    }
+
+    pub fn get_text_range(&self) -> &Range<usize> {
+        &self.ir_node.range
     }
   }
 
@@ -277,11 +263,12 @@ impl NodeLocation {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
       }
 
-      pub fn get_location(&self) -> NodeLocation {
-        NodeLocation {
-          file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
-          text_range: self.ir_node.range.clone(),
-        }
+      pub fn get_file_id(&self) -> &str {
+          self.semantic.file_id_from_node_id(self.ir_node.id())
+      }
+
+      pub fn get_text_range(&self) -> &Range<usize> {
+          &self.ir_node.range
       }
     }
   {% endif %}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -1,12 +1,28 @@
 {%- set target = model.ir_language_model.target -%}
 #![allow(unused)]
 #![allow(non_camel_case_types)]
+use std::ops::Range;
 use std::rc::Rc;
 
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use super::types::Type;
+
+pub struct NodeLocation {
+    file_id: String,
+    text_range: Range<usize>,
+}
+
+impl NodeLocation {
+    pub fn file_id(&self) -> &str {
+        &self.file_id
+    }
+
+    pub fn text_range(&self) -> &Range<usize> {
+        &self.text_range
+    }
+}
 
 //
 // Sequences
@@ -102,6 +118,13 @@ use super::types::Type;
 
     pub fn get_type(&self) -> Option<Type> {
       Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+    }
+
+    pub fn get_location(&self) -> NodeLocation {
+      NodeLocation {
+        file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+        text_range: self.ir_node.range.clone(),
+      }
     }
   }
 
@@ -252,6 +275,13 @@ use super::types::Type;
 
       pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
+      }
+
+      pub fn get_location(&self) -> NodeLocation {
+        NodeLocation {
+          file_id: self.semantic.file_id_from_node_id(self.ir_node.id()),
+          text_range: self.ir_node.range.clone(),
+        }
       }
     }
   {% endif %}

--- a/crates/solidity-v2/outputs/cargo/cst/src/structured_cst/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/cst/src/structured_cst/mod.rs
@@ -1,4 +1,4 @@
-mod text_range;
+pub mod text_range;
 
 #[path = "nodes.generated.rs"]
 pub mod nodes;

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -7,6 +7,7 @@
 use std::rc::Rc;
 
 use slang_solidity_v2_cst::structured_cst::nodes as input;
+use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
 
 use super::CstToIrBuilder;
 use crate::ir::{nodes as output, Source};
@@ -21,9 +22,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AbicoderPragma,
     ) -> output::AbicoderPragma {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let version = self.build_abicoder_version(&source.version);
 
-        Rc::new(output::AbicoderPragmaStruct { id, version })
+        Rc::new(output::AbicoderPragmaStruct { id, range, version })
     }
 
     pub(super) fn build_additive_expression(
@@ -31,6 +33,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AdditiveExpression,
     ) -> output::AdditiveExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_additive_expression_operator = self
             .build_expression_additive_expression_operator(
@@ -40,6 +43,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::AdditiveExpressionStruct {
             id,
+            range,
             left_operand,
             expression_additive_expression_operator,
             right_operand,
@@ -51,10 +55,12 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AddressType,
     ) -> output::AddressType {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let payable_keyword = source.payable_keyword.is_some();
 
         Rc::new(output::AddressTypeStruct {
             id,
+            range,
             payable_keyword,
         })
     }
@@ -64,11 +70,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AndExpression,
     ) -> output::AndExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::AndExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -79,9 +87,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ArrayExpression,
     ) -> output::ArrayExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let items = self.build_array_values(&source.items);
 
-        Rc::new(output::ArrayExpressionStruct { id, items })
+        Rc::new(output::ArrayExpressionStruct { id, range, items })
     }
 
     pub(super) fn build_array_type_name(
@@ -89,13 +98,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ArrayTypeName,
     ) -> output::ArrayTypeName {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_type_name(&source.operand);
         let index = source
             .index
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::ArrayTypeNameStruct { id, operand, index })
+        Rc::new(output::ArrayTypeNameStruct {
+            id,
+            range,
+            operand,
+            index,
+        })
     }
 
     pub(super) fn build_assembly_statement(
@@ -103,6 +118,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AssemblyStatement,
     ) -> output::AssemblyStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let label = source
             .label
             .as_ref()
@@ -115,6 +131,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::AssemblyStatementStruct {
             id,
+            range,
             label,
             flags,
             body,
@@ -126,6 +143,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AssignmentExpression,
     ) -> output::AssignmentExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_assignment_expression_operator = self
             .build_expression_assignment_expression_operator(
@@ -135,6 +153,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::AssignmentExpressionStruct {
             id,
+            range,
             left_operand,
             expression_assignment_expression_operator,
             right_operand,
@@ -146,11 +165,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::BitwiseAndExpression,
     ) -> output::BitwiseAndExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseAndExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -161,11 +182,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::BitwiseOrExpression,
     ) -> output::BitwiseOrExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseOrExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -176,11 +199,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::BitwiseXorExpression,
     ) -> output::BitwiseXorExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::BitwiseXorExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -188,9 +213,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     pub(super) fn build_block(&mut self, source: &input::Block) -> output::Block {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let statements = self.build_statements(&source.statements);
 
-        Rc::new(output::BlockStruct { id, statements })
+        Rc::new(output::BlockStruct {
+            id,
+            range,
+            statements,
+        })
     }
 
     pub(super) fn build_break_statement(
@@ -198,8 +228,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::BreakStatement,
     ) -> output::BreakStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
 
-        Rc::new(output::BreakStatementStruct { id })
+        Rc::new(output::BreakStatementStruct { id, range })
     }
 
     pub(super) fn build_call_options_expression(
@@ -207,11 +238,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::CallOptionsExpression,
     ) -> output::CallOptionsExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let options = self.build_call_options(&source.options);
 
         Rc::new(output::CallOptionsExpressionStruct {
             id,
+            range,
             operand,
             options,
         })
@@ -222,13 +255,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::CatchClause,
     ) -> output::CatchClause {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let error = source
             .error
             .as_ref()
             .map(|value| self.build_catch_clause_error(value));
         let body = self.build_block(&source.body);
 
-        Rc::new(output::CatchClauseStruct { id, error, body })
+        Rc::new(output::CatchClauseStruct {
+            id,
+            range,
+            error,
+            body,
+        })
     }
 
     pub(super) fn build_catch_clause_error(
@@ -236,6 +275,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::CatchClauseError,
     ) -> output::CatchClauseError {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = source
             .name
             .as_ref()
@@ -244,6 +284,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::CatchClauseErrorStruct {
             id,
+            range,
             name,
             parameters,
         })
@@ -254,12 +295,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ConditionalExpression,
     ) -> output::ConditionalExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let true_expression = self.build_expression(&source.true_expression);
         let false_expression = self.build_expression(&source.false_expression);
 
         Rc::new(output::ConditionalExpressionStruct {
             id,
+            range,
             operand,
             true_expression,
             false_expression,
@@ -271,8 +314,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ContinueStatement,
     ) -> output::ContinueStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
 
-        Rc::new(output::ContinueStatementStruct { id })
+        Rc::new(output::ContinueStatementStruct { id, range })
     }
 
     pub(super) fn build_decimal_number_expression(
@@ -280,13 +324,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::DecimalNumberExpression,
     ) -> output::DecimalNumberExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let literal = self.build_decimal_literal(&source.literal);
         let unit = source
             .unit
             .as_ref()
             .map(|value| self.build_number_unit(value));
 
-        Rc::new(output::DecimalNumberExpressionStruct { id, literal, unit })
+        Rc::new(output::DecimalNumberExpressionStruct {
+            id,
+            range,
+            literal,
+            unit,
+        })
     }
 
     pub(super) fn build_do_while_statement(
@@ -294,11 +344,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::DoWhileStatement,
     ) -> output::DoWhileStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let body = self.build_statement(&source.body);
         let condition = self.build_expression(&source.condition);
 
         Rc::new(output::DoWhileStatementStruct {
             id,
+            range,
             body,
             condition,
         })
@@ -309,11 +361,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::EmitStatement,
     ) -> output::EmitStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let event = self.build_identifier_path(&source.event);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
         Rc::new(output::EmitStatementStruct {
             id,
+            range,
             event,
             arguments,
         })
@@ -324,10 +378,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::EnumDefinition,
     ) -> output::EnumDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let members = self.build_enum_members(&source.members);
 
-        Rc::new(output::EnumDefinitionStruct { id, name, members })
+        Rc::new(output::EnumDefinitionStruct {
+            id,
+            range,
+            name,
+            members,
+        })
     }
 
     pub(super) fn build_equality_expression(
@@ -335,6 +395,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::EqualityExpression,
     ) -> output::EqualityExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_equality_expression_operator = self
             .build_expression_equality_expression_operator(
@@ -344,6 +405,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::EqualityExpressionStruct {
             id,
+            range,
             left_operand,
             expression_equality_expression_operator,
             right_operand,
@@ -355,9 +417,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ExperimentalPragma,
     ) -> output::ExperimentalPragma {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let feature = self.build_experimental_feature(&source.feature);
 
-        Rc::new(output::ExperimentalPragmaStruct { id, feature })
+        Rc::new(output::ExperimentalPragmaStruct { id, range, feature })
     }
 
     pub(super) fn build_exponentiation_expression(
@@ -365,11 +428,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ExponentiationExpression,
     ) -> output::ExponentiationExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::ExponentiationExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -380,9 +445,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ExpressionStatement,
     ) -> output::ExpressionStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = self.build_expression(&source.expression);
 
-        Rc::new(output::ExpressionStatementStruct { id, expression })
+        Rc::new(output::ExpressionStatementStruct {
+            id,
+            range,
+            expression,
+        })
     }
 
     pub(super) fn build_for_statement(
@@ -390,6 +460,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ForStatement,
     ) -> output::ForStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let initialization = self.build_for_statement_initialization(&source.initialization);
         let condition = self.build_for_statement_condition(&source.condition);
         let iterator = source
@@ -400,6 +471,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ForStatementStruct {
             id,
+            range,
             initialization,
             condition,
             iterator,
@@ -412,11 +484,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::FunctionCallExpression,
     ) -> output::FunctionCallExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
         Rc::new(output::FunctionCallExpressionStruct {
             id,
+            range,
             operand,
             arguments,
         })
@@ -427,9 +501,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::HexNumberExpression,
     ) -> output::HexNumberExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let literal = self.build_hex_literal(&source.literal);
 
-        Rc::new(output::HexNumberExpressionStruct { id, literal })
+        Rc::new(output::HexNumberExpressionStruct { id, range, literal })
     }
 
     pub(super) fn build_if_statement(
@@ -437,6 +512,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::IfStatement,
     ) -> output::IfStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
         let else_branch = source
@@ -446,6 +522,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::IfStatementStruct {
             id,
+            range,
             condition,
             body,
             else_branch,
@@ -457,10 +534,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ImportDeconstruction,
     ) -> output::ImportDeconstruction {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let symbols = self.build_import_deconstruction_symbols(&source.symbols);
         let path = self.build_string_literal(&source.path);
 
-        Rc::new(output::ImportDeconstructionStruct { id, symbols, path })
+        Rc::new(output::ImportDeconstructionStruct {
+            id,
+            range,
+            symbols,
+            path,
+        })
     }
 
     pub(super) fn build_import_deconstruction_symbol(
@@ -468,13 +551,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ImportDeconstructionSymbol,
     ) -> output::ImportDeconstructionSymbol {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_import_alias(value));
 
-        Rc::new(output::ImportDeconstructionSymbolStruct { id, name, alias })
+        Rc::new(output::ImportDeconstructionSymbolStruct {
+            id,
+            range,
+            name,
+            alias,
+        })
     }
 
     pub(super) fn build_inequality_expression(
@@ -482,6 +571,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::InequalityExpression,
     ) -> output::InequalityExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_inequality_expression_operator = self
             .build_expression_inequality_expression_operator(
@@ -491,6 +581,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::InequalityExpressionStruct {
             id,
+            range,
             left_operand,
             expression_inequality_expression_operator,
             right_operand,
@@ -502,6 +593,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::InheritanceType,
     ) -> output::InheritanceType {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_identifier_path(&source.type_name);
         let arguments = source
             .arguments
@@ -510,6 +602,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::InheritanceTypeStruct {
             id,
+            range,
             type_name,
             arguments,
         })
@@ -520,6 +613,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::InterfaceDefinition,
     ) -> output::InterfaceDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let inheritance = source
             .inheritance
@@ -529,6 +623,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::InterfaceDefinitionStruct {
             id,
+            range,
             name,
             inheritance,
             members,
@@ -540,10 +635,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::LibraryDefinition,
     ) -> output::LibraryDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let members = self.build_library_members(&source.members);
 
-        Rc::new(output::LibraryDefinitionStruct { id, name, members })
+        Rc::new(output::LibraryDefinitionStruct {
+            id,
+            range,
+            name,
+            members,
+        })
     }
 
     pub(super) fn build_member_access_expression(
@@ -551,11 +652,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::MemberAccessExpression,
     ) -> output::MemberAccessExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let member = self.build_identifier_path_element(&source.member);
 
         Rc::new(output::MemberAccessExpressionStruct {
             id,
+            range,
             operand,
             member,
         })
@@ -566,6 +669,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ModifierInvocation,
     ) -> output::ModifierInvocation {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier_path(&source.name);
         let arguments = source
             .arguments
@@ -574,6 +678,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ModifierInvocationStruct {
             id,
+            range,
             name,
             arguments,
         })
@@ -584,11 +689,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::MultiTypedDeclaration,
     ) -> output::MultiTypedDeclaration {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let elements = self.build_multi_typed_declaration_elements(&source.elements);
         let value = self.build_variable_declaration_value(&source.value);
 
         Rc::new(output::MultiTypedDeclarationStruct {
             id,
+            range,
             elements,
             value,
         })
@@ -599,12 +706,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::MultiTypedDeclarationElement,
     ) -> output::MultiTypedDeclarationElement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let member = source
             .member
             .as_ref()
             .map(|value| self.build_variable_declaration(value));
 
-        Rc::new(output::MultiTypedDeclarationElementStruct { id, member })
+        Rc::new(output::MultiTypedDeclarationElementStruct { id, range, member })
     }
 
     pub(super) fn build_multiplicative_expression(
@@ -612,6 +720,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::MultiplicativeExpression,
     ) -> output::MultiplicativeExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_multiplicative_expression_operator = self
             .build_expression_multiplicative_expression_operator(
@@ -621,6 +730,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::MultiplicativeExpressionStruct {
             id,
+            range,
             left_operand,
             expression_multiplicative_expression_operator,
             right_operand,
@@ -632,10 +742,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::NamedArgument,
     ) -> output::NamedArgument {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let value = self.build_expression(&source.value);
 
-        Rc::new(output::NamedArgumentStruct { id, name, value })
+        Rc::new(output::NamedArgumentStruct {
+            id,
+            range,
+            name,
+            value,
+        })
     }
 
     pub(super) fn build_new_expression(
@@ -643,9 +759,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::NewExpression,
     ) -> output::NewExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
 
-        Rc::new(output::NewExpressionStruct { id, type_name })
+        Rc::new(output::NewExpressionStruct {
+            id,
+            range,
+            type_name,
+        })
     }
 
     pub(super) fn build_or_expression(
@@ -653,11 +774,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::OrExpression,
     ) -> output::OrExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let right_operand = self.build_expression(&source.right_operand);
 
         Rc::new(output::OrExpressionStruct {
             id,
+            range,
             left_operand,
             right_operand,
         })
@@ -665,13 +788,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     pub(super) fn build_path_import(&mut self, source: &input::PathImport) -> output::PathImport {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let path = self.build_string_literal(&source.path);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_import_alias(value));
 
-        Rc::new(output::PathImportStruct { id, path, alias })
+        Rc::new(output::PathImportStruct {
+            id,
+            range,
+            path,
+            alias,
+        })
     }
 
     pub(super) fn build_postfix_expression(
@@ -679,6 +808,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::PostfixExpression,
     ) -> output::PostfixExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let expression_postfix_expression_operator = self
             .build_expression_postfix_expression_operator(
@@ -687,6 +817,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::PostfixExpressionStruct {
             id,
+            range,
             operand,
             expression_postfix_expression_operator,
         })
@@ -697,9 +828,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::PragmaDirective,
     ) -> output::PragmaDirective {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let pragma = self.build_pragma(&source.pragma);
 
-        Rc::new(output::PragmaDirectiveStruct { id, pragma })
+        Rc::new(output::PragmaDirectiveStruct { id, range, pragma })
     }
 
     pub(super) fn build_prefix_expression(
@@ -707,6 +839,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::PrefixExpression,
     ) -> output::PrefixExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression_prefix_expression_operator = self
             .build_expression_prefix_expression_operator(
                 &source.expression_prefix_expression_operator,
@@ -715,6 +848,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::PrefixExpressionStruct {
             id,
+            range,
             expression_prefix_expression_operator,
             operand,
         })
@@ -725,12 +859,17 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ReturnStatement,
     ) -> output::ReturnStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = source
             .expression
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::ReturnStatementStruct { id, expression })
+        Rc::new(output::ReturnStatementStruct {
+            id,
+            range,
+            expression,
+        })
     }
 
     pub(super) fn build_revert_statement(
@@ -738,11 +877,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::RevertStatement,
     ) -> output::RevertStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let error = self.build_identifier_path(&source.error);
         let arguments = self.build_arguments_declaration(&source.arguments);
 
         Rc::new(output::RevertStatementStruct {
             id,
+            range,
             error,
             arguments,
         })
@@ -753,6 +894,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ShiftExpression,
     ) -> output::ShiftExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let left_operand = self.build_expression(&source.left_operand);
         let expression_shift_expression_operator = self.build_expression_shift_expression_operator(
             &source.expression_shift_expression_operator,
@@ -761,6 +903,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ShiftExpressionStruct {
             id,
+            range,
             left_operand,
             expression_shift_expression_operator,
             right_operand,
@@ -772,6 +915,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::SingleTypedDeclaration,
     ) -> output::SingleTypedDeclaration {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let declaration = self.build_variable_declaration(&source.declaration);
         let value = source
             .value
@@ -780,6 +924,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::SingleTypedDeclarationStruct {
             id,
+            range,
             declaration,
             value,
         })
@@ -787,9 +932,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     pub(super) fn build_source_unit(&mut self, source: &input::SourceUnit) -> output::SourceUnit {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let members = self.build_source_unit_members(&source.members);
 
-        Rc::new(output::SourceUnitStruct { id, members })
+        Rc::new(output::SourceUnitStruct { id, range, members })
     }
 
     pub(super) fn build_struct_definition(
@@ -797,10 +943,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::StructDefinition,
     ) -> output::StructDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let members = self.build_struct_members(&source.members);
 
-        Rc::new(output::StructDefinitionStruct { id, name, members })
+        Rc::new(output::StructDefinitionStruct {
+            id,
+            range,
+            name,
+            members,
+        })
     }
 
     pub(super) fn build_struct_member(
@@ -808,11 +960,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::StructMember,
     ) -> output::StructMember {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
 
         Rc::new(output::StructMemberStruct {
             id,
+            range,
             type_name,
             name,
         })
@@ -823,6 +977,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::TryStatement,
     ) -> output::TryStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = self.build_expression(&source.expression);
         let returns = source
             .returns
@@ -833,6 +988,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::TryStatementStruct {
             id,
+            range,
             expression,
             returns,
             body,
@@ -845,19 +1001,25 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::TupleExpression,
     ) -> output::TupleExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let items = self.build_tuple_values(&source.items);
 
-        Rc::new(output::TupleExpressionStruct { id, items })
+        Rc::new(output::TupleExpressionStruct { id, range, items })
     }
 
     pub(super) fn build_tuple_value(&mut self, source: &input::TupleValue) -> output::TupleValue {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = source
             .expression
             .as_ref()
             .map(|value| self.build_expression(value));
 
-        Rc::new(output::TupleValueStruct { id, expression })
+        Rc::new(output::TupleValueStruct {
+            id,
+            range,
+            expression,
+        })
     }
 
     pub(super) fn build_type_expression(
@@ -865,9 +1027,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::TypeExpression,
     ) -> output::TypeExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
 
-        Rc::new(output::TypeExpressionStruct { id, type_name })
+        Rc::new(output::TypeExpressionStruct {
+            id,
+            range,
+            type_name,
+        })
     }
 
     pub(super) fn build_unchecked_block(
@@ -875,9 +1042,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::UncheckedBlock,
     ) -> output::UncheckedBlock {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let block = self.build_block(&source.block);
 
-        Rc::new(output::UncheckedBlockStruct { id, block })
+        Rc::new(output::UncheckedBlockStruct { id, range, block })
     }
 
     pub(super) fn build_user_defined_value_type_definition(
@@ -885,11 +1053,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::UserDefinedValueTypeDefinition,
     ) -> output::UserDefinedValueTypeDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let value_type = self.build_elementary_type(&source.value_type);
 
         Rc::new(output::UserDefinedValueTypeDefinitionStruct {
             id,
+            range,
             name,
             value_type,
         })
@@ -900,9 +1070,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::UsingDeconstruction,
     ) -> output::UsingDeconstruction {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let symbols = self.build_using_deconstruction_symbols(&source.symbols);
 
-        Rc::new(output::UsingDeconstructionStruct { id, symbols })
+        Rc::new(output::UsingDeconstructionStruct { id, range, symbols })
     }
 
     pub(super) fn build_using_deconstruction_symbol(
@@ -910,13 +1081,19 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::UsingDeconstructionSymbol,
     ) -> output::UsingDeconstructionSymbol {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier_path(&source.name);
         let alias = source
             .alias
             .as_ref()
             .map(|value| self.build_using_alias(value));
 
-        Rc::new(output::UsingDeconstructionSymbolStruct { id, name, alias })
+        Rc::new(output::UsingDeconstructionSymbolStruct {
+            id,
+            range,
+            name,
+            alias,
+        })
     }
 
     pub(super) fn build_using_directive(
@@ -924,12 +1101,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::UsingDirective,
     ) -> output::UsingDirective {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let clause = self.build_using_clause(&source.clause);
         let target = self.build_using_target(&source.target);
         let global_keyword = source.global_keyword.is_some();
 
         Rc::new(output::UsingDirectiveStruct {
             id,
+            range,
             clause,
             target,
             global_keyword,
@@ -941,6 +1120,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::VariableDeclaration,
     ) -> output::VariableDeclaration {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let storage_location = source
             .storage_location
@@ -950,6 +1130,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::VariableDeclarationStruct {
             id,
+            range,
             type_name,
             storage_location,
             name,
@@ -961,9 +1142,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::VariableDeclarationStatement,
     ) -> output::VariableDeclarationStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let target = self.build_variable_declaration_target(&source.target);
 
-        Rc::new(output::VariableDeclarationStatementStruct { id, target })
+        Rc::new(output::VariableDeclarationStatementStruct { id, range, target })
     }
 
     pub(super) fn build_version_pragma(
@@ -971,9 +1153,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::VersionPragma,
     ) -> output::VersionPragma {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let sets = self.build_version_expression_sets(&source.sets);
 
-        Rc::new(output::VersionPragmaStruct { id, sets })
+        Rc::new(output::VersionPragmaStruct { id, range, sets })
     }
 
     pub(super) fn build_version_range(
@@ -981,10 +1164,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::VersionRange,
     ) -> output::VersionRange {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let start = self.build_version_literal(&source.start);
         let end = self.build_version_literal(&source.end);
 
-        Rc::new(output::VersionRangeStruct { id, start, end })
+        Rc::new(output::VersionRangeStruct {
+            id,
+            range,
+            start,
+            end,
+        })
     }
 
     pub(super) fn build_version_term(
@@ -992,6 +1181,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::VersionTerm,
     ) -> output::VersionTerm {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operator = source
             .operator
             .as_ref()
@@ -1000,6 +1190,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::VersionTermStruct {
             id,
+            range,
             operator,
             literal,
         })
@@ -1010,11 +1201,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::WhileStatement,
     ) -> output::WhileStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let condition = self.build_expression(&source.condition);
         let body = self.build_statement(&source.body);
 
         Rc::new(output::WhileStatementStruct {
             id,
+            range,
             condition,
             body,
         })
@@ -1022,9 +1215,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     pub(super) fn build_yul_block(&mut self, source: &input::YulBlock) -> output::YulBlock {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let statements = self.build_yul_statements(&source.statements);
 
-        Rc::new(output::YulBlockStruct { id, statements })
+        Rc::new(output::YulBlockStruct {
+            id,
+            range,
+            statements,
+        })
     }
 
     pub(super) fn build_yul_break_statement(
@@ -1032,8 +1230,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulBreakStatement,
     ) -> output::YulBreakStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
 
-        Rc::new(output::YulBreakStatementStruct { id })
+        Rc::new(output::YulBreakStatementStruct { id, range })
     }
 
     pub(super) fn build_yul_continue_statement(
@@ -1041,8 +1240,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulContinueStatement,
     ) -> output::YulContinueStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
 
-        Rc::new(output::YulContinueStatementStruct { id })
+        Rc::new(output::YulContinueStatementStruct { id, range })
     }
 
     pub(super) fn build_yul_default_case(
@@ -1050,9 +1250,10 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulDefaultCase,
     ) -> output::YulDefaultCase {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::YulDefaultCaseStruct { id, body })
+        Rc::new(output::YulDefaultCaseStruct { id, range, body })
     }
 
     pub(super) fn build_yul_for_statement(
@@ -1060,6 +1261,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulForStatement,
     ) -> output::YulForStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let initialization = self.build_yul_block(&source.initialization);
         let condition = self.build_yul_expression(&source.condition);
         let iterator = self.build_yul_block(&source.iterator);
@@ -1067,6 +1269,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::YulForStatementStruct {
             id,
+            range,
             initialization,
             condition,
             iterator,
@@ -1079,11 +1282,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulFunctionCallExpression,
     ) -> output::YulFunctionCallExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_yul_expression(&source.operand);
         let arguments = self.build_yul_arguments(&source.arguments);
 
         Rc::new(output::YulFunctionCallExpressionStruct {
             id,
+            range,
             operand,
             arguments,
         })
@@ -1094,6 +1299,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulFunctionDefinition,
     ) -> output::YulFunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_yul_identifier(&source.name);
         let parameters = self.build_yul_parameters_declaration(&source.parameters);
         let returns = source
@@ -1104,6 +1310,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::YulFunctionDefinitionStruct {
             id,
+            range,
             name,
             parameters,
             returns,
@@ -1116,11 +1323,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulIfStatement,
     ) -> output::YulIfStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let condition = self.build_yul_expression(&source.condition);
         let body = self.build_yul_block(&source.body);
 
         Rc::new(output::YulIfStatementStruct {
             id,
+            range,
             condition,
             body,
         })
@@ -1131,8 +1340,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulLeaveStatement,
     ) -> output::YulLeaveStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
 
-        Rc::new(output::YulLeaveStatementStruct { id })
+        Rc::new(output::YulLeaveStatementStruct { id, range })
     }
 
     pub(super) fn build_yul_switch_statement(
@@ -1140,11 +1350,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulSwitchStatement,
     ) -> output::YulSwitchStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = self.build_yul_expression(&source.expression);
         let cases = self.build_yul_switch_cases(&source.cases);
 
         Rc::new(output::YulSwitchStatementStruct {
             id,
+            range,
             expression,
             cases,
         })
@@ -1155,10 +1367,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulValueCase,
     ) -> output::YulValueCase {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let value = self.build_yul_literal(&source.value);
         let body = self.build_yul_block(&source.body);
 
-        Rc::new(output::YulValueCaseStruct { id, value, body })
+        Rc::new(output::YulValueCaseStruct {
+            id,
+            range,
+            value,
+            body,
+        })
     }
 
     pub(super) fn build_yul_variable_assignment_statement(
@@ -1166,11 +1384,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulVariableAssignmentStatement,
     ) -> output::YulVariableAssignmentStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let variables = self.build_yul_paths(&source.variables);
         let expression = self.build_yul_expression(&source.expression);
 
         Rc::new(output::YulVariableAssignmentStatementStruct {
             id,
+            range,
             variables,
             expression,
         })
@@ -1181,6 +1401,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulVariableDeclarationStatement,
     ) -> output::YulVariableDeclarationStatement {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let variables = self.build_yul_variable_names(&source.variables);
         let value = source
             .value
@@ -1189,6 +1410,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::YulVariableDeclarationStatementStruct {
             id,
+            range,
             variables,
             value,
         })
@@ -1199,9 +1421,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::YulVariableDeclarationValue,
     ) -> output::YulVariableDeclarationValue {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let expression = self.build_yul_expression(&source.expression);
 
-        Rc::new(output::YulVariableDeclarationValueStruct { id, expression })
+        Rc::new(output::YulVariableDeclarationValueStruct {
+            id,
+            range,
+            expression,
+        })
     }
 
     //

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use crate::ir::nodes as output;
 use crate::ir::Source;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
+use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
 use super::CstToIrBuilder;
 
 impl<S: Source> CstToIrBuilder<'_, S> {
@@ -19,6 +20,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
       pub(super) fn build_{{ parent_type | snake_case }}(&mut self, source: &input::{{ parent_type }}) -> output::{{ parent_type }}
       {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         {%- for field in sequence.fields %}
           let {{ field.label | snake_case }} =
           {%- if field.is_optional -%}
@@ -37,6 +39,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::{{ parent_type }}Struct {
           id,
+          range,
           {%- for field in sequence.fields -%}
             {{ field.label | snake_case }},
           {%- endfor %}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use slang_solidity_v2_cst::structured_cst::nodes as input;
+use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
 
 #[path = "default.generated.rs"]
 mod default;
@@ -65,6 +66,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ConstantDefinition,
     ) -> output::ConstantDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
         let visibility = None;
@@ -72,6 +74,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ConstantDefinitionStruct {
             id,
+            range,
             type_name,
             name,
             visibility,
@@ -84,6 +87,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ContractDefinition,
     ) -> output::ContractDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let abstract_keyword = source.abstract_keyword.is_some();
         let name = self.build_identifier(&source.name);
         let members = self.build_contract_members(&source.members);
@@ -109,6 +113,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ContractDefinitionStruct {
             id,
+            range,
             abstract_keyword,
             name,
             inheritance_types,
@@ -122,6 +127,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ErrorDefinition,
     ) -> output::ErrorDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let parameters = source
             .members
@@ -133,6 +139,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ErrorDefinitionStruct {
             id,
+            range,
             name,
             parameters,
         })
@@ -143,6 +150,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::EventDefinition,
     ) -> output::EventDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
         let anonymous_keyword = source.anonymous_keyword.is_some();
         let parameters = source
@@ -155,6 +163,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::EventDefinitionStruct {
             id,
+            range,
             name,
             anonymous_keyword,
             parameters,
@@ -166,6 +175,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::FunctionDefinition,
     ) -> output::FunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let (kind, name) = match &source.name {
             input::FunctionName::Identifier(identifier) => (
                 output::FunctionKind::Regular,
@@ -193,6 +203,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionDefinitionStruct {
             id,
+            range,
             kind,
             name,
             parameters,
@@ -208,6 +219,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_function_type(&mut self, source: &input::FunctionType) -> output::FunctionType {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let parameters = self.build_parameters_declaration(&source.parameters);
         let visibility = Self::function_type_visibility(&source.attributes);
         let mutability = Self::function_type_mutability(&source.attributes);
@@ -218,6 +230,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionTypeStruct {
             id,
+            range,
             parameters,
             visibility,
             mutability,
@@ -230,6 +243,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::IndexAccessExpression,
     ) -> output::IndexAccessExpression {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let operand = self.build_expression(&source.operand);
         let start = source
             .start
@@ -242,6 +256,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::IndexAccessExpressionStruct {
             id,
+            range,
             operand,
             start,
             end,
@@ -250,11 +265,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_mapping_type(&mut self, source: &input::MappingType) -> output::MappingType {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let key_type = self.build_mapping_key_as_parameter(&source.key_type);
         let value_type = self.build_mapping_value_as_parameter(&source.value_type);
 
         Rc::new(output::MappingTypeStruct {
             id,
+            range,
             key_type,
             value_type,
         })
@@ -262,6 +279,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_parameter(&mut self, source: &input::Parameter) -> output::Parameter {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let storage_location = source
             .storage_location
@@ -271,6 +289,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::ParameterStruct {
             id,
+            range,
             type_name,
             storage_location,
             name,
@@ -283,6 +302,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::StateVariableDefinition,
     ) -> output::StateVariableDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let name = self.build_identifier(&source.name);
         let value = source
@@ -295,6 +315,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::StateVariableDefinitionStruct {
             id,
+            range,
             type_name,
             name,
             value,
@@ -500,6 +521,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ConstructorDefinition,
     ) -> output::FunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let kind = output::FunctionKind::Constructor;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -515,6 +537,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionDefinitionStruct {
             id,
+            range,
             kind,
             name,
             parameters,
@@ -579,6 +602,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::FallbackFunctionDefinition,
     ) -> output::FunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let kind = output::FunctionKind::Fallback;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -601,6 +625,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionDefinitionStruct {
             id,
+            range,
             kind,
             name,
             parameters,
@@ -669,6 +694,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ReceiveFunctionDefinition,
     ) -> output::FunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let kind = output::FunctionKind::Receive;
         let name = None;
         let parameters = self.build_parameters_declaration(&source.parameters);
@@ -689,6 +715,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionDefinitionStruct {
             id,
+            range,
             kind,
             name,
             parameters,
@@ -737,6 +764,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::ModifierDefinition,
     ) -> output::FunctionDefinition {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let kind = output::FunctionKind::Modifier;
         let name = Some(self.build_identifier(&source.name));
         let parameters = source.parameters.as_ref().map_or(Vec::new(), |parameter| {
@@ -757,6 +785,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
         Rc::new(output::FunctionDefinitionStruct {
             id,
+            range,
             kind,
             name,
             parameters,
@@ -848,6 +877,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     ) -> output::ConstantDefinition {
         Rc::new(output::ConstantDefinitionStruct {
             id: state_variable_definition.id(),
+            range: state_variable_definition.range,
             type_name: state_variable_definition.type_name,
             name: state_variable_definition.name,
             visibility: Some(state_variable_definition.visibility),
@@ -877,11 +907,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_mapping_key_as_parameter(&mut self, source: &input::MappingKey) -> output::Parameter {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_mapping_key_type(&source.key_type);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
             id,
+            range,
             type_name,
             storage_location: None,
             name,
@@ -905,11 +937,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::MappingValue,
     ) -> output::Parameter {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
             id,
+            range,
             type_name,
             storage_location: None,
             name,
@@ -926,10 +960,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::NamedImport,
     ) -> output::PathImport {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let path = self.build_string_literal(&source.path);
         let alias = Some(self.build_import_alias(&source.alias));
 
-        Rc::new(output::PathImportStruct { id, path, alias })
+        Rc::new(output::PathImportStruct {
+            id,
+            range,
+            path,
+            alias,
+        })
     }
 
     //
@@ -938,12 +978,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_event_parameter(&mut self, source: &input::EventParameter) -> output::Parameter {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let indexed = source.indexed_keyword.is_some();
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
             id,
+            range,
             type_name,
             storage_location: None,
             name,
@@ -953,11 +995,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
 
     fn build_error_parameter(&mut self, source: &input::ErrorParameter) -> output::Parameter {
         let id = self.next_id();
+        let range = source.text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Rc::new(output::ParameterStruct {
             id,
+            range,
             type_name,
             storage_location: None,
             name,

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -17,6 +17,7 @@ pub type AbicoderPragma = Rc<AbicoderPragmaStruct>;
 #[derive(Debug)]
 pub struct AbicoderPragmaStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub version: AbicoderVersion,
 }
 
@@ -31,6 +32,7 @@ pub type AdditiveExpression = Rc<AdditiveExpressionStruct>;
 #[derive(Debug)]
 pub struct AdditiveExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_additive_expression_operator: Expression_AdditiveExpression_Operator,
     pub right_operand: Expression,
@@ -47,6 +49,7 @@ pub type AddressType = Rc<AddressTypeStruct>;
 #[derive(Debug)]
 pub struct AddressTypeStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub payable_keyword: bool,
 }
 
@@ -61,6 +64,7 @@ pub type AndExpression = Rc<AndExpressionStruct>;
 #[derive(Debug)]
 pub struct AndExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -76,6 +80,7 @@ pub type ArrayExpression = Rc<ArrayExpressionStruct>;
 #[derive(Debug)]
 pub struct ArrayExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub items: ArrayValues,
 }
 
@@ -90,6 +95,7 @@ pub type ArrayTypeName = Rc<ArrayTypeNameStruct>;
 #[derive(Debug)]
 pub struct ArrayTypeNameStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: TypeName,
     pub index: Option<Expression>,
 }
@@ -105,6 +111,7 @@ pub type AssemblyStatement = Rc<AssemblyStatementStruct>;
 #[derive(Debug)]
 pub struct AssemblyStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub label: Option<StringLiteral>,
     pub flags: Option<YulFlags>,
     pub body: YulBlock,
@@ -121,6 +128,7 @@ pub type AssignmentExpression = Rc<AssignmentExpressionStruct>;
 #[derive(Debug)]
 pub struct AssignmentExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_assignment_expression_operator: Expression_AssignmentExpression_Operator,
     pub right_operand: Expression,
@@ -137,6 +145,7 @@ pub type BitwiseAndExpression = Rc<BitwiseAndExpressionStruct>;
 #[derive(Debug)]
 pub struct BitwiseAndExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -152,6 +161,7 @@ pub type BitwiseOrExpression = Rc<BitwiseOrExpressionStruct>;
 #[derive(Debug)]
 pub struct BitwiseOrExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -167,6 +177,7 @@ pub type BitwiseXorExpression = Rc<BitwiseXorExpressionStruct>;
 #[derive(Debug)]
 pub struct BitwiseXorExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -182,6 +193,7 @@ pub type Block = Rc<BlockStruct>;
 #[derive(Debug)]
 pub struct BlockStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub statements: Statements,
 }
 
@@ -196,6 +208,7 @@ pub type BreakStatement = Rc<BreakStatementStruct>;
 #[derive(Debug)]
 pub struct BreakStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
 }
 
 impl BreakStatementStruct {
@@ -209,6 +222,7 @@ pub type CallOptionsExpression = Rc<CallOptionsExpressionStruct>;
 #[derive(Debug)]
 pub struct CallOptionsExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub options: CallOptions,
 }
@@ -224,6 +238,7 @@ pub type CatchClause = Rc<CatchClauseStruct>;
 #[derive(Debug)]
 pub struct CatchClauseStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub error: Option<CatchClauseError>,
     pub body: Block,
 }
@@ -239,6 +254,7 @@ pub type CatchClauseError = Rc<CatchClauseErrorStruct>;
 #[derive(Debug)]
 pub struct CatchClauseErrorStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Option<Identifier>,
     pub parameters: Parameters,
 }
@@ -254,6 +270,7 @@ pub type ConditionalExpression = Rc<ConditionalExpressionStruct>;
 #[derive(Debug)]
 pub struct ConditionalExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub true_expression: Expression,
     pub false_expression: Expression,
@@ -270,6 +287,7 @@ pub type ConstantDefinition = Rc<ConstantDefinitionStruct>;
 #[derive(Debug)]
 pub struct ConstantDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
     pub name: Identifier,
     pub visibility: Option<StateVariableVisibility>,
@@ -287,6 +305,7 @@ pub type ContinueStatement = Rc<ContinueStatementStruct>;
 #[derive(Debug)]
 pub struct ContinueStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
 }
 
 impl ContinueStatementStruct {
@@ -300,6 +319,7 @@ pub type ContractDefinition = Rc<ContractDefinitionStruct>;
 #[derive(Debug)]
 pub struct ContractDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub abstract_keyword: bool,
     pub name: Identifier,
     pub inheritance_types: InheritanceTypes,
@@ -318,6 +338,7 @@ pub type DecimalNumberExpression = Rc<DecimalNumberExpressionStruct>;
 #[derive(Debug)]
 pub struct DecimalNumberExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub literal: DecimalLiteral,
     pub unit: Option<NumberUnit>,
 }
@@ -333,6 +354,7 @@ pub type DoWhileStatement = Rc<DoWhileStatementStruct>;
 #[derive(Debug)]
 pub struct DoWhileStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub body: Statement,
     pub condition: Expression,
 }
@@ -348,6 +370,7 @@ pub type EmitStatement = Rc<EmitStatementStruct>;
 #[derive(Debug)]
 pub struct EmitStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub event: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
 }
@@ -363,6 +386,7 @@ pub type EnumDefinition = Rc<EnumDefinitionStruct>;
 #[derive(Debug)]
 pub struct EnumDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub members: EnumMembers,
 }
@@ -378,6 +402,7 @@ pub type EqualityExpression = Rc<EqualityExpressionStruct>;
 #[derive(Debug)]
 pub struct EqualityExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_equality_expression_operator: Expression_EqualityExpression_Operator,
     pub right_operand: Expression,
@@ -394,6 +419,7 @@ pub type ErrorDefinition = Rc<ErrorDefinitionStruct>;
 #[derive(Debug)]
 pub struct ErrorDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub parameters: Parameters,
 }
@@ -409,6 +435,7 @@ pub type EventDefinition = Rc<EventDefinitionStruct>;
 #[derive(Debug)]
 pub struct EventDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub anonymous_keyword: bool,
     pub parameters: Parameters,
@@ -425,6 +452,7 @@ pub type ExperimentalPragma = Rc<ExperimentalPragmaStruct>;
 #[derive(Debug)]
 pub struct ExperimentalPragmaStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub feature: ExperimentalFeature,
 }
 
@@ -439,6 +467,7 @@ pub type ExponentiationExpression = Rc<ExponentiationExpressionStruct>;
 #[derive(Debug)]
 pub struct ExponentiationExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -454,6 +483,7 @@ pub type ExpressionStatement = Rc<ExpressionStatementStruct>;
 #[derive(Debug)]
 pub struct ExpressionStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: Expression,
 }
 
@@ -468,6 +498,7 @@ pub type ForStatement = Rc<ForStatementStruct>;
 #[derive(Debug)]
 pub struct ForStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub initialization: ForStatementInitialization,
     pub condition: ForStatementCondition,
     pub iterator: Option<Expression>,
@@ -485,6 +516,7 @@ pub type FunctionCallExpression = Rc<FunctionCallExpressionStruct>;
 #[derive(Debug)]
 pub struct FunctionCallExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub arguments: ArgumentsDeclaration,
 }
@@ -500,6 +532,7 @@ pub type FunctionDefinition = Rc<FunctionDefinitionStruct>;
 #[derive(Debug)]
 pub struct FunctionDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub kind: FunctionKind,
     pub name: Option<Identifier>,
     pub parameters: Parameters,
@@ -523,6 +556,7 @@ pub type FunctionType = Rc<FunctionTypeStruct>;
 #[derive(Debug)]
 pub struct FunctionTypeStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub parameters: Parameters,
     pub visibility: FunctionVisibility,
     pub mutability: FunctionMutability,
@@ -540,6 +574,7 @@ pub type HexNumberExpression = Rc<HexNumberExpressionStruct>;
 #[derive(Debug)]
 pub struct HexNumberExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub literal: HexLiteral,
 }
 
@@ -554,6 +589,7 @@ pub type IfStatement = Rc<IfStatementStruct>;
 #[derive(Debug)]
 pub struct IfStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub condition: Expression,
     pub body: Statement,
     pub else_branch: Option<Statement>,
@@ -570,6 +606,7 @@ pub type ImportDeconstruction = Rc<ImportDeconstructionStruct>;
 #[derive(Debug)]
 pub struct ImportDeconstructionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub symbols: ImportDeconstructionSymbols,
     pub path: StringLiteral,
 }
@@ -585,6 +622,7 @@ pub type ImportDeconstructionSymbol = Rc<ImportDeconstructionSymbolStruct>;
 #[derive(Debug)]
 pub struct ImportDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub alias: Option<Identifier>,
 }
@@ -600,6 +638,7 @@ pub type IndexAccessExpression = Rc<IndexAccessExpressionStruct>;
 #[derive(Debug)]
 pub struct IndexAccessExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub start: Option<Expression>,
     pub end: Option<Expression>,
@@ -616,6 +655,7 @@ pub type InequalityExpression = Rc<InequalityExpressionStruct>;
 #[derive(Debug)]
 pub struct InequalityExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_inequality_expression_operator: Expression_InequalityExpression_Operator,
     pub right_operand: Expression,
@@ -632,6 +672,7 @@ pub type InheritanceType = Rc<InheritanceTypeStruct>;
 #[derive(Debug)]
 pub struct InheritanceTypeStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
 }
@@ -647,6 +688,7 @@ pub type InterfaceDefinition = Rc<InterfaceDefinitionStruct>;
 #[derive(Debug)]
 pub struct InterfaceDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub inheritance: Option<InheritanceTypes>,
     pub members: InterfaceMembers,
@@ -663,6 +705,7 @@ pub type LibraryDefinition = Rc<LibraryDefinitionStruct>;
 #[derive(Debug)]
 pub struct LibraryDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub members: LibraryMembers,
 }
@@ -678,6 +721,7 @@ pub type MappingType = Rc<MappingTypeStruct>;
 #[derive(Debug)]
 pub struct MappingTypeStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub key_type: Parameter,
     pub value_type: Parameter,
 }
@@ -693,6 +737,7 @@ pub type MemberAccessExpression = Rc<MemberAccessExpressionStruct>;
 #[derive(Debug)]
 pub struct MemberAccessExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub member: Identifier,
 }
@@ -708,6 +753,7 @@ pub type ModifierInvocation = Rc<ModifierInvocationStruct>;
 #[derive(Debug)]
 pub struct ModifierInvocationStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: IdentifierPath,
     pub arguments: Option<ArgumentsDeclaration>,
 }
@@ -723,6 +769,7 @@ pub type MultiTypedDeclaration = Rc<MultiTypedDeclarationStruct>;
 #[derive(Debug)]
 pub struct MultiTypedDeclarationStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub elements: MultiTypedDeclarationElements,
     pub value: Expression,
 }
@@ -738,6 +785,7 @@ pub type MultiTypedDeclarationElement = Rc<MultiTypedDeclarationElementStruct>;
 #[derive(Debug)]
 pub struct MultiTypedDeclarationElementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub member: Option<VariableDeclaration>,
 }
 
@@ -752,6 +800,7 @@ pub type MultiplicativeExpression = Rc<MultiplicativeExpressionStruct>;
 #[derive(Debug)]
 pub struct MultiplicativeExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_multiplicative_expression_operator: Expression_MultiplicativeExpression_Operator,
     pub right_operand: Expression,
@@ -768,6 +817,7 @@ pub type NamedArgument = Rc<NamedArgumentStruct>;
 #[derive(Debug)]
 pub struct NamedArgumentStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub value: Expression,
 }
@@ -783,6 +833,7 @@ pub type NewExpression = Rc<NewExpressionStruct>;
 #[derive(Debug)]
 pub struct NewExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
 }
 
@@ -797,6 +848,7 @@ pub type OrExpression = Rc<OrExpressionStruct>;
 #[derive(Debug)]
 pub struct OrExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub right_operand: Expression,
 }
@@ -812,6 +864,7 @@ pub type Parameter = Rc<ParameterStruct>;
 #[derive(Debug)]
 pub struct ParameterStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
     pub name: Option<Identifier>,
@@ -829,6 +882,7 @@ pub type PathImport = Rc<PathImportStruct>;
 #[derive(Debug)]
 pub struct PathImportStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub path: StringLiteral,
     pub alias: Option<Identifier>,
 }
@@ -844,6 +898,7 @@ pub type PostfixExpression = Rc<PostfixExpressionStruct>;
 #[derive(Debug)]
 pub struct PostfixExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: Expression,
     pub expression_postfix_expression_operator: Expression_PostfixExpression_Operator,
 }
@@ -859,6 +914,7 @@ pub type PragmaDirective = Rc<PragmaDirectiveStruct>;
 #[derive(Debug)]
 pub struct PragmaDirectiveStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub pragma: Pragma,
 }
 
@@ -873,6 +929,7 @@ pub type PrefixExpression = Rc<PrefixExpressionStruct>;
 #[derive(Debug)]
 pub struct PrefixExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression_prefix_expression_operator: Expression_PrefixExpression_Operator,
     pub operand: Expression,
 }
@@ -888,6 +945,7 @@ pub type ReturnStatement = Rc<ReturnStatementStruct>;
 #[derive(Debug)]
 pub struct ReturnStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: Option<Expression>,
 }
 
@@ -902,6 +960,7 @@ pub type RevertStatement = Rc<RevertStatementStruct>;
 #[derive(Debug)]
 pub struct RevertStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub error: IdentifierPath,
     pub arguments: ArgumentsDeclaration,
 }
@@ -917,6 +976,7 @@ pub type ShiftExpression = Rc<ShiftExpressionStruct>;
 #[derive(Debug)]
 pub struct ShiftExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub left_operand: Expression,
     pub expression_shift_expression_operator: Expression_ShiftExpression_Operator,
     pub right_operand: Expression,
@@ -933,6 +993,7 @@ pub type SingleTypedDeclaration = Rc<SingleTypedDeclarationStruct>;
 #[derive(Debug)]
 pub struct SingleTypedDeclarationStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub declaration: VariableDeclaration,
     pub value: Option<Expression>,
 }
@@ -948,6 +1009,7 @@ pub type SourceUnit = Rc<SourceUnitStruct>;
 #[derive(Debug)]
 pub struct SourceUnitStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub members: SourceUnitMembers,
 }
 
@@ -962,6 +1024,7 @@ pub type StateVariableDefinition = Rc<StateVariableDefinitionStruct>;
 #[derive(Debug)]
 pub struct StateVariableDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
     pub name: Identifier,
     pub value: Option<Expression>,
@@ -981,6 +1044,7 @@ pub type StructDefinition = Rc<StructDefinitionStruct>;
 #[derive(Debug)]
 pub struct StructDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub members: StructMembers,
 }
@@ -996,6 +1060,7 @@ pub type StructMember = Rc<StructMemberStruct>;
 #[derive(Debug)]
 pub struct StructMemberStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
     pub name: Identifier,
 }
@@ -1011,6 +1076,7 @@ pub type TryStatement = Rc<TryStatementStruct>;
 #[derive(Debug)]
 pub struct TryStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: Expression,
     pub returns: Option<Parameters>,
     pub body: Block,
@@ -1028,6 +1094,7 @@ pub type TupleExpression = Rc<TupleExpressionStruct>;
 #[derive(Debug)]
 pub struct TupleExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub items: TupleValues,
 }
 
@@ -1042,6 +1109,7 @@ pub type TupleValue = Rc<TupleValueStruct>;
 #[derive(Debug)]
 pub struct TupleValueStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: Option<Expression>,
 }
 
@@ -1056,6 +1124,7 @@ pub type TypeExpression = Rc<TypeExpressionStruct>;
 #[derive(Debug)]
 pub struct TypeExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
 }
 
@@ -1070,6 +1139,7 @@ pub type UncheckedBlock = Rc<UncheckedBlockStruct>;
 #[derive(Debug)]
 pub struct UncheckedBlockStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub block: Block,
 }
 
@@ -1084,6 +1154,7 @@ pub type UserDefinedValueTypeDefinition = Rc<UserDefinedValueTypeDefinitionStruc
 #[derive(Debug)]
 pub struct UserDefinedValueTypeDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub value_type: ElementaryType,
 }
@@ -1099,6 +1170,7 @@ pub type UsingDeconstruction = Rc<UsingDeconstructionStruct>;
 #[derive(Debug)]
 pub struct UsingDeconstructionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub symbols: UsingDeconstructionSymbols,
 }
 
@@ -1113,6 +1185,7 @@ pub type UsingDeconstructionSymbol = Rc<UsingDeconstructionSymbolStruct>;
 #[derive(Debug)]
 pub struct UsingDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: IdentifierPath,
     pub alias: Option<UsingOperator>,
 }
@@ -1128,6 +1201,7 @@ pub type UsingDirective = Rc<UsingDirectiveStruct>;
 #[derive(Debug)]
 pub struct UsingDirectiveStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub clause: UsingClause,
     pub target: UsingTarget,
     pub global_keyword: bool,
@@ -1144,6 +1218,7 @@ pub type VariableDeclaration = Rc<VariableDeclarationStruct>;
 #[derive(Debug)]
 pub struct VariableDeclarationStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
     pub name: Identifier,
@@ -1160,6 +1235,7 @@ pub type VariableDeclarationStatement = Rc<VariableDeclarationStatementStruct>;
 #[derive(Debug)]
 pub struct VariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub target: VariableDeclarationTarget,
 }
 
@@ -1174,6 +1250,7 @@ pub type VersionPragma = Rc<VersionPragmaStruct>;
 #[derive(Debug)]
 pub struct VersionPragmaStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub sets: VersionExpressionSets,
 }
 
@@ -1188,6 +1265,7 @@ pub type VersionRange = Rc<VersionRangeStruct>;
 #[derive(Debug)]
 pub struct VersionRangeStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub start: VersionLiteral,
     pub end: VersionLiteral,
 }
@@ -1203,6 +1281,7 @@ pub type VersionTerm = Rc<VersionTermStruct>;
 #[derive(Debug)]
 pub struct VersionTermStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operator: Option<VersionOperator>,
     pub literal: VersionLiteral,
 }
@@ -1218,6 +1297,7 @@ pub type WhileStatement = Rc<WhileStatementStruct>;
 #[derive(Debug)]
 pub struct WhileStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub condition: Expression,
     pub body: Statement,
 }
@@ -1233,6 +1313,7 @@ pub type YulBlock = Rc<YulBlockStruct>;
 #[derive(Debug)]
 pub struct YulBlockStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub statements: YulStatements,
 }
 
@@ -1247,6 +1328,7 @@ pub type YulBreakStatement = Rc<YulBreakStatementStruct>;
 #[derive(Debug)]
 pub struct YulBreakStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
 }
 
 impl YulBreakStatementStruct {
@@ -1260,6 +1342,7 @@ pub type YulContinueStatement = Rc<YulContinueStatementStruct>;
 #[derive(Debug)]
 pub struct YulContinueStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
 }
 
 impl YulContinueStatementStruct {
@@ -1273,6 +1356,7 @@ pub type YulDefaultCase = Rc<YulDefaultCaseStruct>;
 #[derive(Debug)]
 pub struct YulDefaultCaseStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub body: YulBlock,
 }
 
@@ -1287,6 +1371,7 @@ pub type YulForStatement = Rc<YulForStatementStruct>;
 #[derive(Debug)]
 pub struct YulForStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub initialization: YulBlock,
     pub condition: YulExpression,
     pub iterator: YulBlock,
@@ -1304,6 +1389,7 @@ pub type YulFunctionCallExpression = Rc<YulFunctionCallExpressionStruct>;
 #[derive(Debug)]
 pub struct YulFunctionCallExpressionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub operand: YulExpression,
     pub arguments: YulArguments,
 }
@@ -1319,6 +1405,7 @@ pub type YulFunctionDefinition = Rc<YulFunctionDefinitionStruct>;
 #[derive(Debug)]
 pub struct YulFunctionDefinitionStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub name: Identifier,
     pub parameters: YulParameters,
     pub returns: Option<YulVariableNames>,
@@ -1336,6 +1423,7 @@ pub type YulIfStatement = Rc<YulIfStatementStruct>;
 #[derive(Debug)]
 pub struct YulIfStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub condition: YulExpression,
     pub body: YulBlock,
 }
@@ -1351,6 +1439,7 @@ pub type YulLeaveStatement = Rc<YulLeaveStatementStruct>;
 #[derive(Debug)]
 pub struct YulLeaveStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
 }
 
 impl YulLeaveStatementStruct {
@@ -1364,6 +1453,7 @@ pub type YulSwitchStatement = Rc<YulSwitchStatementStruct>;
 #[derive(Debug)]
 pub struct YulSwitchStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: YulExpression,
     pub cases: YulSwitchCases,
 }
@@ -1379,6 +1469,7 @@ pub type YulValueCase = Rc<YulValueCaseStruct>;
 #[derive(Debug)]
 pub struct YulValueCaseStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub value: YulLiteral,
     pub body: YulBlock,
 }
@@ -1394,6 +1485,7 @@ pub type YulVariableAssignmentStatement = Rc<YulVariableAssignmentStatementStruc
 #[derive(Debug)]
 pub struct YulVariableAssignmentStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub variables: YulPaths,
     pub expression: YulExpression,
 }
@@ -1409,6 +1501,7 @@ pub type YulVariableDeclarationStatement = Rc<YulVariableDeclarationStatementStr
 #[derive(Debug)]
 pub struct YulVariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub variables: YulVariableNames,
     pub value: Option<YulVariableDeclarationValue>,
 }
@@ -1424,6 +1517,7 @@ pub type YulVariableDeclarationValue = Rc<YulVariableDeclarationValueStruct>;
 #[derive(Debug)]
 pub struct YulVariableDeclarationValueStruct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     pub expression: YulExpression,
 }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -17,6 +17,7 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
   #[derive(Debug)]
   pub struct {{ parent_type }}Struct {
     pub(crate) id: NodeId,
+    pub range: Range<usize>,
     {%- for field in sequence.fields %}
       pub {{ field.label | snake_case }}:
       {%- if field.type.kind == "UniqueTerminal" -%}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
@@ -15,11 +15,11 @@ struct FileNodeInfo {
 /// which allows us to efficiently determine which file a node belongs to. This
 /// is by construction of the IR trees and the use of a monotonic
 /// `NodeIdGenerator`.
-pub(super) struct NodeMapper {
+pub(super) struct FileNodeMapper {
     files: Vec<FileNodeInfo>,
 }
 
-impl NodeMapper {
+impl FileNodeMapper {
     pub(super) fn build_from(files: &[impl SemanticFile]) -> Self {
         let mut files: Vec<FileNodeInfo> = files
             .iter()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
@@ -36,7 +36,7 @@ impl FileNodeMapper {
         Self { files }
     }
 
-    pub(super) fn file_id_from_node_id(&self, node_id: NodeId) -> String {
+    pub(super) fn file_id_from_node_id(&self, node_id: NodeId) -> &str {
         let index = match self
             .files
             .binary_search_by_key(&node_id, |file| file.first_node_id)
@@ -48,6 +48,6 @@ impl FileNodeMapper {
                 index - 1
             }
         };
-        self.files[index].file_id.clone()
+        &self.files[index].file_id
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -107,7 +107,7 @@ impl SemanticContext {
 }
 
 impl SemanticContext {
-    pub fn file_id_from_node_id(&self, node_id: NodeId) -> String {
+    pub fn file_id_from_node_id(&self, node_id: NodeId) -> &str {
         self.file_node_mapper.file_id_from_node_id(node_id)
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
-use node_mapper::NodeMapper;
+use file_node_mapper::FileNodeMapper;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
@@ -12,7 +12,7 @@ use crate::passes::{
 };
 use crate::types::{Type, TypeId, TypeRegistry};
 
-mod node_mapper;
+mod file_node_mapper;
 
 /// Trait for files that can be used as input to the semantic analysis passes.
 pub trait SemanticFile {
@@ -52,7 +52,7 @@ pub fn extract_import_paths_from_source_unit(
 pub struct SemanticContext {
     binder: Binder,
     types: TypeRegistry,
-    node_mapper: NodeMapper,
+    file_node_mapper: FileNodeMapper,
 }
 
 impl SemanticContext {
@@ -65,12 +65,12 @@ impl SemanticContext {
         p3_type_definitions::run(files, &mut binder, &mut types);
         p4_resolve_references::run(files, &mut binder, &mut types, language_version);
 
-        let node_mapper = NodeMapper::build_from(files);
+        let file_node_mapper = FileNodeMapper::build_from(files);
 
         Self {
             binder,
             types,
-            node_mapper,
+            file_node_mapper,
         }
     }
 
@@ -108,7 +108,7 @@ impl SemanticContext {
 
 impl SemanticContext {
     pub fn file_id_from_node_id(&self, node_id: NodeId) -> String {
-        self.node_mapper.file_id_from_node_id(node_id)
+        self.file_node_mapper.file_id_from_node_id(node_id)
     }
 
     pub fn resolve_reference_identifier_to_definition_id(&self, node_id: NodeId) -> Option<NodeId> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,15 +1,18 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use node_mapper::NodeMapper;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
 
-use crate::binder::{Binder, Definition, Reference, Scope};
+use crate::binder::{Binder, Definition, Reference};
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
 use crate::types::{Type, TypeId, TypeRegistry};
+
+mod node_mapper;
 
 /// Trait for files that can be used as input to the semantic analysis passes.
 pub trait SemanticFile {
@@ -49,6 +52,7 @@ pub fn extract_import_paths_from_source_unit(
 pub struct SemanticContext {
     binder: Binder,
     types: TypeRegistry,
+    node_mapper: NodeMapper,
 }
 
 impl SemanticContext {
@@ -61,7 +65,13 @@ impl SemanticContext {
         p3_type_definitions::run(files, &mut binder, &mut types);
         p4_resolve_references::run(files, &mut binder, &mut types, language_version);
 
-        Self { binder, types }
+        let node_mapper = NodeMapper::build_from(files);
+
+        Self {
+            binder,
+            types,
+            node_mapper,
+        }
     }
 
     // TODO: this should not be public
@@ -97,12 +107,8 @@ impl SemanticContext {
 }
 
 impl SemanticContext {
-    pub fn node_id_to_file_id(&self, node_id: NodeId) -> Option<String> {
-        let scope_id = self.binder().scope_id_for_node_id(node_id)?;
-        let Scope::File(file_scope) = self.binder().get_scope_by_id(scope_id) else {
-            return None;
-        };
-        Some(file_scope.file_id.clone())
+    pub fn file_id_from_node_id(&self, node_id: NodeId) -> String {
+        self.node_mapper.file_id_from_node_id(node_id)
     }
 
     pub fn resolve_reference_identifier_to_definition_id(&self, node_id: NodeId) -> Option<NodeId> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/node_mapper.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/node_mapper.rs
@@ -1,0 +1,53 @@
+use slang_solidity_v2_common::nodes::NodeId;
+
+use super::SemanticFile;
+
+struct FileNodeInfo {
+    /// File ID to map `NodeId`s to
+    file_id: String,
+    /// `NodeId` of the first node in the file, which should always correspond
+    /// to the ID of the root `SourceUnit` (by construction)
+    first_node_id: NodeId,
+}
+
+/// An ordered collection of file IDs + first `NodeId` of the files a
+/// `SemanticContext` was built from. The order is ascending `first_node_id`
+/// which allows us to efficiently determine which file a node belongs to. This
+/// is by construction of the IR trees and the use of a monotonic
+/// `NodeIdGenerator`.
+pub(super) struct NodeMapper {
+    files: Vec<FileNodeInfo>,
+}
+
+impl NodeMapper {
+    pub(super) fn build_from(files: &[impl SemanticFile]) -> Self {
+        let mut files: Vec<FileNodeInfo> = files
+            .iter()
+            .map(|file| {
+                let file_id = file.id().to_string();
+                let first_node_id = file.ir_root().id();
+                FileNodeInfo {
+                    file_id,
+                    first_node_id,
+                }
+            })
+            .collect();
+        files.sort_by_key(|file| file.first_node_id);
+        Self { files }
+    }
+
+    pub(super) fn file_id_from_node_id(&self, node_id: NodeId) -> String {
+        let index = match self
+            .files
+            .binary_search_by_key(&node_id, |file| file.first_node_id)
+        {
+            Ok(index) => index,
+            Err(index) => {
+                // NB. this cannot possibly underflow because there should be no
+                // valid node before the `SourceUnit` of the first file
+                index - 1
+            }
+        };
+        self.files[index].file_id.clone()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -465,15 +465,13 @@ impl ast::visitor::Visitor for BuiltInCollector {
 }
 
 #[test]
-fn test_get_location() -> Result<()> {
+fn test_get_file_id_and_text_range() -> Result<()> {
     let unit = fixtures::Counter::build_compilation_unit()?;
 
     let ownable = unit
         .find_contract_by_name("Ownable")
         .expect("contract is found");
-
-    let ownable_location = ownable.get_location();
-    assert_eq!(ownable_location.file_id(), "ownable.sol");
+    assert_eq!(ownable.get_file_id(), "ownable.sol");
 
     let owner = ownable
         .members()
@@ -487,25 +485,21 @@ fn test_get_location() -> Result<()> {
         })
         .expect("_owner state variable is found");
     assert_eq!(owner.name().name(), "_owner");
-
-    let owner_location = owner.get_location();
-    assert_eq!(owner_location.file_id(), "ownable.sol");
+    assert_eq!(owner.get_file_id(), "ownable.sol");
 
     // The state variable's range must sit within the enclosing contract's range.
-    assert!(ownable_location.text_range().start <= owner_location.text_range().start);
-    assert!(ownable_location.text_range().end >= owner_location.text_range().end);
+    assert!(ownable.get_text_range().start <= owner.get_text_range().start);
+    assert!(ownable.get_text_range().end >= owner.get_text_range().end);
 
     let activatable = unit
         .find_contract_by_name("Activatable")
         .expect("contract is found");
-    let activatable_location = activatable.get_location();
-    assert_eq!(activatable_location.file_id(), "activatable.sol");
+    assert_eq!(activatable.get_file_id(), "activatable.sol");
 
     let counter = unit
         .find_contract_by_name("Counter")
         .expect("contract is found");
-    let counter_location = counter.get_location();
-    assert_eq!(counter_location.file_id(), "main.sol");
+    assert_eq!(counter.get_file_id(), "main.sol");
 
     Ok(())
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -463,3 +463,49 @@ impl ast::visitor::Visitor for BuiltInCollector {
         }
     }
 }
+
+#[test]
+fn test_get_location() -> Result<()> {
+    let unit = fixtures::Counter::build_compilation_unit()?;
+
+    let ownable = unit
+        .find_contract_by_name("Ownable")
+        .expect("contract is found");
+
+    let ownable_location = ownable.get_location();
+    assert_eq!(ownable_location.file_id(), "ownable.sol");
+
+    let owner = ownable
+        .members()
+        .iter()
+        .find_map(|member| {
+            if let ast::ContractMember::StateVariableDefinition(definition) = member {
+                Some(definition)
+            } else {
+                None
+            }
+        })
+        .expect("_owner state variable is found");
+    assert_eq!(owner.name().name(), "_owner");
+
+    let owner_location = owner.get_location();
+    assert_eq!(owner_location.file_id(), "ownable.sol");
+
+    // The state variable's range must sit within the enclosing contract's range.
+    assert!(ownable_location.text_range().start <= owner_location.text_range().start);
+    assert!(ownable_location.text_range().end >= owner_location.text_range().end);
+
+    let activatable = unit
+        .find_contract_by_name("Activatable")
+        .expect("contract is found");
+    let activatable_location = activatable.get_location();
+    assert_eq!(activatable_location.file_id(), "activatable.sol");
+
+    let counter = unit
+        .find_contract_by_name("Counter")
+        .expect("contract is found");
+    let counter_location = counter.get_location();
+    assert_eq!(counter_location.file_id(), "main.sol");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a `get_location()` getter to sequence and terminal AST nodes, which have `file_id()` and `text_range()` available.

This information is extracted from the CST nodes and copied over to the IR nodes when building. For this reason both cycles/instructions count and memory usage are expected to increase by these changes.

