### PR TITLE
[v2] Narrow literal typing and constant folding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,6 +4067,7 @@ name = "slang_solidity_v2_ast"
 version = "1.3.5"
 dependencies = [
  "num-bigint",
+ "num-rational",
  "paste",
  "sha3 0.11.0",
  "slang_solidity_v2_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,6 +4066,7 @@ dependencies = [
 name = "slang_solidity_v2_ast"
 version = "1.3.5"
 dependencies = [
+ "num-bigint",
  "paste",
  "sha3 0.11.0",
  "slang_solidity_v2_common",
@@ -4116,6 +4117,7 @@ version = "1.3.5"
 dependencies = [
  "indexmap",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "indexmap",
  "num-bigint",
  "num-integer",
+ "num-rational",
  "num-traits",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ nom = { version = "8.0.0" }
 num-bigint = { version = "0.4.6" }
 num-format = { version = "0.4.4" }
 num-integer = { version = "0.1.46" }
+num-rational = { version = "0.4.2" }
 num-traits = { version = "0.2.18" }
 paste = { version = "1.0.15" }
 proc-macro2 = { version = "1.0.106" }

--- a/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+num-bigint = { workspace = true }
 paste = { workspace = true }
 sha3 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["compilers", "utilities"]
 
 [dependencies]
 num-bigint = { workspace = true }
+num-rational = { workspace = true }
 paste = { workspace = true }
 sha3 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -131,6 +131,8 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_ast::abi::StorageIt
 pub fn slang_solidity_v2_ast::abi::selector_from_signature(signature: &str) -> u32
 pub type slang_solidity_v2_ast::abi::AbiMutability = slang_solidity_v2_semantic::types::FunctionMutability
 pub mod slang_solidity_v2_ast::ast
+pub use slang_solidity_v2_ast::ast::LiteralKind
+pub use slang_solidity_v2_ast::ast::Number
 pub mod slang_solidity_v2_ast::ast::visitor
 pub trait slang_solidity_v2_ast::ast::visitor::Visitor
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_abicoder_pragma(&mut self, _node: &slang_solidity_v2_ast::ast::AbicoderPragma) -> bool
@@ -1272,6 +1274,10 @@ pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::get_type(&self
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::literal(&self) -> slang_solidity_v2_ast::ast::DecimalLiteral
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::unit(&self) -> core::option::Option<slang_solidity_v2_ast::ast::NumberUnit>
+impl slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct
+pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::integer_value(&self) -> core::option::Option<num_bigint::bigint::BigInt>
+pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::number_value(&self) -> core::option::Option<slang_solidity_v2_semantic::types::literals::numbers::Number>
+pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::rational_value(&self) -> core::option::Option<num_rational::BigRational>
 pub struct slang_solidity_v2_ast::ast::DeleteKeywordStruct
 impl slang_solidity_v2_ast::ast::DeleteKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_file_id(&self) -> &str
@@ -1522,6 +1528,9 @@ pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_text_range(&se
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::literal(&self) -> slang_solidity_v2_ast::ast::HexLiteral
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl slang_solidity_v2_ast::ast::HexNumberExpressionStruct
+pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::integer_value(&self) -> core::option::Option<num_bigint::bigint::BigInt>
+pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::number_value(&self) -> core::option::Option<slang_solidity_v2_semantic::types::literals::numbers::Number>
 pub struct slang_solidity_v2_ast::ast::HexStringLiteralStruct
 impl slang_solidity_v2_ast::ast::HexStringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_file_id(&self) -> &str
@@ -1534,6 +1543,8 @@ impl slang_solidity_v2_ast::ast::HexStringLiteralsStruct
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralsStruct::is_empty(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralsStruct::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::HexStringLiteral> + use<'_>
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralsStruct::len(&self) -> usize
+impl slang_solidity_v2_ast::ast::HexStringLiteralsStruct
+pub fn slang_solidity_v2_ast::ast::HexStringLiteralsStruct::value(&self) -> alloc::vec::Vec<u8>
 pub struct slang_solidity_v2_ast::ast::HoursKeywordStruct
 impl slang_solidity_v2_ast::ast::HoursKeywordStruct
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_file_id(&self) -> &str
@@ -2098,6 +2109,8 @@ impl slang_solidity_v2_ast::ast::StringLiteralsStruct
 pub fn slang_solidity_v2_ast::ast::StringLiteralsStruct::is_empty(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::StringLiteralsStruct::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::StringLiteral> + use<'_>
 pub fn slang_solidity_v2_ast::ast::StringLiteralsStruct::len(&self) -> usize
+impl slang_solidity_v2_ast::ast::StringLiteralsStruct
+pub fn slang_solidity_v2_ast::ast::StringLiteralsStruct::value(&self) -> alloc::vec::Vec<u8>
 pub struct slang_solidity_v2_ast::ast::StructDefinitionStruct
 impl slang_solidity_v2_ast::ast::StructDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
@@ -2218,6 +2231,8 @@ impl slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct::is_empty(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::UnicodeStringLiteral> + use<'_>
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct::len(&self) -> usize
+impl slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct
+pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralsStruct::value(&self) -> alloc::vec::Vec<u8>
 pub struct slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct
 impl slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
@@ -12,7 +12,7 @@ mod references;
 pub use references::Reference;
 
 mod types;
-pub use types::{LiteralKind, Type};
+pub use types::{LiteralKind, Number, Type};
 
 #[path = "visitor.generated.rs"]
 pub mod visitor;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
@@ -12,7 +12,7 @@ mod references;
 pub use references::Reference;
 
 mod types;
-pub use types::Type;
+pub use types::{LiteralKind, Type};
 
 #[path = "visitor.generated.rs"]
 pub mod visitor;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
@@ -2,32 +2,31 @@ use num_bigint::BigInt;
 use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use slang_solidity_v2_semantic::types::{LiteralKind, Type};
+use slang_solidity_v2_semantic::types::{Number, Type};
 
-/// Returns the integer value carried by a number-literal node's type, when
-/// the type is an integer-shaped literal. Rational literals return `None`.
-pub(crate) fn integer_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<BigInt> {
+/// Returns the literal number carried by a node's type, when the type is a
+/// number-shaped literal kind (integer, hex-integer, or rational).
+pub(crate) fn number_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<Number> {
     let type_id = semantic.binder().node_typing(node_id).as_type_id()?;
     match semantic.types().get_type_by_id(type_id) {
-        Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
-            Some(value.clone())
-        }
+        Type::Literal(kind) => Number::from_literal_kind(kind),
         _ => None,
     }
 }
 
-/// Returns the rational value carried by a number-literal node's type. Integer
-/// literals are returned as a rational with denominator one.
+pub(crate) fn integer_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<BigInt> {
+    match number_value_of_node(semantic, node_id)? {
+        Number::Integer(value) => Some(value),
+        Number::Rational(_) => None,
+    }
+}
+
 pub(crate) fn rational_value_of_node(
     semantic: &SemanticContext,
     node_id: NodeId,
 ) -> Option<BigRational> {
-    let type_id = semantic.binder().node_typing(node_id).as_type_id()?;
-    match semantic.types().get_type_by_id(type_id) {
-        Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
-            Some(BigRational::from(value.clone()))
-        }
-        Type::Literal(LiteralKind::Rational(value)) => Some(value.clone()),
-        _ => None,
+    match number_value_of_node(semantic, node_id)? {
+        Number::Integer(value) => Some(BigRational::from(value)),
+        Number::Rational(value) => Some(value),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
@@ -1,0 +1,33 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_semantic::context::SemanticContext;
+use slang_solidity_v2_semantic::types::{LiteralKind, Type};
+
+/// Returns the integer value carried by a number-literal node's type, when
+/// the type is an integer-shaped literal. Rational literals return `None`.
+pub(crate) fn integer_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<BigInt> {
+    let type_id = semantic.binder().node_typing(node_id).as_type_id()?;
+    match semantic.types().get_type_by_id(type_id) {
+        Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
+            Some(value.clone())
+        }
+        _ => None,
+    }
+}
+
+/// Returns the rational value carried by a number-literal node's type. Integer
+/// literals are returned as a rational with denominator one.
+pub(crate) fn rational_value_of_node(
+    semantic: &SemanticContext,
+    node_id: NodeId,
+) -> Option<BigRational> {
+    let type_id = semantic.binder().node_typing(node_id).as_type_id()?;
+    match semantic.types().get_type_by_id(type_id) {
+        Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
+            Some(BigRational::from(value.clone()))
+        }
+        Type::Literal(LiteralKind::Rational(value)) => Some(value.clone()),
+        _ => None,
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/common.rs
@@ -2,16 +2,13 @@ use num_bigint::BigInt;
 use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use slang_solidity_v2_semantic::types::{Number, Type};
+use slang_solidity_v2_semantic::types::Number;
 
 /// Returns the literal number carried by a node's type, when the type is a
 /// number-shaped literal kind (integer, hex-integer, or rational).
 pub(crate) fn number_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<Number> {
     let type_id = semantic.binder().node_typing(node_id).as_type_id()?;
-    match semantic.types().get_type_by_id(type_id) {
-        Type::Literal(kind) => Number::from_literal_kind(kind),
-        _ => None,
-    }
+    semantic.types().number_value_of_type_id(type_id)
 }
 
 pub(crate) fn integer_value_of_node(semantic: &SemanticContext, node_id: NodeId) -> Option<BigInt> {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
@@ -1,8 +1,9 @@
 use num_bigint::BigInt;
 use num_rational::BigRational;
+use slang_solidity_v2_semantic::types::Number;
 
 use super::super::DecimalNumberExpressionStruct;
-use super::common::{integer_value_of_node, rational_value_of_node};
+use super::common::{integer_value_of_node, number_value_of_node, rational_value_of_node};
 
 impl DecimalNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` for rationals
@@ -16,5 +17,11 @@ impl DecimalNumberExpressionStruct {
     /// denominator one.
     pub fn rational_value(&self) -> Option<BigRational> {
         rational_value_of_node(&self.semantic, self.ir_node.id())
+    }
+
+    /// Returns the literal number carried by this node's type, preserving the
+    /// integer-vs-rational distinction.
+    pub fn number_value(&self) -> Option<Number> {
+        number_value_of_node(&self.semantic, self.ir_node.id())
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
@@ -1,0 +1,12 @@
+use num_bigint::BigInt;
+use slang_solidity_v2_semantic::types::integer_value_of_decimal_number_expression;
+
+use super::super::DecimalNumberExpressionStruct;
+
+impl DecimalNumberExpressionStruct {
+    /// Returns the integer value of this literal, or `None` for rationals
+    /// that do not reduce to an integer after unit multiplication.
+    pub fn integer_value(&self) -> Option<BigInt> {
+        integer_value_of_decimal_number_expression(&self.ir_node)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/decimal_number_expression.rs
@@ -1,12 +1,20 @@
 use num_bigint::BigInt;
-use slang_solidity_v2_semantic::types::integer_value_of_decimal_number_expression;
+use num_rational::BigRational;
 
 use super::super::DecimalNumberExpressionStruct;
+use super::common::{integer_value_of_node, rational_value_of_node};
 
 impl DecimalNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` for rationals
     /// that do not reduce to an integer after unit multiplication.
     pub fn integer_value(&self) -> Option<BigInt> {
-        integer_value_of_decimal_number_expression(&self.ir_node)
+        integer_value_of_node(&self.semantic, self.ir_node.id())
+    }
+
+    /// Returns the rational value of this literal, or `None` if the literal
+    /// cannot be evaluated. Integer literals lift to a rational with
+    /// denominator one.
+    pub fn rational_value(&self) -> Option<BigRational> {
+        rational_value_of_node(&self.semantic, self.ir_node.id())
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
@@ -1,12 +1,12 @@
 use num_bigint::BigInt;
-use slang_solidity_v2_semantic::types::integer_value_of_hex_number_expression;
 
 use super::super::HexNumberExpressionStruct;
+use super::common::integer_value_of_node;
 
 impl HexNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` if the literal
     /// cannot be evaluated (e.g. a malformed hex digit sequence).
     pub fn integer_value(&self) -> Option<BigInt> {
-        integer_value_of_hex_number_expression(&self.ir_node)
+        integer_value_of_node(&self.semantic, self.ir_node.id())
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
@@ -1,0 +1,12 @@
+use num_bigint::BigInt;
+use slang_solidity_v2_semantic::types::integer_value_of_hex_number_expression;
+
+use super::super::HexNumberExpressionStruct;
+
+impl HexNumberExpressionStruct {
+    /// Returns the integer value of this literal, or `None` if the literal
+    /// cannot be evaluated (e.g. a malformed hex digit sequence).
+    pub fn integer_value(&self) -> Option<BigInt> {
+        integer_value_of_hex_number_expression(&self.ir_node)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/hex_number_expression.rs
@@ -1,12 +1,19 @@
 use num_bigint::BigInt;
+use slang_solidity_v2_semantic::types::Number;
 
 use super::super::HexNumberExpressionStruct;
-use super::common::integer_value_of_node;
+use super::common::{integer_value_of_node, number_value_of_node};
 
 impl HexNumberExpressionStruct {
     /// Returns the integer value of this literal, or `None` if the literal
     /// cannot be evaluated (e.g. a malformed hex digit sequence).
     pub fn integer_value(&self) -> Option<BigInt> {
         integer_value_of_node(&self.semantic, self.ir_node.id())
+    }
+
+    /// Returns the literal number carried by this node's type. Hex number
+    /// expressions only ever fold to integers.
+    pub fn number_value(&self) -> Option<Number> {
+        number_value_of_node(&self.semantic, self.ir_node.id())
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -1,6 +1,8 @@
 mod contract_base;
 mod contract_definition;
 mod contract_members;
+mod decimal_number_expression;
+mod hex_number_expression;
 mod interface_definition;
 pub use contract_base::ContractBase;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -1,3 +1,5 @@
+mod common;
+
 mod contract_base;
 mod contract_definition;
 mod contract_members;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/string_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/string_expression.rs
@@ -1,300 +1,33 @@
+use slang_solidity_v2_semantic::types::literals;
+
 use super::super::StringExpression;
+use crate::ast::{HexStringLiteralsStruct, StringLiteralsStruct, UnicodeStringLiteralsStruct};
 
 impl StringExpression {
     /// Returns the concatenated decoded string value as bytes.
-    ///
-    /// Handles all three variants:
-    /// - `StringLiterals` — strips quotes, decodes escape sequences, returns
-    ///   the decoded bytes
-    /// - `HexStringLiterals` — strips `hex"..."`, decodes hex pairs to bytes
-    /// - `UnicodeStringLiterals` — strips `unicode"..."`, decodes escape
-    ///   sequences, returns UTF-8 bytes
-    ///
-    /// Escape sequences decoded for string and unicode-string variants:
-    /// `\n`, `\r`, `\t`, `\'`, `\"`, `\\`, line continuations (`\<LF>`,
-    /// `\<CR>`, `\<CRLF>`), `\xNN` (hex byte), and `\uNNNN` (Unicode code
-    /// point, UTF-8 encoded).
     pub fn value(&self) -> Vec<u8> {
-        // TODO: this implementation should live in the semantic crate to be
-        // used by the typing pass. This is required for example to check for
-        // valid implicit conversion of a string into a bytesXX array.
-        let mut result = Vec::new();
         match self {
-            StringExpression::StringLiterals(terminals) => {
-                for terminal in terminals.iter() {
-                    let content = strip_prefix_and_quotes(terminal.unparse(), "");
-                    result.extend(decode_escape_sequences(content));
-                }
-            }
-            StringExpression::HexStringLiterals(terminals) => {
-                for terminal in terminals.iter() {
-                    let content = strip_prefix_and_quotes(terminal.unparse(), "hex");
-                    result.extend(decode_hex_string(content));
-                }
-            }
-            StringExpression::UnicodeStringLiterals(terminals) => {
-                for terminal in terminals.iter() {
-                    let content = strip_prefix_and_quotes(terminal.unparse(), "unicode");
-                    result.extend(decode_escape_sequences(content));
-                }
-            }
+            StringExpression::StringLiterals(literals) => literals.value(),
+            StringExpression::HexStringLiterals(literals) => literals.value(),
+            StringExpression::UnicodeStringLiterals(literals) => literals.value(),
         }
-        result
     }
 }
 
-fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
-    text.strip_prefix(prefix)
-        .and_then(|stripped| {
-            stripped
-                .strip_prefix('"')
-                .and_then(|s| s.strip_suffix('"'))
-                .or_else(|| {
-                    stripped
-                        .strip_prefix('\'')
-                        .and_then(|s| s.strip_suffix('\''))
-                })
-        })
-        .expect("string prefix mismatch or not quoted")
+impl StringLiteralsStruct {
+    pub fn value(&self) -> Vec<u8> {
+        literals::value_of_string_literals(&self.ir_nodes)
+    }
 }
 
-fn decode_hex_string(content: &str) -> Vec<u8> {
-    let mut result = Vec::with_capacity(content.len() / 2);
-    let mut i = 0usize;
-    while i < content.len() {
-        // Decode pairs of hex digits skipping over underscore separators
-        if content.as_bytes()[i] == b'_' {
-            i += 1;
-        }
-        // Parser grammar guarantees that we have at least 2 more digits
-        result.push(u8::from_str_radix(&content[i..i + 2], 16).unwrap());
-        i += 2;
+impl HexStringLiteralsStruct {
+    pub fn value(&self) -> Vec<u8> {
+        literals::value_of_hex_string_literals(&self.ir_nodes)
     }
-    result
 }
 
-fn decode_escape_sequences(content: &str) -> Vec<u8> {
-    let mut out = Vec::with_capacity(content.len());
-    let mut buf = [0u8; 4];
-    let mut chars = content.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
-            continue;
-        }
-        // Grammar guarantees at least one char after backslash; if input
-        // is malformed we just stop.
-        let next = chars.next().expect("unterminated escape sequence");
-        match next {
-            'n' => out.push(b'\n'),
-            'r' => out.push(b'\r'),
-            't' => out.push(b'\t'),
-            '\'' => out.push(b'\''),
-            '"' => out.push(b'"'),
-            '\\' => out.push(b'\\'),
-            // Line continuation: `\<CR>`, `\<CRLF>`, `\<LF>` all decode to empty.
-            '\r' => {
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
-                }
-            }
-            '\n' => {}
-            'x' => {
-                let h1 = chars.next().unwrap();
-                let h2 = chars.next().unwrap();
-                let hex: String = [h1, h2].iter().collect();
-                out.push(u8::from_str_radix(&hex, 16).unwrap());
-            }
-            'u' => {
-                let h1 = chars.next().unwrap();
-                let h2 = chars.next().unwrap();
-                let h3 = chars.next().unwrap();
-                let h4 = chars.next().unwrap();
-                let hex: String = [h1, h2, h3, h4].iter().collect();
-                let code_point = u32::from_str_radix(&hex, 16).unwrap();
-                // `\uNNNN` code points in the surrogate range (0xD800..=0xDFFF)
-                // are not valid Unicode scalars; skip them silently.
-                if let Some(ch) = char::from_u32(code_point) {
-                    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
-                }
-                // TODO(validation): emit an error/warning if the unicode scalar
-                // is not valid
-            }
-            other => {
-                // Grammar should prevent unknown escape chars, but pass
-                // them through verbatim as a defensive fallback.
-                out.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
-            }
-        }
-    }
-    out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{decode_escape_sequences, decode_hex_string, strip_prefix_and_quotes};
-
-    // ----- decode_hex_string ------
-
-    #[test]
-    fn decode_hex_string_no_underscores() {
-        assert_eq!(decode_hex_string("303132"), b"012");
-    }
-
-    #[test]
-    fn decode_hex_string_with_underscores() {
-        assert_eq!(decode_hex_string("30_31_32"), b"012");
-    }
-
-    // ----- decode_escape_sequences -----
-
-    #[test]
-    fn decode_empty() {
-        assert_eq!(decode_escape_sequences(""), Vec::<u8>::new());
-    }
-
-    #[test]
-    fn decode_no_escapes() {
-        assert_eq!(decode_escape_sequences("hello"), b"hello");
-    }
-
-    #[test]
-    fn decode_ascii_escapes() {
-        assert_eq!(decode_escape_sequences(r"\n"), b"\n");
-        assert_eq!(decode_escape_sequences(r"\r"), b"\r");
-        assert_eq!(decode_escape_sequences(r"\t"), b"\t");
-        assert_eq!(decode_escape_sequences(r"\'"), b"'");
-        assert_eq!(decode_escape_sequences(r#"\""#), b"\"");
-        assert_eq!(decode_escape_sequences(r"\\"), b"\\");
-    }
-
-    #[test]
-    fn decode_mixed_text_and_escapes() {
-        assert_eq!(
-            decode_escape_sequences(r"hello\tworld\n"),
-            b"hello\tworld\n",
-        );
-    }
-
-    #[test]
-    fn decode_multiple_ascii_escapes() {
-        assert_eq!(
-            decode_escape_sequences(r#"\t\n\r\'\"\\"#),
-            &[0x09, 0x0a, 0x0d, 0x27, 0x22, 0x5c]
-        );
-    }
-
-    #[test]
-    fn decode_line_continuation_lf() {
-        // Backslash followed by raw LF → empty.
-        assert_eq!(decode_escape_sequences("a\\\nb"), b"ab");
-    }
-
-    #[test]
-    fn decode_line_continuation_cr() {
-        // Backslash followed by raw CR → empty.
-        assert_eq!(decode_escape_sequences("a\\\rb"), b"ab");
-    }
-
-    #[test]
-    fn decode_line_continuation_crlf() {
-        // Backslash followed by raw CRLF → empty (CR and LF both consumed).
-        assert_eq!(decode_escape_sequences("a\\\r\nb"), b"ab");
-    }
-
-    #[test]
-    fn decode_hex_byte_escape() {
-        assert_eq!(decode_escape_sequences(r"\x41"), b"A");
-        assert_eq!(decode_escape_sequences(r"\xff"), &[0xffu8]);
-        assert_eq!(decode_escape_sequences(r"\x00"), &[0x00u8]);
-    }
-
-    #[test]
-    fn decode_unicode_escape_ascii() {
-        // U+0041 → 'A' (single UTF-8 byte).
-        assert_eq!(decode_escape_sequences(r"\u0041"), b"A");
-    }
-
-    #[test]
-    fn decode_unicode_escape_multibyte() {
-        // U+00E9 é → 0xC3 0xA9.
-        assert_eq!(decode_escape_sequences(r"\u00e9"), &[0xC3, 0xA9]);
-        // U+2713 ✓ → 0xE2 0x9C 0x93.
-        assert_eq!(decode_escape_sequences(r"\u2713"), &[0xE2, 0x9C, 0x93]);
-    }
-
-    #[test]
-    fn decode_unicode_escape_combined_multibyte() {
-        // Dollar sign
-        assert_eq!(decode_escape_sequences(r"aaa\u0024aaa"), b"aaa$aaa");
-        // Cent
-        assert_eq!(decode_escape_sequences(r"aaa\u00A2aaa"), b"aaa\xc2\xa2aaa");
-        // Euro
-        assert_eq!(
-            decode_escape_sequences(r"aaa\u20ACaaa"),
-            b"aaa\xe2\x82\xacaaa"
-        );
-        // All combined
-        assert_eq!(
-            decode_escape_sequences(r"\u0024\u00A2\u20AC"),
-            b"$\xc2\xa2\xe2\x82\xac"
-        );
-    }
-
-    #[test]
-    fn decode_unicode_escape_surrogate_skipped() {
-        // Lone surrogate 0xD800 is not a valid Unicode scalar → skipped.
-        assert_eq!(decode_escape_sequences(r"\ud800"), Vec::<u8>::new());
-    }
-
-    #[test]
-    fn decode_raw_non_ascii_passthrough() {
-        // Raw multibyte input (legal in unicode strings) passes through as
-        // its UTF-8 encoding.
-        assert_eq!(decode_escape_sequences("ñ"), &[0xC3, 0xB1]);
-    }
-
-    // ----- strip_prefix_and_quotes -----
-
-    #[test]
-    fn strip_double_quotes_no_prefix() {
-        assert_eq!(strip_prefix_and_quotes(r#""hello""#, ""), "hello");
-    }
-
-    #[test]
-    fn strip_single_quotes_no_prefix() {
-        assert_eq!(strip_prefix_and_quotes("'hello'", ""), "hello");
-    }
-
-    #[test]
-    fn strip_hex_prefix_double_quotes() {
-        assert_eq!(strip_prefix_and_quotes(r#"hex"414243""#, "hex"), "414243");
-    }
-
-    #[test]
-    fn strip_hex_prefix_single_quotes() {
-        assert_eq!(strip_prefix_and_quotes("hex'414243'", "hex"), "414243");
-    }
-
-    #[test]
-    fn strip_unicode_prefix() {
-        assert_eq!(strip_prefix_and_quotes(r#"unicode"ñ""#, "unicode"), "ñ");
-    }
-
-    #[test]
-    fn strip_empty_content() {
-        assert_eq!(strip_prefix_and_quotes(r#""""#, ""), "");
-    }
-
-    #[test]
-    #[should_panic(expected = "string prefix mismatch or not quoted")]
-    fn strip_panics_when_not_quoted() {
-        strip_prefix_and_quotes("unquoted", "");
-    }
-
-    #[test]
-    #[should_panic(expected = "string prefix mismatch or not quoted")]
-    fn strip_panics_on_prefix_mismatch() {
-        strip_prefix_and_quotes("hex'1234'", "unicode");
+impl UnicodeStringLiteralsStruct {
+    pub fn value(&self) -> Vec<u8> {
+        literals::value_of_unicode_string_literals(&self.ir_nodes)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -3,10 +3,10 @@ use std::rc::Rc;
 use paste::paste;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::context::SemanticContext;
-pub use slang_solidity_v2_semantic::types::LiteralKind;
 use slang_solidity_v2_semantic::types::{
     self, DataLocation, FunctionMutability, FunctionVisibility, TypeId,
 };
+pub use slang_solidity_v2_semantic::types::{LiteralKind, Number};
 
 use super::Definition;
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use paste::paste;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::context::SemanticContext;
+pub use slang_solidity_v2_semantic::types::LiteralKind;
 use slang_solidity_v2_semantic::types::{
     self, DataLocation, FunctionMutability, FunctionVisibility, TypeId,
 };
@@ -324,7 +325,15 @@ impl InterfaceType {
     }
 }
 
-impl LiteralType {}
+impl LiteralType {
+    /// Returns the narrowed kind of this literal type.
+    pub fn kind(&self) -> LiteralKind {
+        let types::Type::Literal(kind) = self.internal_type() else {
+            unreachable!("LiteralType wraps a literal variant by construction")
+        };
+        kind.clone()
+    }
+}
 
 impl MappingType {
     pub fn key_type(&self) -> Type {

--- a/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["compilers", "utilities"]
 [dependencies]
 indexmap = { workspace = true }
 num-bigint = { workspace = true }
+num-integer = { workspace = true }
 num-traits = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["compilers", "utilities"]
 indexmap = { workspace = true }
 num-bigint = { workspace = true }
 num-integer = { workspace = true }
+num-rational = { workspace = true }
 num-traits = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -281,6 +281,10 @@ pub fn slang_solidity_v2_semantic::context::SemanticFile::ir_root(&self) -> &sla
 pub fn slang_solidity_v2_semantic::context::SemanticFile::resolved_import_by_node_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&alloc::string::String>
 pub fn slang_solidity_v2_semantic::context::extract_import_paths_from_source_unit(source_unit: &slang_solidity_v2_ir::ir::nodes::SourceUnit) -> alloc::vec::Vec<(slang_solidity_v2_common::nodes::NodeId, alloc::string::String)>
 pub mod slang_solidity_v2_semantic::types
+pub mod slang_solidity_v2_semantic::types::literals
+pub fn slang_solidity_v2_semantic::types::literals::value_of_hex_string_literals(literals: &[slang_solidity_v2_ir::ir::nodes::HexStringLiteral]) -> alloc::vec::Vec<u8>
+pub fn slang_solidity_v2_semantic::types::literals::value_of_string_literals(literals: &[slang_solidity_v2_ir::ir::nodes::StringLiteral]) -> alloc::vec::Vec<u8>
+pub fn slang_solidity_v2_semantic::types::literals::value_of_unicode_string_literals(literals: &[slang_solidity_v2_ir::ir::nodes::UnicodeStringLiteral]) -> alloc::vec::Vec<u8>
 pub enum slang_solidity_v2_semantic::types::DataLocation
 pub slang_solidity_v2_semantic::types::DataLocation::Calldata
 pub slang_solidity_v2_semantic::types::DataLocation::Inherited
@@ -339,15 +343,17 @@ impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionVisibilit
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionVisibility
 pub enum slang_solidity_v2_semantic::types::LiteralKind
 pub slang_solidity_v2_semantic::types::LiteralKind::Address
-pub slang_solidity_v2_semantic::types::LiteralKind::DecimalInteger
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::bytes: u32
+pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::value: num_bigint::bigint::BigInt
 pub slang_solidity_v2_semantic::types::LiteralKind::HexString
-pub slang_solidity_v2_semantic::types::LiteralKind::HexString::bytes: u32
+pub slang_solidity_v2_semantic::types::LiteralKind::HexString::bytes: usize
+pub slang_solidity_v2_semantic::types::LiteralKind::Integer
+pub slang_solidity_v2_semantic::types::LiteralKind::Integer::value: num_bigint::bigint::BigInt
 pub slang_solidity_v2_semantic::types::LiteralKind::Rational
+pub slang_solidity_v2_semantic::types::LiteralKind::Rational::value: num_rational::BigRational
 pub slang_solidity_v2_semantic::types::LiteralKind::String
-pub slang_solidity_v2_semantic::types::LiteralKind::String::bytes: u32
-pub slang_solidity_v2_semantic::types::LiteralKind::Zero
+pub slang_solidity_v2_semantic::types::LiteralKind::String::bytes: usize
 impl core::clone::Clone for slang_solidity_v2_semantic::types::LiteralKind
 pub fn slang_solidity_v2_semantic::types::LiteralKind::clone(&self) -> slang_solidity_v2_semantic::types::LiteralKind
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::LiteralKind
@@ -358,6 +364,20 @@ pub fn slang_solidity_v2_semantic::types::LiteralKind::fmt(&self, f: &mut core::
 impl core::hash::Hash for slang_solidity_v2_semantic::types::LiteralKind
 pub fn slang_solidity_v2_semantic::types::LiteralKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::LiteralKind
+pub enum slang_solidity_v2_semantic::types::Number
+pub slang_solidity_v2_semantic::types::Number::Integer(num_bigint::bigint::BigInt)
+pub slang_solidity_v2_semantic::types::Number::Rational(num_rational::BigRational)
+impl slang_solidity_v2_semantic::types::Number
+pub fn slang_solidity_v2_semantic::types::Number::from_literal_kind(kind: &slang_solidity_v2_semantic::types::LiteralKind) -> core::option::Option<Self>
+pub fn slang_solidity_v2_semantic::types::Number::is_negative(&self) -> bool
+pub fn slang_solidity_v2_semantic::types::Number::is_zero(&self) -> bool
+impl core::clone::Clone for slang_solidity_v2_semantic::types::Number
+pub fn slang_solidity_v2_semantic::types::Number::clone(&self) -> slang_solidity_v2_semantic::types::Number
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::Number
+pub fn slang_solidity_v2_semantic::types::Number::eq(&self, other: &slang_solidity_v2_semantic::types::Number) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::Number
+pub fn slang_solidity_v2_semantic::types::Number::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Number
 pub enum slang_solidity_v2_semantic::types::Type
 pub slang_solidity_v2_semantic::types::Type::Address
 pub slang_solidity_v2_semantic::types::Type::Address::payable: bool
@@ -404,8 +424,10 @@ pub slang_solidity_v2_semantic::types::Type::Void
 impl slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::can_return_from_getter(&self) -> bool
 pub fn slang_solidity_v2_semantic::types::Type::data_location(&self) -> core::option::Option<slang_solidity_v2_semantic::types::DataLocation>
+pub fn slang_solidity_v2_semantic::types::Type::is_contract_or_interface(&self) -> bool
 pub fn slang_solidity_v2_semantic::types::Type::is_inherited_location(&self) -> bool
 pub fn slang_solidity_v2_semantic::types::Type::is_literal_number(&self) -> bool
+pub fn slang_solidity_v2_semantic::types::Type::number_value(&self) -> core::option::Option<slang_solidity_v2_semantic::types::Number>
 impl slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::from_bytes_keyword(keyword: &str, data_location: core::option::Option<slang_solidity_v2_semantic::types::DataLocation>) -> core::option::Option<Self>
 pub fn slang_solidity_v2_semantic::types::Type::from_fixed_keyword(keyword: &str) -> Self
@@ -456,6 +478,7 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Ty
 pub struct slang_solidity_v2_semantic::types::TypeRegistry
 impl slang_solidity_v2_semantic::types::TypeRegistry
 pub fn slang_solidity_v2_semantic::types::TypeRegistry::get_type_by_id(&self, type_id: slang_solidity_v2_semantic::types::TypeId) -> &slang_solidity_v2_semantic::types::Type
+pub fn slang_solidity_v2_semantic::types::TypeRegistry::number_value_of_type_id(&self, type_id: slang_solidity_v2_semantic::types::TypeId) -> core::option::Option<slang_solidity_v2_semantic::types::Number>
 pub fn slang_solidity_v2_semantic::types::TypeRegistry::type_id_is_function_and_overrides(&self, type_id: slang_solidity_v2_semantic::types::TypeId, other_type_id: slang_solidity_v2_semantic::types::TypeId) -> bool
 impl core::default::Default for slang_solidity_v2_semantic::types::TypeRegistry
 pub fn slang_solidity_v2_semantic::types::TypeRegistry::default() -> Self

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -47,6 +47,7 @@ pub struct ContractDefinition {
     pub ir_node: ir::ContractDefinition,
     pub bases: Option<Vec<NodeId>>,
     pub(crate) constructor_parameters_scope_id: Option<ScopeId>,
+    // TODO: this should be `Option<u256>`
     pub base_slot: Option<usize>,
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, ImportDefinition, Reference, Resolution, ScopeId};
@@ -65,4 +66,58 @@ pub(super) fn resolve_identifier_path_in_scope(
         last_resolution = resolution;
     }
     last_resolution
+}
+
+/// Since `StringExpression` nodes are plain enums and each variant is in
+/// turn a collection of terminals, they don't have a `NodeId`. So we pick
+/// the `NodeId` of the first terminal of the collection.
+pub(super) fn node_id_for_string_expression_typing(node: &ir::StringExpression) -> NodeId {
+    match node {
+        ir::StringExpression::StringLiterals(strings) => strings[0].id(),
+        ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
+        ir::StringExpression::UnicodeStringLiterals(unicode_strings) => unicode_strings[0].id(),
+    }
+}
+
+/// Returns the `NodeId` of an `ir::Expression`, dispatching across the variants
+/// sub-expression types. This is `NodeId` is what the typing pass uses to
+/// register the typing of the `Expression`.
+pub(super) fn node_id_for_expression_typing(node: &ir::Expression) -> Option<NodeId> {
+    match node {
+        ir::Expression::AssignmentExpression(e) => Some(e.id()),
+        ir::Expression::ConditionalExpression(e) => Some(e.id()),
+        ir::Expression::OrExpression(e) => Some(e.id()),
+        ir::Expression::AndExpression(e) => Some(e.id()),
+        ir::Expression::EqualityExpression(e) => Some(e.id()),
+        ir::Expression::InequalityExpression(e) => Some(e.id()),
+        ir::Expression::BitwiseOrExpression(e) => Some(e.id()),
+        ir::Expression::BitwiseXorExpression(e) => Some(e.id()),
+        ir::Expression::BitwiseAndExpression(e) => Some(e.id()),
+        ir::Expression::ShiftExpression(e) => Some(e.id()),
+        ir::Expression::AdditiveExpression(e) => Some(e.id()),
+        ir::Expression::MultiplicativeExpression(e) => Some(e.id()),
+        ir::Expression::ExponentiationExpression(e) => Some(e.id()),
+        ir::Expression::PostfixExpression(e) => Some(e.id()),
+        ir::Expression::PrefixExpression(e) => Some(e.id()),
+        ir::Expression::FunctionCallExpression(e) => Some(e.id()),
+        ir::Expression::CallOptionsExpression(e) => Some(e.id()),
+        ir::Expression::MemberAccessExpression(e) => Some(e.id()),
+        ir::Expression::IndexAccessExpression(e) => Some(e.id()),
+        ir::Expression::NewExpression(e) => Some(e.id()),
+        ir::Expression::TupleExpression(e) => Some(e.id()),
+        ir::Expression::TypeExpression(e) => Some(e.id()),
+        ir::Expression::ArrayExpression(e) => Some(e.id()),
+        ir::Expression::HexNumberExpression(e) => Some(e.id()),
+        ir::Expression::DecimalNumberExpression(e) => Some(e.id()),
+        ir::Expression::StringExpression(s) => Some(node_id_for_string_expression_typing(s)),
+        ir::Expression::Identifier(ident) => Some(ident.id()),
+
+        // Other expression variants don't register typing by `NodeId`
+        ir::Expression::ElementaryType(_)
+        | ir::Expression::PayableKeyword(_)
+        | ir::Expression::ThisKeyword(_)
+        | ir::Expression::SuperKeyword(_)
+        | ir::Expression::TrueKeyword(_)
+        | ir::Expression::FalseKeyword(_) => None,
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -1,9 +1,8 @@
-use std::str::FromStr;
-
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
-use num_traits::Num;
 use slang_solidity_v2_ir::ir;
+
+use crate::types::ConstantValue;
 
 pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
     expression: &ir::Expression,
@@ -24,18 +23,6 @@ fn evaluate_compile_time_constant<Scope>(
         scope_stack: Vec::new(),
     };
     evaluator.evaluate_expression_in_scope(expression, start_scope)
-}
-
-#[derive(Clone, Debug, PartialEq)]
-enum ConstantValue {
-    Integer(BigInt),
-}
-
-impl ConstantValue {
-    fn as_usize(&self) -> Option<usize> {
-        let Self::Integer(value) = self;
-        value.to_usize()
-    }
 }
 
 pub(crate) trait ConstantIdentifierResolver<Scope> {
@@ -102,10 +89,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 self.evaluate_prefix_expression(prefix_expression)
             }
             ir::Expression::HexNumberExpression(hex_number_expression) => {
-                Self::evaluate_hex_number_expression(hex_number_expression)
+                ConstantValue::from_hex_number_expression(hex_number_expression)
             }
             ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                Self::evaluate_decimal_number_expression(decimal_number_expression)
+                ConstantValue::from_decimal_number_expression(decimal_number_expression)
             }
             ir::Expression::Identifier(identifier) => self.evaluate_identifier(identifier),
             ir::Expression::TupleExpression(tuple_expression) => {
@@ -253,25 +240,6 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         }
     }
 
-    fn evaluate_hex_number_expression(
-        hex_number_expression: &ir::HexNumberExpression,
-    ) -> Option<ConstantValue> {
-        let hex = hex_number_expression.literal.unparse();
-        // skip `0x` prefix and parse the hexadecimal number
-        BigInt::from_str_radix(&hex[2..], 16)
-            .ok()
-            .map(ConstantValue::Integer)
-    }
-
-    fn evaluate_decimal_number_expression(
-        decimal_number_expression: &ir::DecimalNumberExpression,
-    ) -> Option<ConstantValue> {
-        // TODO: this only handles integers but not rational numbers
-        // TODO: handle number units
-        let decimal = decimal_number_expression.literal.unparse();
-        BigInt::from_str(decimal).ok().map(ConstantValue::Integer)
-    }
-
     fn evaluate_identifier(&mut self, identifier: &ir::Identifier) -> Option<ConstantValue> {
         let current_scope = self.scope_stack.last().expect("scope stack is empty");
         let (target_expression, target_scope) = self
@@ -393,6 +361,74 @@ mod tests {
             .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
         assert!(eval_string("0xa0")
             .is_some_and(|value| value == ConstantValue::Integer(160.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_literals_with_digit_separators() {
+        assert!(eval_string("1_000")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
+        assert!(eval_string("1_000_000")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000_000.to_bigint().unwrap())));
+        assert!(eval_string("0xdead_beef").is_some_and(
+            |value| value == ConstantValue::Integer(0xdead_beef_u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("0x1234_5678").is_some_and(
+            |value| value == ConstantValue::Integer(0x1234_5678_u64.to_bigint().unwrap())
+        ));
+    }
+
+    #[test]
+    fn test_literals_with_number_units() {
+        assert!(eval_string("1 wei")
+            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+        assert!(eval_string("1 gwei").is_some_and(
+            |value| value == ConstantValue::Integer(1_000_000_000u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("1 ether").is_some_and(|value| value
+            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("2 ether").is_some_and(|value| value
+            == ConstantValue::Integer(2_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1 seconds")
+            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+        assert!(eval_string("1 minutes")
+            .is_some_and(|value| value == ConstantValue::Integer(60.to_bigint().unwrap())));
+        assert!(eval_string("1 hours")
+            .is_some_and(|value| value == ConstantValue::Integer(3_600.to_bigint().unwrap())));
+        assert!(eval_string("1 days")
+            .is_some_and(|value| value == ConstantValue::Integer(86_400.to_bigint().unwrap())));
+        assert!(eval_string("1 weeks")
+            .is_some_and(|value| value == ConstantValue::Integer(604_800.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_literals_with_scientific_notation() {
+        assert!(eval_string("1e3")
+            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
+        assert!(eval_string("2e10").is_some_and(
+            |value| value == ConstantValue::Integer(20_000_000_000u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("1e18").is_some_and(|value| value
+            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1.5e3")
+            .is_some_and(|value| value == ConstantValue::Integer(1_500.to_bigint().unwrap())));
+    }
+
+    #[test]
+    fn test_reducible_rational_literals() {
+        assert!(eval_string("1.5 ether").is_some_and(|value| value
+            == ConstantValue::Integer(1_500_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("0.5 ether").is_some_and(|value| value
+            == ConstantValue::Integer(500_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("0.5 gwei").is_some_and(
+            |value| value == ConstantValue::Integer(500_000_000u64.to_bigint().unwrap())
+        ));
+    }
+
+    #[test]
+    fn test_non_reducible_rational_literals() {
+        assert!(eval_string("0.5").is_none());
+        assert!(eval_string("3.14").is_none());
+        assert!(eval_string("1e-1").is_none());
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -1,21 +1,21 @@
 use slang_solidity_v2_ir::ir;
 
-use crate::types::ConstantValue;
+use crate::types::Number;
 
 pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
 ) -> Option<usize> {
-    evaluate_compile_time_constant(expression, start_scope, identifier_resolver)
+    evaluate_compile_time_number_constant(expression, start_scope, identifier_resolver)
         .and_then(|value| value.as_usize())
 }
 
-fn evaluate_compile_time_constant<Scope>(
+fn evaluate_compile_time_number_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
-) -> Option<ConstantValue> {
+) -> Option<Number> {
     let mut evaluator = CompileConstantEvaluator {
         identifier_resolver,
         scope_stack: Vec::new(),
@@ -47,7 +47,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         &mut self,
         expression: &ir::Expression,
         scope: Scope,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         if self.scope_stack.len() >= Self::MAX_SCOPE_DEPTH {
             // TODO(validation): cyclic dependency in constant resolution or max depth reached
             return None;
@@ -60,7 +60,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         result
     }
 
-    fn evaluate_expression(&mut self, expression: &ir::Expression) -> Option<ConstantValue> {
+    fn evaluate_expression(&mut self, expression: &ir::Expression) -> Option<Number> {
         match expression {
             ir::Expression::BitwiseOrExpression(bitwise_or_expression) => {
                 self.evaluate_bitwise_or_expression(bitwise_or_expression)
@@ -87,10 +87,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 self.evaluate_prefix_expression(prefix_expression)
             }
             ir::Expression::HexNumberExpression(hex_number_expression) => {
-                ConstantValue::from_hex_number_expression(hex_number_expression)
+                Number::from_hex_number_expression(hex_number_expression)
             }
             ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                ConstantValue::from_decimal_number_expression(decimal_number_expression)
+                Number::from_decimal_number_expression(decimal_number_expression)
             }
             ir::Expression::Identifier(identifier) => self.evaluate_identifier(identifier),
             ir::Expression::TupleExpression(tuple_expression) => {
@@ -108,7 +108,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_bitwise_or_expression(
         &mut self,
         bitwise_or_expression: &ir::BitwiseOrExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&bitwise_or_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_or_expression.right_operand)?;
         lhs.bit_or(&rhs)
@@ -117,7 +117,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_bitwise_xor_expression(
         &mut self,
         bitwise_xor_expression: &ir::BitwiseXorExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&bitwise_xor_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_xor_expression.right_operand)?;
         lhs.bit_xor(&rhs)
@@ -126,7 +126,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_bitwise_and_expression(
         &mut self,
         bitwise_and_expression: &ir::BitwiseAndExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&bitwise_and_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_and_expression.right_operand)?;
         lhs.bit_and(&rhs)
@@ -135,7 +135,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_shift_expression(
         &mut self,
         shift_expression: &ir::ShiftExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&shift_expression.left_operand)?;
         let rhs = self.evaluate_expression(&shift_expression.right_operand)?;
         match &shift_expression.operator {
@@ -148,7 +148,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_additive_expression(
         &mut self,
         additive_expression: &ir::AdditiveExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&additive_expression.left_operand)?;
         let rhs = self.evaluate_expression(&additive_expression.right_operand)?;
         match &additive_expression.operator {
@@ -160,7 +160,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_multiplicative_expression(
         &mut self,
         multiplicative_expression: &ir::MultiplicativeExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&multiplicative_expression.left_operand)?;
         let rhs = self.evaluate_expression(&multiplicative_expression.right_operand)?;
         match &multiplicative_expression.operator {
@@ -173,7 +173,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_exponentiation_expression(
         &mut self,
         exponentiation_expression: &ir::ExponentiationExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let lhs = self.evaluate_expression(&exponentiation_expression.left_operand)?;
         let rhs = self.evaluate_expression(&exponentiation_expression.right_operand)?;
         // v2 ExponentiationExpression has no explicit operator field (only `**` exists)
@@ -183,7 +183,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_prefix_expression(
         &mut self,
         prefix_expression: &ir::PrefixExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         let operand = self.evaluate_expression(&prefix_expression.operand)?;
         match &prefix_expression.operator {
             ir::PrefixExpressionOperator::Minus(_) => Some(operand.negate()),
@@ -192,7 +192,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         }
     }
 
-    fn evaluate_identifier(&mut self, identifier: &ir::Identifier) -> Option<ConstantValue> {
+    fn evaluate_identifier(&mut self, identifier: &ir::Identifier) -> Option<Number> {
         let current_scope = self.scope_stack.last().expect("scope stack is empty");
         let (target_expression, target_scope) = self
             .identifier_resolver
@@ -203,7 +203,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     fn evaluate_tuple_expression(
         &mut self,
         tuple_expression: &ir::TupleExpression,
-    ) -> Option<ConstantValue> {
+    ) -> Option<Number> {
         if tuple_expression.items.len() == 1 {
             let inner_expression = tuple_expression.items[0].expression.as_ref()?;
             self.evaluate_expression(inner_expression)
@@ -276,9 +276,9 @@ mod tests {
         }
     }
 
-    fn eval_string(input: &str) -> Option<ConstantValue> {
+    fn eval_string(input: &str) -> Option<Number> {
         let expression = parse_expression(input);
-        evaluate_compile_time_constant(&expression, String::new(), &MapResolver::default())
+        evaluate_compile_time_number_constant(&expression, String::new(), &MapResolver::default())
     }
 
     // `context` is given as a list of constants defined as:
@@ -286,10 +286,7 @@ mod tests {
     // - the target expression (to be parsed)
     // - the target scope
     // Resolution always starts at the empty string scope in these tests.
-    fn eval_string_with_context(
-        input: &str,
-        context: &[(&str, &str, &str)],
-    ) -> Option<ConstantValue> {
+    fn eval_string_with_context(input: &str, context: &[(&str, &str, &str)]) -> Option<Number> {
         let context: HashMap<String, (ir::Expression, String)> = context
             .iter()
             .map(|(name, input, target_scope)| {
@@ -301,154 +298,160 @@ mod tests {
             .collect();
         let expression = parse_expression(input);
 
-        evaluate_compile_time_constant(&expression, String::new(), &MapResolver { context })
+        evaluate_compile_time_number_constant(&expression, String::new(), &MapResolver { context })
     }
 
     #[test]
     fn test_literals() {
-        assert!(eval_string("1")
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+        assert!(
+            eval_string("1").is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap()))
+        );
         assert!(eval_string("42")
-            .is_some_and(|value| value == ConstantValue::Integer(42.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(42.to_bigint().unwrap())));
         assert!(eval_string("0x01")
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap())));
         assert!(eval_string("0xa0")
-            .is_some_and(|value| value == ConstantValue::Integer(160.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(160.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_literals_with_digit_separators() {
         assert!(eval_string("1_000")
-            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1_000.to_bigint().unwrap())));
         assert!(eval_string("1_000_000")
-            .is_some_and(|value| value == ConstantValue::Integer(1_000_000.to_bigint().unwrap())));
-        assert!(eval_string("0xdead_beef").is_some_and(
-            |value| value == ConstantValue::Integer(0xdead_beef_u64.to_bigint().unwrap())
-        ));
-        assert!(eval_string("0x1234_5678").is_some_and(
-            |value| value == ConstantValue::Integer(0x1234_5678_u64.to_bigint().unwrap())
-        ));
+            .is_some_and(|value| value == Number::Integer(1_000_000.to_bigint().unwrap())));
+        assert!(eval_string("0xdead_beef")
+            .is_some_and(|value| value == Number::Integer(0xdead_beef_u64.to_bigint().unwrap())));
+        assert!(eval_string("0x1234_5678")
+            .is_some_and(|value| value == Number::Integer(0x1234_5678_u64.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_literals_with_number_units() {
         assert!(eval_string("1 wei")
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
-        assert!(eval_string("1 gwei").is_some_and(
-            |value| value == ConstantValue::Integer(1_000_000_000u64.to_bigint().unwrap())
+            .is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap())));
+        assert!(eval_string("1 gwei")
+            .is_some_and(|value| value == Number::Integer(1_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1 ether").is_some_and(
+            |value| value == Number::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())
         ));
-        assert!(eval_string("1 ether").is_some_and(|value| value
-            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
-        assert!(eval_string("2 ether").is_some_and(|value| value
-            == ConstantValue::Integer(2_000_000_000_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("2 ether").is_some_and(
+            |value| value == Number::Integer(2_000_000_000_000_000_000u64.to_bigint().unwrap())
+        ));
         assert!(eval_string("1 seconds")
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap())));
         assert!(eval_string("1 minutes")
-            .is_some_and(|value| value == ConstantValue::Integer(60.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(60.to_bigint().unwrap())));
         assert!(eval_string("1 hours")
-            .is_some_and(|value| value == ConstantValue::Integer(3_600.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(3_600.to_bigint().unwrap())));
         assert!(eval_string("1 days")
-            .is_some_and(|value| value == ConstantValue::Integer(86_400.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(86_400.to_bigint().unwrap())));
         assert!(eval_string("1 weeks")
-            .is_some_and(|value| value == ConstantValue::Integer(604_800.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(604_800.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_literals_with_scientific_notation() {
         assert!(eval_string("1e3")
-            .is_some_and(|value| value == ConstantValue::Integer(1_000.to_bigint().unwrap())));
-        assert!(eval_string("2e10").is_some_and(
-            |value| value == ConstantValue::Integer(20_000_000_000u64.to_bigint().unwrap())
+            .is_some_and(|value| value == Number::Integer(1_000.to_bigint().unwrap())));
+        assert!(eval_string("2e10")
+            .is_some_and(|value| value == Number::Integer(20_000_000_000u64.to_bigint().unwrap())));
+        assert!(eval_string("1e18").is_some_and(
+            |value| value == Number::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())
         ));
-        assert!(eval_string("1e18").is_some_and(|value| value
-            == ConstantValue::Integer(1_000_000_000_000_000_000u64.to_bigint().unwrap())));
         assert!(eval_string("1.5e3")
-            .is_some_and(|value| value == ConstantValue::Integer(1_500.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1_500.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_reducible_rational_literals() {
-        assert!(eval_string("1.5 ether").is_some_and(|value| value
-            == ConstantValue::Integer(1_500_000_000_000_000_000u64.to_bigint().unwrap())));
-        assert!(eval_string("0.5 ether").is_some_and(|value| value
-            == ConstantValue::Integer(500_000_000_000_000_000u64.to_bigint().unwrap())));
-        assert!(eval_string("0.5 gwei").is_some_and(
-            |value| value == ConstantValue::Integer(500_000_000u64.to_bigint().unwrap())
+        assert!(eval_string("1.5 ether").is_some_and(
+            |value| value == Number::Integer(1_500_000_000_000_000_000u64.to_bigint().unwrap())
         ));
+        assert!(eval_string("0.5 ether").is_some_and(
+            |value| value == Number::Integer(500_000_000_000_000_000u64.to_bigint().unwrap())
+        ));
+        assert!(eval_string("0.5 gwei")
+            .is_some_and(|value| value == Number::Integer(500_000_000u64.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_non_reducible_rational_literals() {
-        assert!(eval_string("0.5").is_some_and(|value| value
-            == ConstantValue::Rational(BigRational::new(BigInt::from(1), BigInt::from(2)))));
+        assert!(eval_string("0.5")
+            .is_some_and(|value| value
+                == Number::Rational(BigRational::new(BigInt::from(1), BigInt::from(2)))));
         assert!(eval_string("3.14").is_some_and(|value| value
-            == ConstantValue::Rational(BigRational::new(BigInt::from(157), BigInt::from(50)))));
-        assert!(eval_string("1e-1").is_some_and(|value| value
-            == ConstantValue::Rational(BigRational::new(BigInt::from(1), BigInt::from(10)))));
+            == Number::Rational(BigRational::new(BigInt::from(157), BigInt::from(50)))));
+        assert!(eval_string("1e-1")
+            .is_some_and(|value| value
+                == Number::Rational(BigRational::new(BigInt::from(1), BigInt::from(10)))));
     }
 
     #[test]
     fn test_rational_arithmetic_folds() {
         // Reducible rational result normalises back to an Integer.
-        assert!(eval_string("1.5 * 2")
-            .is_some_and(|value| value == ConstantValue::Integer(BigInt::from(3))));
+        assert!(
+            eval_string("1.5 * 2").is_some_and(|value| value == Number::Integer(BigInt::from(3)))
+        );
         // Integer division that does not divide evenly yields a Rational.
-        assert!(eval_string("5 / 2").is_some_and(|value| value
-            == ConstantValue::Rational(BigRational::new(BigInt::from(5), BigInt::from(2)))));
+        assert!(eval_string("5 / 2")
+            .is_some_and(|value| value
+                == Number::Rational(BigRational::new(BigInt::from(5), BigInt::from(2)))));
         // Negation of a non-reducing rational stays Rational.
-        assert!(eval_string("-0.5").is_some_and(|value| value
-            == ConstantValue::Rational(BigRational::new(BigInt::from(-1), BigInt::from(2)))));
+        assert!(eval_string("-0.5")
+            .is_some_and(|value| value
+                == Number::Rational(BigRational::new(BigInt::from(-1), BigInt::from(2)))));
     }
 
     #[test]
     fn test_prefix_expression() {
         assert!(eval_string("-42")
-            .is_some_and(|value| value == ConstantValue::Integer((-42).to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer((-42).to_bigint().unwrap())));
     }
 
     #[test]
     fn test_binary_expression() {
         assert!(eval_string("1 + 2")
-            .is_some_and(|value| value == ConstantValue::Integer(3.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(3.to_bigint().unwrap())));
         assert!(eval_string("2 - 2")
-            .is_some_and(|value| value == ConstantValue::Integer(0.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(0.to_bigint().unwrap())));
         assert!(eval_string("1 - 2")
-            .is_some_and(|value| value == ConstantValue::Integer((-1).to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer((-1).to_bigint().unwrap())));
         assert!(eval_string("1 * 2")
-            .is_some_and(|value| value == ConstantValue::Integer(2.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(2.to_bigint().unwrap())));
         assert!(eval_string("4 / 2")
-            .is_some_and(|value| value == ConstantValue::Integer(2.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(2.to_bigint().unwrap())));
         assert!(eval_string("5 % 2")
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap())));
         assert!(eval_string("2 ** 5")
-            .is_some_and(|value| value == ConstantValue::Integer(32.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(32.to_bigint().unwrap())));
         assert!(eval_string("32 << 2")
-            .is_some_and(|value| value == ConstantValue::Integer(128.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(128.to_bigint().unwrap())));
         assert!(eval_string("32 >> 2")
-            .is_some_and(|value| value == ConstantValue::Integer(8.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(8.to_bigint().unwrap())));
         assert!(eval_string("32 | 16")
-            .is_some_and(|value| value == ConstantValue::Integer(48.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(48.to_bigint().unwrap())));
         assert!(eval_string("15 ^ 31")
-            .is_some_and(|value| value == ConstantValue::Integer(16.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(16.to_bigint().unwrap())));
         assert!(eval_string("15 & 31")
-            .is_some_and(|value| value == ConstantValue::Integer(15.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(15.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_nesting_expressions() {
         assert!(eval_string("1 + (2 + 3)")
-            .is_some_and(|value| value == ConstantValue::Integer(6.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(6.to_bigint().unwrap())));
         assert!(eval_string("3 * (2 + 1)")
-            .is_some_and(|value| value == ConstantValue::Integer(9.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(9.to_bigint().unwrap())));
     }
 
     #[test]
     fn test_identifier_lookup() {
         assert!(eval_string_with_context("FOO", &[("FOO", "1", "")])
-            .is_some_and(|value| value == ConstantValue::Integer(1.to_bigint().unwrap())));
+            .is_some_and(|value| value == Number::Integer(1.to_bigint().unwrap())));
         assert!(
             eval_string_with_context("FOO + 2*BAR", &[("FOO", "1", ""), ("BAR", "5", "")])
-                .is_some_and(|value| value == ConstantValue::Integer(11.to_bigint().unwrap()))
+                .is_some_and(|value| value == Number::Integer(11.to_bigint().unwrap()))
         );
         // undefined symbols
         assert!(eval_string_with_context("FOO", &[]).is_none());
@@ -462,6 +465,6 @@ mod tests {
             "FOO",
             &[("FOO", "BAR", "CTX."), ("CTX.BAR", "42", "CTX.")]
         )
-        .is_some_and(|value| value == ConstantValue::Integer(42.to_bigint().unwrap())));
+        .is_some_and(|value| value == Number::Integer(42.to_bigint().unwrap())));
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -187,7 +187,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let operand = self.evaluate_expression(&prefix_expression.operand)?;
         match &prefix_expression.operator {
             ir::PrefixExpressionOperator::Minus(_) => Some(operand.negate()),
-            // No unary plus in Solidity >= 0.5.0 (v2 only supports >= 0.8.0)
+            ir::PrefixExpressionOperator::Tilde(_) => Some(operand.bit_not()?),
             _ => None,
         }
     }
@@ -407,6 +407,19 @@ mod tests {
     fn test_prefix_expression() {
         assert!(eval_string("-42")
             .is_some_and(|value| value == Number::Integer((-42).to_bigint().unwrap())));
+
+        // Bitwise NOT on an arbitrary-precision integer: `~x = -x - 1`.
+        assert!(eval_string("~1")
+            .is_some_and(|value| value == Number::Integer((-2).to_bigint().unwrap())));
+        assert!(eval_string("~0")
+            .is_some_and(|value| value == Number::Integer((-1).to_bigint().unwrap())));
+        assert!(eval_string("~(-1)")
+            .is_some_and(|value| value == Number::Integer(0.to_bigint().unwrap())));
+        // Hex source: `~` operates on the integer value (provenance is irrelevant here).
+        assert!(eval_string("~0xff")
+            .is_some_and(|value| value == Number::Integer((-256).to_bigint().unwrap())));
+        // Bitwise NOT is not defined on rationals.
+        assert!(eval_string("~0.5").is_none());
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigInt;
-use num_traits::cast::ToPrimitive;
 use slang_solidity_v2_ir::ir;
 
 use crate::types::ConstantValue;
@@ -113,11 +111,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     ) -> Option<ConstantValue> {
         let lhs = self.evaluate_expression(&bitwise_or_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_or_expression.right_operand)?;
-        match (lhs, rhs) {
-            (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                Some(ConstantValue::Integer(lhs | rhs))
-            }
-        }
+        lhs.bit_or(&rhs)
     }
 
     fn evaluate_bitwise_xor_expression(
@@ -126,11 +120,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     ) -> Option<ConstantValue> {
         let lhs = self.evaluate_expression(&bitwise_xor_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_xor_expression.right_operand)?;
-        match (lhs, rhs) {
-            (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                Some(ConstantValue::Integer(lhs ^ rhs))
-            }
-        }
+        lhs.bit_xor(&rhs)
     }
 
     fn evaluate_bitwise_and_expression(
@@ -139,11 +129,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     ) -> Option<ConstantValue> {
         let lhs = self.evaluate_expression(&bitwise_and_expression.left_operand)?;
         let rhs = self.evaluate_expression(&bitwise_and_expression.right_operand)?;
-        match (lhs, rhs) {
-            (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                Some(ConstantValue::Integer(lhs & rhs))
-            }
-        }
+        lhs.bit_and(&rhs)
     }
 
     fn evaluate_shift_expression(
@@ -153,16 +139,8 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let lhs = self.evaluate_expression(&shift_expression.left_operand)?;
         let rhs = self.evaluate_expression(&shift_expression.right_operand)?;
         match &shift_expression.operator {
-            ir::ShiftExpressionOperator::LessThanLessThan(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs << rhs.to_u32()?))
-                }
-            },
-            ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs >> rhs.to_u32()?))
-                }
-            },
+            ir::ShiftExpressionOperator::LessThanLessThan(_) => lhs.shl(&rhs),
+            ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => lhs.shr(&rhs),
             ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => None,
         }
     }
@@ -174,16 +152,8 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let lhs = self.evaluate_expression(&additive_expression.left_operand)?;
         let rhs = self.evaluate_expression(&additive_expression.right_operand)?;
         match &additive_expression.operator {
-            ir::AdditiveExpressionOperator::Plus(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs + rhs))
-                }
-            },
-            ir::AdditiveExpressionOperator::Minus(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs - rhs))
-                }
-            },
+            ir::AdditiveExpressionOperator::Plus(_) => Some(lhs.add(&rhs)),
+            ir::AdditiveExpressionOperator::Minus(_) => Some(lhs.sub(&rhs)),
         }
     }
 
@@ -194,21 +164,9 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let lhs = self.evaluate_expression(&multiplicative_expression.left_operand)?;
         let rhs = self.evaluate_expression(&multiplicative_expression.right_operand)?;
         match &multiplicative_expression.operator {
-            ir::MultiplicativeExpressionOperator::Asterisk(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs * rhs))
-                }
-            },
-            ir::MultiplicativeExpressionOperator::Slash(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs / rhs))
-                }
-            },
-            ir::MultiplicativeExpressionOperator::Percent(_) => match (lhs, rhs) {
-                (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                    Some(ConstantValue::Integer(lhs % rhs))
-                }
-            },
+            ir::MultiplicativeExpressionOperator::Asterisk(_) => Some(lhs.mul(&rhs)),
+            ir::MultiplicativeExpressionOperator::Slash(_) => lhs.div(&rhs),
+            ir::MultiplicativeExpressionOperator::Percent(_) => lhs.rem(&rhs),
         }
     }
 
@@ -219,11 +177,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         let lhs = self.evaluate_expression(&exponentiation_expression.left_operand)?;
         let rhs = self.evaluate_expression(&exponentiation_expression.right_operand)?;
         // v2 ExponentiationExpression has no explicit operator field (only `**` exists)
-        match (lhs, rhs) {
-            (ConstantValue::Integer(lhs), ConstantValue::Integer(rhs)) => {
-                Some(ConstantValue::Integer(lhs.pow(rhs.to_u32()?)))
-            }
-        }
+        lhs.pow(&rhs)
     }
 
     fn evaluate_prefix_expression(
@@ -232,9 +186,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
     ) -> Option<ConstantValue> {
         let operand = self.evaluate_expression(&prefix_expression.operand)?;
         match &prefix_expression.operator {
-            ir::PrefixExpressionOperator::Minus(_) => match operand {
-                ConstantValue::Integer(value) => Some(ConstantValue::Integer(BigInt::ZERO - value)),
-            },
+            ir::PrefixExpressionOperator::Minus(_) => Some(operand.negate()),
             // No unary plus in Solidity >= 0.5.0 (v2 only supports >= 0.8.0)
             _ => None,
         }
@@ -265,7 +217,8 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
 mod tests {
     use std::collections::HashMap;
 
-    use num_bigint::ToBigInt;
+    use num_bigint::{BigInt, ToBigInt};
+    use num_rational::BigRational;
     use slang_solidity_v2_common::versions::LanguageVersion;
     use slang_solidity_v2_parser::{ParseOutput, Parser};
 
@@ -426,9 +379,25 @@ mod tests {
 
     #[test]
     fn test_non_reducible_rational_literals() {
-        assert!(eval_string("0.5").is_none());
-        assert!(eval_string("3.14").is_none());
-        assert!(eval_string("1e-1").is_none());
+        assert!(eval_string("0.5").is_some_and(|value| value
+            == ConstantValue::Rational(BigRational::new(BigInt::from(1), BigInt::from(2)))));
+        assert!(eval_string("3.14").is_some_and(|value| value
+            == ConstantValue::Rational(BigRational::new(BigInt::from(157), BigInt::from(50)))));
+        assert!(eval_string("1e-1").is_some_and(|value| value
+            == ConstantValue::Rational(BigRational::new(BigInt::from(1), BigInt::from(10)))));
+    }
+
+    #[test]
+    fn test_rational_arithmetic_folds() {
+        // Reducible rational result normalises back to an Integer.
+        assert!(eval_string("1.5 * 2")
+            .is_some_and(|value| value == ConstantValue::Integer(BigInt::from(3))));
+        // Integer division that does not divide evenly yields a Rational.
+        assert!(eval_string("5 / 2").is_some_and(|value| value
+            == ConstantValue::Rational(BigRational::new(BigInt::from(5), BigInt::from(2)))));
+        // Negation of a non-reducing rational stays Rational.
+        assert!(eval_string("-0.5").is_some_and(|value| value
+            == ConstantValue::Rational(BigRational::new(BigInt::from(-1), BigInt::from(2)))));
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -258,7 +258,7 @@ impl Pass<'_> {
 
     pub(super) fn register_super_types(&mut self, type_id: TypeId, bases: &[NodeId]) {
         // register super types in the type registry
-        let super_types = bases
+        let super_types: Vec<_> = bases
             .iter()
             .filter_map(|base_id| {
                 let Some(base) = self.binder.find_definition_by_id(*base_id) else {
@@ -276,6 +276,6 @@ impl Pass<'_> {
                 Some(self.types.register_type(base_type))
             })
             .collect();
-        self.types.register_super_types(type_id, super_types);
+        self.types.register_super_types(type_id, &super_types);
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{DataLocation, FunctionType, LiteralKind, Number, Type, TypeId};
+use crate::types::{literals, DataLocation, FunctionType, LiteralKind, Number, Type, TypeId};
 
 impl Pass<'_> {
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
@@ -80,7 +80,7 @@ impl Pass<'_> {
             }
             ir::Expression::StringExpression(string_expression) => self
                 .binder
-                .node_typing(Self::string_expression_node_id(string_expression)),
+                .node_typing(Self::node_id_for_string_expression(string_expression)),
             ir::Expression::ElementaryType(elementary_type) => {
                 Typing::MetaType(Self::type_of_elementary_type(elementary_type))
             }
@@ -638,7 +638,10 @@ fn reference_node_id_for_expression(node: &ir::Expression) -> Option<NodeId> {
 
 /// Typing functions for literals
 impl Pass<'_> {
-    pub(super) fn string_expression_node_id(node: &ir::StringExpression) -> NodeId {
+    // Since `StringExpression` nodes are plain enums and each variant is in
+    // turn a collection of terminals, they don't have a `NodeId`. So we pick
+    // the `NodeId` of the first terminal of the collection.
+    pub(super) fn node_id_for_string_expression(node: &ir::StringExpression) -> NodeId {
         match node {
             ir::StringExpression::StringLiterals(strings) => strings[0].id(),
             ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
@@ -647,34 +650,21 @@ impl Pass<'_> {
     }
 
     pub(super) fn type_of_string_expression(node: &ir::StringExpression) -> Type {
+        // Hex string literals carry distinct provenance (mirroring `HexInteger`
+        // vs `Integer`); regular and unicode strings share `String` since they
+        // are indistinguishable once decoded.
         let kind = match node {
-            ir::StringExpression::StringLiterals(strings) => {
-                let size = strings.iter().fold(0usize, |acc, string| {
-                    // TODO: consider escaped characters
-                    acc + string.unparse().len() - 2
-                });
-                LiteralKind::String {
-                    bytes: u32::try_from(size).unwrap(),
-                }
+            ir::StringExpression::StringLiterals(literals) => {
+                let value = literals::value_of_string_literals(literals);
+                LiteralKind::String { bytes: value.len() }
             }
-            ir::StringExpression::HexStringLiterals(hex_strings) => {
-                let size = hex_strings.iter().fold(0usize, |acc, hex_string| {
-                    // 5 is the length of the `hex` prefix plus the quotes
-                    acc + (hex_string.unparse().len() - 5) / 2
-                });
-                LiteralKind::String {
-                    bytes: u32::try_from(size).unwrap(),
-                }
+            ir::StringExpression::HexStringLiterals(literals) => {
+                let value = literals::value_of_hex_string_literals(literals);
+                LiteralKind::HexString { bytes: value.len() }
             }
-            ir::StringExpression::UnicodeStringLiterals(unicode_strings) => {
-                let size = unicode_strings.iter().fold(0usize, |acc, unicode_string| {
-                    // TODO: actually parse the string
-                    // 9 is the length of the `unicode` prefix plus quotes
-                    acc + unicode_string.unparse().len() - 9
-                });
-                LiteralKind::String {
-                    bytes: u32::try_from(size).unwrap(),
-                }
+            ir::StringExpression::UnicodeStringLiterals(literals) => {
+                let value = literals::value_of_unicode_string_literals(literals);
+                LiteralKind::String { bytes: value.len() }
             }
         };
         Type::Literal(kind)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -205,48 +205,26 @@ impl Pass<'_> {
         }
     }
 
-    /// Returns a type that both branches can flow into, used by the
-    /// conditional expression typing. Falls back to lifting two distinct
-    /// integer literal arms to the smallest holding integer type — matching
-    /// solc's "common type" rule for two `RationalNumberType` operands.
-    pub(super) fn common_type_for_conditional_branches(
+    pub(super) fn type_of_array_expression(
         &mut self,
-        true_type_id: TypeId,
-        false_type_id: TypeId,
+        array: &ir::ArrayExpression,
     ) -> Option<TypeId> {
-        if self
-            .types
-            .implicitly_convertible_to(false_type_id, true_type_id)
-        {
-            return Some(true_type_id);
+        let mut item_type_ids: Vec<TypeId> = Vec::with_capacity(array.items.len());
+        for item in &array.items {
+            item_type_ids.push(self.typing_of_expression(item).as_type_id()?);
         }
-        if self
-            .types
-            .implicitly_convertible_to(true_type_id, false_type_id)
-        {
-            return Some(false_type_id);
-        }
-        // TODO: handle rational numbers with conversion to fixed/ufixed
-        let true_value = match self.types.get_type_by_id(true_type_id) {
-            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
-                Some(value.clone())
-            }
-            _ => None,
-        }?;
-        let false_value = match self.types.get_type_by_id(false_type_id) {
-            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
-                Some(value.clone())
-            }
-            _ => None,
-        }?;
-        self.types
-            .common_integer_literal_type(&true_value, &false_value)
+        let element_type = self.types.reified_common_type(&item_type_ids)?;
+        Some(self.types.register_type(Type::FixedSizeArray {
+            element_type,
+            size: array.items.len(),
+            location: DataLocation::Memory,
+        }))
     }
 
     /// Returns the compile-time number value of an expression, when its type
     /// is a value-bearing literal (integer or rational). Used by the constant
     /// folding logic in the binary/prefix expression visitors.
-    pub(super) fn number_value_of_expression(&self, expression: &ir::Expression) -> Option<Number> {
+    fn number_value_of_expression(&self, expression: &ir::Expression) -> Option<Number> {
         let type_id = self.typing_of_expression(expression).as_type_id()?;
         match self.types.get_type_by_id(type_id) {
             Type::Literal(kind) => Number::from_literal_kind(kind),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -4,90 +4,37 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::built_ins::BuiltIn;
+use crate::passes::common::node_id_for_expression_typing;
 use crate::types::{literals, DataLocation, FunctionType, LiteralKind, Number, Type, TypeId};
 
 impl Pass<'_> {
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
         match node {
-            ir::Expression::AssignmentExpression(assignment_expression) => {
-                self.binder.node_typing(assignment_expression.id())
-            }
-            ir::Expression::ConditionalExpression(conditional_expression) => {
-                self.binder.node_typing(conditional_expression.id())
-            }
+            // These are always typed as boolean
             ir::Expression::OrExpression(_)
             | ir::Expression::AndExpression(_)
             | ir::Expression::EqualityExpression(_)
             | ir::Expression::InequalityExpression(_)
             | ir::Expression::TrueKeyword(_)
             | ir::Expression::FalseKeyword(_) => Typing::Resolved(self.types.boolean()),
-            ir::Expression::BitwiseOrExpression(bitwise_or_expression) => {
-                self.binder.node_typing(bitwise_or_expression.id())
-            }
-            ir::Expression::BitwiseXorExpression(bitwise_xor_expression) => {
-                self.binder.node_typing(bitwise_xor_expression.id())
-            }
-            ir::Expression::BitwiseAndExpression(bitwise_and_expression) => {
-                self.binder.node_typing(bitwise_and_expression.id())
-            }
-            ir::Expression::ShiftExpression(shift_expression) => {
-                self.binder.node_typing(shift_expression.id())
-            }
-            ir::Expression::AdditiveExpression(additive_expression) => {
-                self.binder.node_typing(additive_expression.id())
-            }
-            ir::Expression::MultiplicativeExpression(multiplicative_expression) => {
-                self.binder.node_typing(multiplicative_expression.id())
-            }
-            ir::Expression::ExponentiationExpression(exponentiation_expression) => {
-                self.binder.node_typing(exponentiation_expression.id())
-            }
-            ir::Expression::PostfixExpression(postfix_expression) => {
-                self.binder.node_typing(postfix_expression.id())
-            }
-            ir::Expression::PrefixExpression(prefix_expression) => {
-                self.binder.node_typing(prefix_expression.id())
-            }
-            ir::Expression::FunctionCallExpression(function_call_expression) => {
-                self.binder.node_typing(function_call_expression.id())
-            }
-            ir::Expression::CallOptionsExpression(call_options_expression) => {
-                self.binder.node_typing(call_options_expression.id())
-            }
-            ir::Expression::MemberAccessExpression(member_access_expression) => {
-                self.binder.node_typing(member_access_expression.id())
-            }
-            ir::Expression::IndexAccessExpression(index_access_expression) => {
-                self.binder.node_typing(index_access_expression.id())
-            }
-            ir::Expression::NewExpression(new_expression) => {
-                self.binder.node_typing(new_expression.id())
-            }
-            ir::Expression::TupleExpression(tuple_expression) => {
-                self.binder.node_typing(tuple_expression.id())
-            }
-            ir::Expression::TypeExpression(type_expression) => {
-                self.binder.node_typing(type_expression.id())
-            }
-            ir::Expression::ArrayExpression(array_expression) => {
-                self.binder.node_typing(array_expression.id())
-            }
-            ir::Expression::HexNumberExpression(hex_number_expression) => {
-                self.binder.node_typing(hex_number_expression.id())
-            }
-            ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
-                self.binder.node_typing(decimal_number_expression.id())
-            }
-            ir::Expression::StringExpression(string_expression) => self
-                .binder
-                .node_typing(Self::node_id_for_string_expression(string_expression)),
+
+            // Special case for elementary types: it's always a meta-type
             ir::Expression::ElementaryType(elementary_type) => {
                 Typing::MetaType(Self::type_of_elementary_type(elementary_type))
             }
-            ir::Expression::Identifier(identifier) => self.typing_of_identifier(identifier),
+
+            // Other special cases
             ir::Expression::PayableKeyword(_) => Typing::MetaType(Type::Address { payable: true }),
             ir::Expression::ThisKeyword(_) => Typing::This,
             ir::Expression::SuperKeyword(_) => Typing::Super,
+
+            // By default, query the binder for registered typing information
+            _ => {
+                let node_id = node_id_for_expression_typing(node).expect(
+                    "typing of expression variant not handled and it doesn't have a NodeId",
+                );
+                self.binder.node_typing(node_id)
+            }
         }
     }
 
@@ -129,18 +76,6 @@ impl Pass<'_> {
             Definition::UserDefinedValueType(_) => Some(Type::UserDefinedValue { definition_id }),
             _ => None,
         }
-    }
-
-    fn typing_of_identifier(&self, identifier: &ir::Identifier) -> Typing {
-        let resolution = &self
-            .binder
-            .find_reference_by_identifier_node_id(identifier.id())
-            .unwrap()
-            .resolution;
-        // The resolution may point to an imported symbol, so we need to follow
-        // through in order to get to the actual typing
-        let resolution = self.binder.follow_symbol_aliases(resolution);
-        self.typing_of_resolution(&resolution)
     }
 
     /// Returns the type of an binary operator expression. If both operands are
@@ -642,17 +577,6 @@ fn reference_node_id_for_expression(node: &ir::Expression) -> Option<NodeId> {
 
 /// Typing functions for literals
 impl Pass<'_> {
-    // Since `StringExpression` nodes are plain enums and each variant is in
-    // turn a collection of terminals, they don't have a `NodeId`. So we pick
-    // the `NodeId` of the first terminal of the collection.
-    pub(super) fn node_id_for_string_expression(node: &ir::StringExpression) -> NodeId {
-        match node {
-            ir::StringExpression::StringLiterals(strings) => strings[0].id(),
-            ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
-            ir::StringExpression::UnicodeStringLiterals(unicode_strings) => unicode_strings[0].id(),
-        }
-    }
-
     pub(super) fn type_of_string_expression(node: &ir::StringExpression) -> Type {
         // Hex string literals carry distinct provenance (mirroring `HexInteger`
         // vs `Integer`); regular and unicode strings share `String` since they

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{DataLocation, FunctionType, LiteralKind, Type, TypeId};
+use crate::types::{ConstantValue, DataLocation, FunctionType, LiteralKind, Type, TypeId};
 
 impl Pass<'_> {
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
@@ -169,6 +169,54 @@ impl Pass<'_> {
             }
         } else {
             None
+        }
+    }
+
+    pub(super) fn type_of_prefix_expression(
+        &mut self,
+        node: &ir::PrefixExpression,
+    ) -> Option<TypeId> {
+        match node.operator {
+            ir::PrefixExpressionOperator::Minus(_) => {
+                // `-literal` folds into a signed literal kind carrying the
+                // two's-complement width of the negated value, matching
+                // solc's `RationalNumberType::integerType()` behaviour for
+                // negated rational-number literals.
+                // TODO: this covers some edge cases but not all of them. We
+                // need full constant folding at the semantic level and that
+                // means keeping the actual value of literals in their type,
+                // similar to what `solc` does.
+                let folded = match &node.operand {
+                    ir::Expression::DecimalNumberExpression(decimal_number) => {
+                        ConstantValue::from_decimal_number_expression(decimal_number)
+                    }
+                    ir::Expression::HexNumberExpression(hex_number) => {
+                        ConstantValue::from_hex_number_expression(hex_number)
+                    }
+                    _ => None,
+                };
+                if let Some(constant) = &folded {
+                    let ConstantValue::Integer(magnitude) = constant;
+                    if magnitude.sign() != num_bigint::Sign::NoSign {
+                        return Some(
+                            self.types
+                                .register_type(Type::Literal(constant.get_signed_literal_kind())),
+                        );
+                    }
+                }
+                self.typing_of_expression(&node.operand).as_type_id()
+            }
+            ir::PrefixExpressionOperator::PlusPlus(_)
+            | ir::PrefixExpressionOperator::MinusMinus(_)
+            | ir::PrefixExpressionOperator::Tilde(_) => {
+                // TODO(validation): check that the operand is integer
+                self.typing_of_expression(&node.operand).as_type_id()
+            }
+            ir::PrefixExpressionOperator::Bang(_) => {
+                // TODO(validation): check that the operand is boolean
+                Some(self.types.boolean())
+            }
+            ir::PrefixExpressionOperator::DeleteKeyword(_) => Some(self.types.void()),
         }
     }
 
@@ -580,7 +628,8 @@ impl Pass<'_> {
     pub(super) fn hex_number_literal_kind(
         hex_number_expression: &ir::HexNumberExpression,
     ) -> LiteralKind {
-        let hex_number = hex_number_expression.literal.unparse();
+        let mut hex_number = hex_number_expression.literal.unparse().to_owned();
+        hex_number.retain(|character| character != '_');
         if hex_number.len() == 42 {
             // TODO(validation): verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -178,33 +178,18 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         match node.operator {
             ir::PrefixExpressionOperator::Minus(_) => {
-                // `-literal` folds into a signed literal kind carrying the
-                // two's-complement width of the negated value, matching
-                // solc's `RationalNumberType::integerType()` behaviour for
-                // negated rational-number literals.
-                // TODO: this covers some edge cases but not all of them. We
-                // need full constant folding at the semantic level and that
-                // means keeping the actual value of literals in their type,
-                // similar to what `solc` does.
-                let folded = match &node.operand {
-                    ir::Expression::DecimalNumberExpression(decimal_number) => {
-                        ConstantValue::from_decimal_number_expression(decimal_number)
-                    }
-                    ir::Expression::HexNumberExpression(hex_number) => {
-                        ConstantValue::from_hex_number_expression(hex_number)
-                    }
-                    _ => None,
-                };
-                if let Some(constant) = &folded {
-                    let ConstantValue::Integer(magnitude) = constant;
-                    if magnitude.sign() != num_bigint::Sign::NoSign {
-                        return Some(
-                            self.types
-                                .register_type(Type::Literal(constant.get_signed_literal_kind())),
-                        );
-                    }
+                // Fold `-literal` (and more generally `-<constant>`) by
+                // negating the operand's known constant value.
+                if let Some(value) = self.constant_value_of_expression(&node.operand) {
+                    Some(
+                        self.types
+                            .register_type(Type::Literal(value.negate().to_literal_kind())),
+                    )
+                } else {
+                    // TODO(validation): check that the operand type supports
+                    // negation (ie. uint does not)
+                    self.typing_of_expression(&node.operand).as_type_id()
                 }
-                self.typing_of_expression(&node.operand).as_type_id()
             }
             ir::PrefixExpressionOperator::PlusPlus(_)
             | ir::PrefixExpressionOperator::MinusMinus(_)
@@ -218,6 +203,79 @@ impl Pass<'_> {
             }
             ir::PrefixExpressionOperator::DeleteKeyword(_) => Some(self.types.void()),
         }
+    }
+
+    /// Returns a type that both branches can flow into, used by the
+    /// conditional expression typing. Falls back to lifting two distinct
+    /// integer literal arms to the smallest holding integer type — matching
+    /// solc's "common type" rule for two `RationalNumberType` operands.
+    pub(super) fn common_type_for_conditional_branches(
+        &mut self,
+        true_type_id: TypeId,
+        false_type_id: TypeId,
+    ) -> Option<TypeId> {
+        if self
+            .types
+            .implicitly_convertible_to(false_type_id, true_type_id)
+        {
+            return Some(true_type_id);
+        }
+        if self
+            .types
+            .implicitly_convertible_to(true_type_id, false_type_id)
+        {
+            return Some(false_type_id);
+        }
+        // TODO: handle rational numbers with conversion to fixed/ufixed
+        let true_value = match self.types.get_type_by_id(true_type_id) {
+            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
+                Some(value.clone())
+            }
+            _ => None,
+        }?;
+        let false_value = match self.types.get_type_by_id(false_type_id) {
+            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
+                Some(value.clone())
+            }
+            _ => None,
+        }?;
+        self.types
+            .common_integer_literal_type(&true_value, &false_value)
+    }
+
+    /// Returns the compile-time constant value of an expression, when its type
+    /// is a value-bearing literal (integer or rational). Used by the constant
+    /// folding logic in the binary/prefix expression visitors.
+    pub(super) fn constant_value_of_expression(
+        &self,
+        expression: &ir::Expression,
+    ) -> Option<ConstantValue> {
+        let type_id = self.typing_of_expression(expression).as_type_id()?;
+        match self.types.get_type_by_id(type_id) {
+            Type::Literal(kind) => ConstantValue::from_literal_kind(kind),
+            _ => None,
+        }
+    }
+
+    /// If both operands are constant literals, applies `op` to their values
+    /// and returns the resulting narrowed literal type. Returns `None` to let
+    /// the caller fall back to its non-folding type rule.
+    pub(super) fn fold_binary_literal_expression<F>(
+        &mut self,
+        left: &ir::Expression,
+        right: &ir::Expression,
+        op: F,
+    ) -> Option<TypeId>
+    where
+        F: FnOnce(&ConstantValue, &ConstantValue) -> Option<ConstantValue>,
+    {
+        let left_value = self.constant_value_of_expression(left)?;
+        let right_value = self.constant_value_of_expression(right)?;
+        let result = op(&left_value, &right_value)?;
+        Some(
+            self.types
+                .register_type(Type::Literal(result.to_literal_kind())),
+        )
     }
 
     pub(super) fn typing_of_resolution(&self, resolution: &Resolution) -> Typing {
@@ -627,19 +685,21 @@ impl Pass<'_> {
 
     pub(super) fn hex_number_literal_kind(
         hex_number_expression: &ir::HexNumberExpression,
-    ) -> LiteralKind {
+    ) -> Option<LiteralKind> {
         let mut hex_number = hex_number_expression.literal.unparse().to_owned();
         hex_number.retain(|character| character != '_');
-        if hex_number.len() == 42 {
+        // Source-text byte width: `0x` prefix is stripped
+        let digits = u32::try_from(hex_number.len().saturating_sub(2)).ok()?;
+        if digits == 40 {
             // TODO(validation): verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum
-            LiteralKind::Address
-        } else if hex_number == "0x0" {
-            LiteralKind::Zero
-        } else {
-            LiteralKind::HexInteger {
-                bytes: u32::try_from((hex_number.len() - 3) / 2 + 1).unwrap(),
-            }
+            return Some(LiteralKind::Address);
         }
+        let value = ConstantValue::from_hex_number_expression(hex_number_expression)?
+            .into_integer()
+            .expect("hex literal must parse to an integer");
+        // Each pair of hex digits is one byte (with odd digit counts rounded up).
+        let bytes = digits.div_ceil(2).max(1);
+        Some(LiteralKind::HexInteger { value, bytes })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -143,31 +143,48 @@ impl Pass<'_> {
         self.typing_of_resolution(&resolution)
     }
 
-    pub(super) fn type_of_integer_binary_expression(
-        &self,
+    /// Returns the type of an binary operator expression. If both operands are
+    /// number literals, applies `op` to fold them into a narrowed literal type;
+    /// otherwise falls back to the implicit-convertibility rule between the
+    /// operand types.
+    pub(super) fn type_of_binary_operator_expression<F>(
+        &mut self,
         left_operand: &ir::Expression,
         right_operand: &ir::Expression,
-    ) -> Option<TypeId> {
-        let left_type_id = self.typing_of_expression(left_operand).as_type_id();
-        let right_type_id = self.typing_of_expression(right_operand).as_type_id();
-        // TODO(validation): check that both operands are indeed integers
-        if let (Some(left_type_id), Some(right_type_id)) = (left_type_id, right_type_id) {
-            if self
-                .types
-                .implicitly_convertible_to(right_type_id, left_type_id)
-            {
-                Some(left_type_id)
-            } else if self
-                .types
-                .implicitly_convertible_to(left_type_id, right_type_id)
-            {
-                Some(right_type_id)
-            } else {
-                // TODO(validation): the types are not compatible, we should
-                // emit an error, or signal our caller
-                None
-            }
+        op: F,
+    ) -> Option<TypeId>
+    where
+        F: FnOnce(&Number, &Number) -> Option<Number>,
+    {
+        let left_type_id = self.typing_of_expression(left_operand).as_type_id()?;
+        let right_type_id = self.typing_of_expression(right_operand).as_type_id()?;
+
+        // If both operands are number constants, fold them using the given operator.
+        if let (Some(left_value), Some(right_value)) = (
+            self.types.number_value_of_type_id(left_type_id),
+            self.types.number_value_of_type_id(right_type_id),
+        ) {
+            return op(&left_value, &right_value).map(|result| {
+                self.types
+                    .register_type(Type::Literal(result.to_literal_kind()))
+            });
+        }
+
+        // TODO(validation): check that both operands are valid for the operator
+        // (needs additional parameter or check at the call site)
+        if self
+            .types
+            .implicitly_convertible_to(right_type_id, left_type_id)
+        {
+            Some(left_type_id)
+        } else if self
+            .types
+            .implicitly_convertible_to(left_type_id, right_type_id)
+        {
+            Some(right_type_id)
         } else {
+            // TODO(validation): the types are not compatible, we should
+            // emit an error, or signal our caller
             None
         }
     }
@@ -178,9 +195,10 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         match node.operator {
             ir::PrefixExpressionOperator::Minus(_) => {
+                let operand_type_id = self.typing_of_expression(&node.operand).as_type_id()?;
                 // Fold `-literal` (and more generally `-<constant>`) by
                 // negating the operand's known number value.
-                if let Some(value) = self.number_value_of_expression(&node.operand) {
+                if let Some(value) = self.types.number_value_of_type_id(operand_type_id) {
                     Some(
                         self.types
                             .register_type(Type::Literal(value.negate().to_literal_kind())),
@@ -188,7 +206,7 @@ impl Pass<'_> {
                 } else {
                     // TODO(validation): check that the operand type supports
                     // negation (ie. uint does not)
-                    self.typing_of_expression(&node.operand).as_type_id()
+                    Some(operand_type_id)
                 }
             }
             ir::PrefixExpressionOperator::PlusPlus(_)
@@ -213,7 +231,7 @@ impl Pass<'_> {
         for item in &array.items {
             item_type_ids.push(self.typing_of_expression(item).as_type_id()?);
         }
-        let element_type = self.types.reified_common_type(&item_type_ids)?;
+        let element_type = self.types.common_mobile_type(&item_type_ids)?;
         Some(self.types.register_type(Type::FixedSizeArray {
             element_type,
             size: array.items.len(),
@@ -221,36 +239,44 @@ impl Pass<'_> {
         }))
     }
 
-    /// Returns the compile-time number value of an expression, when its type
-    /// is a value-bearing literal (integer or rational). Used by the constant
-    /// folding logic in the binary/prefix expression visitors.
-    fn number_value_of_expression(&self, expression: &ir::Expression) -> Option<Number> {
-        let type_id = self.typing_of_expression(expression).as_type_id()?;
-        match self.types.get_type_by_id(type_id) {
-            Type::Literal(kind) => Number::from_literal_kind(kind),
-            _ => None,
-        }
-    }
-
-    /// If both operands are numbers literals, applies `op` to their values
-    /// and returns the resulting narrowed literal type. Returns `None` to let
-    /// the caller fall back to its non-folding type rule.
-    pub(super) fn fold_binary_literal_expression<F>(
+    pub(super) fn type_of_left_typed_binary_operator_expression<F>(
         &mut self,
-        left: &ir::Expression,
-        right: &ir::Expression,
+        left_operand: &ir::Expression,
+        right_operand: &ir::Expression,
         op: F,
     ) -> Option<TypeId>
     where
         F: FnOnce(&Number, &Number) -> Option<Number>,
     {
-        let left_value = self.number_value_of_expression(left)?;
-        let right_value = self.number_value_of_expression(right)?;
-        let result = op(&left_value, &right_value)?;
-        Some(
-            self.types
-                .register_type(Type::Literal(result.to_literal_kind())),
-        )
+        let left_type_id = self.typing_of_expression(left_operand).as_type_id()?;
+        let right_type_id = self.typing_of_expression(right_operand).as_type_id()?;
+
+        let left_value = self.types.number_value_of_type_id(left_type_id);
+        let right_value = self.types.number_value_of_type_id(right_type_id);
+
+        if let (Some(left_value), Some(right_value)) = (&left_value, &right_value) {
+            // Both constants, so fold them
+            op(left_value, right_value).map(|result| {
+                self.types
+                    .register_type(Type::Literal(result.to_literal_kind()))
+            })
+        } else if let Some(left_value) = &left_value {
+            // For shifts or exponentiations, if the left operand is a literal,
+            // the result is either a `uint256` or an `int256` depending on the
+            // sign of `left_operand`.
+            if left_value.is_negative() {
+                Some(self.types.register_type(Type::Integer {
+                    signed: true,
+                    bits: 256,
+                }))
+            } else {
+                Some(self.types.uint256())
+            }
+        } else {
+            // TODO(validation): check that the operand types are valid (needs
+            // additional parameter or validation at call site)
+            Some(left_type_id)
+        }
     }
 
     pub(super) fn typing_of_resolution(&self, resolution: &Resolution) -> Typing {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{ConstantValue, DataLocation, FunctionType, LiteralKind, Type, TypeId};
+use crate::types::{DataLocation, FunctionType, LiteralKind, Number, Type, TypeId};
 
 impl Pass<'_> {
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
@@ -179,8 +179,8 @@ impl Pass<'_> {
         match node.operator {
             ir::PrefixExpressionOperator::Minus(_) => {
                 // Fold `-literal` (and more generally `-<constant>`) by
-                // negating the operand's known constant value.
-                if let Some(value) = self.constant_value_of_expression(&node.operand) {
+                // negating the operand's known number value.
+                if let Some(value) = self.number_value_of_expression(&node.operand) {
                     Some(
                         self.types
                             .register_type(Type::Literal(value.negate().to_literal_kind())),
@@ -243,21 +243,18 @@ impl Pass<'_> {
             .common_integer_literal_type(&true_value, &false_value)
     }
 
-    /// Returns the compile-time constant value of an expression, when its type
+    /// Returns the compile-time number value of an expression, when its type
     /// is a value-bearing literal (integer or rational). Used by the constant
     /// folding logic in the binary/prefix expression visitors.
-    pub(super) fn constant_value_of_expression(
-        &self,
-        expression: &ir::Expression,
-    ) -> Option<ConstantValue> {
+    pub(super) fn number_value_of_expression(&self, expression: &ir::Expression) -> Option<Number> {
         let type_id = self.typing_of_expression(expression).as_type_id()?;
         match self.types.get_type_by_id(type_id) {
-            Type::Literal(kind) => ConstantValue::from_literal_kind(kind),
+            Type::Literal(kind) => Number::from_literal_kind(kind),
             _ => None,
         }
     }
 
-    /// If both operands are constant literals, applies `op` to their values
+    /// If both operands are numbers literals, applies `op` to their values
     /// and returns the resulting narrowed literal type. Returns `None` to let
     /// the caller fall back to its non-folding type rule.
     pub(super) fn fold_binary_literal_expression<F>(
@@ -267,10 +264,10 @@ impl Pass<'_> {
         op: F,
     ) -> Option<TypeId>
     where
-        F: FnOnce(&ConstantValue, &ConstantValue) -> Option<ConstantValue>,
+        F: FnOnce(&Number, &Number) -> Option<Number>,
     {
-        let left_value = self.constant_value_of_expression(left)?;
-        let right_value = self.constant_value_of_expression(right)?;
+        let left_value = self.number_value_of_expression(left)?;
+        let right_value = self.number_value_of_expression(right)?;
         let result = op(&left_value, &right_value)?;
         Some(
             self.types
@@ -695,7 +692,7 @@ impl Pass<'_> {
             // We need at least an implementation of SHA3 to compute the checksum
             return Some(LiteralKind::Address);
         }
-        let value = ConstantValue::from_hex_number_expression(hex_number_expression)?
+        let value = Number::from_hex_number_expression(hex_number_expression)?
             .into_integer()
             .expect("hex literal must parse to an integer");
         // Each pair of hex digits is one byte (with odd digit counts rounded up).

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -129,25 +129,27 @@ impl Pass<'_> {
         node: &ir::PrefixExpression,
     ) -> Option<TypeId> {
         match node.operator {
-            ir::PrefixExpressionOperator::Minus(_) => {
+            ir::PrefixExpressionOperator::Minus(_) | ir::PrefixExpressionOperator::Tilde(_) => {
+                // Fold `-<constant>` or `~<constant>` by operating on the
+                // operand's known number value.
                 let operand_type_id = self.typing_of_expression(&node.operand).as_type_id()?;
-                // Fold `-literal` (and more generally `-<constant>`) by
-                // negating the operand's known number value.
                 if let Some(value) = self.types.number_value_of_type_id(operand_type_id) {
+                    let result = match node.operator {
+                        ir::PrefixExpressionOperator::Minus(_) => value.negate(),
+                        ir::PrefixExpressionOperator::Tilde(_) => value.bit_not()?,
+                        _ => unreachable!(),
+                    };
                     Some(
                         self.types
-                            .register_type(Type::Literal(value.negate().to_literal_kind())),
+                            .register_type(Type::Literal(result.to_literal_kind())),
                     )
                 } else {
-                    // TODO(validation): check that the operand type supports
-                    // negation (ie. uint does not)
+                    // TODO(validation): check that the operand type supports the operator
                     Some(operand_type_id)
                 }
             }
             ir::PrefixExpressionOperator::PlusPlus(_)
-            | ir::PrefixExpressionOperator::MinusMinus(_)
-            | ir::PrefixExpressionOperator::Tilde(_) => {
-                // TODO(validation): check that the operand is integer
+            | ir::PrefixExpressionOperator::MinusMinus(_) => {
                 self.typing_of_expression(&node.operand).as_type_id()
             }
             ir::PrefixExpressionOperator::Bang(_) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -6,6 +6,7 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::BuiltIn;
+use crate::passes::common::node_id_for_string_expression_typing;
 use crate::types::{DataLocation, Number, Type};
 
 impl Visitor for Pass<'_> {
@@ -121,6 +122,15 @@ impl Visitor for Pass<'_> {
                 let scope_id = self.current_scope_id();
                 self.filter_overriden_definitions(self.resolve_symbol_in_scope(scope_id, symbol))
             };
+
+            // Set the typing for the `Identifier` node.
+            // The resolution may point to an imported symbol, so we need to
+            // follow through in order to get to the actual typing.
+            let followed_resolution = self.binder.follow_symbol_aliases(&resolution);
+            let typing = self.typing_of_resolution(&followed_resolution);
+            self.binder.set_node_typing(identifier.id(), typing);
+
+            // Finally, create the reference for the identifier.
             let reference = Reference::new(Rc::clone(identifier), resolution);
             self.binder.insert_reference(reference);
         }
@@ -145,7 +155,7 @@ impl Visitor for Pass<'_> {
         let type_id = self
             .types
             .register_type(Self::type_of_string_expression(node));
-        let node_id = Self::node_id_for_string_expression(node);
+        let node_id = node_id_for_string_expression_typing(node);
         self.binder.set_node_type(node_id, Some(type_id));
     }
 
@@ -175,20 +185,28 @@ impl Visitor for Pass<'_> {
         self.binder.set_node_type(node.id(), type_id);
     }
 
-    fn leave_or_expression(&mut self, _node: &ir::OrExpression) {
+    fn leave_or_expression(&mut self, node: &ir::OrExpression) {
         // TODO(validation): check that both operands are boolean
+        self.binder
+            .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
-    fn leave_and_expression(&mut self, _node: &ir::AndExpression) {
+    fn leave_and_expression(&mut self, node: &ir::AndExpression) {
         // TODO(validation): check that both operands are boolean
+        self.binder
+            .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
-    fn leave_equality_expression(&mut self, _node: &ir::EqualityExpression) {
+    fn leave_equality_expression(&mut self, node: &ir::EqualityExpression) {
         // TODO(validation): check that both operands have a compatible type
+        self.binder
+            .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
-    fn leave_inequality_expression(&mut self, _node: &ir::InequalityExpression) {
+    fn leave_inequality_expression(&mut self, node: &ir::InequalityExpression) {
         // TODO(validation): check that both operands have a compatible type
+        self.binder
+            .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
     fn leave_bitwise_or_expression(&mut self, node: &ir::BitwiseOrExpression) {
@@ -337,9 +355,10 @@ impl Visitor for Pass<'_> {
             }
         }
 
-        // store the typing
+        // Store the typing
         self.binder.set_node_typing(node.id(), typing);
 
+        // And create the reference for the member identifier.
         let reference = Reference::new(Rc::clone(&node.member), resolution);
         self.binder.insert_reference(reference);
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -145,7 +145,7 @@ impl Visitor for Pass<'_> {
         let type_id = self
             .types
             .register_type(Self::type_of_string_expression(node));
-        let node_id = Self::string_expression_node_id(node);
+        let node_id = Self::node_id_for_string_expression(node);
         self.binder.set_node_type(node_id, Some(type_id));
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -169,7 +169,7 @@ impl Visitor for Pass<'_> {
         let type_id = match (true_type_id, false_type_id) {
             (Some(true_type_id), Some(false_type_id)) => self
                 .types
-                .reified_common_type(&[true_type_id, false_type_id]),
+                .common_mobile_type(&[true_type_id, false_type_id]),
             _ => None,
         };
         self.binder.set_node_type(node.id(), type_id);
@@ -192,113 +192,76 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_bitwise_or_expression(&mut self, node: &ir::BitwiseOrExpression) {
-        let type_id = self
-            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                l.bit_or(r)
-            })
-            .or_else(|| {
-                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
-            });
+        let type_id = self.type_of_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| l.bit_or(r),
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_bitwise_xor_expression(&mut self, node: &ir::BitwiseXorExpression) {
-        let type_id = self
-            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                l.bit_xor(r)
-            })
-            .or_else(|| {
-                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
-            });
+        let type_id = self.type_of_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| l.bit_xor(r),
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_bitwise_and_expression(&mut self, node: &ir::BitwiseAndExpression) {
-        let type_id = self
-            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                l.bit_and(r)
-            })
-            .or_else(|| {
-                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
-            });
+        let type_id = self.type_of_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| l.bit_and(r),
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_shift_expression(&mut self, node: &ir::ShiftExpression) {
-        // TODO(validation): check that the left operand is an integer and the
-        // right operand is an _unsigned_ integer
-        let folded =
-            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                match &node.operator {
-                    ir::ShiftExpressionOperator::LessThanLessThan(_) => l.shl(r),
-                    ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => l.shr(r),
-                    ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => None,
-                }
-            });
-        // TODO: if the left operand is a literal integer but the right operand
-        // is not, `folded` will be `None` and the operand needs to be converted
-        // into uint256/int256 depending on the sign of left.
-        let type_id = folded.or_else(|| self.typing_of_expression(&node.left_operand).as_type_id());
+        let type_id = self.type_of_left_typed_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| match &node.operator {
+                ir::ShiftExpressionOperator::LessThanLessThan(_) => l.shl(r),
+                ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => l.shr(r),
+                ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => None,
+            },
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_additive_expression(&mut self, node: &ir::AdditiveExpression) {
-        let folded =
-            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                match &node.operator {
-                    ir::AdditiveExpressionOperator::Plus(_) => Some(l.add(r)),
-                    ir::AdditiveExpressionOperator::Minus(_) => Some(l.sub(r)),
-                }
-            });
-        let type_id = folded.or_else(|| {
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
-        });
+        let type_id = self.type_of_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| match &node.operator {
+                ir::AdditiveExpressionOperator::Plus(_) => Some(l.add(r)),
+                ir::AdditiveExpressionOperator::Minus(_) => Some(l.sub(r)),
+            },
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_multiplicative_expression(&mut self, node: &ir::MultiplicativeExpression) {
-        let folded =
-            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                match &node.operator {
-                    ir::MultiplicativeExpressionOperator::Asterisk(_) => Some(l.mul(r)),
-                    ir::MultiplicativeExpressionOperator::Slash(_) => l.div(r),
-                    ir::MultiplicativeExpressionOperator::Percent(_) => l.rem(r),
-                }
-            });
-        let type_id = folded.or_else(|| {
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
-        });
+        let type_id = self.type_of_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| match &node.operator {
+                ir::MultiplicativeExpressionOperator::Asterisk(_) => Some(l.mul(r)),
+                ir::MultiplicativeExpressionOperator::Slash(_) => l.div(r),
+                ir::MultiplicativeExpressionOperator::Percent(_) => l.rem(r),
+            },
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_exponentiation_expression(&mut self, node: &ir::ExponentiationExpression) {
-        // TODO(validation): check that the left operand is an integer and the
-        // right operand is an _unsigned_ integer
-        if let Some(type_id) =
-            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
-                l.pow(r)
-            })
-        {
-            self.binder.set_node_type(node.id(), Some(type_id));
-            return;
-        }
-        // TODO: if the left operand is a literal integer but the right operand
-        // is not, the operand needs to be converted into uint256/int256
-        // depending on the sign of left (refactor with shift operations).
-        let mut type_id = self.typing_of_expression(&node.left_operand).as_type_id();
-        if type_id.is_some_and(|type_id| self.types.get_type_by_id(type_id).is_literal_number()) {
-            // if the base is a literal but the exponent is not, then the result is uint256
-            if self
-                .typing_of_expression(&node.right_operand)
-                .as_type_id()
-                .is_none_or(|exponent_type| {
-                    !self.types.get_type_by_id(exponent_type).is_literal_number()
-                })
-            {
-                // TODO: this needs to look at the sign of the left operand.
-                type_id = Some(self.types.uint256());
-            }
-        }
+        let type_id = self.type_of_left_typed_binary_operator_expression(
+            &node.left_operand,
+            &node.right_operand,
+            |l, r| l.pow(r),
+        );
         self.binder.set_node_type(node.id(), type_id);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -6,7 +6,7 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{ConstantValue, DataLocation, Type};
+use crate::types::{DataLocation, Number, Type};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -134,9 +134,9 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_decimal_number_expression(&mut self, node: &ir::DecimalNumberExpression) {
-        let type_id = ConstantValue::from_decimal_number_expression(node).map(|constant| {
+        let type_id = Number::from_decimal_number_expression(node).map(|number| {
             self.types
-                .register_type(Type::Literal(constant.to_literal_kind()))
+                .register_type(Type::Literal(number.to_literal_kind()))
         });
         self.binder.set_node_type(node.id(), type_id);
     }
@@ -295,7 +295,7 @@ impl Visitor for Pass<'_> {
                     !self.types.get_type_by_id(exponent_type).is_literal_number()
                 })
             {
-                // TODO: this needs to look at the sign of the left constant.
+                // TODO: this needs to look at the sign of the left operand.
                 type_id = Some(self.types.uint256());
             }
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -6,7 +6,7 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{ConstantValue, DataLocation, LiteralKind, Type};
+use crate::types::{ConstantValue, DataLocation, Type};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -128,22 +128,17 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_hex_number_expression(&mut self, node: &ir::HexNumberExpression) {
-        let kind = Self::hex_number_literal_kind(node);
-        let type_id = self.types.register_type(Type::Literal(kind));
-        self.binder.set_node_type(node.id(), Some(type_id));
+        let type_id = Self::hex_number_literal_kind(node)
+            .map(|kind| self.types.register_type(Type::Literal(kind)));
+        self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_decimal_number_expression(&mut self, node: &ir::DecimalNumberExpression) {
-        let type_ = if node.unit.is_none() && node.literal.unparse() == "0" {
-            Type::Literal(LiteralKind::Zero)
-        } else {
-            match ConstantValue::from_decimal_number_expression(node) {
-                Some(constant) => Type::Literal(constant.get_literal_kind()),
-                None => Type::Literal(LiteralKind::Rational),
-            }
-        };
-        let type_id = self.types.register_type(type_);
-        self.binder.set_node_type(node.id(), Some(type_id));
+        let type_id = ConstantValue::from_decimal_number_expression(node).map(|constant| {
+            self.types
+                .register_type(Type::Literal(constant.to_literal_kind()))
+        });
+        self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_string_expression(&mut self, node: &ir::StringExpression) {
@@ -173,19 +168,7 @@ impl Visitor for Pass<'_> {
         // have the compatible types
         let type_id = match (true_type_id, false_type_id) {
             (Some(true_type_id), Some(false_type_id)) => {
-                if self
-                    .types
-                    .implicitly_convertible_to(false_type_id, true_type_id)
-                {
-                    Some(true_type_id)
-                } else if self
-                    .types
-                    .implicitly_convertible_to(true_type_id, false_type_id)
-                {
-                    Some(false_type_id)
-                } else {
-                    None
-                }
+                self.common_type_for_conditional_branches(true_type_id, false_type_id)
             }
             _ => None,
         };
@@ -209,46 +192,100 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_bitwise_or_expression(&mut self, node: &ir::BitwiseOrExpression) {
-        let type_id =
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand);
+        let type_id = self
+            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                l.bit_or(r)
+            })
+            .or_else(|| {
+                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
+            });
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_bitwise_xor_expression(&mut self, node: &ir::BitwiseXorExpression) {
-        let type_id =
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand);
+        let type_id = self
+            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                l.bit_xor(r)
+            })
+            .or_else(|| {
+                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
+            });
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_bitwise_and_expression(&mut self, node: &ir::BitwiseAndExpression) {
-        let type_id =
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand);
+        let type_id = self
+            .fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                l.bit_and(r)
+            })
+            .or_else(|| {
+                self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
+            });
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_shift_expression(&mut self, node: &ir::ShiftExpression) {
-        let type_id = self.typing_of_expression(&node.left_operand).as_type_id();
         // TODO(validation): check that the left operand is an integer and the
         // right operand is an _unsigned_ integer
+        let folded =
+            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                match &node.operator {
+                    ir::ShiftExpressionOperator::LessThanLessThan(_) => l.shl(r),
+                    ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => l.shr(r),
+                    ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => None,
+                }
+            });
+        // TODO: if the left operand is a literal integer but the right operand
+        // is not, `folded` will be `None` and the operand needs to be converted
+        // into uint256/int256 depending on the sign of left.
+        let type_id = folded.or_else(|| self.typing_of_expression(&node.left_operand).as_type_id());
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_additive_expression(&mut self, node: &ir::AdditiveExpression) {
-        let type_id =
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand);
+        let folded =
+            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                match &node.operator {
+                    ir::AdditiveExpressionOperator::Plus(_) => Some(l.add(r)),
+                    ir::AdditiveExpressionOperator::Minus(_) => Some(l.sub(r)),
+                }
+            });
+        let type_id = folded.or_else(|| {
+            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
+        });
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_multiplicative_expression(&mut self, node: &ir::MultiplicativeExpression) {
-        let type_id =
-            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand);
+        let folded =
+            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                match &node.operator {
+                    ir::MultiplicativeExpressionOperator::Asterisk(_) => Some(l.mul(r)),
+                    ir::MultiplicativeExpressionOperator::Slash(_) => l.div(r),
+                    ir::MultiplicativeExpressionOperator::Percent(_) => l.rem(r),
+                }
+            });
+        let type_id = folded.or_else(|| {
+            self.type_of_integer_binary_expression(&node.left_operand, &node.right_operand)
+        });
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_exponentiation_expression(&mut self, node: &ir::ExponentiationExpression) {
-        let mut type_id = self.typing_of_expression(&node.left_operand).as_type_id();
         // TODO(validation): check that the left operand is an integer and the
         // right operand is an _unsigned_ integer
+        if let Some(type_id) =
+            self.fold_binary_literal_expression(&node.left_operand, &node.right_operand, |l, r| {
+                l.pow(r)
+            })
+        {
+            self.binder.set_node_type(node.id(), Some(type_id));
+            return;
+        }
+        // TODO: if the left operand is a literal integer but the right operand
+        // is not, the operand needs to be converted into uint256/int256
+        // depending on the sign of left (refactor with shift operations).
+        let mut type_id = self.typing_of_expression(&node.left_operand).as_type_id();
         if type_id.is_some_and(|type_id| self.types.get_type_by_id(type_id).is_literal_number()) {
             // if the base is a rational but the exponent is not, then the result is uint256
             if self
@@ -258,6 +295,7 @@ impl Visitor for Pass<'_> {
                     !self.types.get_type_by_id(exponent_type).is_literal_number()
                 })
             {
+                // TODO: this needs to look at the sign of the left constant.
                 type_id = Some(self.types.uint256());
             }
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -167,9 +167,9 @@ impl Visitor for Pass<'_> {
         // TODO(validation): both true_expression and false_expression should
         // have the compatible types
         let type_id = match (true_type_id, false_type_id) {
-            (Some(true_type_id), Some(false_type_id)) => {
-                self.common_type_for_conditional_branches(true_type_id, false_type_id)
-            }
+            (Some(true_type_id), Some(false_type_id)) => self
+                .types
+                .reified_common_type(&[true_type_id, false_type_id]),
             _ => None,
         };
         self.binder.set_node_type(node.id(), type_id);
@@ -287,7 +287,7 @@ impl Visitor for Pass<'_> {
         // depending on the sign of left (refactor with shift operations).
         let mut type_id = self.typing_of_expression(&node.left_operand).as_type_id();
         if type_id.is_some_and(|type_id| self.types.get_type_by_id(type_id).is_literal_number()) {
-            // if the base is a rational but the exponent is not, then the result is uint256
+            // if the base is a literal but the exponent is not, then the result is uint256
             if self
                 .typing_of_expression(&node.right_operand)
                 .as_type_id()
@@ -456,28 +456,13 @@ impl Visitor for Pass<'_> {
 
     fn leave_array_expression(&mut self, node: &ir::ArrayExpression) {
         let typing = if node.items.is_empty() {
+            // TODO(validation): an empty array literal cannot be typed
             Typing::Unresolved
-        } else if let Some(element_type) = self
-            .typing_of_expression(node.items.first().unwrap())
-            .as_type_id()
-        {
-            // TODO(validation): all expressions in the array should have the
-            // same (or implicitly convertible) types
-            // TODO: the type class is determined by the first element, but then
-            // its size can grow to accommodate the other elements (eg. `[1,
-            // 1024]` should type to `uint16[2]`, but `[1, 1.1]` is invalid)
-            if let Some(element_type) = self.types.reified_type(element_type) {
-                let type_id = self.types.register_type(Type::FixedSizeArray {
-                    element_type,
-                    size: node.items.len(),
-                    location: DataLocation::Memory,
-                });
-                Typing::Resolved(type_id)
-            } else {
-                // Literals cannot be reified (eg. integer exceeds 256 bits)
-                Typing::Unresolved
-            }
+        } else if let Some(type_id) = self.type_of_array_expression(node) {
+            Typing::Resolved(type_id)
         } else {
+            // TODO(validation): all expressions in the array should have a type
+            // and fit in the type dictated by the first element
             Typing::Unresolved
         };
         self.binder.set_node_typing(node.id(), typing);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -461,21 +461,12 @@ impl Visitor for Pass<'_> {
             .typing_of_expression(node.items.first().unwrap())
             .as_type_id()
         {
-            let element_type = self.types.reified_type(element_type);
-            let type_id = self.types.register_type(Type::FixedSizeArray {
-                element_type,
-                size: node.items.len(),
-                location: DataLocation::Memory,
-            });
-            Typing::Resolved(type_id)
-        } else {
             // TODO(validation): all expressions in the array should have the
             // same (or implicitly convertible) types
-            if let Some(element_type) = self
-                .typing_of_expression(node.items.first().unwrap())
-                .as_type_id()
-            {
-                let element_type = self.types.reified_type(element_type);
+            // TODO: the type class is determined by the first element, but then
+            // its size can grow to accommodate the other elements (eg. `[1,
+            // 1024]` should type to `uint16[2]`, but `[1, 1.1]` is invalid)
+            if let Some(element_type) = self.types.reified_type(element_type) {
                 let type_id = self.types.register_type(Type::FixedSizeArray {
                     element_type,
                     size: node.items.len(),
@@ -483,8 +474,11 @@ impl Visitor for Pass<'_> {
                 });
                 Typing::Resolved(type_id)
             } else {
+                // Literals cannot be reified (eg. integer exceeds 256 bits)
                 Typing::Unresolved
             }
+        } else {
+            Typing::Unresolved
         };
         self.binder.set_node_typing(node.id(), typing);
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -237,6 +237,8 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_shift_expression(&mut self, node: &ir::ShiftExpression) {
+        // TODO(validation): check that the left operand is an integer and the
+        // right operand is an _unsigned_ integer
         let type_id = self.type_of_left_typed_binary_operator_expression(
             &node.left_operand,
             &node.right_operand,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -2,12 +2,11 @@ use std::rc::Rc;
 
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
-use slang_solidity_v2_ir::ir::PrefixExpressionOperator;
 
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::BuiltIn;
-use crate::types::{DataLocation, LiteralKind, Type};
+use crate::types::{ConstantValue, DataLocation, LiteralKind, Type};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -138,7 +137,10 @@ impl Visitor for Pass<'_> {
         let type_ = if node.unit.is_none() && node.literal.unparse() == "0" {
             Type::Literal(LiteralKind::Zero)
         } else {
-            Type::Literal(LiteralKind::DecimalInteger)
+            match ConstantValue::from_decimal_number_expression(node) {
+                Some(constant) => Type::Literal(constant.get_literal_kind()),
+                None => Type::Literal(LiteralKind::Rational),
+            }
         };
         let type_id = self.types.register_type(type_);
         self.binder.set_node_type(node.id(), Some(type_id));
@@ -269,20 +271,7 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_prefix_expression(&mut self, node: &ir::PrefixExpression) {
-        let type_id = match node.operator {
-            PrefixExpressionOperator::PlusPlus(_)
-            | PrefixExpressionOperator::MinusMinus(_)
-            | PrefixExpressionOperator::Minus(_)
-            | PrefixExpressionOperator::Tilde(_) => {
-                // TODO(validation): check that the operand is integer
-                self.typing_of_expression(&node.operand).as_type_id()
-            }
-            PrefixExpressionOperator::Bang(_) => {
-                // TODO(validation): check that the operand is boolean
-                Some(self.types.boolean())
-            }
-            PrefixExpressionOperator::DeleteKeyword(_) => Some(self.types.void()),
-        };
+        let type_id = self.type_of_prefix_expression(node);
         self.binder.set_node_type(node.id(), type_id);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -1,62 +1,14 @@
 use std::collections::HashMap;
 
-use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
-use slang_solidity_v2_parser::{ParseOutput, Parser};
+use slang_solidity_v2_ir::ir::NodeIdGenerator;
 
+use super::build_file;
 use crate::binder::{Binder, Resolution};
-use crate::context::SemanticFile;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
 use crate::types::TypeRegistry;
-
-struct TestFile {
-    id: String,
-    ir_root: ir::SourceUnit,
-}
-
-impl SemanticFile for TestFile {
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn ir_root(&self) -> &ir::SourceUnit {
-        &self.ir_root
-    }
-
-    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&String> {
-        None
-    }
-}
-
-fn build_file(name: &str, contents: &str, id_generator: &mut NodeIdGenerator) -> TestFile {
-    let ParseOutput {
-        source_unit,
-        diagnostics,
-    } = Parser::parse(name, contents, LanguageVersion::V0_8_30);
-
-    assert!(
-        diagnostics.is_empty(),
-        "Parser diagnostics: {diagnostics:?}"
-    );
-
-    let ir::BuildOutput {
-        ir_root,
-        diagnostics,
-    } = ir::build(name, &source_unit, &contents, id_generator);
-
-    assert!(
-        diagnostics.is_empty(),
-        "IR builder diagnostics: {diagnostics:?}"
-    );
-
-    TestFile {
-        id: name.to_string(),
-        ir_root,
-    }
-}
 
 #[test]
 fn test_collect_definitions_and_linearise_contracts() {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -1,0 +1,55 @@
+mod binder;
+mod typing;
+
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
+use slang_solidity_v2_parser::{ParseOutput, Parser};
+
+use crate::context::SemanticFile;
+
+struct TestFile {
+    id: String,
+    ir_root: ir::SourceUnit,
+}
+
+impl SemanticFile for TestFile {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn ir_root(&self) -> &ir::SourceUnit {
+        &self.ir_root
+    }
+
+    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&String> {
+        None
+    }
+}
+
+fn build_file(name: &str, contents: &str, id_generator: &mut NodeIdGenerator) -> TestFile {
+    let ParseOutput {
+        source_unit,
+        diagnostics,
+    } = Parser::parse(name, contents, LanguageVersion::V0_8_30);
+
+    assert!(
+        diagnostics.is_empty(),
+        "Parser diagnostics: {diagnostics:?}"
+    );
+
+    let ir::BuildOutput {
+        ir_root,
+        diagnostics,
+    } = ir::build(name, &source_unit, &contents, id_generator);
+
+    assert!(
+        diagnostics.is_empty(),
+        "IR builder diagnostics: {diagnostics:?}"
+    );
+
+    TestFile {
+        id: name.to_string(),
+        ir_root,
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -10,12 +10,21 @@ use crate::context::SemanticFile;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
-use crate::types::{LiteralKind, Type, TypeRegistry};
+use crate::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
 
 /// Parses a Solidity expression as the value of a top-level `uint constant`,
 /// runs all semantic passes, and returns a clone of the inferred type assigned
 /// to that value expression along with the populated `TypeRegistry`.
 fn type_of_value_expression(input: &str) -> (Type, TypeRegistry) {
+    let (expr_type, types) = try_type_of_value_expression(input);
+    let expr_type = expr_type.expect("expected resolved type for value expression");
+    (expr_type, types)
+}
+
+/// Like `type_of_value_expression`, but returns `None` if the expression
+/// did not resolve to a `Typing::Resolved`. Lets tests assert on the
+/// "unresolved" outcome without panicking.
+fn try_type_of_value_expression(input: &str) -> (Option<Type>, TypeRegistry) {
     let source = format!("uint constant x = {input};");
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file("test.sol", &source, &mut id_generator);
@@ -35,17 +44,18 @@ fn type_of_value_expression(input: &str) -> (Type, TypeRegistry) {
         other => panic!("expected ConstantDefinition, got {other:?}"),
     };
 
-    let type_id = match binder.node_typing(expression_node_id(value_expr)) {
-        Typing::Resolved(type_id) => type_id,
-        other => panic!("expected resolved type for value expression, got {other:?}"),
+    let expr_type = match binder.node_typing(expression_node_id(value_expr)) {
+        Typing::Resolved(type_id) => Some(types.get_type_by_id(type_id).clone()),
+        _ => None,
     };
 
-    (types.get_type_by_id(type_id).clone(), types)
+    (expr_type, types)
 }
 
 /// Returns the `NodeId` of an `ir::Expression`, dispatching across the
 /// variants that can appear as the value of a top-level constant in our
-/// typing tests.
+/// typing tests. `StringExpression` does not have its own `NodeId`, so its
+/// typing is recorded against the first terminal of the literal collection.
 fn expression_node_id(expr: &ir::Expression) -> NodeId {
     match expr {
         ir::Expression::AdditiveExpression(e) => e.id(),
@@ -57,11 +67,24 @@ fn expression_node_id(expr: &ir::Expression) -> NodeId {
         ir::Expression::HexNumberExpression(e) => e.id(),
         ir::Expression::TupleExpression(e) => e.id(),
         ir::Expression::ConditionalExpression(e) => e.id(),
+        ir::Expression::ArrayExpression(e) => e.id(),
         ir::Expression::BitwiseOrExpression(e) => e.id(),
         ir::Expression::BitwiseXorExpression(e) => e.id(),
         ir::Expression::BitwiseAndExpression(e) => e.id(),
+        ir::Expression::StringExpression(s) => match s {
+            ir::StringExpression::StringLiterals(strings) => strings[0].id(),
+            ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
+            ir::StringExpression::UnicodeStringLiterals(unicode_strings) => unicode_strings[0].id(),
+        },
         other => panic!("expression variant {other:?} not supported by typing tests"),
     }
+}
+
+fn register_uint_type(types: &mut TypeRegistry, bits: u32) -> TypeId {
+    types.register_type(Type::Integer {
+        signed: false,
+        bits,
+    })
 }
 
 #[test]
@@ -155,14 +178,8 @@ fn test_implicit_conversion_uses_literal_value() {
         signed: true,
         bits: 8,
     });
-    let uint8 = types.register_type(Type::Integer {
-        signed: false,
-        bits: 8,
-    });
-    let uint256 = types.register_type(Type::Integer {
-        signed: false,
-        bits: 256,
-    });
+    let uint8 = types.uint8();
+    let uint256 = types.uint256();
 
     let lit_127 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(127))));
     let lit_128 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(128))));
@@ -257,4 +274,178 @@ fn test_hex_literal_to_byte_array_conversion() {
     assert!(types.implicitly_convertible_to(dec_0, bytes4));
     assert!(types.implicitly_convertible_to(hex_0x0, bytes2));
     assert!(types.implicitly_convertible_to(hex_0x0000, bytes4));
+}
+
+#[test]
+fn test_conditional_expression_unifies_branch_types() {
+    // Both branches reify to uint8 — common type is uint8.
+    let (type_, _) = type_of_value_expression("true ? 1 : 2");
+    assert_eq!(
+        type_,
+        Type::Integer {
+            signed: false,
+            bits: 8,
+        }
+    );
+
+    // uint8 (1) widens to uint16 (256).
+    let (type_, _) = type_of_value_expression("true ? 1 : 256");
+    assert_eq!(
+        type_,
+        Type::Integer {
+            signed: false,
+            bits: 16,
+        }
+    );
+
+    // int8 (-1) and int8 (1) — common type is int8.
+    let (type_, _) = type_of_value_expression("true ? -1 : -128");
+    assert_eq!(
+        type_,
+        Type::Integer {
+            signed: true,
+            bits: 8,
+        }
+    );
+
+    // Both branches are string literals — both reify to `string memory`.
+    let (type_, _) = type_of_value_expression(r#"true ? "abc" : "x""#);
+    assert_eq!(
+        type_,
+        Type::String {
+            location: DataLocation::Memory,
+        }
+    );
+}
+
+#[test]
+fn test_conditional_expression_unresolved_when_branches_incompatible() {
+    // uint8 (1) and int8 (-1): neither converts to the other at the same
+    // bit width, so unification fails and the conditional is unresolved.
+    let (type_, _) = try_type_of_value_expression("true ? 1 : -1");
+    assert_eq!(type_, None);
+
+    // A non-reducing rational has no `reified` type yet, so any conditional
+    // involving one is unresolved.
+    let (type_, _) = try_type_of_value_expression("true ? 0.5 : 1");
+    assert_eq!(type_, None);
+}
+
+#[test]
+fn test_array_literal_unifies_element_types() {
+    // Homogeneous uint8 elements.
+    let (expr_type, types) = type_of_value_expression("[1, 2, 3]");
+    let Type::FixedSizeArray {
+        element_type,
+        size,
+        location,
+    } = expr_type
+    else {
+        panic!("expected FixedSizeArray, got {expr_type:?}");
+    };
+    assert_eq!(size, 3);
+    assert_eq!(location, DataLocation::Memory);
+    assert_eq!(element_type, types.uint8());
+
+    // Mixed widths widen to the largest required.
+    let (expr_type, mut types) = type_of_value_expression("[1, 256, 3]");
+    let Type::FixedSizeArray {
+        element_type, size, ..
+    } = expr_type
+    else {
+        panic!("expected FixedSizeArray, got {expr_type:?}");
+    };
+    assert_eq!(size, 3);
+    assert_eq!(element_type, register_uint_type(&mut types, 16));
+
+    // Negative values force the result to a signed type.
+    let (expr_type, mut types) = type_of_value_expression("[-1, -2]");
+    let Type::FixedSizeArray { element_type, .. } = expr_type else {
+        panic!("expected FixedSizeArray, got {expr_type:?}");
+    };
+    assert_eq!(
+        element_type,
+        types.register_type(Type::Integer {
+            signed: true,
+            bits: 8,
+        })
+    );
+
+    // String literal arrays reify each element to `string memory`.
+    let (expr_type, types) = type_of_value_expression(r#"["abc", "x"]"#);
+    let Type::FixedSizeArray {
+        element_type, size, ..
+    } = expr_type
+    else {
+        panic!("expected FixedSizeArray, got {expr_type:?}");
+    };
+    assert_eq!(size, 2);
+    assert_eq!(element_type, types.string());
+}
+
+#[test]
+fn test_array_literal_unresolved_when_elements_incompatible() {
+    // uint8 (1) and int8 (-1) cannot be unified (same bit width, opposite sign).
+    let (type_, _) = try_type_of_value_expression("[1, -1]");
+    assert_eq!(type_, None);
+
+    // Non-reducing rationals don't reify yet — array unification fails.
+    let (type_, _) = try_type_of_value_expression("[0.5, 1]");
+    assert_eq!(type_, None);
+}
+
+#[test]
+fn test_string_literal_byte_count_with_escapes() {
+    // Plain ASCII: one byte per char.
+    let (type_, _) = type_of_value_expression(r#""abc""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 3 }));
+
+    // Each `\n`, `\t`, etc. decodes to a single byte.
+    let (type_, _) = type_of_value_expression(r#""\n\t\\""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 3 }));
+
+    // `\xNN` escapes decode to one byte each, regardless of the 4-char source
+    // length per escape.
+    let (type_, _) = type_of_value_expression(r#""\x41\x42""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 2 }));
+
+    // Line continuations (`\<newline>`) decode to nothing.
+    let (type_, _) = type_of_value_expression("\"a\\\nb\"");
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 2 }));
+
+    // Concatenated string literals: byte counts add up across pieces.
+    let (type_, _) = type_of_value_expression(r#""abc" "de""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 5 }));
+}
+
+#[test]
+fn test_unicode_string_literal_byte_count() {
+    // ASCII unicode-string literal: one byte per char.
+    let (type_, _) = type_of_value_expression(r#"unicode"abc""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 3 }));
+
+    // Multi-byte UTF-8 passes through with its full byte length:
+    // `€` is 3 bytes in UTF-8.
+    let (type_, _) = type_of_value_expression(r#"unicode"€""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 3 }));
+
+    // `\uNNNN` escapes decode to their UTF-8 byte length:
+    // `\u20AC` (€) → 3 bytes, `\u00A2` (¢) → 2 bytes, `\u0024` ($) → 1 byte.
+    let (type_, _) = type_of_value_expression(r#"unicode"\u20AC\u00A2\u0024""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::String { bytes: 6 }));
+}
+
+#[test]
+fn test_hex_string_literal_byte_count() {
+    // Pairs of hex digits, no separators: one byte per pair.
+    let (type_, _) = type_of_value_expression(r#"hex"414243""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::HexString { bytes: 3 }));
+
+    // Underscore separators don't contribute to the decoded length.
+    let (type_, _) = type_of_value_expression(r#"hex"41_42""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::HexString { bytes: 2 }));
+
+    // Concatenated hex string literals: byte counts add up across pieces.
+    let (type_, _) = type_of_value_expression(r#"hex"4142" hex"43""#);
+    assert_eq!(type_, Type::Literal(LiteralKind::HexString { bytes: 3 }));
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -67,13 +67,17 @@ fn test_value_bearing_integer_literal_types() {
     let (type_, _) = type_of_value_expression("127");
     assert_eq!(
         type_,
-        Type::Literal(LiteralKind::Integer(BigInt::from(127)))
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(127)
+        })
     );
 
     let (type_, _) = type_of_value_expression("-128");
     assert_eq!(
         type_,
-        Type::Literal(LiteralKind::Integer(BigInt::from(-128)))
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-128)
+        })
     );
 
     // Hex literals carry source byte width as `HexInteger`, distinct from
@@ -99,50 +103,78 @@ fn test_value_bearing_integer_literal_types() {
 
     // Folding a hex literal demotes it to a plain `Integer` (provenance lost).
     let (type_, _) = type_of_value_expression("0x10 + 0");
-    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(16))));
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(16)
+        })
+    );
 }
 
 #[test]
 fn test_binary_arithmetic_folds_to_narrowed_literal() {
     // Addition.
     let (type_, _) = type_of_value_expression("1 + 1");
-    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(2))));
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(2)
+        })
+    );
 
     // Multiplication.
     let (type_, _) = type_of_value_expression("3 * 4");
-    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(12))));
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(12)
+        })
+    );
 
     // Power.
     let (type_, _) = type_of_value_expression("2 ** 10");
     assert_eq!(
         type_,
-        Type::Literal(LiteralKind::Integer(BigInt::from(1024)))
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(1024)
+        })
     );
 
     // Shift.
     let (type_, _) = type_of_value_expression("1 << 32");
     assert_eq!(
         type_,
-        Type::Literal(LiteralKind::Integer(BigInt::from(1u64 << 32)))
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(1u64 << 32)
+        })
     );
 
     // Reducible rational arithmetic normalises back to an integer.
     let (type_, _) = type_of_value_expression("1.5 * 2");
-    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(3))));
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(3)
+        })
+    );
 
     // Non-reducing rational division stays rational.
     let (type_, _) = type_of_value_expression("5 / 2");
     assert_eq!(
         type_,
-        Type::Literal(LiteralKind::Rational(BigRational::new(
-            BigInt::from(5),
-            BigInt::from(2)
-        )))
+        Type::Literal(LiteralKind::Rational {
+            value: BigRational::new(BigInt::from(5), BigInt::from(2))
+        })
     );
 
     // Negation of a folded constant.
     let (type_, _) = type_of_value_expression("-(1 + 1)");
-    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(-2))));
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-2)
+        })
+    );
 }
 
 #[test]
@@ -156,21 +188,36 @@ fn test_implicit_conversion_uses_literal_value() {
     let uint8 = types.uint8();
     let uint256 = types.uint256();
 
-    let lit_127 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(127))));
-    let lit_128 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(128))));
-    let lit_neg_128 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-128))));
-    let lit_neg_129 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-129))));
-    let lit_neg_1 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-1))));
-    let lit_0 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(0))));
-    let lit_255 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(255))));
-    let lit_256 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(256))));
-    let lit_big = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(
-        12_345_678,
-    ))));
-    let lit_half = types.register_type(Type::Literal(LiteralKind::Rational(BigRational::new(
-        BigInt::from(1),
-        BigInt::from(2),
-    ))));
+    let lit_127 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(127),
+    }));
+    let lit_128 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(128),
+    }));
+    let lit_neg_128 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(-128),
+    }));
+    let lit_neg_129 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(-129),
+    }));
+    let lit_neg_1 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(-1),
+    }));
+    let lit_0 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(0),
+    }));
+    let lit_255 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(255),
+    }));
+    let lit_256 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(256),
+    }));
+    let lit_big = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(12_345_678),
+    }));
+    let lit_half = types.register_type(Type::Literal(LiteralKind::Rational {
+        value: BigRational::new(BigInt::from(1), BigInt::from(2)),
+    }));
 
     // Within int8 range (signed):
     assert!(types.implicitly_convertible_to(lit_127, int8));
@@ -230,13 +277,17 @@ fn test_hex_literal_to_byte_array_conversion() {
 
     // Decimal-source integer of the same value does NOT convert to a byte
     // array (provenance matters).
-    let dec_18 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(18))));
+    let dec_18 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(18),
+    }));
     assert!(!types.implicitly_convertible_to(dec_18, bytes1));
     assert!(!types.implicitly_convertible_to(dec_18, bytes2));
 
     // Zero in any source — decimal, hex of any width, or folded — converts
     // to a byte array of any width.
-    let dec_0 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(0))));
+    let dec_0 = types.register_type(Type::Literal(LiteralKind::Integer {
+        value: BigInt::from(0),
+    }));
     let hex_0x0 = types.register_type(Type::Literal(LiteralKind::HexInteger {
         value: BigInt::from(0),
         bytes: 1,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1,0 +1,260 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
+
+use super::build_file;
+use crate::binder::{Binder, Typing};
+use crate::context::SemanticFile;
+use crate::passes::{
+    p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
+};
+use crate::types::{LiteralKind, Type, TypeRegistry};
+
+/// Parses a Solidity expression as the value of a top-level `uint constant`,
+/// runs all semantic passes, and returns a clone of the inferred type assigned
+/// to that value expression along with the populated `TypeRegistry`.
+fn type_of_value_expression(input: &str) -> (Type, TypeRegistry) {
+    let source = format!("uint constant x = {input};");
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", &source, &mut id_generator);
+    let files = [file];
+
+    let mut binder = Binder::default();
+    let mut types = TypeRegistry::default();
+    let language_version = LanguageVersion::V0_8_30;
+
+    p1_collect_definitions::run(&files, &mut binder);
+    p2_linearise_contracts::run(&files, &mut binder);
+    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
+
+    let value_expr = match files[0].ir_root().members.first().unwrap() {
+        ir::SourceUnitMember::ConstantDefinition(definition) => definition.value.as_ref().unwrap(),
+        other => panic!("expected ConstantDefinition, got {other:?}"),
+    };
+
+    let type_id = match binder.node_typing(expression_node_id(value_expr)) {
+        Typing::Resolved(type_id) => type_id,
+        other => panic!("expected resolved type for value expression, got {other:?}"),
+    };
+
+    (types.get_type_by_id(type_id).clone(), types)
+}
+
+/// Returns the `NodeId` of an `ir::Expression`, dispatching across the
+/// variants that can appear as the value of a top-level constant in our
+/// typing tests.
+fn expression_node_id(expr: &ir::Expression) -> NodeId {
+    match expr {
+        ir::Expression::AdditiveExpression(e) => e.id(),
+        ir::Expression::MultiplicativeExpression(e) => e.id(),
+        ir::Expression::ShiftExpression(e) => e.id(),
+        ir::Expression::ExponentiationExpression(e) => e.id(),
+        ir::Expression::PrefixExpression(e) => e.id(),
+        ir::Expression::DecimalNumberExpression(e) => e.id(),
+        ir::Expression::HexNumberExpression(e) => e.id(),
+        ir::Expression::TupleExpression(e) => e.id(),
+        ir::Expression::ConditionalExpression(e) => e.id(),
+        ir::Expression::BitwiseOrExpression(e) => e.id(),
+        ir::Expression::BitwiseXorExpression(e) => e.id(),
+        ir::Expression::BitwiseAndExpression(e) => e.id(),
+        other => panic!("expression variant {other:?} not supported by typing tests"),
+    }
+}
+
+#[test]
+fn test_value_bearing_integer_literal_types() {
+    let (type_, _) = type_of_value_expression("127");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer(BigInt::from(127)))
+    );
+
+    let (type_, _) = type_of_value_expression("-128");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer(BigInt::from(-128)))
+    );
+
+    // Hex literals carry source byte width as `HexInteger`, distinct from
+    // decimal `Integer` so the byte-array conversion rule can fire.
+    let (type_, _) = type_of_value_expression("0xff");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::HexInteger {
+            value: BigInt::from(255),
+            bytes: 1,
+        })
+    );
+
+    // Source byte width is preserved across leading zeros.
+    let (type_, _) = type_of_value_expression("0x0012");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::HexInteger {
+            value: BigInt::from(18),
+            bytes: 2,
+        })
+    );
+
+    // Folding a hex literal demotes it to a plain `Integer` (provenance lost).
+    let (type_, _) = type_of_value_expression("0x10 + 0");
+    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(16))));
+}
+
+#[test]
+fn test_binary_arithmetic_folds_to_narrowed_literal() {
+    // Addition.
+    let (type_, _) = type_of_value_expression("1 + 1");
+    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(2))));
+
+    // Multiplication.
+    let (type_, _) = type_of_value_expression("3 * 4");
+    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(12))));
+
+    // Power.
+    let (type_, _) = type_of_value_expression("2 ** 10");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer(BigInt::from(1024)))
+    );
+
+    // Shift.
+    let (type_, _) = type_of_value_expression("1 << 32");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer(BigInt::from(1u64 << 32)))
+    );
+
+    // Reducible rational arithmetic normalises back to an integer.
+    let (type_, _) = type_of_value_expression("1.5 * 2");
+    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(3))));
+
+    // Non-reducing rational division stays rational.
+    let (type_, _) = type_of_value_expression("5 / 2");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Rational(BigRational::new(
+            BigInt::from(5),
+            BigInt::from(2)
+        )))
+    );
+
+    // Negation of a folded constant.
+    let (type_, _) = type_of_value_expression("-(1 + 1)");
+    assert_eq!(type_, Type::Literal(LiteralKind::Integer(BigInt::from(-2))));
+}
+
+#[test]
+fn test_implicit_conversion_uses_literal_value() {
+    let (_, mut types) = type_of_value_expression("0");
+
+    let int8 = types.register_type(Type::Integer {
+        signed: true,
+        bits: 8,
+    });
+    let uint8 = types.register_type(Type::Integer {
+        signed: false,
+        bits: 8,
+    });
+    let uint256 = types.register_type(Type::Integer {
+        signed: false,
+        bits: 256,
+    });
+
+    let lit_127 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(127))));
+    let lit_128 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(128))));
+    let lit_neg_128 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-128))));
+    let lit_neg_129 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-129))));
+    let lit_neg_1 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(-1))));
+    let lit_0 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(0))));
+    let lit_255 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(255))));
+    let lit_256 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(256))));
+    let lit_big = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(
+        12_345_678,
+    ))));
+    let lit_half = types.register_type(Type::Literal(LiteralKind::Rational(BigRational::new(
+        BigInt::from(1),
+        BigInt::from(2),
+    ))));
+
+    // Within int8 range (signed):
+    assert!(types.implicitly_convertible_to(lit_127, int8));
+    assert!(types.implicitly_convertible_to(lit_neg_128, int8));
+
+    // Outside int8 range:
+    assert!(!types.implicitly_convertible_to(lit_128, int8));
+    assert!(!types.implicitly_convertible_to(lit_neg_129, int8));
+
+    // Within uint8 range (unsigned):
+    assert!(types.implicitly_convertible_to(lit_0, uint8));
+    assert!(types.implicitly_convertible_to(lit_255, uint8));
+
+    // Outside uint8 range:
+    assert!(!types.implicitly_convertible_to(lit_256, uint8));
+    assert!(!types.implicitly_convertible_to(lit_neg_1, uint8));
+
+    // Anything within uint256 (any non-negative literal we'd use here):
+    assert!(types.implicitly_convertible_to(lit_0, uint256));
+    assert!(types.implicitly_convertible_to(lit_big, uint256));
+
+    // Non-integer rationals never convert to integers.
+    assert!(!types.implicitly_convertible_to(lit_half, uint8));
+    assert!(!types.implicitly_convertible_to(lit_half, int8));
+    assert!(!types.implicitly_convertible_to(lit_half, uint256));
+}
+
+#[test]
+fn test_hex_literal_to_byte_array_conversion() {
+    let (_, mut types) = type_of_value_expression("0");
+
+    let bytes1 = types.register_type(Type::ByteArray { width: 1 });
+    let bytes2 = types.register_type(Type::ByteArray { width: 2 });
+    let bytes4 = types.register_type(Type::ByteArray { width: 4 });
+
+    // Hex source literal: byte-width must match the target exactly.
+    let hex_0x12 = types.register_type(Type::Literal(LiteralKind::HexInteger {
+        value: BigInt::from(0x12),
+        bytes: 1,
+    }));
+    let hex_0x0012 = types.register_type(Type::Literal(LiteralKind::HexInteger {
+        value: BigInt::from(0x12),
+        bytes: 2,
+    }));
+    let hex_0x10203040 = types.register_type(Type::Literal(LiteralKind::HexInteger {
+        value: BigInt::from(0x1020_3040u32),
+        bytes: 4,
+    }));
+
+    // Same value, different source widths convert to different byte arrays.
+    assert!(types.implicitly_convertible_to(hex_0x12, bytes1));
+    assert!(!types.implicitly_convertible_to(hex_0x12, bytes2));
+    assert!(types.implicitly_convertible_to(hex_0x0012, bytes2));
+    assert!(!types.implicitly_convertible_to(hex_0x0012, bytes1));
+    assert!(types.implicitly_convertible_to(hex_0x10203040, bytes4));
+    assert!(!types.implicitly_convertible_to(hex_0x10203040, bytes2));
+
+    // Decimal-source integer of the same value does NOT convert to a byte
+    // array (provenance matters).
+    let dec_18 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(18))));
+    assert!(!types.implicitly_convertible_to(dec_18, bytes1));
+    assert!(!types.implicitly_convertible_to(dec_18, bytes2));
+
+    // Zero in any source — decimal, hex of any width, or folded — converts
+    // to a byte array of any width.
+    let dec_0 = types.register_type(Type::Literal(LiteralKind::Integer(BigInt::from(0))));
+    let hex_0x0 = types.register_type(Type::Literal(LiteralKind::HexInteger {
+        value: BigInt::from(0),
+        bytes: 1,
+    }));
+    let hex_0x0000 = types.register_type(Type::Literal(LiteralKind::HexInteger {
+        value: BigInt::from(0),
+        bytes: 2,
+    }));
+    assert!(types.implicitly_convertible_to(dec_0, bytes1));
+    assert!(types.implicitly_convertible_to(dec_0, bytes4));
+    assert!(types.implicitly_convertible_to(hex_0x0, bytes2));
+    assert!(types.implicitly_convertible_to(hex_0x0000, bytes4));
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1,12 +1,12 @@
 use num_bigint::BigInt;
 use num_rational::BigRational;
-use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 
 use super::build_file;
 use crate::binder::{Binder, Typing};
 use crate::context::SemanticFile;
+use crate::passes::common::node_id_for_expression_typing;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
@@ -44,40 +44,15 @@ fn try_type_of_value_expression(input: &str) -> (Option<Type>, TypeRegistry) {
         other => panic!("expected ConstantDefinition, got {other:?}"),
     };
 
-    let expr_type = match binder.node_typing(expression_node_id(value_expr)) {
+    let expr_type = match binder.node_typing(
+        node_id_for_expression_typing(value_expr)
+            .expect("expression registers its typing in the binder"),
+    ) {
         Typing::Resolved(type_id) => Some(types.get_type_by_id(type_id).clone()),
         _ => None,
     };
 
     (expr_type, types)
-}
-
-/// Returns the `NodeId` of an `ir::Expression`, dispatching across the
-/// variants that can appear as the value of a top-level constant in our
-/// typing tests. `StringExpression` does not have its own `NodeId`, so its
-/// typing is recorded against the first terminal of the literal collection.
-fn expression_node_id(expr: &ir::Expression) -> NodeId {
-    match expr {
-        ir::Expression::AdditiveExpression(e) => e.id(),
-        ir::Expression::MultiplicativeExpression(e) => e.id(),
-        ir::Expression::ShiftExpression(e) => e.id(),
-        ir::Expression::ExponentiationExpression(e) => e.id(),
-        ir::Expression::PrefixExpression(e) => e.id(),
-        ir::Expression::DecimalNumberExpression(e) => e.id(),
-        ir::Expression::HexNumberExpression(e) => e.id(),
-        ir::Expression::TupleExpression(e) => e.id(),
-        ir::Expression::ConditionalExpression(e) => e.id(),
-        ir::Expression::ArrayExpression(e) => e.id(),
-        ir::Expression::BitwiseOrExpression(e) => e.id(),
-        ir::Expression::BitwiseXorExpression(e) => e.id(),
-        ir::Expression::BitwiseAndExpression(e) => e.id(),
-        ir::Expression::StringExpression(s) => match s {
-            ir::StringExpression::StringLiterals(strings) => strings[0].id(),
-            ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
-            ir::StringExpression::UnicodeStringLiterals(unicode_strings) => unicode_strings[0].id(),
-        },
-        other => panic!("expression variant {other:?} not supported by typing tests"),
-    }
 }
 
 fn register_uint_type(types: &mut TypeRegistry, bits: u32) -> TypeId {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -178,6 +178,129 @@ fn test_binary_arithmetic_folds_to_narrowed_literal() {
 }
 
 #[test]
+fn test_binary_bitwise_folds_to_literal() {
+    // OR
+    let (type_, _) = type_of_value_expression("1 | 2");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(3)
+        })
+    );
+
+    // AND
+    let (type_, _) = type_of_value_expression("12 & 10");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(8)
+        })
+    );
+
+    // XOR
+    let (type_, _) = type_of_value_expression("6 ^ 3");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(5)
+        })
+    );
+
+    // Folding hex operands demotes the result to a plain `Integer`
+    // (mirroring the additive folding behaviour).
+    let (type_, _) = type_of_value_expression("0xf0 | 0x0f");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(0xff)
+        })
+    );
+
+    // Bitwise AND with a negative literal: BigInt uses arbitrary-precision
+    // two's-complement, so `-1 & 0xff` masks to the low byte.
+    let (type_, _) = type_of_value_expression("(-1) & 0xff");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(0xff)
+        })
+    );
+
+    // Bitwise OR of a folded constant feeds further folding.
+    let (type_, _) = type_of_value_expression("(1 | 2) ^ 4");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(7)
+        })
+    );
+}
+
+#[test]
+fn test_bitwise_not_folds_to_literal() {
+    // ~x = -x - 1 (two's complement on an infinite-precision integer).
+    let (type_, _) = type_of_value_expression("~1");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-2)
+        })
+    );
+
+    let (type_, _) = type_of_value_expression("~0");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-1)
+        })
+    );
+
+    // Double-complement returns to the original value.
+    let (type_, _) = type_of_value_expression("~(-1)");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(0)
+        })
+    );
+
+    // Folding `~hex` demotes the result to a plain `Integer`.
+    let (type_, _) = type_of_value_expression("~0xff");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-256)
+        })
+    );
+
+    // `~` of a folded constant.
+    let (type_, _) = type_of_value_expression("~(1 | 2)");
+    assert_eq!(
+        type_,
+        Type::Literal(LiteralKind::Integer {
+            value: BigInt::from(-4)
+        })
+    );
+}
+
+#[test]
+fn test_bitwise_operations_unresolved_for_rationals() {
+    // Bitwise binary operators don't apply to non-reducing rationals.
+    let (type_, _) = try_type_of_value_expression("1.5 | 1");
+    assert_eq!(type_, None);
+
+    let (type_, _) = try_type_of_value_expression("1 & 0.5");
+    assert_eq!(type_, None);
+
+    let (type_, _) = try_type_of_value_expression("0.5 ^ 0.25");
+    assert_eq!(type_, None);
+
+    // Likewise for the unary bitwise NOT.
+    let (type_, _) = try_type_of_value_expression("~0.5");
+    assert_eq!(type_, None);
+}
+
+#[test]
 fn test_implicit_conversion_uses_literal_value() {
     let (_, mut types) = type_of_value_expression("0");
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
@@ -9,22 +9,6 @@ use slang_solidity_v2_ir::ir;
 
 use super::LiteralKind;
 
-/// Returns the integer value of a decimal number literal, or `None` for
-/// rationals that do not reduce to an integer after unit multiplication.
-pub fn integer_value_of_decimal_number_expression(
-    decimal_number_expression: &ir::DecimalNumberExpression,
-) -> Option<BigInt> {
-    ConstantValue::from_decimal_number_expression(decimal_number_expression)?.into_integer()
-}
-
-/// Returns the integer value of a hex number literal, or `None` if the
-/// literal cannot be parsed.
-pub fn integer_value_of_hex_number_expression(
-    hex_number_expression: &ir::HexNumberExpression,
-) -> Option<BigInt> {
-    ConstantValue::from_hex_number_expression(hex_number_expression)?.into_integer()
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ConstantValue {
     Integer(BigInt),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
@@ -1,0 +1,113 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::cast::ToPrimitive;
+use num_traits::Num;
+use slang_solidity_v2_ir::ir;
+
+use super::LiteralKind;
+
+/// Returns the integer value of a decimal number literal, or `None` for
+/// rationals that do not reduce to an integer after unit multiplication.
+// TODO: support returning rational values (numerator/denominator) once the
+// evaluator exposes them.
+pub fn integer_value_of_decimal_number_expression(
+    decimal_number_expression: &ir::DecimalNumberExpression,
+) -> Option<BigInt> {
+    ConstantValue::from_decimal_number_expression(decimal_number_expression)
+        .map(|ConstantValue::Integer(integer)| integer)
+}
+
+/// Returns the integer value of a hex number literal, or `None` if the
+/// literal cannot be evaluated (e.g. a malformed hex digit sequence).
+// TODO: support returning rational values once the evaluator exposes them.
+pub fn integer_value_of_hex_number_expression(
+    hex_number_expression: &ir::HexNumberExpression,
+) -> Option<BigInt> {
+    ConstantValue::from_hex_number_expression(hex_number_expression)
+        .map(|ConstantValue::Integer(integer)| integer)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ConstantValue {
+    Integer(BigInt),
+}
+
+impl ConstantValue {
+    pub(crate) fn from_hex_number_expression(
+        hex_number_expression: &ir::HexNumberExpression,
+    ) -> Option<Self> {
+        let hex = hex_number_expression.literal.unparse();
+        // Skip `0x` prefix and parse the hexadecimal number.
+        // `BigInt::from_str_radix` can handle `_` separators.
+        let value = BigInt::from_str_radix(&hex[2..], 16).ok()?;
+        Some(Self::Integer(value))
+    }
+
+    pub(crate) fn from_decimal_number_expression(
+        decimal_number_expression: &ir::DecimalNumberExpression,
+    ) -> Option<Self> {
+        let mut decimal = decimal_number_expression.literal.unparse().to_owned();
+        decimal.retain(|c| c != '_');
+        let (mantissa, exponent) = match decimal.split_once(['e', 'E']) {
+            Some((m, e)) => (m, e.parse::<i64>().ok()?),
+            None => (decimal.as_str(), 0),
+        };
+        let (int_part, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+        let numerator = BigInt::from_str(&format!("{int_part}{fraction}")).ok()?;
+        let unit = decimal_number_expression
+            .unit
+            .as_ref()
+            .map_or_else(|| BigInt::from(1u32), number_unit_multiplier);
+        let scaled_numerator = numerator * unit;
+        let decimal_shift = exponent - i64::try_from(fraction.len()).ok()?;
+        let denominator =
+            BigInt::from(10u32).pow(u32::try_from(decimal_shift.unsigned_abs()).ok()?);
+        if decimal_shift >= 0 {
+            Some(Self::Integer(scaled_numerator * denominator))
+        } else {
+            // TODO: support returning a rational value (numerator/denominator)
+            // when the literal does not reduce to an integer.
+            scaled_numerator
+                .is_multiple_of(&denominator)
+                .then(|| Self::Integer(scaled_numerator / denominator))
+        }
+    }
+
+    pub(crate) fn as_usize(&self) -> Option<usize> {
+        let Self::Integer(value) = self;
+        value.to_usize()
+    }
+
+    pub(crate) fn get_literal_kind(&self) -> LiteralKind {
+        let Self::Integer(value) = self;
+        let bytes = u32::try_from(value.bits().div_ceil(8)).unwrap().max(1);
+        LiteralKind::DecimalInteger {
+            bytes,
+            signed: false,
+        }
+    }
+
+    pub(crate) fn get_signed_literal_kind(&self) -> LiteralKind {
+        let Self::Integer(magnitude) = self;
+        let negated_bits = (magnitude - 1u32).bits() + 1;
+        let bytes = u32::try_from(negated_bits.div_ceil(8)).unwrap().max(1);
+        LiteralKind::DecimalInteger {
+            bytes,
+            signed: true,
+        }
+    }
+}
+
+fn number_unit_multiplier(unit: &ir::NumberUnit) -> BigInt {
+    match unit {
+        ir::NumberUnit::WeiKeyword(_) | ir::NumberUnit::SecondsKeyword(_) => BigInt::from(1u32),
+        ir::NumberUnit::GweiKeyword(_) => BigInt::from(10u64.pow(9)),
+        ir::NumberUnit::EtherKeyword(_) => BigInt::from(10u64.pow(18)),
+        ir::NumberUnit::MinutesKeyword(_) => BigInt::from(60u32),
+        ir::NumberUnit::HoursKeyword(_) => BigInt::from(60u32 * 60),
+        ir::NumberUnit::DaysKeyword(_) => BigInt::from(60u32 * 60 * 24),
+        ir::NumberUnit::WeeksKeyword(_) => BigInt::from(60u32 * 60 * 24 * 7),
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/constants.rs
@@ -1,37 +1,34 @@
 use std::str::FromStr;
 
 use num_bigint::BigInt;
-use num_integer::Integer;
+use num_integer::Integer as _;
+use num_rational::BigRational;
 use num_traits::cast::ToPrimitive;
-use num_traits::Num;
+use num_traits::{Num, One, Signed, Zero};
 use slang_solidity_v2_ir::ir;
 
 use super::LiteralKind;
 
 /// Returns the integer value of a decimal number literal, or `None` for
 /// rationals that do not reduce to an integer after unit multiplication.
-// TODO: support returning rational values (numerator/denominator) once the
-// evaluator exposes them.
 pub fn integer_value_of_decimal_number_expression(
     decimal_number_expression: &ir::DecimalNumberExpression,
 ) -> Option<BigInt> {
-    ConstantValue::from_decimal_number_expression(decimal_number_expression)
-        .map(|ConstantValue::Integer(integer)| integer)
+    ConstantValue::from_decimal_number_expression(decimal_number_expression)?.into_integer()
 }
 
 /// Returns the integer value of a hex number literal, or `None` if the
-/// literal cannot be evaluated (e.g. a malformed hex digit sequence).
-// TODO: support returning rational values once the evaluator exposes them.
+/// literal cannot be parsed.
 pub fn integer_value_of_hex_number_expression(
     hex_number_expression: &ir::HexNumberExpression,
 ) -> Option<BigInt> {
-    ConstantValue::from_hex_number_expression(hex_number_expression)
-        .map(|ConstantValue::Integer(integer)| integer)
+    ConstantValue::from_hex_number_expression(hex_number_expression)?.into_integer()
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ConstantValue {
     Integer(BigInt),
+    Rational(BigRational),
 }
 
 impl ConstantValue {
@@ -66,36 +63,185 @@ impl ConstantValue {
             BigInt::from(10u32).pow(u32::try_from(decimal_shift.unsigned_abs()).ok()?);
         if decimal_shift >= 0 {
             Some(Self::Integer(scaled_numerator * denominator))
+        } else if scaled_numerator.is_multiple_of(&denominator) {
+            Some(Self::Integer(scaled_numerator / denominator))
         } else {
-            // TODO: support returning a rational value (numerator/denominator)
-            // when the literal does not reduce to an integer.
-            scaled_numerator
-                .is_multiple_of(&denominator)
-                .then(|| Self::Integer(scaled_numerator / denominator))
+            Some(Self::from_rational(BigRational::new(
+                scaled_numerator,
+                denominator,
+            )))
+        }
+    }
+
+    pub(crate) fn from_literal_kind(kind: &LiteralKind) -> Option<Self> {
+        match kind {
+            LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. } => {
+                Some(Self::Integer(value.clone()))
+            }
+            LiteralKind::Rational(value) => Some(Self::Rational(value.clone())),
+            LiteralKind::HexString { .. } | LiteralKind::String { .. } | LiteralKind::Address => {
+                None
+            }
+        }
+    }
+
+    pub(crate) fn into_integer(self) -> Option<BigInt> {
+        match self {
+            Self::Integer(value) => Some(value),
+            Self::Rational(_) => None,
+        }
+    }
+
+    pub(crate) fn as_integer(&self) -> Option<&BigInt> {
+        match self {
+            Self::Integer(value) => Some(value),
+            Self::Rational(_) => None,
         }
     }
 
     pub(crate) fn as_usize(&self) -> Option<usize> {
-        let Self::Integer(value) = self;
-        value.to_usize()
+        self.as_integer()?.to_usize()
     }
 
-    pub(crate) fn get_literal_kind(&self) -> LiteralKind {
-        let Self::Integer(value) = self;
-        let bytes = u32::try_from(value.bits().div_ceil(8)).unwrap().max(1);
-        LiteralKind::DecimalInteger {
-            bytes,
-            signed: false,
+    pub(crate) fn to_literal_kind(&self) -> LiteralKind {
+        match self {
+            Self::Integer(value) => LiteralKind::Integer(value.clone()),
+            Self::Rational(value) => LiteralKind::Rational(value.clone()),
         }
     }
 
-    pub(crate) fn get_signed_literal_kind(&self) -> LiteralKind {
-        let Self::Integer(magnitude) = self;
-        let negated_bits = (magnitude - 1u32).bits() + 1;
-        let bytes = u32::try_from(negated_bits.div_ceil(8)).unwrap().max(1);
-        LiteralKind::DecimalInteger {
-            bytes,
-            signed: true,
+    pub(crate) fn is_zero(&self) -> bool {
+        match self {
+            Self::Integer(value) => value.is_zero(),
+            Self::Rational(value) => value.is_zero(),
+        }
+    }
+
+    fn to_rational(&self) -> BigRational {
+        match self {
+            Self::Integer(value) => BigRational::from(value.clone()),
+            Self::Rational(value) => value.clone(),
+        }
+    }
+
+    /// Constructs from a `BigRational`, normalising to `Integer` when the
+    /// denominator reduces to one.
+    fn from_rational(value: BigRational) -> Self {
+        if value.is_integer() {
+            Self::Integer(value.to_integer())
+        } else {
+            Self::Rational(value)
+        }
+    }
+
+    pub(crate) fn negate(&self) -> Self {
+        match self {
+            Self::Integer(value) => Self::Integer(-value),
+            Self::Rational(value) => Self::Rational(-value.clone()),
+        }
+    }
+
+    pub(crate) fn add(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Self::Integer(lhs + rhs),
+            _ => Self::from_rational(self.to_rational() + other.to_rational()),
+        }
+    }
+
+    pub(crate) fn sub(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Self::Integer(lhs - rhs),
+            _ => Self::from_rational(self.to_rational() - other.to_rational()),
+        }
+    }
+
+    pub(crate) fn mul(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Self::Integer(lhs * rhs),
+            _ => Self::from_rational(self.to_rational() * other.to_rational()),
+        }
+    }
+
+    /// Solidity literal arithmetic uses rational division even between two
+    /// integer literals — `5 / 2` yields the rational `5/2`, not the integer
+    /// `2`. Only division by zero returns `None`.
+    pub(crate) fn div(&self, other: &Self) -> Option<Self> {
+        if other.is_zero() {
+            // TODO(validation): division by zero
+            return None;
+        }
+        Some(Self::from_rational(
+            self.to_rational() / other.to_rational(),
+        ))
+    }
+
+    pub(crate) fn rem(&self, other: &Self) -> Option<Self> {
+        if other.is_zero() {
+            // TODO(validation): division by zero
+            return None;
+        }
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs % rhs)),
+            // TODO(validation): Modulo on rationals is not supported.
+            _ => None,
+        }
+    }
+
+    pub(crate) fn pow(&self, exponent: &Self) -> Option<Self> {
+        let exponent = exponent.as_integer()?;
+        let exp_abs = exponent.abs().to_u32()?;
+        let raised = match self {
+            Self::Integer(base) => Self::Integer(base.pow(exp_abs)),
+            Self::Rational(base) => {
+                let exp_i32 = i32::try_from(exp_abs).ok()?;
+                Self::from_rational(base.pow(exp_i32))
+            }
+        };
+        if exponent.is_negative() {
+            if raised.is_zero() {
+                // TODO(validation): division by zero
+                return None;
+            }
+            Some(Self::from_rational(
+                BigRational::one() / raised.to_rational(),
+            ))
+        } else {
+            Some(raised)
+        }
+    }
+
+    pub(crate) fn bit_or(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs | rhs)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn bit_xor(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs ^ rhs)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn bit_and(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs & rhs)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn shl(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs << rhs.to_u32()?)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn shr(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs >> rhs.to_u32()?)),
+            _ => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod numbers;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/mod.rs
@@ -1,1 +1,6 @@
 pub(crate) mod numbers;
+pub(crate) mod strings;
+
+pub use strings::{
+    value_of_hex_string_literals, value_of_string_literals, value_of_unicode_string_literals,
+};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -7,15 +7,15 @@ use num_traits::cast::ToPrimitive;
 use num_traits::{Num, One, Signed, Zero};
 use slang_solidity_v2_ir::ir;
 
-use super::LiteralKind;
+use crate::types::LiteralKind;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum ConstantValue {
+pub(crate) enum Number {
     Integer(BigInt),
     Rational(BigRational),
 }
 
-impl ConstantValue {
+impl Number {
     pub(crate) fn from_hex_number_expression(
         hex_number_expression: &ir::HexNumberExpression,
     ) -> Option<Self> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -67,10 +67,10 @@ impl Number {
 
     pub fn from_literal_kind(kind: &LiteralKind) -> Option<Self> {
         match kind {
-            LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. } => {
+            LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
                 Some(Self::Integer(value.clone()))
             }
-            LiteralKind::Rational(value) => Some(Self::Rational(value.clone())),
+            LiteralKind::Rational { value } => Some(Self::Rational(value.clone())),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } | LiteralKind::Address => {
                 None
             }
@@ -97,8 +97,12 @@ impl Number {
 
     pub(crate) fn to_literal_kind(&self) -> LiteralKind {
         match self {
-            Self::Integer(value) => LiteralKind::Integer(value.clone()),
-            Self::Rational(value) => LiteralKind::Rational(value.clone()),
+            Self::Integer(value) => LiteralKind::Integer {
+                value: value.clone(),
+            },
+            Self::Rational(value) => LiteralKind::Rational {
+                value: value.clone(),
+            },
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -31,18 +31,26 @@ impl Number {
     ) -> Option<Self> {
         let mut decimal = decimal_number_expression.literal.unparse().to_owned();
         decimal.retain(|c| c != '_');
-        let (mantissa, exponent) = match decimal.split_once(['e', 'E']) {
-            Some((m, e)) => (m, e.parse::<i64>().ok()?),
-            None => (decimal.as_str(), 0),
+        // Split off the exponent in-place, leaving `decimal` as the mantissa.
+        let exponent = match decimal.find(['e', 'E']) {
+            Some(idx) => {
+                let exp = decimal[idx + 1..].parse::<i64>().ok()?;
+                decimal.truncate(idx);
+                exp
+            }
+            None => 0,
         };
-        let (int_part, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
-        let numerator = BigInt::from_str(&format!("{int_part}{fraction}")).ok()?;
+        // Record the fraction width and then strip the `.` so the buffer is
+        // pure digits ready to be parsed as the numerator.
+        let fraction_len = decimal.find('.').map_or(0, |idx| decimal.len() - idx - 1);
+        decimal.retain(|c| c != '.');
+        let numerator = BigInt::from_str(&decimal).ok()?;
         let unit = decimal_number_expression
             .unit
             .as_ref()
             .map_or_else(|| BigInt::from(1u32), number_unit_multiplier);
         let scaled_numerator = numerator * unit;
-        let decimal_shift = exponent - i64::try_from(fraction.len()).ok()?;
+        let decimal_shift = exponent - i64::try_from(fraction_len).ok()?;
         let denominator =
             BigInt::from(10u32).pow(u32::try_from(decimal_shift.unsigned_abs()).ok()?);
         if decimal_shift >= 0 {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -191,6 +191,7 @@ impl Number {
     }
 
     pub(crate) fn pow(&self, exponent: &Self) -> Option<Self> {
+        // TODO(validation): validate range of exponent
         let exponent = exponent.as_integer()?;
         let exp_abs = exponent.abs().to_u32()?;
         let raised = match self {
@@ -269,6 +270,7 @@ fn number_unit_multiplier(unit: &ir::NumberUnit) -> BigInt {
 /// - signed negative: `(-value - 1).bits() + 1` (two's-complement width).
 fn integer_bits_required(value: &BigInt, signed: bool) -> u32 {
     if !signed {
+        debug_assert!(!value.is_negative());
         u32::try_from(value.bits()).unwrap().max(1)
     } else if value.is_negative() {
         let magnitude_minus_one = -value - 1u32;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -102,10 +102,17 @@ impl Number {
         }
     }
 
-    pub(crate) fn is_zero(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         match self {
             Self::Integer(value) => value.is_zero(),
             Self::Rational(value) => value.is_zero(),
+        }
+    }
+
+    pub fn is_negative(&self) -> bool {
+        match self {
+            Self::Integer(value) => value.is_negative(),
+            Self::Rational(value) => value.is_negative(),
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -228,6 +228,13 @@ impl Number {
         }
     }
 
+    pub(crate) fn bit_not(&self) -> Option<Self> {
+        match self {
+            Self::Integer(value) => Some(Self::Integer(!value)),
+            Self::Rational(_) => None,
+        }
+    }
+
     pub(crate) fn bit_and(&self, other: &Self) -> Option<Self> {
         match (self, other) {
             (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs & rhs)),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -7,7 +7,7 @@ use num_traits::cast::ToPrimitive;
 use num_traits::{Num, One, Signed, Zero};
 use slang_solidity_v2_ir::ir;
 
-use crate::types::LiteralKind;
+use crate::types::{LiteralKind, Type};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Number {
@@ -240,4 +240,43 @@ fn number_unit_multiplier(unit: &ir::NumberUnit) -> BigInt {
         ir::NumberUnit::DaysKeyword(_) => BigInt::from(60u32 * 60 * 24),
         ir::NumberUnit::WeeksKeyword(_) => BigInt::from(60u32 * 60 * 24 * 7),
     }
+}
+
+/// Number of bits required to hold `value` as a Solidity integer of the given
+/// signedness:
+/// - unsigned: exactly `value.bits()` (with at least 1, so zero still has a
+///   positive width).
+/// - signed positive: `value.bits() + 1` (one extra bit for the sign).
+/// - signed negative: `(-value - 1).bits() + 1` (two's-complement width).
+fn integer_bits_required(value: &BigInt, signed: bool) -> u32 {
+    if !signed {
+        u32::try_from(value.bits()).unwrap().max(1)
+    } else if value.is_negative() {
+        let magnitude_minus_one = -value - 1u32;
+        u32::try_from(magnitude_minus_one.bits()).unwrap() + 1
+    } else {
+        u32::try_from(value.bits()).unwrap() + 1
+    }
+}
+
+/// Returns true if `value` fits in the integer type described by `signed` and
+/// `bits`. Range is `[-2^(bits-1), 2^(bits-1) - 1]` for signed and
+/// `[0, 2^bits - 1]` for unsigned.
+pub(crate) fn integer_literal_fits(value: &BigInt, signed: bool, bits: u32) -> bool {
+    if !signed && value.is_negative() {
+        return false;
+    }
+    integer_bits_required(value, signed) <= bits
+}
+
+pub(crate) fn smallest_integer_type_to_fit(value: &BigInt) -> Option<Type> {
+    let signed = value.is_negative();
+    let bits = integer_bits_required(value, signed);
+
+    if bits > 256 {
+        // TODO(validation): the integers don't fit in the EVM
+        return None;
+    }
+    let bits = bits.next_multiple_of(8).max(8);
+    Some(Type::Integer { signed, bits })
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -10,7 +10,7 @@ use slang_solidity_v2_ir::ir;
 use crate::types::LiteralKind;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Number {
+pub enum Number {
     Integer(BigInt),
     Rational(BigRational),
 }
@@ -57,7 +57,7 @@ impl Number {
         }
     }
 
-    pub(crate) fn from_literal_kind(kind: &LiteralKind) -> Option<Self> {
+    pub fn from_literal_kind(kind: &LiteralKind) -> Option<Self> {
         match kind {
             LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. } => {
                 Some(Self::Integer(value.clone()))

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
@@ -93,18 +93,16 @@ fn decode_escape_sequences(content: &str) -> Vec<u8> {
             }
             '\n' => {}
             'x' => {
-                let h1 = chars.next().unwrap();
-                let h2 = chars.next().unwrap();
-                let hex: String = [h1, h2].iter().collect();
-                out.push(u8::from_str_radix(&hex, 16).unwrap());
+                let h1 = u8::try_from(chars.next().unwrap().to_digit(16).unwrap()).unwrap();
+                let h2 = u8::try_from(chars.next().unwrap().to_digit(16).unwrap()).unwrap();
+                out.push((h1 << 4) | h2);
             }
             'u' => {
-                let h1 = chars.next().unwrap();
-                let h2 = chars.next().unwrap();
-                let h3 = chars.next().unwrap();
-                let h4 = chars.next().unwrap();
-                let hex: String = [h1, h2, h3, h4].iter().collect();
-                let code_point = u32::from_str_radix(&hex, 16).unwrap();
+                let h1 = chars.next().unwrap().to_digit(16).unwrap();
+                let h2 = chars.next().unwrap().to_digit(16).unwrap();
+                let h3 = chars.next().unwrap().to_digit(16).unwrap();
+                let h4 = chars.next().unwrap().to_digit(16).unwrap();
+                let code_point = (h1 << 12) | (h2 << 8) | (h3 << 4) | h4;
                 // `\uNNNN` code points in the surrogate range (0xD800..=0xDFFF)
                 // are not valid Unicode scalars; skip them silently.
                 if let Some(ch) = char::from_u32(code_point) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
@@ -1,0 +1,293 @@
+use slang_solidity_v2_ir::ir;
+
+/// Decodes the concatenated value of a collection of `StringLiteral` to its raw bytes.
+///
+/// Strips quotes and decodes escape sequences.
+pub fn value_of_string_literals(literals: &[ir::StringLiteral]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for literal in literals {
+        let content = strip_prefix_and_quotes(&literal.text, "");
+        result.extend(decode_escape_sequences(content));
+    }
+    result
+}
+
+/// Decodes the concatenated value of a collection of `HexStringLiteral` to its raw bytes.
+///
+/// Strips prefix and quotes.
+pub fn value_of_hex_string_literals(literals: &[ir::HexStringLiteral]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for literal in literals {
+        let content = strip_prefix_and_quotes(&literal.text, "hex");
+        result.extend(decode_hex_string(content));
+    }
+    result
+}
+
+/// Decodes the concatenated value of a collection of `StringLiteral` to its raw bytes.
+///
+/// Strips prefix and quotes, and decodes escape sequences.
+pub fn value_of_unicode_string_literals(literals: &[ir::UnicodeStringLiteral]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for literal in literals {
+        let content = strip_prefix_and_quotes(&literal.text, "unicode");
+        result.extend(decode_escape_sequences(content));
+    }
+    result
+}
+
+fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
+    text.strip_prefix(prefix)
+        .and_then(|stripped| {
+            stripped
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .or_else(|| {
+                    stripped
+                        .strip_prefix('\'')
+                        .and_then(|s| s.strip_suffix('\''))
+                })
+        })
+        .expect("string prefix mismatch or not quoted")
+}
+
+fn decode_hex_string(content: &str) -> Vec<u8> {
+    let mut result = Vec::with_capacity(content.len() / 2);
+    let mut i = 0usize;
+    while i < content.len() {
+        // Decode pairs of hex digits skipping over underscore separators
+        if content.as_bytes()[i] == b'_' {
+            i += 1;
+        }
+        // Parser grammar guarantees that we have at least 2 more digits
+        result.push(u8::from_str_radix(&content[i..i + 2], 16).unwrap());
+        i += 2;
+    }
+    result
+}
+
+fn decode_escape_sequences(content: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(content.len());
+    let mut buf = [0u8; 4];
+    let mut chars = content.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            continue;
+        }
+        // Grammar guarantees at least one char after backslash; if input
+        // is malformed we just stop.
+        let next = chars.next().expect("unterminated escape sequence");
+        match next {
+            'n' => out.push(b'\n'),
+            'r' => out.push(b'\r'),
+            't' => out.push(b'\t'),
+            '\'' => out.push(b'\''),
+            '"' => out.push(b'"'),
+            '\\' => out.push(b'\\'),
+            // Line continuation: `\<CR>`, `\<CRLF>`, `\<LF>` all decode to empty.
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+            }
+            '\n' => {}
+            'x' => {
+                let h1 = chars.next().unwrap();
+                let h2 = chars.next().unwrap();
+                let hex: String = [h1, h2].iter().collect();
+                out.push(u8::from_str_radix(&hex, 16).unwrap());
+            }
+            'u' => {
+                let h1 = chars.next().unwrap();
+                let h2 = chars.next().unwrap();
+                let h3 = chars.next().unwrap();
+                let h4 = chars.next().unwrap();
+                let hex: String = [h1, h2, h3, h4].iter().collect();
+                let code_point = u32::from_str_radix(&hex, 16).unwrap();
+                // `\uNNNN` code points in the surrogate range (0xD800..=0xDFFF)
+                // are not valid Unicode scalars; skip them silently.
+                if let Some(ch) = char::from_u32(code_point) {
+                    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                }
+                // TODO(validation): emit an error/warning if the unicode scalar
+                // is not valid
+            }
+            other => {
+                // Grammar should prevent unknown escape chars, but pass
+                // them through verbatim as a defensive fallback.
+                out.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_escape_sequences, decode_hex_string, strip_prefix_and_quotes};
+
+    // ----- decode_hex_string ------
+
+    #[test]
+    fn decode_hex_string_no_underscores() {
+        assert_eq!(decode_hex_string("303132"), b"012");
+    }
+
+    #[test]
+    fn decode_hex_string_with_underscores() {
+        assert_eq!(decode_hex_string("30_31_32"), b"012");
+    }
+
+    // ----- decode_escape_sequences -----
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(decode_escape_sequences(""), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn decode_no_escapes() {
+        assert_eq!(decode_escape_sequences("hello"), b"hello");
+    }
+
+    #[test]
+    fn decode_ascii_escapes() {
+        assert_eq!(decode_escape_sequences(r"\n"), b"\n");
+        assert_eq!(decode_escape_sequences(r"\r"), b"\r");
+        assert_eq!(decode_escape_sequences(r"\t"), b"\t");
+        assert_eq!(decode_escape_sequences(r"\'"), b"'");
+        assert_eq!(decode_escape_sequences(r#"\""#), b"\"");
+        assert_eq!(decode_escape_sequences(r"\\"), b"\\");
+    }
+
+    #[test]
+    fn decode_mixed_text_and_escapes() {
+        assert_eq!(
+            decode_escape_sequences(r"hello\tworld\n"),
+            b"hello\tworld\n",
+        );
+    }
+
+    #[test]
+    fn decode_multiple_ascii_escapes() {
+        assert_eq!(
+            decode_escape_sequences(r#"\t\n\r\'\"\\"#),
+            &[0x09, 0x0a, 0x0d, 0x27, 0x22, 0x5c]
+        );
+    }
+
+    #[test]
+    fn decode_line_continuation_lf() {
+        // Backslash followed by raw LF → empty.
+        assert_eq!(decode_escape_sequences("a\\\nb"), b"ab");
+    }
+
+    #[test]
+    fn decode_line_continuation_cr() {
+        // Backslash followed by raw CR → empty.
+        assert_eq!(decode_escape_sequences("a\\\rb"), b"ab");
+    }
+
+    #[test]
+    fn decode_line_continuation_crlf() {
+        // Backslash followed by raw CRLF → empty (CR and LF both consumed).
+        assert_eq!(decode_escape_sequences("a\\\r\nb"), b"ab");
+    }
+
+    #[test]
+    fn decode_hex_byte_escape() {
+        assert_eq!(decode_escape_sequences(r"\x41"), b"A");
+        assert_eq!(decode_escape_sequences(r"\xff"), &[0xffu8]);
+        assert_eq!(decode_escape_sequences(r"\x00"), &[0x00u8]);
+    }
+
+    #[test]
+    fn decode_unicode_escape_ascii() {
+        // U+0041 → 'A' (single UTF-8 byte).
+        assert_eq!(decode_escape_sequences(r"\u0041"), b"A");
+    }
+
+    #[test]
+    fn decode_unicode_escape_multibyte() {
+        // U+00E9 é → 0xC3 0xA9.
+        assert_eq!(decode_escape_sequences(r"\u00e9"), &[0xC3, 0xA9]);
+        // U+2713 ✓ → 0xE2 0x9C 0x93.
+        assert_eq!(decode_escape_sequences(r"\u2713"), &[0xE2, 0x9C, 0x93]);
+    }
+
+    #[test]
+    fn decode_unicode_escape_combined_multibyte() {
+        // Dollar sign
+        assert_eq!(decode_escape_sequences(r"aaa\u0024aaa"), b"aaa$aaa");
+        // Cent
+        assert_eq!(decode_escape_sequences(r"aaa\u00A2aaa"), b"aaa\xc2\xa2aaa");
+        // Euro
+        assert_eq!(
+            decode_escape_sequences(r"aaa\u20ACaaa"),
+            b"aaa\xe2\x82\xacaaa"
+        );
+        // All combined
+        assert_eq!(
+            decode_escape_sequences(r"\u0024\u00A2\u20AC"),
+            b"$\xc2\xa2\xe2\x82\xac"
+        );
+    }
+
+    #[test]
+    fn decode_unicode_escape_surrogate_skipped() {
+        // Lone surrogate 0xD800 is not a valid Unicode scalar → skipped.
+        assert_eq!(decode_escape_sequences(r"\ud800"), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn decode_raw_non_ascii_passthrough() {
+        // Raw multibyte input (legal in unicode strings) passes through as
+        // its UTF-8 encoding.
+        assert_eq!(decode_escape_sequences("ñ"), &[0xC3, 0xB1]);
+    }
+
+    // ----- strip_prefix_and_quotes -----
+
+    #[test]
+    fn strip_double_quotes_no_prefix() {
+        assert_eq!(strip_prefix_and_quotes(r#""hello""#, ""), "hello");
+    }
+
+    #[test]
+    fn strip_single_quotes_no_prefix() {
+        assert_eq!(strip_prefix_and_quotes("'hello'", ""), "hello");
+    }
+
+    #[test]
+    fn strip_hex_prefix_double_quotes() {
+        assert_eq!(strip_prefix_and_quotes(r#"hex"414243""#, "hex"), "414243");
+    }
+
+    #[test]
+    fn strip_hex_prefix_single_quotes() {
+        assert_eq!(strip_prefix_and_quotes("hex'414243'", "hex"), "414243");
+    }
+
+    #[test]
+    fn strip_unicode_prefix() {
+        assert_eq!(strip_prefix_and_quotes(r#"unicode"ñ""#, "unicode"), "ñ");
+    }
+
+    #[test]
+    fn strip_empty_content() {
+        assert_eq!(strip_prefix_and_quotes(r#""""#, ""), "");
+    }
+
+    #[test]
+    #[should_panic(expected = "string prefix mismatch or not quoted")]
+    fn strip_panics_when_not_quoted() {
+        strip_prefix_and_quotes("unquoted", "");
+    }
+
+    #[test]
+    #[should_panic(expected = "string prefix mismatch or not quoted")]
+    fn strip_panics_on_prefix_mismatch() {
+        strip_prefix_and_quotes("hex'1234'", "unicode");
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
@@ -24,7 +24,8 @@ pub fn value_of_hex_string_literals(literals: &[ir::HexStringLiteral]) -> Vec<u8
     result
 }
 
-/// Decodes the concatenated value of a collection of `StringLiteral` to its raw bytes.
+/// Decodes the concatenated value of a collection of `UnicodeStringLiteral` to
+/// its raw bytes.
 ///
 /// Strips prefix and quotes, and decodes escape sequences.
 pub fn value_of_unicode_string_literals(literals: &[ir::UnicodeStringLiteral]) -> Vec<u8> {
@@ -75,8 +76,8 @@ fn decode_escape_sequences(content: &str) -> Vec<u8> {
             out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
             continue;
         }
-        // Grammar guarantees at least one char after backslash; if input
-        // is malformed we just stop.
+        // Parser guarantees at least one char after backslash according to
+        // grammar definition.
         let next = chars.next().expect("unterminated escape sequence");
         match next {
             'n' => out.push(b'\n'),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -7,7 +7,7 @@ pub mod literals;
 mod parsing;
 mod registry;
 
-pub(crate) use literals::numbers::Number;
+pub use literals::numbers::Number;
 pub use registry::TypeRegistry;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -8,9 +8,6 @@ mod parsing;
 mod registry;
 
 pub(crate) use constants::ConstantValue;
-pub use constants::{
-    integer_value_of_decimal_number_expression, integer_value_of_hex_number_expression,
-};
 pub use registry::TypeRegistry;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -84,7 +84,7 @@ pub enum LiteralKind {
     },
     /// A hex-source integer literal. Carries the parsed value plus the
     /// source-text byte width (number of hex digits / 2, rounded up). The
-    /// width is what determines convertability with `bytesN` and is preserved
+    /// width is what determines convertibility with `bytesN` and is preserved
     /// distinctly from the value because `0x0012` and `0x12` share value `18`
     /// but convert to `bytes2` and `bytes1` respectively.
     HexInteger {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -44,8 +44,7 @@ pub enum Type {
     FixedSizeArray {
         element_type: TypeId,
         location: DataLocation,
-        // TODO: this probably should be a u256, although in practice usize or
-        // even u32 should suffice
+        // TODO: this should be u256, although in practice usize should suffice
         size: usize,
     },
     Function(FunctionType),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -3,11 +3,11 @@ use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
-mod constants;
+mod literals;
 mod parsing;
 mod registry;
 
-pub(crate) use constants::ConstantValue;
+pub(crate) use literals::numbers::Number;
 pub use registry::TypeRegistry;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,3 +1,5 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -80,14 +82,23 @@ pub enum Type {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum LiteralKind {
-    Zero,
-    // TODO: model rational values as part of compile-time constant folding,
-    // so that expressions like `1.5 * 2` can reduce to an integer literal.
-    Rational,
-    DecimalInteger { bytes: u32, signed: bool },
-    HexInteger { bytes: u32 },
-    HexString { bytes: u32 },
-    String { bytes: u32 },
+    Integer(BigInt),
+    /// A hex-source integer literal. Carries the parsed value plus the
+    /// source-text byte width (number of hex digits / 2, rounded up). The
+    /// width is what determines convertability with `bytesN` and is preserved
+    /// distinctly from the value because `0x0012` and `0x12` share value `18`
+    /// but convert to `bytes2` and `bytes1` respectively.
+    HexInteger {
+        value: BigInt,
+        bytes: u32,
+    },
+    Rational(BigRational),
+    HexString {
+        bytes: u32,
+    },
+    String {
+        bytes: u32,
+    },
     Address,
 }
 
@@ -293,10 +304,7 @@ impl Type {
         matches!(
             self,
             Type::Literal(
-                LiteralKind::Zero
-                    | LiteralKind::DecimalInteger { .. }
-                    | LiteralKind::HexInteger { .. }
-                    | LiteralKind::Rational
+                LiteralKind::Integer(_) | LiteralKind::HexInteger { .. } | LiteralKind::Rational(_)
             )
         )
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -79,7 +79,9 @@ pub enum Type {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum LiteralKind {
-    Integer(BigInt),
+    Integer {
+        value: BigInt,
+    },
     /// A hex-source integer literal. Carries the parsed value plus the
     /// source-text byte width (number of hex digits / 2, rounded up). The
     /// width is what determines convertability with `bytesN` and is preserved
@@ -89,7 +91,9 @@ pub enum LiteralKind {
         value: BigInt,
         bytes: u32,
     },
-    Rational(BigRational),
+    Rational {
+        value: BigRational,
+    },
     HexString {
         bytes: usize,
     },
@@ -301,7 +305,9 @@ impl Type {
         matches!(
             self,
             Type::Literal(
-                LiteralKind::Integer(_) | LiteralKind::HexInteger { .. } | LiteralKind::Rational(_)
+                LiteralKind::Integer { .. }
+                    | LiteralKind::HexInteger { .. }
+                    | LiteralKind::Rational { .. }
             )
         )
     }
@@ -333,10 +339,10 @@ impl Type {
     /// computing the type of literal arrays or conditional branches.
     pub(crate) fn mobile_type(&self) -> Option<Self> {
         match self {
-            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
-                numbers::smallest_integer_type_to_fit(value)
-            }
-            Type::Literal(LiteralKind::Rational(_)) => {
+            Type::Literal(
+                LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
+            ) => numbers::smallest_integer_type_to_fit(value),
+            Type::Literal(LiteralKind::Rational { .. }) => {
                 // TODO: not supported yet, but narrow the rational type to the
                 // smallest fixed/ufixed available (eg. 1.2 -> ufixed8x1).
                 None

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,9 +1,14 @@
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
+mod constants;
 mod parsing;
 mod registry;
 
+pub(crate) use constants::ConstantValue;
+pub use constants::{
+    integer_value_of_decimal_number_expression, integer_value_of_hex_number_expression,
+};
 pub use registry::TypeRegistry;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -76,9 +81,10 @@ pub enum Type {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum LiteralKind {
     Zero,
-    // TODO: collect and store more information about literal numbers
+    // TODO: model rational values as part of compile-time constant folding,
+    // so that expressions like `1.5 * 2` can reduce to an integer literal.
     Rational,
-    DecimalInteger,
+    DecimalInteger { bytes: u32, signed: bool },
     HexInteger { bytes: u32 },
     HexString { bytes: u32 },
     String { bytes: u32 },
@@ -288,7 +294,7 @@ impl Type {
             self,
             Type::Literal(
                 LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { .. }
                     | LiteralKind::HexInteger { .. }
                     | LiteralKind::Rational
             )

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -3,7 +3,7 @@ use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
-mod literals;
+pub mod literals;
 mod parsing;
 mod registry;
 
@@ -90,10 +90,10 @@ pub enum LiteralKind {
     },
     Rational(BigRational),
     HexString {
-        bytes: u32,
+        bytes: usize,
     },
     String {
-        bytes: u32,
+        bytes: usize,
     },
     Address,
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,3 +1,4 @@
+use literals::numbers;
 use num_bigint::BigInt;
 use num_rational::BigRational;
 use slang_solidity_v2_common::nodes::NodeId;
@@ -317,6 +318,33 @@ impl Type {
             | Type::Struct { definition_id, .. }
             | Type::UserDefinedValue { definition_id } => Some(*definition_id),
             _ => None,
+        }
+    }
+
+    /// Returns a new non-literal `Type` this can flow into. For use when
+    /// computing the type of literal arrays or conditional branches.
+    pub(crate) fn reified(&self) -> Option<Self> {
+        match self {
+            Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
+                numbers::smallest_integer_type_to_fit(value)
+            }
+            Type::Literal(LiteralKind::Rational(_)) => {
+                // TODO: not supported yet, but narrow the rational type to the
+                // smallest fixed/ufixed available (eg. 1.2 -> ufixed8x1).
+                None
+            }
+            Type::Literal(LiteralKind::HexString { .. } | LiteralKind::String { .. }) => {
+                Some(Type::String {
+                    location: DataLocation::Memory,
+                })
+            }
+            Type::Literal(LiteralKind::Address) => Some(Type::Address { payable: false }),
+
+            // Some values cannot be elements of arrays
+            Type::Mapping { .. } | Type::Tuple { .. } | Type::Void => None,
+
+            // Return self for all other cases
+            _ => Some(self.clone()),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -306,6 +306,14 @@ impl Type {
         )
     }
 
+    /// For literal numeric types, return their value.
+    pub fn number_value(&self) -> Option<Number> {
+        match self {
+            Type::Literal(kind) => Number::from_literal_kind(kind),
+            _ => None,
+        }
+    }
+
     pub fn is_contract_or_interface(&self) -> bool {
         matches!(self, Type::Contract { .. } | Type::Interface { .. })
     }
@@ -323,7 +331,7 @@ impl Type {
 
     /// Returns a new non-literal `Type` this can flow into. For use when
     /// computing the type of literal arrays or conditional branches.
-    pub(crate) fn reified(&self) -> Option<Self> {
+    pub(crate) fn mobile_type(&self) -> Option<Self> {
         match self {
             Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }) => {
                 numbers::smallest_integer_type_to_fit(value)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -304,4 +304,19 @@ impl Type {
             )
         )
     }
+
+    pub fn is_contract_or_interface(&self) -> bool {
+        matches!(self, Type::Contract { .. } | Type::Interface { .. })
+    }
+
+    pub(crate) fn get_definition_id(&self) -> Option<NodeId> {
+        match self {
+            Type::Contract { definition_id }
+            | Type::Enum { definition_id }
+            | Type::Interface { definition_id }
+            | Type::Struct { definition_id, .. }
+            | Type::UserDefinedValue { definition_id } => Some(*definition_id),
+            _ => None,
+        }
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -1,9 +1,38 @@
 use std::collections::HashMap;
 
 use indexmap::IndexSet;
+use num_bigint::BigInt;
+use num_traits::{Signed, Zero};
 
 use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Type, TypeId};
 use crate::types::ImplicitlyConvertible;
+
+/// Number of bits required to hold `value` as a Solidity integer of the given
+/// signedness:
+/// - unsigned: exactly `value.bits()` (with at least 1, so zero still has a
+///   positive width).
+/// - signed positive: `value.bits() + 1` (one extra bit for the sign).
+/// - signed negative: `(-value - 1).bits() + 1` (two's-complement width).
+fn integer_bits_required(value: &BigInt, signed: bool) -> u32 {
+    if !signed {
+        u32::try_from(value.bits()).unwrap().max(1)
+    } else if value.is_negative() {
+        let magnitude_minus_one = -value - 1u32;
+        u32::try_from(magnitude_minus_one.bits()).unwrap() + 1
+    } else {
+        u32::try_from(value.bits()).unwrap() + 1
+    }
+}
+
+/// Returns true if `value` fits in the integer type described by `signed` and
+/// `bits`. Range is `[-2^(bits-1), 2^(bits-1) - 1]` for signed and
+/// `[0, 2^bits - 1]` for unsigned.
+fn integer_literal_fits(value: &BigInt, signed: bool, bits: u32) -> bool {
+    if !signed && value.is_negative() {
+        return false;
+    }
+    integer_bits_required(value, signed) <= bits
+}
 
 /// The `TypeRegistry` stores an index of registered types, both elementary
 /// types and user defined types. Each type is given a `TypeId` for efficient
@@ -145,83 +174,17 @@ impl TypeRegistry {
             }
 
             (
-                Type::Literal(
-                    LiteralKind::Zero
-                    // TODO: rationals cannot be always converted to integers,
-                    // unless their fractional part is zero. But for now and
-                    // without further information about the literal number
-                    // itself, assume it can.
-                    | LiteralKind::Rational,
-                ),
-                Type::Integer { .. },
-            ) => {
-                // TODO(validation): check that the literal can fit in the given integer type
-                true
-            }
+                Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }),
+                Type::Integer { signed, bits },
+            ) => integer_literal_fits(value, *signed, *bits),
 
-            // TODO: verify against solc's RationalNumberType::isImplicitlyConvertibleTo.
-            (
-                Type::Literal(
-                    LiteralKind::DecimalInteger {
-                        bytes,
-                        signed: false,
-                    }
-                    | LiteralKind::HexInteger { bytes },
-                ),
-                Type::Integer { bits: to_bits, .. },
-            ) => bytes * 8 <= *to_bits,
+            // Non-integer rational literals never implicitly convert to an
+            // integer type — if a rational reduced to an integer it would have
+            // been normalised to `LiteralKind::Integer` at construction time.
+            (Type::Literal(LiteralKind::Rational(_)), Type::Integer { .. }) => false,
 
-            // A signed decimal literal (produced by `-literal`) may only
-            // implicitly convert to a signed integer type.
-            (
-                Type::Literal(LiteralKind::DecimalInteger {
-                    bytes,
-                    signed: true,
-                }),
-                Type::Integer {
-                    signed: true,
-                    bits: to_bits,
-                },
-            ) => bytes * 8 <= *to_bits,
-
-            (
-                Type::Literal(
-                    LiteralKind::Zero
-                    | LiteralKind::DecimalInteger { .. }
-                    | LiteralKind::Rational
-                    | LiteralKind::HexInteger { .. },
-                ),
-                Type::Literal(LiteralKind::Rational),
-            ) => true,
-
-            (
-                Type::Literal(LiteralKind::Zero),
-                Type::Literal(
-                    LiteralKind::DecimalInteger { .. } | LiteralKind::HexInteger { .. },
-                ),
-            ) => true,
-
-            (
-                Type::Literal(LiteralKind::HexInteger { bytes: from_bytes }),
-                Type::Literal(
-                    LiteralKind::HexInteger { bytes: to_bytes }
-                    | LiteralKind::DecimalInteger { bytes: to_bytes, .. },
-                ),
-            ) => from_bytes <= to_bytes,
-
-            // A signed decimal literal (produced by `-literal`) only
-            // implicitly converts to a signed `DecimalInteger` target.
-            (
-                Type::Literal(LiteralKind::DecimalInteger {
-                    bytes: from_bytes,
-                    signed: from_signed,
-                }),
-                Type::Literal(LiteralKind::DecimalInteger {
-                    bytes: to_bytes,
-                    signed: to_signed,
-                }),
-            ) if !*from_signed || *to_signed => from_bytes <= to_bytes,
-
+            // TODO: Rational -> FixedPointNumber once v2 models implicit
+            // conversion of rational literals to fixed-point types.
             (Type::Integer { .. }, Type::Literal(_)) => false,
 
             (
@@ -229,13 +192,25 @@ impl TypeRegistry {
                 Type::String { location } | Type::Bytes { location },
             ) if *location == DataLocation::Memory || *location == DataLocation::Calldata => true,
 
-            (Type::Literal(LiteralKind::Zero), Type::ByteArray { .. }) => true,
+            // Zero (any source — decimal, hex, or folded) is always
+            // implicitly convertible to any byte-array type.
             (
-                Type::Literal(
-                    LiteralKind::HexInteger { bytes }
-                    | LiteralKind::HexString { bytes }
-                    | LiteralKind::String { bytes },
-                ),
+                Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }),
+                Type::ByteArray { .. },
+            ) if value.is_zero() => true,
+
+            // Non-zero hex-source literals convert to `bytesN` of exactly
+            // matching source byte width. Plain `Integer` literals (decimal
+            // source or any folded result) do NOT — folding any operation
+            // erases the hex provenance and disables this conversion.
+            (Type::Literal(LiteralKind::HexInteger { bytes, .. }), Type::ByteArray { width })
+                if *bytes == *width =>
+            {
+                true
+            }
+
+            (
+                Type::Literal(LiteralKind::HexString { bytes } | LiteralKind::String { bytes }),
                 Type::ByteArray { width },
             ) if *bytes == *width => true,
 
@@ -306,7 +281,9 @@ impl TypeRegistry {
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
                 // This is full equality except for visibility and mutability
                 // which can be converted to, and definition_id which can differ
-                from_function_type.visibility.implicitly_convertible_to(to_function_type.visibility)
+                from_function_type
+                    .visibility
+                    .implicitly_convertible_to(to_function_type.visibility)
                     && from_function_type
                         .mutability
                         .implicitly_convertible_to(to_function_type.mutability)
@@ -535,6 +512,20 @@ impl TypeRegistry {
         self.register_type(type_with_location)
     }
 
+    /// Returns the smallest `Type::Integer { signed, bits }` that holds both
+    /// `a` and `b` (with `bits` rounded up to a multiple of 8, in the range
+    /// 8..=256). Used to unify two distinct integer literal values when one
+    /// is not implicitly convertible to the other (e.g. in `cond ? 0 : 1`).
+    pub fn common_integer_literal_type(&mut self, a: &BigInt, b: &BigInt) -> Option<TypeId> {
+        let signed = a.is_negative() || b.is_negative();
+        let bits = integer_bits_required(a, signed).max(integer_bits_required(b, signed));
+        if bits > 256 {
+            return None;
+        }
+        let bits = bits.next_multiple_of(8).max(8);
+        Some(self.register_type(Type::Integer { signed, bits }))
+    }
+
     // Return a type that can be stored in the EVM. In short, convert literal
     // types into the appropriate "real" type
     pub(crate) fn reified_type(&mut self, type_id: TypeId) -> TypeId {
@@ -542,13 +533,12 @@ impl TypeRegistry {
             return type_id;
         };
         match kind {
-            // TODO: implementing these cases requires access to the value
-            // itself, to fit the number in the smallest possible type. Eg. solc
-            // will convert 1, 2, 3, etc into uint8 and 1.2 into ufixed8x1
-            LiteralKind::Zero
-            | LiteralKind::Rational
-            | LiteralKind::DecimalInteger { .. }
-            | LiteralKind::HexInteger { .. } => self.uint256(),
+            // TODO: narrow these to the smallest holding type, matching solc
+            // (eg. literal 1 -> uint8, 1.2 -> ufixed8x1). For now, default to
+            // uint256 to preserve current behaviour.
+            LiteralKind::Integer(_) | LiteralKind::HexInteger { .. } | LiteralKind::Rational(_) => {
+                self.uint256()
+            }
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => self.string(),
             LiteralKind::Address => self.address(),
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -1,56 +1,12 @@
 use std::collections::HashMap;
 
 use indexmap::IndexSet;
-use num_bigint::BigInt;
-use num_traits::{Signed, Zero};
+use num_traits::Zero;
 use slang_solidity_v2_common::nodes::NodeId;
 
+use super::literals::numbers;
 use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Type, TypeId};
 use crate::types::ImplicitlyConvertible;
-
-/// Number of bits required to hold `value` as a Solidity integer of the given
-/// signedness:
-/// - unsigned: exactly `value.bits()` (with at least 1, so zero still has a
-///   positive width).
-/// - signed positive: `value.bits() + 1` (one extra bit for the sign).
-/// - signed negative: `(-value - 1).bits() + 1` (two's-complement width).
-fn integer_bits_required(value: &BigInt, signed: bool) -> u32 {
-    if !signed {
-        u32::try_from(value.bits()).unwrap().max(1)
-    } else if value.is_negative() {
-        let magnitude_minus_one = -value - 1u32;
-        u32::try_from(magnitude_minus_one.bits()).unwrap() + 1
-    } else {
-        u32::try_from(value.bits()).unwrap() + 1
-    }
-}
-
-/// Returns true if `value` fits in the integer type described by `signed` and
-/// `bits`. Range is `[-2^(bits-1), 2^(bits-1) - 1]` for signed and
-/// `[0, 2^bits - 1]` for unsigned.
-fn integer_literal_fits(value: &BigInt, signed: bool, bits: u32) -> bool {
-    if !signed && value.is_negative() {
-        return false;
-    }
-    integer_bits_required(value, signed) <= bits
-}
-
-fn smallest_integer_type_to_fit(values: &[&BigInt]) -> Option<Type> {
-    if values.is_empty() {
-        return None;
-    }
-    let signed = values.iter().all(|value| value.is_negative());
-    let bits = values.iter().fold(0u32, |acc, value| {
-        acc.max(integer_bits_required(value, signed))
-    });
-
-    if bits > 256 {
-        // TODO(validation): the integers don't fit in the EVM
-        return None;
-    }
-    let bits = bits.next_multiple_of(8).max(8);
-    Some(Type::Integer { signed, bits })
-}
 
 /// The `TypeRegistry` stores an index of registered types, both elementary
 /// types and user defined types. Each type is given a `TypeId` for efficient
@@ -172,7 +128,11 @@ impl TypeRegistry {
         self.types.get_index(type_id.0).unwrap()
     }
 
-    pub(crate) fn implicitly_convertible_to(&self, from_type_id: TypeId, to_type_id: TypeId) -> bool {
+    pub(crate) fn implicitly_convertible_to(
+        &self,
+        from_type_id: TypeId,
+        to_type_id: TypeId,
+    ) -> bool {
         if from_type_id == to_type_id {
             return true;
         }
@@ -214,7 +174,7 @@ impl TypeRegistry {
             (
                 Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }),
                 Type::Integer { signed, bits },
-            ) => integer_literal_fits(value, *signed, *bits),
+            ) => numbers::integer_literal_fits(value, *signed, *bits),
 
             // Non-integer rational literals never implicitly convert to an
             // integer type — if a rational reduced to an integer it would have
@@ -573,33 +533,30 @@ impl TypeRegistry {
         self.register_type(type_with_location)
     }
 
-    /// Returns the smallest `Type::Integer { signed, bits }` that holds both
-    /// `a` and `b` (with `bits` rounded up to a multiple of 8, in the range
-    /// 8..=256). Used to unify two distinct integer literal values when one
-    /// is not implicitly convertible to the other (e.g. in `cond ? 0 : 1`).
-    pub fn common_integer_literal_type(&mut self, a: &BigInt, b: &BigInt) -> Option<TypeId> {
-        smallest_integer_type_to_fit(&[a, b]).map(|type_| self.register_type(type_))
-    }
-
-    // Return a type that can be stored in the EVM. In short, convert literal
-    // types into the appropriate "real" type
-    pub(crate) fn reified_type(&mut self, type_id: TypeId) -> Option<TypeId> {
-        let Type::Literal(kind) = self.get_type_by_id(type_id) else {
-            return Some(type_id);
-        };
-        match kind {
-            LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. } => {
-                smallest_integer_type_to_fit(&[value]).map(|type_| self.register_type(type_))
-            }
-            LiteralKind::Rational(_) => {
-                // TODO: narrow the rational type to the smallest fixed/ufixed
-                // available (eg. 1.2 -> ufixed8x1). For now, default to uint256
-                // to preserve current behaviour.
-                Some(self.uint256())
-            }
-            LiteralKind::HexString { .. } | LiteralKind::String { .. } => Some(self.string()),
-            LiteralKind::Address => Some(self.address()),
+    /// Return a type that can be stored in the EVM and can hold values of all
+    /// the given types. The first element dictates the type class. Returns
+    /// `None` if the types cannot be reified or they are not compatible. This
+    /// is used to unify types of literal arrays and conditional branches.
+    pub(crate) fn reified_common_type(&mut self, type_ids: &[TypeId]) -> Option<TypeId> {
+        if type_ids.is_empty() {
+            return None;
         }
+        let initial_type = self.get_type_by_id(type_ids[0]);
+        let mut element_type = initial_type.reified()?;
+
+        for item_type_id in &type_ids[1..] {
+            let item_type = self.get_type_by_id(*item_type_id).reified()?;
+            if self.internal_implicitly_convertible_to(&item_type, &element_type) {
+                // ok, `element_type` can already hold `item_type`
+            } else if self.internal_implicitly_convertible_to(&element_type, &item_type) {
+                // `item_type` is "bigger"
+                element_type = item_type;
+            } else {
+                // TODO(validation): types are not compatible
+                return None;
+            }
+        }
+        Some(self.register_type(element_type))
     }
 
     // Returns true if a function type overrides another

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -5,7 +5,7 @@ use num_traits::Zero;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::literals::numbers;
-use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Type, TypeId};
+use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Number, Type, TypeId};
 use crate::types::ImplicitlyConvertible;
 
 /// The `TypeRegistry` stores an index of registered types, both elementary
@@ -537,15 +537,15 @@ impl TypeRegistry {
     /// the given types. The first element dictates the type class. Returns
     /// `None` if the types cannot be reified or they are not compatible. This
     /// is used to unify types of literal arrays and conditional branches.
-    pub(crate) fn reified_common_type(&mut self, type_ids: &[TypeId]) -> Option<TypeId> {
+    pub(crate) fn common_mobile_type(&mut self, type_ids: &[TypeId]) -> Option<TypeId> {
         if type_ids.is_empty() {
             return None;
         }
         let initial_type = self.get_type_by_id(type_ids[0]);
-        let mut element_type = initial_type.reified()?;
+        let mut element_type = initial_type.mobile_type()?;
 
         for item_type_id in &type_ids[1..] {
-            let item_type = self.get_type_by_id(*item_type_id).reified()?;
+            let item_type = self.get_type_by_id(*item_type_id).mobile_type()?;
             if self.internal_implicitly_convertible_to(&item_type, &element_type) {
                 // ok, `element_type` can already hold `item_type`
             } else if self.internal_implicitly_convertible_to(&element_type, &item_type) {
@@ -695,6 +695,15 @@ impl TypeRegistry {
                 self.function_type_overrides(ftype, other)
             }
             _ => false,
+        }
+    }
+
+    /// Returns the compile-time number value of a type, when it is a
+    /// value-bearing literal (integer or rational).
+    pub fn number_value_of_type_id(&self, type_id: TypeId) -> Option<Number> {
+        match self.get_type_by_id(type_id) {
+            Type::Literal(kind) => Number::from_literal_kind(kind),
+            _ => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -147,13 +147,11 @@ impl TypeRegistry {
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
                     // TODO: rationals cannot be always converted to integers,
                     // unless their fractional part is zero. But for now and
                     // without further information about the literal number
                     // itself, assume it can.
-                    | LiteralKind::Rational
-                    | LiteralKind::HexInteger { .. },
+                    | LiteralKind::Rational,
                 ),
                 Type::Integer { .. },
             ) => {
@@ -161,30 +159,68 @@ impl TypeRegistry {
                 true
             }
 
+            // TODO: verify against solc's RationalNumberType::isImplicitlyConvertibleTo.
+            (
+                Type::Literal(
+                    LiteralKind::DecimalInteger {
+                        bytes,
+                        signed: false,
+                    }
+                    | LiteralKind::HexInteger { bytes },
+                ),
+                Type::Integer { bits: to_bits, .. },
+            ) => bytes * 8 <= *to_bits,
+
+            // A signed decimal literal (produced by `-literal`) may only
+            // implicitly convert to a signed integer type.
+            (
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: true,
+                }),
+                Type::Integer {
+                    signed: true,
+                    bits: to_bits,
+                },
+            ) => bytes * 8 <= *to_bits,
+
             (
                 Type::Literal(
                     LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
+                    | LiteralKind::DecimalInteger { .. }
                     | LiteralKind::Rational
                     | LiteralKind::HexInteger { .. },
                 ),
                 Type::Literal(LiteralKind::Rational),
-            ) |
-            (
-                Type::Literal(
-                    LiteralKind::Zero
-                    | LiteralKind::DecimalInteger
-                    | LiteralKind::HexInteger { .. },
-                ),
-                Type::Literal(LiteralKind::DecimalInteger),
-            ) |
-            (
-                Type::Literal(
-                    LiteralKind::Zero
-                    | LiteralKind::HexInteger { .. },
-                ),
-                Type::Literal(LiteralKind::HexInteger { .. }),
             ) => true,
+
+            (
+                Type::Literal(LiteralKind::Zero),
+                Type::Literal(
+                    LiteralKind::DecimalInteger { .. } | LiteralKind::HexInteger { .. },
+                ),
+            ) => true,
+
+            (
+                Type::Literal(LiteralKind::HexInteger { bytes: from_bytes }),
+                Type::Literal(
+                    LiteralKind::HexInteger { bytes: to_bytes }
+                    | LiteralKind::DecimalInteger { bytes: to_bytes, .. },
+                ),
+            ) => from_bytes <= to_bytes,
+
+            // A signed decimal literal (produced by `-literal`) only
+            // implicitly converts to a signed `DecimalInteger` target.
+            (
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes: from_bytes,
+                    signed: from_signed,
+                }),
+                Type::Literal(LiteralKind::DecimalInteger {
+                    bytes: to_bytes,
+                    signed: to_signed,
+                }),
+            ) if !*from_signed || *to_signed => from_bytes <= to_bytes,
 
             (Type::Integer { .. }, Type::Literal(_)) => false,
 
@@ -511,7 +547,7 @@ impl TypeRegistry {
             // will convert 1, 2, 3, etc into uint8 and 1.2 into ufixed8x1
             LiteralKind::Zero
             | LiteralKind::Rational
-            | LiteralKind::DecimalInteger
+            | LiteralKind::DecimalInteger { .. }
             | LiteralKind::HexInteger { .. } => self.uint256(),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => self.string(),
             LiteralKind::Address => self.address(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use indexmap::IndexSet;
 use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
+use slang_solidity_v2_common::nodes::NodeId;
 
 use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Type, TypeId};
 use crate::types::ImplicitlyConvertible;
@@ -58,7 +59,10 @@ fn smallest_integer_type_to_fit(values: &[&BigInt]) -> Option<Type> {
 /// some kinds of expressions (eg. the boolean type).
 pub struct TypeRegistry {
     types: IndexSet<Type>,
-    super_types: HashMap<TypeId, Vec<TypeId>>,
+    // This is used to register the _is-subclass_ and _implements_ relationships
+    // between contract/interface types. The `NodeId`s correspond to the
+    // `definition_id` in the respective `Type` variants.
+    super_types: HashMap<NodeId, Vec<NodeId>>,
 
     // Pre-defined core types
     address_type_id: TypeId,
@@ -143,26 +147,43 @@ impl TypeRegistry {
         TypeId(index)
     }
 
-    pub(crate) fn register_super_types(&mut self, type_id: TypeId, super_types: Vec<TypeId>) {
-        self.super_types.insert(type_id, super_types);
+    pub(crate) fn register_super_types(&mut self, type_id: TypeId, super_types: &[TypeId]) {
+        let type_ = self.get_type_by_id(type_id);
+        assert!(
+            type_.is_contract_or_interface(),
+            "can only register super types of contracts and interfaces",
+        );
+        let type_node_id = type_.get_definition_id().unwrap();
+        let super_type_node_ids = super_types
+            .iter()
+            .map(|super_type_id| {
+                let super_type = self.get_type_by_id(*super_type_id);
+                assert!(
+                    super_type.is_contract_or_interface(),
+                    "super types can only be contracts or interfaces",
+                );
+                super_type.get_definition_id().unwrap()
+            })
+            .collect();
+        self.super_types.insert(type_node_id, super_type_node_ids);
     }
 
     pub fn get_type_by_id(&self, type_id: TypeId) -> &Type {
         self.types.get_index(type_id.0).unwrap()
     }
 
-    #[allow(clippy::too_many_lines)]
-    pub(crate) fn implicitly_convertible_to(
-        &self,
-        from_type_id: TypeId,
-        to_type_id: TypeId,
-    ) -> bool {
+    pub(crate) fn implicitly_convertible_to(&self, from_type_id: TypeId, to_type_id: TypeId) -> bool {
         if from_type_id == to_type_id {
             return true;
         }
         let from_type = self.get_type_by_id(from_type_id);
         let to_type = self.get_type_by_id(to_type_id);
 
+        self.internal_implicitly_convertible_to(from_type, to_type)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn internal_implicitly_convertible_to(&self, from_type: &Type, to_type: &Type) -> bool {
         match (from_type, to_type) {
             (
                 Type::Address {
@@ -308,11 +329,34 @@ impl TypeRegistry {
                     && from_function_type.return_type == to_function_type.return_type
             }
 
-            (Type::Contract { .. }, Type::Contract { .. } | Type::Interface { .. })
-            | (Type::Interface { .. }, Type::Interface { .. }) => self
+            // Contracts and interfaces are implicitly converted to their super types
+            (
+                Type::Contract {
+                    definition_id: from_node_id,
+                    ..
+                },
+                Type::Contract {
+                    definition_id: to_node_id,
+                    ..
+                }
+                | Type::Interface {
+                    definition_id: to_node_id,
+                    ..
+                },
+            )
+            | (
+                Type::Interface {
+                    definition_id: from_node_id,
+                    ..
+                },
+                Type::Interface {
+                    definition_id: to_node_id,
+                    ..
+                },
+            ) => self
                 .super_types
-                .get(&from_type_id)
-                .is_some_and(|super_types| super_types.contains(&to_type_id)),
+                .get(from_node_id)
+                .is_some_and(|super_types| super_types.contains(to_node_id)),
 
             // TODO: add more implicit conversion rules
             _ => false,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -34,6 +34,23 @@ fn integer_literal_fits(value: &BigInt, signed: bool, bits: u32) -> bool {
     integer_bits_required(value, signed) <= bits
 }
 
+fn smallest_integer_type_to_fit(values: &[&BigInt]) -> Option<Type> {
+    if values.is_empty() {
+        return None;
+    }
+    let signed = values.iter().all(|value| value.is_negative());
+    let bits = values.iter().fold(0u32, |acc, value| {
+        acc.max(integer_bits_required(value, signed))
+    });
+
+    if bits > 256 {
+        // TODO(validation): the integers don't fit in the EVM
+        return None;
+    }
+    let bits = bits.next_multiple_of(8).max(8);
+    Some(Type::Integer { signed, bits })
+}
+
 /// The `TypeRegistry` stores an index of registered types, both elementary
 /// types and user defined types. Each type is given a `TypeId` for efficient
 /// storage, lookup and comparison. The registry also provides direct access to
@@ -517,30 +534,27 @@ impl TypeRegistry {
     /// 8..=256). Used to unify two distinct integer literal values when one
     /// is not implicitly convertible to the other (e.g. in `cond ? 0 : 1`).
     pub fn common_integer_literal_type(&mut self, a: &BigInt, b: &BigInt) -> Option<TypeId> {
-        let signed = a.is_negative() || b.is_negative();
-        let bits = integer_bits_required(a, signed).max(integer_bits_required(b, signed));
-        if bits > 256 {
-            return None;
-        }
-        let bits = bits.next_multiple_of(8).max(8);
-        Some(self.register_type(Type::Integer { signed, bits }))
+        smallest_integer_type_to_fit(&[a, b]).map(|type_| self.register_type(type_))
     }
 
     // Return a type that can be stored in the EVM. In short, convert literal
     // types into the appropriate "real" type
-    pub(crate) fn reified_type(&mut self, type_id: TypeId) -> TypeId {
+    pub(crate) fn reified_type(&mut self, type_id: TypeId) -> Option<TypeId> {
         let Type::Literal(kind) = self.get_type_by_id(type_id) else {
-            return type_id;
+            return Some(type_id);
         };
         match kind {
-            // TODO: narrow these to the smallest holding type, matching solc
-            // (eg. literal 1 -> uint8, 1.2 -> ufixed8x1). For now, default to
-            // uint256 to preserve current behaviour.
-            LiteralKind::Integer(_) | LiteralKind::HexInteger { .. } | LiteralKind::Rational(_) => {
-                self.uint256()
+            LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. } => {
+                smallest_integer_type_to_fit(&[value]).map(|type_| self.register_type(type_))
             }
-            LiteralKind::HexString { .. } | LiteralKind::String { .. } => self.string(),
-            LiteralKind::Address => self.address(),
+            LiteralKind::Rational(_) => {
+                // TODO: narrow the rational type to the smallest fixed/ufixed
+                // available (eg. 1.2 -> ufixed8x1). For now, default to uint256
+                // to preserve current behaviour.
+                Some(self.uint256())
+            }
+            LiteralKind::HexString { .. } | LiteralKind::String { .. } => Some(self.string()),
+            LiteralKind::Address => Some(self.address()),
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -172,14 +172,16 @@ impl TypeRegistry {
             }
 
             (
-                Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }),
+                Type::Literal(
+                    LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
+                ),
                 Type::Integer { signed, bits },
             ) => numbers::integer_literal_fits(value, *signed, *bits),
 
             // Non-integer rational literals never implicitly convert to an
             // integer type — if a rational reduced to an integer it would have
             // been normalised to `LiteralKind::Integer` at construction time.
-            (Type::Literal(LiteralKind::Rational(_)), Type::Integer { .. }) => false,
+            (Type::Literal(LiteralKind::Rational { .. }), Type::Integer { .. }) => false,
 
             // TODO: Rational -> FixedPointNumber once v2 models implicit
             // conversion of rational literals to fixed-point types.
@@ -193,7 +195,9 @@ impl TypeRegistry {
             // Zero (any source — decimal, hex, or folded) is always
             // implicitly convertible to any byte-array type.
             (
-                Type::Literal(LiteralKind::Integer(value) | LiteralKind::HexInteger { value, .. }),
+                Type::Literal(
+                    LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
+                ),
                 Type::ByteArray { .. },
             ) if value.is_zero() => true,
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -229,7 +229,7 @@ impl TypeRegistry {
             (
                 Type::Literal(LiteralKind::HexString { bytes } | LiteralKind::String { bytes }),
                 Type::ByteArray { width },
-            ) if *bytes == *width => true,
+            ) if *bytes == *width as usize => true,
 
             (
                 Type::Array {

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -378,11 +378,11 @@ impl CollectedDefinitionDisplay<'_> {
                 )
             }
             Type::Literal(kind) => match kind {
-                LiteralKind::Integer(value) => format!("lit-integer({value})"),
+                LiteralKind::Integer { value } => format!("lit-integer({value})"),
                 LiteralKind::HexInteger { value, bytes } => {
                     format!("lit-hex({value}, {bytes})")
                 }
-                LiteralKind::Rational(value) => format!("lit-rational({value})"),
+                LiteralKind::Rational { value } => format!("lit-rational({value})"),
                 LiteralKind::HexString { bytes } => format!("lit-hexstring({bytes})"),
                 LiteralKind::String { bytes } => format!("lit-string({bytes})"),
                 LiteralKind::Address => "lit-address".to_string(),

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -380,7 +380,14 @@ impl CollectedDefinitionDisplay<'_> {
             Type::Literal(kind) => match kind {
                 LiteralKind::Zero => "lit-zero".to_string(),
                 LiteralKind::Rational => "rational".to_string(),
-                LiteralKind::DecimalInteger => "lit-integer".to_string(),
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: false,
+                } => format!("lit-integer({bytes})"),
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: true,
+                } => format!("lit-integer({bytes}, signed)"),
                 LiteralKind::HexInteger { bytes } => format!("lit-hex({bytes})"),
                 LiteralKind::HexString { bytes } => format!("lit-hexstring({bytes})"),
                 LiteralKind::String { bytes } => format!("lit-string({bytes})"),

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -378,17 +378,11 @@ impl CollectedDefinitionDisplay<'_> {
                 )
             }
             Type::Literal(kind) => match kind {
-                LiteralKind::Zero => "lit-zero".to_string(),
-                LiteralKind::Rational => "rational".to_string(),
-                LiteralKind::DecimalInteger {
-                    bytes,
-                    signed: false,
-                } => format!("lit-integer({bytes})"),
-                LiteralKind::DecimalInteger {
-                    bytes,
-                    signed: true,
-                } => format!("lit-integer({bytes}, signed)"),
-                LiteralKind::HexInteger { bytes } => format!("lit-hex({bytes})"),
+                LiteralKind::Integer(value) => format!("lit-integer({value})"),
+                LiteralKind::HexInteger { value, bytes } => {
+                    format!("lit-hex({value}, {bytes})")
+                }
+                LiteralKind::Rational(value) => format!("lit-rational({value})"),
                 LiteralKind::HexString { bytes } => format!("lit-hexstring({bytes})"),
                 LiteralKind::String { bytes } => format!("lit-string({bytes})"),
                 LiteralKind::Address => "lit-address".to_string(),


### PR DESCRIPTION
- Port changes in v1 introduced in #1722, including:
  - expose `LiteralKind` through the AST
  - add integer value getters to `DecimalNumberExpression` and `HexNumberExpression`
  - parsing literal numbers with unit
- Add support for rational numbers via `num-rational`
- Numeric value is now part of the literal number types
- Perform constant folding for expressions involving literals; the result is conveyed in the type of the result itself
- Improve unification of types for conditional expressions and array literals
- String decoding implementation now lives in the semantic crate, which allows sizing strings with escape sequences for typing
- Add test coverage for typing of expressions; previously this was only tested through snapshots in convoluted ways
- Register node typing for all expression variants, which should make querying the type from the AST API more consistent