### PR TITLE
add GitHub Actions log group markers to infra scripts

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,11 +9,15 @@ _github_collapse_group() {
   local title="$1"
   shift
 
-  [[ -n "${CI:-}" ]] && echo "::group::${title}"
+  if [[ -n "${CI:-}" ]]; then
+    echo "::group::${title}"
+  fi
 
   "$@"
 
-  [[ -n "${CI:-}" ]] && echo "::endgroup::"
+  if [[ -n "${CI:-}" ]]; then
+    echo "::endgroup::"
+  fi
 }
 
 #

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -2,10 +2,24 @@
 set -euo pipefail
 
 #
+# Wrap a command in a GitHub Actions log group when running in CI.
+# Usage: _github_collapse_group "Group Title" <command> [args...]
+#
+_github_collapse_group() {
+  local title="$1"
+  shift
+
+  [[ -n "${CI:-}" ]] && echo "::group::${title}"
+
+  "$@"
+
+  [[ -n "${CI:-}" ]] && echo "::endgroup::"
+}
+
+#
 # Activate the Hermit environment:
 #
-
-{
+_activate_hermit() {
   _repo_root="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 
   # Check if another environment is already active:
@@ -24,6 +38,9 @@ set -euo pipefail
   commands="$("${_repo_root}/bin/hermit" env --activate)"
   eval "${commands}"
 }
+
+_github_collapse_group "Initialize 'hermit' Workspace" \
+  _activate_hermit
 
 #
 # This checks if the rust '$RUST_STABLE_VERSION' toolchain is already installed.

--- a/scripts/bin/infra
+++ b/scripts/bin/infra
@@ -17,10 +17,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
 crate_dir="${REPO_ROOT:?}/crates/infra/cli"
 
-cargo build \
-  --bin "infra_cli" \
-  --manifest-path "${crate_dir}/Cargo.toml" \
-  --target-dir "${crate_dir}/target"
+_github_collapse_group "Build 'infra_cli' binary" \
+  cargo build \
+    --bin "infra_cli" \
+    --manifest-path "${crate_dir}/Cargo.toml" \
+    --target-dir "${crate_dir}/target"
 
 "${crate_dir}/target/debug/infra_cli" "$@"
 


### PR DESCRIPTION
Was running into this debugging a recent CI failure. The grouping helps minimize noise in CI for the `hermit` env activation, and all `infra` CLI invocations.