### PR TITLE
feat(backend): expose UDVT target type and AST Type/Expression accessors

### DIFF
--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use paste::paste;
 
 use super::Definition;
+use crate::backend::binder;
 use crate::backend::types::{self, DataLocation, FunctionTypeKind, LiteralKind, TypeId};
 use crate::backend::SemanticAnalysis;
 
@@ -377,6 +378,26 @@ impl UserDefinedValueType {
         };
         Definition::try_create(*definition_id, &self.semantic)
             .expect("invalid user defined value definition")
+    }
+
+    /// Returns the underlying elementary type that this UDVT wraps, or `None`
+    /// if the binder did not resolve a target type (e.g., the declaration is
+    /// ill-formed or references an unsupported elementary type).
+    pub fn target_type(&self) -> Option<Type> {
+        let types::Type::UserDefinedValue { definition_id } = self.internal_type() else {
+            unreachable!("invalid user defined value type");
+        };
+        let binder_definition = self
+            .semantic
+            .binder()
+            .find_definition_by_id(*definition_id)?;
+        let binder::Definition::UserDefinedValueType(udvt_definition) = binder_definition else {
+            unreachable!("UDVT type id should map to UDVT definition");
+        };
+        Some(Type::create(
+            udvt_definition.target_type_id?,
+            &self.semantic,
+        ))
     }
 }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/types.rs
@@ -3,9 +3,8 @@ use std::rc::Rc;
 use paste::paste;
 
 use super::Definition;
-use crate::backend::binder;
 use crate::backend::types::{self, DataLocation, FunctionTypeKind, LiteralKind, TypeId};
-use crate::backend::SemanticAnalysis;
+use crate::backend::{binder, SemanticAnalysis};
 
 // __SLANG_TYPE_TYPES__ keep in sync with binder types
 #[derive(Clone)]
@@ -125,6 +124,38 @@ impl Type {
             Type::UserDefinedValue(details) => details.type_id,
             Type::Void(details) => details.type_id,
         }
+    }
+
+    /// Returns the data location of this type when it has one.
+    ///
+    /// Container types (`Array`, `Bytes`, `FixedSizeArray`, `String`, `Struct`)
+    /// carry their data location explicitly. `Mapping` is always `Storage`.
+    /// All other types are value types with no associated location and return
+    /// `None`.
+    pub fn data_location(&self) -> Option<DataLocation> {
+        match self {
+            Type::Array(details) => Some(details.location()),
+            Type::Bytes(details) => Some(details.location()),
+            Type::FixedSizeArray(details) => Some(details.location()),
+            Type::String(details) => Some(details.location()),
+            Type::Struct(details) => Some(details.location()),
+            Type::Mapping(_) => Some(DataLocation::Storage),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this type is a Solidity reference type
+    /// (`array`, `fixed-size array`, `bytes`, `string`, `mapping`, `struct`).
+    pub fn is_reference_type(&self) -> bool {
+        matches!(
+            self,
+            Type::Array(_)
+                | Type::FixedSizeArray(_)
+                | Type::Bytes(_)
+                | Type::String(_)
+                | Type::Mapping(_)
+                | Type::Struct(_)
+        )
     }
 }
 


### PR DESCRIPTION
AST-level accessors used by downstream MLIR codegen consumers (solx-slang) — no internals leak.

### New API

- `ast::UserDefinedValueType::target_type() -> Option<Type>`
- `ast::Type::data_location() -> Option<DataLocation>`
- `ast::Type::is_reference_type() -> bool`

### Notes

- `target_type()` reads `target_type_id` from the binder, returns `None` for ill-formed declarations.
- `data_location()` mirrors the semantic [`types::Type::data_location`](https://github.com/NomicFoundation/slang/blob/main/crates/solidity/outputs/cargo/slang_solidity/src/bindings/types.rs).
- `is_reference_type()` encodes the Solidity-spec list (`array`, `fixed-size array`, `bytes`, `string`, `mapping`, `struct`).