### PR TITLE
feat(backend): cache linearised functions and add ContractDefinition::is_payable

### DIFF
--- a/crates/solidity/outputs/cargo/crate/src/backend/binder/definitions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/binder/definitions.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::rc::Rc;
 
 use super::ScopeId;
@@ -48,6 +49,7 @@ pub struct ContractDefinition {
     pub bases: Option<Vec<NodeId>>,
     pub constructor_parameters_scope_id: Option<ScopeId>,
     pub base_slot: Option<usize>,
+    pub linearised_functions: OnceCell<Vec<NodeId>>,
 }
 
 #[derive(Debug)]
@@ -318,6 +320,7 @@ impl Definition {
             bases: None,
             constructor_parameters_scope_id: None,
             base_slot: None,
+            linearised_functions: OnceCell::new(),
         })
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/binder/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/binder/mod.rs
@@ -195,8 +195,11 @@ impl Binder {
         if self.definitions.contains_key(&node_id) {
             unreachable!("attempt to insert duplicate definition on node {node_id:?}");
         }
-        self.definitions_by_identifier
-            .insert(definition.identifier().id(), node_id);
+        if !matches!(&definition, Definition::Function(function) if function.ir_node.name.is_none())
+        {
+            self.definitions_by_identifier
+                .insert(definition.identifier().id(), node_id);
+        }
         self.definitions.insert(node_id, definition);
     }
 

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/contracts.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/contracts.rs
@@ -3,8 +3,10 @@ use std::rc::Rc;
 
 use super::super::{
     ContractDefinition, ContractDefinitionStruct, ContractMember, ContractMembersStruct,
-    Definition, FunctionDefinition, FunctionKind, InterfaceDefinition, StateVariableDefinition,
+    Definition, FunctionDefinition, FunctionKind, FunctionMutability, InterfaceDefinition,
+    StateVariableDefinition,
 };
+use crate::backend::binder;
 use crate::backend::ir::ast::{
     ErrorDefinition, EventDefinition, FunctionDefinitionStruct, InterfaceMembersStruct,
 };
@@ -108,6 +110,23 @@ impl ContractDefinitionStruct {
     /// Returns the list of functions defined in all the hierarchy of the
     /// contract, in alphabetical order
     pub fn compute_linearised_functions(&self) -> Vec<FunctionDefinition> {
+        let Some(binder::Definition::Contract(contract_definition)) = self
+            .semantic
+            .binder()
+            .find_definition_by_id(self.ir_node.node_id)
+        else {
+            unreachable!("ContractDefinition AST node maps to a Contract definition");
+        };
+        if let Some(node_ids) = contract_definition.linearised_functions.get() {
+            return node_ids
+                .iter()
+                .filter_map(|id| match Definition::try_create(*id, &self.semantic)? {
+                    Definition::Function(function) => Some(function),
+                    _ => None,
+                })
+                .collect();
+        }
+
         let mut functions: Vec<FunctionDefinition> = Vec::new();
         let bases = self.compute_linearised_bases();
         for base in &bases {
@@ -143,7 +162,20 @@ impl ContractDefinitionStruct {
             (Some(_), None) => Ordering::Greater,
             (Some(a), Some(b)) => a.name().cmp(&b.name()),
         });
+
+        contract_definition
+            .linearised_functions
+            .set(functions.iter().map(|function| function.node_id()).collect())
+            .expect("cell empty per the get() check above");
         functions
+    }
+
+    pub fn is_payable(&self) -> bool {
+        self.compute_linearised_functions().iter().any(|function| {
+            matches!(function.kind(), FunctionKind::Receive)
+                || (matches!(function.kind(), FunctionKind::Fallback)
+                    && matches!(function.mutability(), FunctionMutability::Payable))
+        })
     }
 
     pub fn errors(&self) -> Vec<ErrorDefinition> {

--- a/crates/solidity/outputs/cargo/crate/src/backend/passes/p2_collect_definitions.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/passes/p2_collect_definitions.rs
@@ -329,6 +329,16 @@ impl Visitor for Pass<'_> {
                     // Register the constructor to resolve named parameters when
                     // constructing this contract
                     self.register_constructor_parameters(parameters_scope_id);
+                } else if matches!(
+                    node.kind,
+                    input_ir::FunctionKind::Fallback
+                        | input_ir::FunctionKind::Receive
+                        | input_ir::FunctionKind::Unnamed
+                ) {
+                    let visibility = (&node.visibility).into();
+                    let definition =
+                        Definition::new_function(node, parameters_scope_id, visibility);
+                    self.binder.insert_definition_no_scope(definition);
                 }
 
                 let function_scope =


### PR DESCRIPTION
[`compute_linearised_functions`](https://github.com/NomicFoundation/slang/blob/0a0ba100ef74c1001e256bea94c5a285c93170ca/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/contracts.rs#L110-L147) is O(B*F^2) per call. Cache the result on `binder::ContractDefinition` via `OnceCell<Vec<NodeId>>`. NodeIds (not `FunctionDefinition`) to avoid an Rc cycle through `Rc<SemanticAnalysis>`.

Add `ContractDefinition::is_payable` mirroring solc's `ContractType::isPayable`. Consumer-side switch lands in [NomicFoundation/solx#390](https://github.com/NomicFoundation/solx/pull/390).