### PR TITLE
Test cargo benchmarks names

### DIFF
--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
-        run: "./scripts/bin/infra perf cargo --smoke comparison"
+        run: "./scripts/bin/infra perf cargo --smoke --pr-benchmark comparison"
 
       - name: "Benchmark > infra perf cargo comparison"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
@@ -90,6 +90,34 @@ jobs:
           BENCHER_PR_START_POINT_HASH: "${{ github.event.pull_request.base.sha }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Bench list > Detect diff"
+        id: "bench_list_diff_comparison"
+        if: "${{ github.event_name == 'pull_request' }}"
+        continue-on-error: true
+        run: |
+          f="target/perf-new-benches-comparison.md"
+          if [ -s "$f" ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Bench list > Sticky comment with diff"
+        if: "${{ steps.bench_list_diff_comparison.outputs.has_diff == 'true' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-comparison"
+          path: "target/perf-new-benches-comparison.md"
+
+      - name: "Bench list > Resolve sticky comment when bench-list matches"
+        if: "${{ steps.bench_list_diff_comparison.outputs.has_diff == 'false' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-comparison"
+          delete: true
 
       - name: "Benchmark > Upload Benchmarking Data"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
-        run: "./scripts/bin/infra perf cargo --smoke slang"
+        run: "./scripts/bin/infra perf cargo --smoke --pr-benchmark slang"
 
       - name: "Benchmark > infra perf cargo slang"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
@@ -90,6 +90,34 @@ jobs:
           BENCHER_PR_START_POINT_HASH: "${{ github.event.pull_request.base.sha }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Bench list > Detect diff"
+        id: "bench_list_diff_slang"
+        if: "${{ github.event_name == 'pull_request' }}"
+        continue-on-error: true
+        run: |
+          f="target/perf-new-benches-slang.md"
+          if [ -s "$f" ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Bench list > Sticky comment with diff"
+        if: "${{ steps.bench_list_diff_slang.outputs.has_diff == 'true' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-slang"
+          path: "target/perf-new-benches-slang.md"
+
+      - name: "Bench list > Resolve sticky comment when bench-list matches"
+        if: "${{ steps.bench_list_diff_slang.outputs.has_diff == 'false' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-slang"
+          delete: true
 
       - name: "Benchmark > Upload Benchmarking Data"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: "Smoke Test > infra perf cargo --smoke slang-v2"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
-        run: "./scripts/bin/infra perf cargo --smoke slang-v2"
+        run: "./scripts/bin/infra perf cargo --smoke --pr-benchmark slang-v2"
 
       - name: "Benchmark > infra perf cargo slang-v2"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
@@ -90,6 +90,34 @@ jobs:
           BENCHER_PR_START_POINT_HASH: "${{ github.event.pull_request.base.sha }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Bench list > Detect diff"
+        id: "bench_list_diff_slang_v2"
+        if: "${{ github.event_name == 'pull_request' }}"
+        continue-on-error: true
+        run: |
+          f="target/perf-new-benches-slang_v2.md"
+          if [ -s "$f" ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Bench list > Sticky comment with diff"
+        if: "${{ steps.bench_list_diff_slang_v2.outputs.has_diff == 'true' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-slang_v2"
+          path: "target/perf-new-benches-slang_v2.md"
+
+      - name: "Bench list > Resolve sticky comment when bench-list matches"
+        if: "${{ steps.bench_list_diff_slang_v2.outputs.has_diff == 'false' }}"
+        continue-on-error: true
+        uses: "marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728" # v2.9.4
+        with:
+          header: "bench-list-slang_v2"
+          delete: true
 
       - name: "Benchmark > Upload Benchmarking Data"
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/crates/infra/cli/src/commands/perf/bench_list.rs
+++ b/crates/infra/cli/src/commands/perf/bench_list.rs
@@ -7,8 +7,9 @@
 //! per-suite submodules below — currently only [`gungraun`].
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Result};
 use infra_utils::paths::PathExtensions;
 
 /// Diff `local_names` against `remote_names` and write any new (locally
@@ -16,27 +17,22 @@ use infra_utils::paths::PathExtensions;
 /// `target/perf-new-benches-<bench_name>.md`. The CI workflow conditionally
 /// surfaces this file as a sticky PR comment.
 ///
-/// The output file is always written (empty when there is no diff); that lets
-/// the workflow distinguish "no diff" (delete the sticky comment) from "step
-/// did not run".
+/// The output file is always written when verification succeeds: an empty body
+/// means "no diff" (the workflow deletes the sticky), and a non-empty body is
+/// the markdown the workflow stickies.
 pub fn verify_bench_list(
     bench_name: &str,
     bencher_project: &str,
     local_names: Vec<String>,
     remote_names: Vec<String>,
-) {
-    let output_path = Path::repo_path("target").join(format!("perf-new-benches-{bench_name}.md"));
-
+) -> Result<()> {
     let local_set: BTreeSet<String> = local_names.into_iter().collect();
     let remote_set: BTreeSet<String> = remote_names.into_iter().collect();
     let new: Vec<&String> = local_set.difference(&remote_set).collect();
     let orphan: Vec<&String> = remote_set.difference(&local_set).collect();
 
     let body = render_bench_diff_markdown(bench_name, bencher_project, &new, &orphan);
-    if let Err(err) = std::fs::write(&output_path, &body) {
-        eprintln!("Failed to write {}: {err:#}", output_path.display());
-        return;
-    }
+    let output_path = write_output(bench_name, &body)?;
 
     if body.is_empty() {
         println!("Bench list matches bencher project '{bencher_project}'.");
@@ -48,6 +44,17 @@ pub fn verify_bench_list(
             orphan.len(),
         );
     }
+    Ok(())
+}
+
+fn write_output(bench_name: &str, body: &str) -> Result<PathBuf> {
+    let target_dir = Path::repo_path("target");
+    std::fs::create_dir_all(&target_dir)
+        .with_context(|| format!("failed to create {}", target_dir.display()))?;
+    let output_path = target_dir.join(format!("perf-new-benches-{bench_name}.md"));
+    std::fs::write(&output_path, body)
+        .with_context(|| format!("failed to write {}", output_path.display()))?;
+    Ok(output_path)
 }
 
 fn render_bench_diff_markdown(
@@ -86,7 +93,8 @@ fn render_bench_diff_markdown(
     body
 }
 
-/// Append a `<details>` block
+/// Append a `<details>` block; renders as a collapsible disclosure in
+/// GitHub markdown.
 fn push_collapsible_list(
     body: &mut String,
     title_html: &str,
@@ -113,9 +121,7 @@ pub mod gungraun {
     use anyhow::{Context, Result};
     use infra_utils::commands::Command;
 
-    /// Collect the local and remote name sets for the given bench. The two
-    /// fetches share the same fail-soft fallback at the call site, so they're
-    /// bundled into one fallible step.
+    /// Collect the local and remote name sets for the given bench.
     pub fn collect_names(
         package: &str,
         bench_name: &str,
@@ -124,6 +130,8 @@ pub mod gungraun {
         let output = Command::new("cargo")
             .args([
                 "bench",
+                "--profile",
+                "dev",
                 "--package",
                 package,
                 "--bench",
@@ -131,8 +139,7 @@ pub mod gungraun {
                 "--",
                 "--list",
             ])
-            .evaluate()
-            .with_context(|| format!("failed to list local benchmarks for {bench_name}"))?;
+            .evaluate()?;
 
         let local = parse_local_names(&output);
         let remote = list_remote_names(bencher_project)?;
@@ -155,6 +162,7 @@ pub mod gungraun {
     /// The slang bencher projects allow read-only public listing, so no token
     /// is required.
     fn list_remote_names(project: &str) -> Result<Vec<String>> {
+        // 255 is the bencher API's per-page cap; using it minimizes round trips.
         const PER_PAGE: usize = 255;
         let mut names = Vec::new();
         let mut page = 1usize;
@@ -170,8 +178,7 @@ pub mod gungraun {
                     "--page",
                     &page.to_string(),
                 ])
-                .evaluate()
-                .with_context(|| format!("failed to query bencher project {project}"))?;
+                .evaluate()?;
 
             let entries: Vec<serde_json::Value> = serde_json::from_str(&output)
                 .with_context(|| format!("failed to parse bencher response for {project}"))?;
@@ -208,6 +215,39 @@ pub mod gungraun {
             format!("{module_path}::{bench_id}")
         } else {
             name.to_owned()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{canonicalize_label, parse_local_names};
+
+        #[test]
+        fn parse_local_names_strips_libtest_suffix() {
+            let output = "\
+                slang::pipeline::parser::merkle_proof: benchmark\n\
+                slang::pipeline::parser::weighted_pool: benchmark\n\
+                \n2 benchmarks\n";
+            assert_eq!(
+                parse_local_names(output),
+                vec![
+                    "slang::pipeline::parser::merkle_proof".to_string(),
+                    "slang::pipeline::parser::weighted_pool".to_string(),
+                ],
+            );
+        }
+
+        #[test]
+        fn canonicalize_label_strips_quoted_description_tail() {
+            assert_eq!(
+                canonicalize_label("slang::pipeline::parser weighted_pool:\"weighted_pool\""),
+                "slang::pipeline::parser::weighted_pool",
+            );
+        }
+
+        #[test]
+        fn canonicalize_label_passes_through_unsplittable_input() {
+            assert_eq!(canonicalize_label("free_form_name"), "free_form_name");
         }
     }
 }

--- a/crates/infra/cli/src/commands/perf/bench_list.rs
+++ b/crates/infra/cli/src/commands/perf/bench_list.rs
@@ -118,8 +118,10 @@ fn push_collapsible_list(
 /// names from `cargo bench -- --list`, and how to fetch + canonicalize the
 /// names recorded on bencher.
 pub mod gungraun {
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use infra_utils::commands::Command;
+
+    use crate::toolchains::bencher;
 
     /// Collect the local and remote name sets for the given bench.
     pub fn collect_names(
@@ -142,7 +144,10 @@ pub mod gungraun {
             .evaluate()?;
 
         let local = parse_local_names(&output);
-        let remote = list_remote_names(bencher_project)?;
+        let remote = bencher::list_project_benchmarks(bencher_project)?
+            .iter()
+            .map(|name| canonicalize_label(name))
+            .collect();
         Ok((local, remote))
     }
 
@@ -153,55 +158,6 @@ pub mod gungraun {
             .lines()
             .filter_map(|line| line.strip_suffix(": benchmark").map(str::to_owned))
             .collect()
-    }
-
-    /// Bulk-fetch every benchmark recorded for `project`, paginating through
-    /// the bencher API and canonicalizing each label back to the form
-    /// gungraun emits locally so the two sides can be set-compared.
-    ///
-    /// The slang bencher projects allow read-only public listing, so no token
-    /// is required.
-    fn list_remote_names(project: &str) -> Result<Vec<String>> {
-        // 255 is the bencher API's per-page cap; using it minimizes round trips.
-        const PER_PAGE: usize = 255;
-        let mut names = Vec::new();
-        let mut page = 1usize;
-
-        loop {
-            let output = Command::new("bencher")
-                .args([
-                    "benchmark",
-                    "list",
-                    project,
-                    "--per-page",
-                    &PER_PAGE.to_string(),
-                    "--page",
-                    &page.to_string(),
-                ])
-                .evaluate()?;
-
-            let entries: Vec<serde_json::Value> = serde_json::from_str(&output)
-                .with_context(|| format!("failed to parse bencher response for {project}"))?;
-
-            if entries.is_empty() {
-                break;
-            }
-
-            let count = entries.len();
-            names.extend(
-                entries
-                    .iter()
-                    .filter_map(|entry| entry.get("name").and_then(|v| v.as_str()))
-                    .map(canonicalize_label),
-            );
-
-            if count < PER_PAGE {
-                break;
-            }
-            page += 1;
-        }
-
-        Ok(names)
     }
 
     /// Convert a bencher-stored label like

--- a/crates/infra/cli/src/commands/perf/bench_list.rs
+++ b/crates/infra/cli/src/commands/perf/bench_list.rs
@@ -1,0 +1,213 @@
+//! Compare a benchmark suite's local bench list against the names recorded on
+//! bencher.dev, and write a markdown summary the CI workflow surfaces as a
+//! sticky PR comment.
+//!
+//! Used by `infra perf cargo --pr-benchmark`. Suite-specific name parsing
+//! (local listing format, remote label canonicalization) lives in the
+//! per-suite submodules below — currently only [`gungraun`].
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use infra_utils::paths::PathExtensions;
+
+/// Diff `local_names` against `remote_names` and write any new (locally
+/// added) and orphan (recorded on bencher but no longer in code) entries to
+/// `target/perf-new-benches-<bench_name>.md`. The CI workflow conditionally
+/// surfaces this file as a sticky PR comment.
+///
+/// The output file is always written (empty when there is no diff); that lets
+/// the workflow distinguish "no diff" (delete the sticky comment) from "step
+/// did not run".
+pub fn verify_bench_list(
+    bench_name: &str,
+    bencher_project: &str,
+    local_names: Vec<String>,
+    remote_names: Vec<String>,
+) {
+    let output_path = Path::repo_path("target").join(format!("perf-new-benches-{bench_name}.md"));
+
+    let local_set: BTreeSet<String> = local_names.into_iter().collect();
+    let remote_set: BTreeSet<String> = remote_names.into_iter().collect();
+    let new: Vec<&String> = local_set.difference(&remote_set).collect();
+    let orphan: Vec<&String> = remote_set.difference(&local_set).collect();
+
+    let body = render_bench_diff_markdown(bench_name, bencher_project, &new, &orphan);
+    if let Err(err) = std::fs::write(&output_path, &body) {
+        eprintln!("Failed to write {}: {err:#}", output_path.display());
+        return;
+    }
+
+    if body.is_empty() {
+        println!("Bench list matches bencher project '{bencher_project}'.");
+    } else {
+        println!(
+            "Bench-list diff written to {} ({} new, {} orphan)",
+            output_path.display(),
+            new.len(),
+            orphan.len(),
+        );
+    }
+}
+
+fn render_bench_diff_markdown(
+    bench_name: &str,
+    bencher_project: &str,
+    new: &[&String],
+    orphan: &[&String],
+) -> String {
+    if new.is_empty() && orphan.is_empty() {
+        return String::new();
+    }
+
+    let mut body =
+        format!("### Bench list diff for `{bench_name}` (project `{bencher_project}`)\n\n");
+
+    if !new.is_empty() {
+        push_collapsible_list(
+            &mut body,
+            &format!("<b>New benchmarks ({})</b>", new.len()),
+            "present in code, not yet recorded on bencher. \
+            Will start a fresh metric history once a <code>ci:perf</code> run uploads results.",
+            new,
+        );
+    }
+
+    if !orphan.is_empty() {
+        push_collapsible_list(
+            &mut body,
+            &format!("<b>Orphan benchmarks ({})</b>", orphan.len()),
+            "recorded on bencher but no longer in code. \
+            Either renamed in this PR or candidates for archival.",
+            orphan,
+        );
+    }
+
+    body
+}
+
+/// Append a `<details>` block
+fn push_collapsible_list(
+    body: &mut String,
+    title_html: &str,
+    description_html: &str,
+    items: &[&String],
+) {
+    body.push_str("<details>\n<summary>");
+    body.push_str(title_html);
+    body.push_str(" — ");
+    body.push_str(description_html);
+    body.push_str("</summary>\n\n");
+    for name in items {
+        body.push_str("- `");
+        body.push_str(name);
+        body.push_str("`\n");
+    }
+    body.push_str("\n</details>\n\n");
+}
+
+/// Suite-specific helpers for the gungraun cargo benches: how to list local
+/// names from `cargo bench -- --list`, and how to fetch + canonicalize the
+/// names recorded on bencher.
+pub mod gungraun {
+    use anyhow::{Context, Result};
+    use infra_utils::commands::Command;
+
+    /// Collect the local and remote name sets for the given bench. The two
+    /// fetches share the same fail-soft fallback at the call site, so they're
+    /// bundled into one fallible step.
+    pub fn collect_names(
+        package: &str,
+        bench_name: &str,
+        bencher_project: &str,
+    ) -> Result<(Vec<String>, Vec<String>)> {
+        let output = Command::new("cargo")
+            .args([
+                "bench",
+                "--package",
+                package,
+                "--bench",
+                bench_name,
+                "--",
+                "--list",
+            ])
+            .evaluate()
+            .with_context(|| format!("failed to list local benchmarks for {bench_name}"))?;
+
+        let local = parse_local_names(&output);
+        let remote = list_remote_names(bencher_project)?;
+        Ok((local, remote))
+    }
+
+    /// Parse libtest-compatible `<name>: benchmark` listings — the format
+    /// gungraun produces with `cargo bench -- --list`.
+    fn parse_local_names(output: &str) -> Vec<String> {
+        output
+            .lines()
+            .filter_map(|line| line.strip_suffix(": benchmark").map(str::to_owned))
+            .collect()
+    }
+
+    /// Bulk-fetch every benchmark recorded for `project`, paginating through
+    /// the bencher API and canonicalizing each label back to the form
+    /// gungraun emits locally so the two sides can be set-compared.
+    ///
+    /// The slang bencher projects allow read-only public listing, so no token
+    /// is required.
+    fn list_remote_names(project: &str) -> Result<Vec<String>> {
+        const PER_PAGE: usize = 255;
+        let mut names = Vec::new();
+        let mut page = 1usize;
+
+        loop {
+            let output = Command::new("bencher")
+                .args([
+                    "benchmark",
+                    "list",
+                    project,
+                    "--per-page",
+                    &PER_PAGE.to_string(),
+                    "--page",
+                    &page.to_string(),
+                ])
+                .evaluate()
+                .with_context(|| format!("failed to query bencher project {project}"))?;
+
+            let entries: Vec<serde_json::Value> = serde_json::from_str(&output)
+                .with_context(|| format!("failed to parse bencher response for {project}"))?;
+
+            if entries.is_empty() {
+                break;
+            }
+
+            let count = entries.len();
+            names.extend(
+                entries
+                    .iter()
+                    .filter_map(|entry| entry.get("name").and_then(|v| v.as_str()))
+                    .map(canonicalize_label),
+            );
+
+            if count < PER_PAGE {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(names)
+    }
+
+    /// Convert a bencher-stored label like
+    /// `slang::pipeline::parser weighted_pool:"weighted_pool"` back to the
+    /// canonical `slang::pipeline::parser::weighted_pool` so it can be
+    /// set-compared with `parse_local_names`. The truncation bencher applies
+    /// to the description tail does not affect the canonical form.
+    fn canonicalize_label(name: &str) -> String {
+        if let Some((module_path, suffix)) = name.split_once(' ') {
+            let bench_id = suffix.split_once(':').map_or(suffix, |(id, _)| id);
+            format!("{module_path}::{bench_id}")
+        } else {
+            name.to_owned()
+        }
+    }
+}

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -71,7 +71,7 @@ impl CargoController {
         };
 
         if self.pr_benchmark {
-            Self::verify_bench_list(package, bench_name, bencher_project);
+            Self::verify_bench_list(package, bench_name, bencher_project)?;
         }
 
         if self.smoke {
@@ -197,18 +197,11 @@ Reports/Logs: {reports_dir:?}
     /// benchmarks on bencher.dev, deferring to the shared `bench_list` helper to
     /// write the markdown summary the CI workflow surfaces as a sticky PR
     /// comment.
-    fn verify_bench_list(package: &str, bench_name: &str, bencher_project: &str) {
-        match bench_list::gungraun::collect_names(package, bench_name, bencher_project) {
-            Ok((local, remote)) => {
-                bench_list::verify_bench_list(bench_name, bencher_project, local, remote);
-            }
-            Err(err) => {
-                eprintln!("Skipping bench-list verification: {err:#}");
-                let output_path =
-                    Path::repo_path("target").join(format!("perf-new-benches-{bench_name}.md"));
-                let _ = std::fs::write(output_path, "");
-            }
-        }
+    fn verify_bench_list(package: &str, bench_name: &str, bencher_project: &str) -> Result<()> {
+        let (local, remote) =
+            bench_list::gungraun::collect_names(package, bench_name, bencher_project)?;
+
+        bench_list::verify_bench_list(bench_name, bencher_project, local, remote)
     }
 
     fn generate_callgraph(reports_dir: std::path::PathBuf) {

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -7,6 +7,7 @@ use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 use infra_utils::paths::{FileWalker, PathExtensions};
 
+use crate::commands::perf::bench_list;
 use crate::toolchains::bencher::{run_bench, BencherThreshold};
 use crate::toolchains::pipenv::PipEnv;
 use crate::utils::DryRun;
@@ -27,7 +28,7 @@ pub struct CargoController {
     #[arg(long)]
     no_deps: bool,
     /// Install deps and build bench binaries, but skip running benchmarks.
-    #[arg(long, conflicts_with = "pr_benchmark")]
+    #[arg(long)]
     smoke: bool,
 }
 
@@ -51,12 +52,29 @@ impl CargoController {
             Self::install_graphviz();
         }
 
+        let (package, bench_name, bencher_project) = match self.bench {
+            Benches::Slang => (
+                "solidity_testing_perf_cargo",
+                "slang",
+                DEFAULT_BENCHER_PROJECT_SLANG,
+            ),
+            Benches::Comparison => (
+                "solidity_testing_perf_cargo",
+                "comparison",
+                DEFAULT_BENCHER_PROJECT_CMP,
+            ),
+            Benches::SlangV2 => (
+                "solidity_testing_perf_cargo",
+                "slang_v2",
+                DEFAULT_BENCHER_PROJECT_SLANG_V2,
+            ),
+        };
+
+        if self.pr_benchmark {
+            Self::verify_bench_list(package, bench_name, bencher_project);
+        }
+
         if self.smoke {
-            let (package, bench_name) = match self.bench {
-                Benches::Slang => ("solidity_testing_perf_cargo", "slang"),
-                Benches::Comparison => ("solidity_testing_perf_cargo", "comparison"),
-                Benches::SlangV2 => ("solidity_testing_perf_cargo", "slang_v2"),
-            };
             Command::new("cargo")
                 .args(["build", "--package", package, "--bench", bench_name])
                 .run();
@@ -65,23 +83,7 @@ impl CargoController {
             return Ok(());
         }
 
-        match self.bench {
-            Benches::Slang => self.run_gungraun_bench(
-                "solidity_testing_perf_cargo",
-                "slang",
-                DEFAULT_BENCHER_PROJECT_SLANG,
-            ),
-            Benches::Comparison => self.run_gungraun_bench(
-                "solidity_testing_perf_cargo",
-                "comparison",
-                DEFAULT_BENCHER_PROJECT_CMP,
-            ),
-            Benches::SlangV2 => self.run_gungraun_bench(
-                "solidity_testing_perf_cargo",
-                "slang_v2",
-                DEFAULT_BENCHER_PROJECT_SLANG_V2,
-            ),
-        }
+        self.run_gungraun_bench(package, bench_name, bencher_project);
         Ok(())
     }
 
@@ -189,6 +191,24 @@ Reports/Logs: {reports_dir:?}
 - DHAT traces (dhat.*.out) can be viewed using the [dhat/dh_view.html] tool from the Valgrind release [https://valgrind.org/downloads/].
 
 ");
+    }
+
+    /// Compare the bench binary's `--list` output against the project's recorded
+    /// benchmarks on bencher.dev, deferring to the shared `bench_list` helper to
+    /// write the markdown summary the CI workflow surfaces as a sticky PR
+    /// comment.
+    fn verify_bench_list(package: &str, bench_name: &str, bencher_project: &str) {
+        match bench_list::gungraun::collect_names(package, bench_name, bencher_project) {
+            Ok((local, remote)) => {
+                bench_list::verify_bench_list(bench_name, bencher_project, local, remote);
+            }
+            Err(err) => {
+                eprintln!("Skipping bench-list verification: {err:#}");
+                let output_path =
+                    Path::repo_path("target").join(format!("perf-new-benches-{bench_name}.md"));
+                let _ = std::fs::write(output_path, "");
+            }
+        }
     }
 
     fn generate_callgraph(reports_dir: std::path::PathBuf) {

--- a/crates/infra/cli/src/commands/perf/mod.rs
+++ b/crates/infra/cli/src/commands/perf/mod.rs
@@ -1,4 +1,5 @@
 mod archive;
+mod bench_list;
 mod cargo;
 mod npm;
 

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -64,6 +64,8 @@ impl NpmController {
     pub fn execute(&self) -> Result<()> {
         Self::install_deps()?;
 
+        // TODO: surface a bench-list diff comment on PRs the way the cargo
+        // workflows do.
         if self.smoke {
             Command::new("cargo")
                 .args(["build", "--package", "solidity_testing_perf_npm"])

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
 
@@ -151,4 +152,55 @@ fn bencher_archive_command(action: &str, project: &str, branch: &str) {
         .property("--branch", branch)
         .secret("BENCHER_API_TOKEN", token)
         .run();
+}
+
+/// List every benchmark name recorded for `project` on bencher.dev,
+/// paginating through the bencher API.
+///
+/// Honours the `SLANG_BENCHER_PROJECT` env var as an override, matching
+/// `run_bench`. Unauthenticated: slang's bencher projects allow public
+/// read-only listing.
+pub(crate) fn list_project_benchmarks(project: &str) -> Result<Vec<String>> {
+    // 255 is the bencher API's per-page cap; using it minimizes round trips.
+    const PER_PAGE: usize = 255;
+
+    let project = std::env::var("SLANG_BENCHER_PROJECT").unwrap_or(project.to_owned());
+
+    let mut names = Vec::new();
+    let mut page = 1usize;
+    loop {
+        let output = Command::new("bencher")
+            .args([
+                "benchmark",
+                "list",
+                &project,
+                "--per-page",
+                &PER_PAGE.to_string(),
+                "--page",
+                &page.to_string(),
+            ])
+            .evaluate()?;
+
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&output)
+            .with_context(|| format!("failed to parse bencher response for {project}"))?;
+
+        if entries.is_empty() {
+            break;
+        }
+
+        let count = entries.len();
+        names.extend(
+            entries
+                .iter()
+                .filter_map(|entry| entry.get("name").and_then(|v| v.as_str()))
+                .map(str::to_owned),
+        );
+
+        if count < PER_PAGE {
+            break;
+        }
+        page += 1;
+    }
+
+    Ok(names)
 }


### PR DESCRIPTION
This PR adds another step to `infra perf cargo --pr-benchmark` to compare the names of the current's code benchmarks and the ones present in bencher. If there are any differences it will report the new and orphan benchmarks.

Given how `gungraun` names benchmarks, how we can recover them locally without actually executing them, and how bencher stores them, we may see some false negatives in the future. If this best effort approach becomes too cumbersome we could revert it.