### PR TITLE
[v2] More AST enhancements

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -923,6 +923,8 @@ pub slang_solidity_v2_ast::ast::Type::UserDefinedValue(slang_solidity_v2_ast::as
 pub slang_solidity_v2_ast::ast::Type::Void(slang_solidity_v2_ast::ast::types::VoidType)
 impl slang_solidity_v2_ast::ast::Type
 pub fn slang_solidity_v2_ast::ast::Type::create(type_id: slang_solidity_v2_semantic::types::TypeId, semantic: &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> Self
+pub fn slang_solidity_v2_ast::ast::Type::data_location(&self) -> core::option::Option<slang_solidity_v2_semantic::types::DataLocation>
+pub fn slang_solidity_v2_ast::ast::Type::is_reference_type(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::Type::try_create_for_node_id(node_id: slang_solidity_v2_common::nodes::NodeId, semantic: &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> core::option::Option<Self>
 pub fn slang_solidity_v2_ast::ast::Type::type_id(&self) -> slang_solidity_v2_semantic::types::TypeId
 impl core::clone::Clone for slang_solidity_v2_ast::ast::Type

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -703,6 +703,8 @@ pub slang_solidity_v2_ast::ast::ElementaryType::IntKeyword(slang_solidity_v2_ast
 pub slang_solidity_v2_ast::ast::ElementaryType::StringKeyword(slang_solidity_v2_ast::ast::StringKeyword)
 pub slang_solidity_v2_ast::ast::ElementaryType::UfixedKeyword(slang_solidity_v2_ast::ast::UfixedKeyword)
 pub slang_solidity_v2_ast::ast::ElementaryType::UintKeyword(slang_solidity_v2_ast::ast::UintKeyword)
+impl slang_solidity_v2_ast::ast::ElementaryType
+pub fn slang_solidity_v2_ast::ast::ElementaryType::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ElementaryType
 pub fn slang_solidity_v2_ast::ast::ElementaryType::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub enum slang_solidity_v2_ast::ast::EqualityExpressionOperator
@@ -750,6 +752,8 @@ pub slang_solidity_v2_ast::ast::Expression::ThisKeyword(slang_solidity_v2_ast::a
 pub slang_solidity_v2_ast::ast::Expression::TrueKeyword(slang_solidity_v2_ast::ast::TrueKeyword)
 pub slang_solidity_v2_ast::ast::Expression::TupleExpression(slang_solidity_v2_ast::ast::TupleExpression)
 pub slang_solidity_v2_ast::ast::Expression::TypeExpression(slang_solidity_v2_ast::ast::TypeExpression)
+impl slang_solidity_v2_ast::ast::Expression
+pub fn slang_solidity_v2_ast::ast::Expression::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::Expression
 pub fn slang_solidity_v2_ast::ast::Expression::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub enum slang_solidity_v2_ast::ast::ForStatementCondition
@@ -898,6 +902,7 @@ pub slang_solidity_v2_ast::ast::StringExpression::HexStringLiterals(slang_solidi
 pub slang_solidity_v2_ast::ast::StringExpression::StringLiterals(slang_solidity_v2_ast::ast::StringLiterals)
 pub slang_solidity_v2_ast::ast::StringExpression::UnicodeStringLiterals(slang_solidity_v2_ast::ast::UnicodeStringLiterals)
 impl slang_solidity_v2_ast::ast::StringExpression
+pub fn slang_solidity_v2_ast::ast::StringExpression::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StringExpression::value(&self) -> alloc::vec::Vec<u8>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StringExpression
 pub fn slang_solidity_v2_ast::ast::StringExpression::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1029,7 +1029,7 @@ impl slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderPragmaStruct
@@ -1046,7 +1046,7 @@ impl slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
@@ -1054,7 +1054,7 @@ impl slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbstractKeywordStruct
@@ -1062,7 +1062,7 @@ impl slang_solidity_v2_ast::ast::AbstractKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbstractKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AdditiveExpressionStruct
@@ -1090,7 +1090,7 @@ impl slang_solidity_v2_ast::ast::AmpersandEqualStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandEqualStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AmpersandStruct
@@ -1098,7 +1098,7 @@ impl slang_solidity_v2_ast::ast::AmpersandStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AmpersandStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AmpersandStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AndExpressionStruct
@@ -1116,7 +1116,7 @@ impl slang_solidity_v2_ast::ast::AnonymousKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AnonymousKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ArrayExpressionStruct
@@ -1172,7 +1172,7 @@ impl slang_solidity_v2_ast::ast::AsteriskEqualStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskEqualStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AsteriskStruct
@@ -1180,7 +1180,7 @@ impl slang_solidity_v2_ast::ast::AsteriskStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AsteriskStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AsteriskStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangEqualStruct
@@ -1188,7 +1188,7 @@ impl slang_solidity_v2_ast::ast::BangEqualStruct
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BangEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BangEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangEqualStruct
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangStruct
@@ -1196,7 +1196,7 @@ impl slang_solidity_v2_ast::ast::BangStruct
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BangStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BangStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangStruct
 pub fn slang_solidity_v2_ast::ast::BangStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarEqualStruct
@@ -1204,7 +1204,7 @@ impl slang_solidity_v2_ast::ast::BarEqualStruct
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BarEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BarEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarEqualStruct
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarStruct
@@ -1212,7 +1212,7 @@ impl slang_solidity_v2_ast::ast::BarStruct
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BarStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BarStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarStruct
 pub fn slang_solidity_v2_ast::ast::BarStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
@@ -1259,7 +1259,7 @@ impl slang_solidity_v2_ast::ast::BoolKeywordStruct
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BoolKeywordStruct
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BreakStatementStruct
@@ -1275,7 +1275,7 @@ impl slang_solidity_v2_ast::ast::BytesKeywordStruct
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BytesKeywordStruct
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1284,7 +1284,7 @@ impl slang_solidity_v2_ast::ast::CallDataKeywordStruct
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CallDataKeywordStruct
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CallOptionsExpressionStruct
@@ -1309,7 +1309,7 @@ impl slang_solidity_v2_ast::ast::CaretEqualStruct
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretEqualStruct
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CaretStruct
@@ -1317,7 +1317,7 @@ impl slang_solidity_v2_ast::ast::CaretStruct
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::CaretStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretStruct
 pub fn slang_solidity_v2_ast::ast::CaretStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CatchClauseErrorStruct
@@ -1424,7 +1424,7 @@ impl slang_solidity_v2_ast::ast::DaysKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DaysKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DecimalLiteralStruct
@@ -1432,7 +1432,7 @@ impl slang_solidity_v2_ast::ast::DecimalLiteralStruct
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DecimalLiteralStruct
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1455,7 +1455,7 @@ impl slang_solidity_v2_ast::ast::DeleteKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DeleteKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DoWhileStatementStruct
@@ -1503,7 +1503,7 @@ impl slang_solidity_v2_ast::ast::EqualEqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualEqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualStruct
@@ -1511,7 +1511,7 @@ impl slang_solidity_v2_ast::ast::EqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::EqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualityExpressionStruct
@@ -1548,7 +1548,7 @@ impl slang_solidity_v2_ast::ast::EtherKeywordStruct
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EtherKeywordStruct
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EventDefinitionStruct
@@ -1603,7 +1603,7 @@ impl slang_solidity_v2_ast::ast::FalseKeywordStruct
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FalseKeywordStruct
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::FixedKeywordStruct
@@ -1611,7 +1611,7 @@ impl slang_solidity_v2_ast::ast::FixedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FixedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1683,7 +1683,7 @@ impl slang_solidity_v2_ast::ast::GlobalKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GlobalKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanEqualStruct
@@ -1691,7 +1691,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
@@ -1699,7 +1699,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
@@ -1707,7 +1707,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
@@ -1715,7 +1715,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
@@ -1723,7 +1723,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanStruct
@@ -1731,7 +1731,7 @@ impl slang_solidity_v2_ast::ast::GreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GweiKeywordStruct
@@ -1739,7 +1739,7 @@ impl slang_solidity_v2_ast::ast::GweiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GweiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HexLiteralStruct
@@ -1747,7 +1747,7 @@ impl slang_solidity_v2_ast::ast::HexLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HexLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1768,7 +1768,7 @@ impl slang_solidity_v2_ast::ast::HexStringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HexStringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1786,7 +1786,7 @@ impl slang_solidity_v2_ast::ast::HoursKeywordStruct
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HoursKeywordStruct
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::IdentifierPathStruct
@@ -1807,7 +1807,6 @@ pub fn slang_solidity_v2_ast::ast::IdentifierStruct::is_definition(&self) -> boo
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::is_name_of_definition(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::is_reference(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::name(&self) -> alloc::string::String
-pub fn slang_solidity_v2_ast::ast::IdentifierStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::resolve_to_built_in(&self) -> core::option::Option<slang_solidity_v2_common::built_ins::built_in::BuiltIn>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::resolve_to_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
@@ -1816,7 +1815,7 @@ impl slang_solidity_v2_ast::ast::IdentifierStruct
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::IdentifierStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::IdentifierStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IdentifierStruct
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1877,7 +1876,7 @@ impl slang_solidity_v2_ast::ast::IndexedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IndexedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::InequalityExpressionStruct
@@ -1913,7 +1912,7 @@ impl slang_solidity_v2_ast::ast::IntKeywordStruct
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IntKeywordStruct
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -1943,7 +1942,7 @@ impl slang_solidity_v2_ast::ast::LessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
@@ -1951,7 +1950,7 @@ impl slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanStruct
@@ -1959,7 +1958,7 @@ impl slang_solidity_v2_ast::ast::LessThanLessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanStruct
@@ -1967,7 +1966,7 @@ impl slang_solidity_v2_ast::ast::LessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::LessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LibraryDefinitionStruct
@@ -2015,7 +2014,7 @@ impl slang_solidity_v2_ast::ast::MemoryKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MemoryKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusEqualStruct
@@ -2023,7 +2022,7 @@ impl slang_solidity_v2_ast::ast::MinusEqualStruct
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusEqualStruct
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusMinusStruct
@@ -2031,7 +2030,7 @@ impl slang_solidity_v2_ast::ast::MinusMinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusMinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusStruct
@@ -2039,7 +2038,7 @@ impl slang_solidity_v2_ast::ast::MinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::MinusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinutesKeywordStruct
@@ -2047,7 +2046,7 @@ impl slang_solidity_v2_ast::ast::MinutesKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinutesKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ModifierInvocationStruct
@@ -2187,7 +2186,7 @@ impl slang_solidity_v2_ast::ast::PayableKeywordStruct
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PayableKeywordStruct
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentEqualStruct
@@ -2195,7 +2194,7 @@ impl slang_solidity_v2_ast::ast::PercentEqualStruct
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentEqualStruct
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentStruct
@@ -2203,7 +2202,7 @@ impl slang_solidity_v2_ast::ast::PercentStruct
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PercentStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PercentStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentStruct
 pub fn slang_solidity_v2_ast::ast::PercentStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusEqualStruct
@@ -2211,7 +2210,7 @@ impl slang_solidity_v2_ast::ast::PlusEqualStruct
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusEqualStruct
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusPlusStruct
@@ -2219,7 +2218,7 @@ impl slang_solidity_v2_ast::ast::PlusPlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusPlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusStruct
@@ -2227,7 +2226,7 @@ impl slang_solidity_v2_ast::ast::PlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PlusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PositionalArgumentsStruct
@@ -2252,7 +2251,7 @@ impl slang_solidity_v2_ast::ast::PragmaCaretStruct
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaCaretStruct
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaDirectiveStruct
@@ -2269,7 +2268,7 @@ impl slang_solidity_v2_ast::ast::PragmaEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
@@ -2277,7 +2276,7 @@ impl slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
@@ -2285,7 +2284,7 @@ impl slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
@@ -2293,7 +2292,7 @@ impl slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanStruct
@@ -2301,7 +2300,7 @@ impl slang_solidity_v2_ast::ast::PragmaLessThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaTildeStruct
@@ -2309,7 +2308,7 @@ impl slang_solidity_v2_ast::ast::PragmaTildeStruct
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaTildeStruct
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PrefixExpressionStruct
@@ -2353,7 +2352,7 @@ impl slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SecondsKeywordStruct
@@ -2361,7 +2360,7 @@ impl slang_solidity_v2_ast::ast::SecondsKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SecondsKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SemicolonStruct
@@ -2369,7 +2368,7 @@ impl slang_solidity_v2_ast::ast::SemicolonStruct
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SemicolonStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SemicolonStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SemicolonStruct
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ShiftExpressionStruct
@@ -2405,7 +2404,7 @@ impl slang_solidity_v2_ast::ast::SlashEqualStruct
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SlashEqualStruct
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SlashStruct
@@ -2413,7 +2412,7 @@ impl slang_solidity_v2_ast::ast::SlashStruct
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SlashStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SlashStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SlashStruct
 pub fn slang_solidity_v2_ast::ast::SlashStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SourceUnitMembersStruct
@@ -2472,7 +2471,7 @@ impl slang_solidity_v2_ast::ast::StorageKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StorageKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringKeywordStruct
@@ -2480,7 +2479,7 @@ impl slang_solidity_v2_ast::ast::StringKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StringKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringLiteralStruct
@@ -2488,7 +2487,7 @@ impl slang_solidity_v2_ast::ast::StringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -2539,7 +2538,7 @@ impl slang_solidity_v2_ast::ast::SuperKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SuperKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ThisKeywordStruct
@@ -2547,7 +2546,7 @@ impl slang_solidity_v2_ast::ast::ThisKeywordStruct
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ThisKeywordStruct
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TildeStruct
@@ -2555,7 +2554,7 @@ impl slang_solidity_v2_ast::ast::TildeStruct
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::TildeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::TildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TildeStruct
 pub fn slang_solidity_v2_ast::ast::TildeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TrueKeywordStruct
@@ -2563,7 +2562,7 @@ impl slang_solidity_v2_ast::ast::TrueKeywordStruct
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TrueKeywordStruct
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TryStatementStruct
@@ -2617,7 +2616,7 @@ impl slang_solidity_v2_ast::ast::UfixedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UfixedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -2626,7 +2625,7 @@ impl slang_solidity_v2_ast::ast::UintKeywordStruct
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UintKeywordStruct
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -2644,7 +2643,7 @@ impl slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -2768,7 +2767,7 @@ impl slang_solidity_v2_ast::ast::VersionSpecifierStruct
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VersionSpecifierStruct
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
@@ -2787,7 +2786,7 @@ impl slang_solidity_v2_ast::ast::VirtualKeywordStruct
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VirtualKeywordStruct
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WeeksKeywordStruct
@@ -2795,7 +2794,7 @@ impl slang_solidity_v2_ast::ast::WeeksKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::WeeksKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WeiKeywordStruct
@@ -2803,7 +2802,7 @@ impl slang_solidity_v2_ast::ast::WeiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::WeiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WhileStatementStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/expression.rs
@@ -1,0 +1,60 @@
+use super::super::{ElementaryType, Expression, Type};
+
+impl Expression {
+    /// Returns the type assigned to this expression by the typing pass, or
+    /// `None` when no type was recorded for the underlying node.
+    pub fn get_type(&self) -> Option<Type> {
+        match self {
+            Expression::AssignmentExpression(expression) => expression.get_type(),
+            Expression::ConditionalExpression(expression) => expression.get_type(),
+            Expression::OrExpression(expression) => expression.get_type(),
+            Expression::AndExpression(expression) => expression.get_type(),
+            Expression::EqualityExpression(expression) => expression.get_type(),
+            Expression::InequalityExpression(expression) => expression.get_type(),
+            Expression::BitwiseOrExpression(expression) => expression.get_type(),
+            Expression::BitwiseXorExpression(expression) => expression.get_type(),
+            Expression::BitwiseAndExpression(expression) => expression.get_type(),
+            Expression::ShiftExpression(expression) => expression.get_type(),
+            Expression::AdditiveExpression(expression) => expression.get_type(),
+            Expression::MultiplicativeExpression(expression) => expression.get_type(),
+            Expression::ExponentiationExpression(expression) => expression.get_type(),
+            Expression::PostfixExpression(expression) => expression.get_type(),
+            Expression::PrefixExpression(expression) => expression.get_type(),
+            Expression::FunctionCallExpression(expression) => expression.get_type(),
+            Expression::CallOptionsExpression(expression) => expression.get_type(),
+            Expression::MemberAccessExpression(expression) => expression.get_type(),
+            Expression::IndexAccessExpression(expression) => expression.get_type(),
+            Expression::NewExpression(expression) => expression.get_type(),
+            Expression::TupleExpression(expression) => expression.get_type(),
+            Expression::TypeExpression(expression) => expression.get_type(),
+            Expression::ArrayExpression(expression) => expression.get_type(),
+            Expression::HexNumberExpression(expression) => expression.get_type(),
+            Expression::DecimalNumberExpression(expression) => expression.get_type(),
+            Expression::StringExpression(expression) => expression.get_type(),
+            Expression::ElementaryType(expression) => expression.get_type(),
+            Expression::PayableKeyword(expression) => expression.get_type(),
+            Expression::ThisKeyword(expression) => expression.get_type(),
+            Expression::SuperKeyword(expression) => expression.get_type(),
+            Expression::TrueKeyword(expression) => expression.get_type(),
+            Expression::FalseKeyword(expression) => expression.get_type(),
+            Expression::Identifier(expression) => expression.get_type(),
+        }
+    }
+}
+
+impl ElementaryType {
+    /// Returns the type assigned to this elementary type by the typing pass,
+    /// dispatched to the underlying keyword/terminal node.
+    pub fn get_type(&self) -> Option<Type> {
+        match self {
+            ElementaryType::BoolKeyword(keyword) => keyword.get_type(),
+            ElementaryType::StringKeyword(keyword) => keyword.get_type(),
+            ElementaryType::AddressType(address_type) => address_type.get_type(),
+            ElementaryType::BytesKeyword(keyword) => keyword.get_type(),
+            ElementaryType::IntKeyword(keyword) => keyword.get_type(),
+            ElementaryType::UintKeyword(keyword) => keyword.get_type(),
+            ElementaryType::FixedKeyword(keyword) => keyword.get_type(),
+            ElementaryType::UfixedKeyword(keyword) => keyword.get_type(),
+        }
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifier.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/identifier.rs
@@ -1,5 +1,4 @@
 use slang_solidity_v2_common::built_ins::BuiltIn;
-use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder;
 
 use super::super::nodes::IdentifierStruct;
@@ -7,10 +6,6 @@ use crate::ast::references::references_binding_to_definition;
 use crate::ast::{Definition, Reference};
 
 impl IdentifierStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
     pub fn name(&self) -> String {
         self.ir_node.unparse().to_string()
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -8,6 +8,7 @@ mod hex_number_expression;
 mod interface_definition;
 pub use contract_base::ContractBase;
 
+mod expression;
 mod function_call_expression;
 mod function_definition;
 mod identifier;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/string_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/string_expression.rs
@@ -1,9 +1,22 @@
 use slang_solidity_v2_semantic::types::literals;
 
-use super::super::StringExpression;
+use super::super::{StringExpression, Type};
 use crate::ast::{HexStringLiteralsStruct, StringLiteralsStruct, UnicodeStringLiteralsStruct};
 
 impl StringExpression {
+    /// Returns the type assigned to this string expression by the typing pass.
+    ///
+    /// The typing pass binds the resolved type to the first literal in the
+    /// sequence; this accessor delegates to that literal. Returns `None` when
+    /// the sequence is empty or the typing pass did not record a type.
+    pub fn get_type(&self) -> Option<Type> {
+        match self {
+            StringExpression::StringLiterals(literals) => literals.iter().next()?.get_type(),
+            StringExpression::HexStringLiterals(literals) => literals.iter().next()?.get_type(),
+            StringExpression::UnicodeStringLiterals(literals) => literals.iter().next()?.get_type(),
+        }
+    }
+
     /// Returns the concatenated decoded string value as bytes.
     pub fn value(&self) -> Vec<u8> {
         match self {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -6750,7 +6750,7 @@ pub(crate) fn create_abi_encoder_v2_keyword(
 }
 
 impl ABIEncoderV2KeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6785,7 +6785,7 @@ pub(crate) fn create_abicoder_v1_keyword(
 }
 
 impl AbicoderV1KeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6820,7 +6820,7 @@ pub(crate) fn create_abicoder_v2_keyword(
 }
 
 impl AbicoderV2KeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6855,7 +6855,7 @@ pub(crate) fn create_abstract_keyword(
 }
 
 impl AbstractKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6890,7 +6890,7 @@ pub(crate) fn create_ampersand(
 }
 
 impl AmpersandStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6925,7 +6925,7 @@ pub(crate) fn create_ampersand_equal(
 }
 
 impl AmpersandEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6960,7 +6960,7 @@ pub(crate) fn create_anonymous_keyword(
 }
 
 impl AnonymousKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -6992,7 +6992,7 @@ pub(crate) fn create_asterisk(ir_node: &ir::Asterisk, semantic: &Arc<SemanticCon
 }
 
 impl AsteriskStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7027,7 +7027,7 @@ pub(crate) fn create_asterisk_equal(
 }
 
 impl AsteriskEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7059,7 +7059,7 @@ pub(crate) fn create_bang(ir_node: &ir::Bang, semantic: &Arc<SemanticContext>) -
 }
 
 impl BangStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7094,7 +7094,7 @@ pub(crate) fn create_bang_equal(
 }
 
 impl BangEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7126,7 +7126,7 @@ pub(crate) fn create_bar(ir_node: &ir::Bar, semantic: &Arc<SemanticContext>) -> 
 }
 
 impl BarStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7161,7 +7161,7 @@ pub(crate) fn create_bar_equal(
 }
 
 impl BarEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7196,7 +7196,7 @@ pub(crate) fn create_bool_keyword(
 }
 
 impl BoolKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7231,7 +7231,7 @@ pub(crate) fn create_bytes_keyword(
 }
 
 impl BytesKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -7269,7 +7269,7 @@ pub(crate) fn create_call_data_keyword(
 }
 
 impl CallDataKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7301,7 +7301,7 @@ pub(crate) fn create_caret(ir_node: &ir::Caret, semantic: &Arc<SemanticContext>)
 }
 
 impl CaretStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7336,7 +7336,7 @@ pub(crate) fn create_caret_equal(
 }
 
 impl CaretEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7371,7 +7371,7 @@ pub(crate) fn create_days_keyword(
 }
 
 impl DaysKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7406,7 +7406,7 @@ pub(crate) fn create_decimal_literal(
 }
 
 impl DecimalLiteralStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -7444,7 +7444,7 @@ pub(crate) fn create_delete_keyword(
 }
 
 impl DeleteKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7476,7 +7476,7 @@ pub(crate) fn create_equal(ir_node: &ir::Equal, semantic: &Arc<SemanticContext>)
 }
 
 impl EqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7511,7 +7511,7 @@ pub(crate) fn create_equal_equal(
 }
 
 impl EqualEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7546,7 +7546,7 @@ pub(crate) fn create_ether_keyword(
 }
 
 impl EtherKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7581,7 +7581,7 @@ pub(crate) fn create_false_keyword(
 }
 
 impl FalseKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7616,7 +7616,7 @@ pub(crate) fn create_fixed_keyword(
 }
 
 impl FixedKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -7654,7 +7654,7 @@ pub(crate) fn create_global_keyword(
 }
 
 impl GlobalKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7689,7 +7689,7 @@ pub(crate) fn create_greater_than(
 }
 
 impl GreaterThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7724,7 +7724,7 @@ pub(crate) fn create_greater_than_equal(
 }
 
 impl GreaterThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7759,7 +7759,7 @@ pub(crate) fn create_greater_than_greater_than(
 }
 
 impl GreaterThanGreaterThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7794,7 +7794,7 @@ pub(crate) fn create_greater_than_greater_than_equal(
 }
 
 impl GreaterThanGreaterThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7829,7 +7829,7 @@ pub(crate) fn create_greater_than_greater_than_greater_than(
 }
 
 impl GreaterThanGreaterThanGreaterThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7864,7 +7864,7 @@ pub(crate) fn create_greater_than_greater_than_greater_than_equal(
 }
 
 impl GreaterThanGreaterThanGreaterThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7899,7 +7899,7 @@ pub(crate) fn create_gwei_keyword(
 }
 
 impl GweiKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -7934,7 +7934,7 @@ pub(crate) fn create_hex_literal(
 }
 
 impl HexLiteralStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -7972,7 +7972,7 @@ pub(crate) fn create_hex_string_literal(
 }
 
 impl HexStringLiteralStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -8010,7 +8010,7 @@ pub(crate) fn create_hours_keyword(
 }
 
 impl HoursKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8045,7 +8045,7 @@ pub(crate) fn create_identifier(
 }
 
 impl IdentifierStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -8083,7 +8083,7 @@ pub(crate) fn create_indexed_keyword(
 }
 
 impl IndexedKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8118,7 +8118,7 @@ pub(crate) fn create_int_keyword(
 }
 
 impl IntKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -8156,7 +8156,7 @@ pub(crate) fn create_less_than(
 }
 
 impl LessThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8191,7 +8191,7 @@ pub(crate) fn create_less_than_equal(
 }
 
 impl LessThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8226,7 +8226,7 @@ pub(crate) fn create_less_than_less_than(
 }
 
 impl LessThanLessThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8261,7 +8261,7 @@ pub(crate) fn create_less_than_less_than_equal(
 }
 
 impl LessThanLessThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8296,7 +8296,7 @@ pub(crate) fn create_memory_keyword(
 }
 
 impl MemoryKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8328,7 +8328,7 @@ pub(crate) fn create_minus(ir_node: &ir::Minus, semantic: &Arc<SemanticContext>)
 }
 
 impl MinusStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8363,7 +8363,7 @@ pub(crate) fn create_minus_equal(
 }
 
 impl MinusEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8398,7 +8398,7 @@ pub(crate) fn create_minus_minus(
 }
 
 impl MinusMinusStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8433,7 +8433,7 @@ pub(crate) fn create_minutes_keyword(
 }
 
 impl MinutesKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8468,7 +8468,7 @@ pub(crate) fn create_payable_keyword(
 }
 
 impl PayableKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8500,7 +8500,7 @@ pub(crate) fn create_percent(ir_node: &ir::Percent, semantic: &Arc<SemanticConte
 }
 
 impl PercentStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8535,7 +8535,7 @@ pub(crate) fn create_percent_equal(
 }
 
 impl PercentEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8567,7 +8567,7 @@ pub(crate) fn create_plus(ir_node: &ir::Plus, semantic: &Arc<SemanticContext>) -
 }
 
 impl PlusStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8602,7 +8602,7 @@ pub(crate) fn create_plus_equal(
 }
 
 impl PlusEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8637,7 +8637,7 @@ pub(crate) fn create_plus_plus(
 }
 
 impl PlusPlusStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8672,7 +8672,7 @@ pub(crate) fn create_pragma_caret(
 }
 
 impl PragmaCaretStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8707,7 +8707,7 @@ pub(crate) fn create_pragma_equal(
 }
 
 impl PragmaEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8742,7 +8742,7 @@ pub(crate) fn create_pragma_greater_than(
 }
 
 impl PragmaGreaterThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8777,7 +8777,7 @@ pub(crate) fn create_pragma_greater_than_equal(
 }
 
 impl PragmaGreaterThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8812,7 +8812,7 @@ pub(crate) fn create_pragma_less_than(
 }
 
 impl PragmaLessThanStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8847,7 +8847,7 @@ pub(crate) fn create_pragma_less_than_equal(
 }
 
 impl PragmaLessThanEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8882,7 +8882,7 @@ pub(crate) fn create_pragma_tilde(
 }
 
 impl PragmaTildeStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8917,7 +8917,7 @@ pub(crate) fn create_smt_checker_keyword(
 }
 
 impl SMTCheckerKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8952,7 +8952,7 @@ pub(crate) fn create_seconds_keyword(
 }
 
 impl SecondsKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -8987,7 +8987,7 @@ pub(crate) fn create_semicolon(
 }
 
 impl SemicolonStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9019,7 +9019,7 @@ pub(crate) fn create_slash(ir_node: &ir::Slash, semantic: &Arc<SemanticContext>)
 }
 
 impl SlashStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9054,7 +9054,7 @@ pub(crate) fn create_slash_equal(
 }
 
 impl SlashEqualStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9089,7 +9089,7 @@ pub(crate) fn create_storage_keyword(
 }
 
 impl StorageKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9124,7 +9124,7 @@ pub(crate) fn create_string_keyword(
 }
 
 impl StringKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9159,7 +9159,7 @@ pub(crate) fn create_string_literal(
 }
 
 impl StringLiteralStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -9197,7 +9197,7 @@ pub(crate) fn create_super_keyword(
 }
 
 impl SuperKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9232,7 +9232,7 @@ pub(crate) fn create_this_keyword(
 }
 
 impl ThisKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9264,7 +9264,7 @@ pub(crate) fn create_tilde(ir_node: &ir::Tilde, semantic: &Arc<SemanticContext>)
 }
 
 impl TildeStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9299,7 +9299,7 @@ pub(crate) fn create_true_keyword(
 }
 
 impl TrueKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9334,7 +9334,7 @@ pub(crate) fn create_ufixed_keyword(
 }
 
 impl UfixedKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -9372,7 +9372,7 @@ pub(crate) fn create_uint_keyword(
 }
 
 impl UintKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -9410,7 +9410,7 @@ pub(crate) fn create_unicode_string_literal(
 }
 
 impl UnicodeStringLiteralStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -9448,7 +9448,7 @@ pub(crate) fn create_version_specifier(
 }
 
 impl VersionSpecifierStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
     pub fn unparse(&self) -> &str {
@@ -9486,7 +9486,7 @@ pub(crate) fn create_virtual_keyword(
 }
 
 impl VirtualKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9521,7 +9521,7 @@ pub(crate) fn create_weeks_keyword(
 }
 
 impl WeeksKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 
@@ -9556,7 +9556,7 @@ pub(crate) fn create_wei_keyword(
 }
 
 impl WeiKeywordStruct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -172,7 +172,7 @@ use super::types::Type;
   }
 
   impl {{ terminal_type }}Struct {
-    pub fn id(&self) -> NodeId {
+    pub fn node_id(&self) -> NodeId {
       self.ir_node.id()
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use paste::paste;
 use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{
     self, DataLocation, FunctionMutability, FunctionVisibility, TypeId,
@@ -136,6 +137,38 @@ impl Type {
             Type::UserDefinedValue(details) => details.type_id,
             Type::Void(details) => details.type_id,
         }
+    }
+
+    /// Returns the data location of this type when it has one.
+    ///
+    /// Container types (`Array`, `Bytes`, `FixedSizeArray`, `String`, `Struct`)
+    /// carry their data location explicitly. `Mapping` is always `Storage`.
+    /// All other types are value types with no associated location and return
+    /// `None`.
+    pub fn data_location(&self) -> Option<DataLocation> {
+        match self {
+            Type::Array(details) => Some(details.location()),
+            Type::Bytes(details) => Some(details.location()),
+            Type::FixedSizeArray(details) => Some(details.location()),
+            Type::String(details) => Some(details.location()),
+            Type::Struct(details) => Some(details.location()),
+            Type::Mapping(_) => Some(DataLocation::Storage),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this type is a Solidity reference type
+    /// (`array`, `fixed-size array`, `bytes`, `string`, `mapping`, `struct`).
+    pub fn is_reference_type(&self) -> bool {
+        matches!(
+            self,
+            Type::Array(_)
+                | Type::FixedSizeArray(_)
+                | Type::Bytes(_)
+                | Type::String(_)
+                | Type::Mapping(_)
+                | Type::Struct(_)
+        )
     }
 }
 
@@ -396,6 +429,26 @@ impl UserDefinedValueType {
         };
         Definition::try_create(*definition_id, &self.semantic)
             .expect("invalid user defined value definition")
+    }
+
+    /// Returns the underlying elementary type that this UDVT wraps, or `None`
+    /// if the binder did not resolve a target type (e.g., the declaration is
+    /// ill-formed or references an unsupported elementary type).
+    pub fn target_type(&self) -> Option<Type> {
+        let types::Type::UserDefinedValue { definition_id } = self.internal_type() else {
+            unreachable!("invalid user defined value type");
+        };
+        let binder_definition = self
+            .semantic
+            .binder()
+            .find_definition_by_id(*definition_id)?;
+        let binder::Definition::UserDefinedValueType(udvt_definition) = binder_definition else {
+            unreachable!("UDVT type id should map to UDVT definition");
+        };
+        Some(Type::create(
+            udvt_definition.target_type_id?,
+            &self.semantic,
+        ))
     }
 }
 


### PR DESCRIPTION
- Port #1761 to v2 adding `UserDefinedValueType::target_type()`, `Type::data_location()` and `Type::is_reference_type()`
- Rename `id()` to `node_id()` in AST terminal types for consistency with sequence types
- Add `Expression::get_type()` that dispatches on the enum's variant payloads (implementing #1762 for v2)

