### PR TITLE
feat(backend): expose Identifier::resolved_type and Expression::get_type

### DIFF
--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/expressions.rs
@@ -1,12 +1,59 @@
 use num_bigint::BigInt;
 
 use super::super::{
-    DecimalNumberExpressionStruct, FunctionCallExpressionStruct, HexNumberExpressionStruct,
-    StringExpression,
+    DecimalNumberExpressionStruct, Expression, FunctionCallExpressionStruct,
+    HexNumberExpressionStruct, StringExpression, Type,
 };
 use crate::backend::binder::Typing;
 use crate::backend::ir::ir2_flat_contracts as input_ir;
 use crate::backend::types::ConstantValue;
+
+impl Expression {
+    /// Returns the slang type of the value produced by this expression.
+    ///
+    /// Dispatches to each variant's `get_type()`. For `Identifier`, follows
+    /// the binder via `resolved_type()` because slang types value-bearing
+    /// references at the definition node, not at the use-site identifier.
+    /// Returns `None` for keyword expressions (`this`, `true`, `false`, etc.)
+    /// and for type-position variants (`ElementaryType`, `StringExpression`).
+    pub fn get_type(&self) -> Option<Type> {
+        match self {
+            Expression::AssignmentExpression(expression) => expression.get_type(),
+            Expression::ConditionalExpression(expression) => expression.get_type(),
+            Expression::OrExpression(expression) => expression.get_type(),
+            Expression::AndExpression(expression) => expression.get_type(),
+            Expression::EqualityExpression(expression) => expression.get_type(),
+            Expression::InequalityExpression(expression) => expression.get_type(),
+            Expression::BitwiseOrExpression(expression) => expression.get_type(),
+            Expression::BitwiseXorExpression(expression) => expression.get_type(),
+            Expression::BitwiseAndExpression(expression) => expression.get_type(),
+            Expression::ShiftExpression(expression) => expression.get_type(),
+            Expression::AdditiveExpression(expression) => expression.get_type(),
+            Expression::MultiplicativeExpression(expression) => expression.get_type(),
+            Expression::ExponentiationExpression(expression) => expression.get_type(),
+            Expression::PostfixExpression(expression) => expression.get_type(),
+            Expression::PrefixExpression(expression) => expression.get_type(),
+            Expression::FunctionCallExpression(expression) => expression.get_type(),
+            Expression::CallOptionsExpression(expression) => expression.get_type(),
+            Expression::MemberAccessExpression(expression) => expression.get_type(),
+            Expression::IndexAccessExpression(expression) => expression.get_type(),
+            Expression::NewExpression(expression) => expression.get_type(),
+            Expression::TupleExpression(expression) => expression.get_type(),
+            Expression::TypeExpression(expression) => expression.get_type(),
+            Expression::ArrayExpression(expression) => expression.get_type(),
+            Expression::HexNumberExpression(expression) => expression.get_type(),
+            Expression::DecimalNumberExpression(expression) => expression.get_type(),
+            Expression::Identifier(identifier) => identifier.resolved_type(),
+            Expression::StringExpression(_)
+            | Expression::ElementaryType(_)
+            | Expression::PayableKeyword
+            | Expression::ThisKeyword
+            | Expression::SuperKeyword
+            | Expression::TrueKeyword
+            | Expression::FalseKeyword => None,
+        }
+    }
+}
 
 impl StringExpression {
     /// Returns the concatenated decoded string value as bytes.

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/identifiers.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/identifiers.rs
@@ -94,6 +94,24 @@ impl IdentifierStruct {
         self.semantic.get_type_from_node_id(self.ir_node.id())
     }
 
+    /// Returns the slang type of the value referenced by this identifier.
+    ///
+    /// Walks `resolve_to_definition` and returns the declared type of the
+    /// targeted state variable / variable / parameter / constant. Unlike
+    /// `get_type()`, which is keyed on the identifier's own node id and
+    /// returns `None` for reference uses (slang types those at the
+    /// definition node, not at every reference site), this accessor follows
+    /// the binder to the definition.
+    pub fn resolved_type(&self) -> Option<Type> {
+        match self.resolve_to_definition()? {
+            Definition::StateVariable(state_variable) => state_variable.get_type(),
+            Definition::Variable(variable) => variable.get_type(),
+            Definition::Parameter(parameter) => parameter.get_type(),
+            Definition::Constant(constant) => constant.get_type(),
+            _ => None,
+        }
+    }
+
     /// If this identifier resolves to a built-in (e.g. `msg`, `block`,
     /// `tx`), returns the corresponding [`BuiltIn`] variant.
     pub fn resolved_built_in(&self) -> Option<BuiltIn> {


### PR DESCRIPTION
AST accessors so consumers can ask "what is the type of this expression / identifier reference" without duplicating a 25-arm enum dispatch.

### New API

- `ast::Identifier::resolved_type() -> Option<Type>`
- `ast::Expression::get_type() -> Option<Type>`

### Notes

- `Identifier::resolved_type()` walks `resolve_to_definition()` (unlike the existing `get_type()`, which is keyed on the identifier's own node id and returns `None` for reference uses).
- `Expression::get_type()` enum-level dispatches; the `Identifier` arm uses `resolved_type()`. Returns `None` for keyword expressions (`this`, `true`, `false`, etc.) and type-position variants (`ElementaryType`, `StringExpression`).