### PR TITLE
fix(benchmark): Semantic benchmarks properly strip paths 

### DIFF
--- a/crates/solidity/testing/perf/cargo/Cargo.toml
+++ b/crates/solidity/testing/perf/cargo/Cargo.toml
@@ -25,9 +25,6 @@ streaming-iterator = { workspace = true }
 tree-sitter-solidity = { workspace = true }
 tree-sitter = { workspace = true }
 
-[dev-dependencies]
-paste = { workspace = true }
-
 [[bench]]
 name = "slang"
 harness = false

--- a/crates/solidity/testing/perf/cargo/Cargo.toml
+++ b/crates/solidity/testing/perf/cargo/Cargo.toml
@@ -25,6 +25,9 @@ streaming-iterator = { workspace = true }
 tree-sitter-solidity = { workspace = true }
 tree-sitter = { workspace = true }
 
+[dev-dependencies]
+paste = { workspace = true }
+
 [[bench]]
 name = "slang"
 harness = false

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -19,6 +19,8 @@ mod unit_tests {
     const CONTRACT_COUNT: usize = 25;
     // Sum of the identifiers resolved by the binder.
     const IDENTIFIER_COUNT: usize = 2829;
+    // Sum of the references resolved by the binder.
+    const RESOLVED_REFERENCES_COUNT: usize = 1443;
 
     mod slang {
         macro_rules! define_payload_test {
@@ -53,35 +55,42 @@ mod unit_tests {
     }
 
     mod slang_v2 {
+        macro_rules! define_payload_test_and_assert_count_eq {
+            ($test_phase:ident, $post_processing:ident, $value:expr) => {
+                paste::paste! {
+                    #[test]
+                    fn [<$test_phase _ $post_processing>]() {
+                        let payload =
+                            crate::tests::slang_v2::$test_phase::setup(super::PROJECT_TO_TEST);
+                        let processed = crate::tests::slang_v2::$test_phase::test(payload);
+                        let value =
+                            crate::tests::slang_v2::$test_phase::$post_processing(&processed);
+                        assert_eq!(value, $value);
+                    }
+                }
+            };
+        }
+
         // __SLANG_V2_INFRA_BENCHMARKS_LIST__ (keep in sync)
+        define_payload_test_and_assert_count_eq!(parser, count_contracts, super::CONTRACT_COUNT);
 
-        #[test]
-        fn parser() {
-            let project = crate::tests::slang_v2::parser::setup(super::PROJECT_TO_TEST);
-            let source_units = crate::tests::slang_v2::parser::test(project);
-            let contract_count = crate::tests::slang_v2::parser::count_contracts(&source_units);
-            assert_eq!(contract_count, super::CONTRACT_COUNT);
-        }
+        define_payload_test_and_assert_count_eq!(
+            ir_builder,
+            count_contracts,
+            super::CONTRACT_COUNT
+        );
+        define_payload_test_and_assert_count_eq!(
+            ir_builder,
+            count_identifiers,
+            super::IDENTIFIER_COUNT
+        );
 
-        #[test]
-        fn ir_builder() {
-            let (project, source_units) =
-                crate::tests::slang_v2::ir_builder::setup(super::PROJECT_TO_TEST);
-            let ir_source_units = crate::tests::slang_v2::ir_builder::test(project, source_units);
-            let ir_contract_count =
-                crate::tests::slang_v2::ir_builder::count_contracts(&ir_source_units);
-            assert_eq!(ir_contract_count, super::CONTRACT_COUNT);
-        }
-
-        #[test]
-        fn semantic() {
-            let (project, input_files) =
-                crate::tests::slang_v2::semantic::setup(super::PROJECT_TO_TEST);
-            let semantic_context = crate::tests::slang_v2::semantic::test(project, input_files);
-            let semantic_contract_count =
-                crate::tests::slang_v2::semantic::count_contracts(&semantic_context);
-            assert_eq!(semantic_contract_count, super::CONTRACT_COUNT);
-        }
+        define_payload_test_and_assert_count_eq!(semantic, count_contracts, super::CONTRACT_COUNT);
+        define_payload_test_and_assert_count_eq!(
+            semantic,
+            count_resolved_references,
+            super::RESOLVED_REFERENCES_COUNT
+        );
     }
 
     mod solar {

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -17,7 +17,7 @@ mod unit_tests {
     const PROJECT_TO_TEST: &str = "ui_pool_data_provider_v3";
     // Sum of the contracts, interfaces, and libraries in all of the files of the project.
     const CONTRACT_COUNT: usize = 25;
-    // Sum of the identifiers resolved by the binder.
+    // Sum of the identifiers in the project.
     const IDENTIFIER_COUNT: usize = 2829;
     // Sum of the references resolved by the binder.
     const RESOLVED_REFERENCES_COUNT: usize = 1443;

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit as InputSourceUnit;
+use slang_solidity_v2_ir::ir::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator, SourceUnit, SourceUnitMember};
 
 use crate::dataset::SolidityProject;
@@ -13,12 +14,11 @@ pub fn run(
     project: &'static SolidityProject,
     sources: Vec<(String, InputSourceUnit)>,
 ) -> Vec<SourceUnit> {
-    test(project, sources)
+    test((project, sources))
 }
 
 pub fn test(
-    project: &'static SolidityProject,
-    sources: Vec<(String, InputSourceUnit)>,
+    (project, sources): (&'static SolidityProject, Vec<(String, InputSourceUnit)>),
 ) -> Vec<SourceUnit> {
     let mut id_generator = NodeIdGenerator::default();
     let mut ir_source_units = Vec::new();
@@ -48,4 +48,22 @@ pub fn count_contracts(source_units: &Vec<SourceUnit>) -> usize {
         }
     }
     contract_count
+}
+
+pub fn count_identifiers(source_units: &Vec<SourceUnit>) -> usize {
+    struct Checker {
+        total: usize,
+    }
+
+    impl Visitor for Checker {
+        fn visit_identifier(&mut self, _node: &ir::Identifier) {
+            self.total += 1;
+        }
+    }
+
+    let mut checker = Checker { total: 0 };
+    for source_unit in source_units {
+        accept_source_unit(source_unit, &mut checker);
+    }
+    checker.total
 }

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -54,18 +54,21 @@ pub fn build_files(
             let import_paths = extract_import_paths_from_source_unit(&ir_root);
             let resolved_imports = import_paths
                 .iter()
-                .filter_map(|(node_id, import_path)| {
+                .map(|(node_id, import_path)| {
                     // Import paths come from the IR as the unparsed string
                     // literal, including the surrounding quotes; strip them
                     // before delegating to the resolver (which expects the
                     // unquoted path).
                     let stripped = import_path
                         .strip_prefix(|c: char| matches!(c, '"' | '\''))
-                        .and_then(|p| p.strip_suffix(|c: char| matches!(c, '"' | '\'')))?
+                        .and_then(|p| p.strip_suffix(|c: char| matches!(c, '"' | '\'')))
+                        .expect("import path should be a quoted string literal")
                         .trim();
-                    let resolved_file_id =
-                        project.import_resolver.resolve_import(file_id, stripped)?;
-                    Some((*node_id, resolved_file_id))
+                    let resolved_file_id = project
+                        .import_resolver
+                        .resolve_import(file_id, stripped)
+                        .expect("files to be resolved");
+                    (*node_id, resolved_file_id)
                 })
                 .collect();
             File {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_semantic::binder;
+use slang_solidity_v2_semantic::binder::{self, Resolution};
 use slang_solidity_v2_semantic::context::{
     extract_import_paths_from_source_unit, SemanticContext, SemanticFile,
 };
@@ -36,8 +36,9 @@ impl SemanticFile for File {
 }
 
 pub fn setup(project: &str) -> (&'static SolidityProject, Vec<File>) {
-    let (project, sources) = super::ir_builder::setup(project);
-    let ir_source_units = super::ir_builder::test(project, sources);
+    let payload = super::ir_builder::setup(project);
+    let project = payload.0;
+    let ir_source_units = super::ir_builder::test(payload);
     let files = build_files(project, ir_source_units);
     (project, files)
 }
@@ -54,9 +55,16 @@ pub fn build_files(
             let resolved_imports = import_paths
                 .iter()
                 .filter_map(|(node_id, import_path)| {
-                    let resolved_file_id = project
-                        .import_resolver
-                        .resolve_import(file_id, import_path)?;
+                    // Import paths come from the IR as the unparsed string
+                    // literal, including the surrounding quotes; strip them
+                    // before delegating to the resolver (which expects the
+                    // unquoted path).
+                    let stripped = import_path
+                        .strip_prefix(|c: char| matches!(c, '"' | '\''))
+                        .and_then(|p| p.strip_suffix(|c: char| matches!(c, '"' | '\'')))?
+                        .trim();
+                    let resolved_file_id =
+                        project.import_resolver.resolve_import(file_id, stripped)?;
                     Some((*node_id, resolved_file_id))
                 })
                 .collect();
@@ -70,10 +78,12 @@ pub fn build_files(
 }
 
 pub fn run(project: &'static SolidityProject, files: Vec<File>) -> SemanticContext {
-    test(project, files)
+    test((project, files))
 }
 
-pub fn test(project: &'static SolidityProject, files: Vec<impl SemanticFile>) -> SemanticContext {
+pub fn test(
+    (project, files): (&'static SolidityProject, Vec<impl SemanticFile>),
+) -> SemanticContext {
     let language_version = super::parser::parse_version(project);
     SemanticContext::build_from(language_version, &files)
 }
@@ -92,4 +102,18 @@ pub fn count_contracts(semantic: &SemanticContext) -> usize {
             )
         })
         .count()
+}
+
+pub fn count_resolved_references(semantic: &SemanticContext) -> usize {
+    let references = semantic.binder().references();
+    // This is a bit stronger than just counting, but it's good to check that these
+    // projects are fully resolved
+    for reference in references.values() {
+        assert!(
+            !matches!(reference.resolution, Resolution::Unresolved),
+            "unresolved reference at node_id={:?}",
+            reference.node_id(),
+        );
+    }
+    references.len()
 }


### PR DESCRIPTION
The perf crate's `tests::slang_v2::semantic::build_files` was passing IR import paths (still surrounded by quotes) straight to the import resolver, which silently returned None for every import. The resulting SemanticContext had no cross-file references resolved, so the semantic stage measured less work than the public-API path real users go through, and any downstream AST/ABI work would short-circuit early.

Fixed the resolver call site to strip the quotes (matching the public `CompilationBuilder` behavior).

Also added three extra tests on v2, counting the number of references and identifiers.

And copied slang v1  approach to creating tests via macros.

