### PR TITLE
Fix build and validate for release pipeline

### DIFF
--- a/crates/infra/cli/src/commands/publish/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/publish/cargo/mod.rs
@@ -30,8 +30,15 @@ impl CargoController {
             return Ok(());
         }
 
-        for crate_name in &changed_crates {
-            run_cargo_publish(crate_name, self.dry_run);
+        if self.dry_run.get() {
+            // Dry-run all changed crates in a single invocation so cargo can
+            // resolve inter-crate path deps locally. Per-crate dry-runs fail
+            // because the new versions of internal deps aren't on crates.io yet.
+            run_cargo_publish_dry_run(&changed_crates);
+        } else {
+            for crate_name in &changed_crates {
+                run_cargo_publish(crate_name);
+            }
         }
 
         Ok(())
@@ -56,14 +63,22 @@ fn prepare_for_publish(crate_name: &str) -> Result<bool> {
     Ok(true)
 }
 
-fn run_cargo_publish(crate_name: &str, dry_run: DryRun) {
-    let mut command = Command::new("cargo")
+fn run_cargo_publish(crate_name: &str) {
+    Command::new("cargo")
         .arg("publish")
         .property("--package", crate_name)
-        .flag("--all-features");
+        .flag("--all-features")
+        .run();
+}
 
-    if dry_run.get() {
-        command = command.flag("--dry-run");
+fn run_cargo_publish_dry_run(crate_names: &[String]) {
+    let mut command = Command::new("cargo")
+        .arg("publish")
+        .flag("--all-features")
+        .flag("--dry-run");
+
+    for crate_name in crate_names {
+        command = command.property("--package", crate_name);
     }
 
     command.run();

--- a/crates/infra/cli/src/commands/publish/npm/mod.rs
+++ b/crates/infra/cli/src/commands/publish/npm/mod.rs
@@ -35,7 +35,11 @@ impl NpmController {
 
         let mut command = Command::new("pnpm")
             .args(["publish", package_dir.unwrap_str()])
-            .property("--access", "public");
+            .property("--access", "public")
+            // CI checkout is detached HEAD, which fails pnpm's branch check.
+            // The workflow's `branches:` filter and the slang-release environment
+            // gate are what actually authorize a release.
+            .flag("--no-git-checks");
 
         if self.dry_run.get() {
             command = command.flag("--dry-run");


### PR DESCRIPTION
I reworked part of the trusted publishing workflow. One aspect that wasn't tested was dry-run for an actual publish run. Apparently this fails due to a detached git head that happens due to a slightly different way of using the checkout action. 


PR #1748 (`changeset-release/main` → `main`) failed `build-and-validate` at `infra publish npm --dry-run`:

  ```
  ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch,
  but your "publish-branch" is set to "master|main".
  ```

Similarly, `infra publish cargo --dry-run` fails as it loops over each user-facing crate and runs `cargo publish --package X --dry-run` individually. resolution fails:
  ```
    error: failed to prepare local package for uploading
    Caused by:
      failed to select a version for the requirement `metaslang_cst = "^1.3.5"`
      candidate versions found which didn't match: 1.3.4, 1.3.3, 1.3.2, ...
  ```

  Fix is to batch all changed crates into a single `cargo publish -p A -p B ... --dry-run` so cargo resolves sibling
  workspace members locally. The real publish keeps its per-crate loop.

## Tested
This branch was originally branched off `changeset-release/main` with the workflow change on top to validate.  See  https://github.com/NomicFoundation/slang/actions/runs/25396635869/job/74485084388?pr=1749
