### PR TITLE
[v2] Ensure data location is memory when reference types from getters

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -435,7 +435,7 @@ impl<'a> BuiltInsResolver<'a> {
             }
             BuiltIn::TxGasPrice => Typing::Resolved(self.types.uint256()),
             BuiltIn::TxOrigin => Typing::Resolved(self.types.address()),
-            BuiltIn::TypeName => Typing::Resolved(self.types.string()),
+            BuiltIn::TypeName => Typing::Resolved(self.types.string_memory()),
             BuiltIn::TypeCreationCode => Typing::Resolved(self.types.bytes_memory()),
             BuiltIn::TypeRuntimeCode => Typing::Resolved(self.types.bytes_memory()),
             BuiltIn::TypeInterfaceId => Typing::Resolved(self.types.bytes4()),
@@ -530,7 +530,7 @@ impl<'a> BuiltInsResolver<'a> {
             BuiltIn::Ripemd160 => Typing::Resolved(self.types.bytes20()),
             BuiltIn::Selfdestruct => Typing::Resolved(self.types.void()),
             BuiltIn::Sha256 => Typing::Resolved(self.types.bytes32()),
-            BuiltIn::StringConcat => Typing::Resolved(self.types.string()),
+            BuiltIn::StringConcat => Typing::Resolved(self.types.string_memory()),
             BuiltIn::Unwrap(definition_id) => {
                 let Some(Definition::UserDefinedValueType(udvt)) =
                     self.binder.find_definition_by_id(*definition_id)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -183,7 +183,7 @@ impl Pass<'_> {
                 }
                 Type::String { .. } => {
                     // getters will always return values in memory
-                    return_type = self.types.string();
+                    return_type = self.types.string_memory();
                     break;
                 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -178,10 +178,14 @@ impl Pass<'_> {
                 | Type::String { .. }
                 | Type::UserDefinedValue { .. } => break,
 
-                Type::Struct { definition_id, .. } => {
+                Type::Struct {
+                    definition_id,
+                    location,
+                } => {
                     // For structs the getter will return a tuple with all value
                     // type and string/bytes fields. It won't return nested
                     // structs or arrays.
+                    let struct_location = *location;
 
                     // To retrieve the fields we need to go through the
                     // scope associated to the struct...
@@ -192,20 +196,31 @@ impl Pass<'_> {
                     let Scope::Struct(struct_scope) = self.binder.get_scope_by_id(scope_id) else {
                         unreachable!("definition in struct type has no valid scope");
                     };
+                    let member_ids: Vec<NodeId> =
+                        struct_scope.definitions.values().copied().collect();
                     let mut types = Vec::new();
-                    for member_id in struct_scope.definitions.values() {
-                        let Some(member_type_id) = self.binder.node_typing(*member_id).as_type_id()
+                    for member_id in member_ids {
+                        let Some(member_type_id) = self.binder.node_typing(member_id).as_type_id()
                         else {
                             // member type cannot be resolved
                             return None;
                         };
-                        if self
-                            .types
-                            .get_type_by_id(member_type_id)
-                            .can_return_from_getter()
-                        {
-                            types.push(member_type_id);
+                        let member_type = self.types.get_type_by_id(member_type_id);
+                        if !member_type.can_return_from_getter() {
+                            continue;
                         }
+                        // Struct member types carry `DataLocation::Inherited` by
+                        // design (the location is the containing struct's).
+                        // Substitute the struct's location so the getter's
+                        // return type doesn't leak `Inherited` out.
+                        let member_type_id = if member_type.is_inherited_location() {
+                            let member_type = member_type.clone();
+                            self.types
+                                .register_type_with_data_location(member_type, struct_location)
+                        } else {
+                            member_type_id
+                        };
+                        types.push(member_type_id);
                     }
                     return_type = match types.len() {
                         0 => return None,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -168,25 +168,29 @@ impl Pass<'_> {
                 Type::Address { .. }
                 | Type::Boolean
                 | Type::ByteArray { .. }
-                | Type::Bytes { .. }
                 | Type::Contract { .. }
                 | Type::Enum { .. }
                 | Type::FixedPointNumber { .. }
                 | Type::Function { .. }
                 | Type::Integer { .. }
                 | Type::Interface { .. }
-                | Type::String { .. }
                 | Type::UserDefinedValue { .. } => break,
 
-                Type::Struct {
-                    definition_id,
-                    location,
-                } => {
+                Type::Bytes { .. } => {
+                    // getters will always return values in memory
+                    return_type = self.types.bytes_memory();
+                    break;
+                }
+                Type::String { .. } => {
+                    // getters will always return values in memory
+                    return_type = self.types.string();
+                    break;
+                }
+
+                Type::Struct { definition_id, .. } => {
                     // For structs the getter will return a tuple with all value
                     // type and string/bytes fields. It won't return nested
                     // structs or arrays.
-                    let struct_location = *location;
-
                     // To retrieve the fields we need to go through the
                     // scope associated to the struct...
                     let scope_id = self
@@ -209,16 +213,17 @@ impl Pass<'_> {
                         if !member_type.can_return_from_getter() {
                             continue;
                         }
-                        // Struct member types carry `DataLocation::Inherited` by
-                        // design (the location is the containing struct's).
-                        // Substitute the struct's location so the getter's
-                        // return type doesn't leak `Inherited` out.
-                        let member_type_id = if member_type.is_inherited_location() {
+                        let member_type_id = if member_type
+                            .data_location()
+                            .is_none_or(|location| location == DataLocation::Memory)
+                        {
+                            member_type_id
+                        } else {
+                            // Data location is always memory for getters, so we
+                            // need to override it if necessary
                             let member_type = member_type.clone();
                             self.types
-                                .register_type_with_data_location(member_type, struct_location)
-                        } else {
-                            member_type_id
+                                .register_type_with_data_location(member_type, DataLocation::Memory)
                         };
                         types.push(member_type_id);
                     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -598,3 +598,125 @@ fn test_hex_string_literal_byte_count() {
     let (type_, _) = type_of_value_expression(r#"hex"4142" hex"43""#);
     assert_eq!(type_, Type::Literal(LiteralKind::HexString { bytes: 3 }));
 }
+
+/// Locates a function definition by `contract_name` and `function_name` within
+/// a source unit. Panics if either the contract or the function is not found.
+fn find_contract_function<'a>(
+    source_unit: &'a ir::SourceUnit,
+    contract_name: &str,
+    function_name: &str,
+) -> &'a ir::FunctionDefinition {
+    let contract = source_unit
+        .members
+        .iter()
+        .find_map(|member| match member {
+            ir::SourceUnitMember::ContractDefinition(contract)
+                if contract.name.unparse() == contract_name =>
+            {
+                Some(contract)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("contract {contract_name} not found"));
+
+    contract
+        .members
+        .iter()
+        .find_map(|member| match member {
+            ir::ContractMember::FunctionDefinition(function)
+                if function
+                    .name
+                    .as_ref()
+                    .is_some_and(|name| name.unparse() == function_name) =>
+            {
+                Some(function)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("function {function_name} not found in contract {contract_name}"))
+}
+
+/// Resolves expression statement types in the body of the given function, in
+/// source order. Skips non-expression statements.
+fn expression_statement_types(
+    function: &ir::FunctionDefinition,
+    binder: &Binder,
+    types: &TypeRegistry,
+) -> Vec<Type> {
+    let body = function.body.as_ref().expect("function has no body");
+    body.statements
+        .iter()
+        .filter_map(|stmt| {
+            let ir::Statement::ExpressionStatement(expression_statement) = stmt else {
+                return None;
+            };
+            let node_id = node_id_for_expression_typing(&expression_statement.expression)
+                .expect("expression has no NodeId for typing");
+            let Typing::Resolved(type_id) = binder.node_typing(node_id) else {
+                panic!("expression did not resolve to a type");
+            };
+            Some(types.get_type_by_id(type_id).clone())
+        })
+        .collect()
+}
+
+#[test]
+fn test_data_locations_of_state_variable_and_getter_accesses() {
+    const CONTENTS: &str = r#"
+contract Test {
+    struct Foo {
+        bytes xs;
+    }
+    bytes public bs;
+    Foo public foo;
+
+    function test(Test t) internal view {
+        bs;      // bytes storage
+        foo.xs;  // bytes storage
+        t.bs();  // bytes memory
+        t.foo(); // bytes memory
+    }
+}
+"#;
+
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let files = [file];
+
+    let mut binder = Binder::default();
+    let mut types = TypeRegistry::default();
+    let language_version = LanguageVersion::V0_8_30;
+
+    p1_collect_definitions::run(&files, &mut binder);
+    p2_linearise_contracts::run(&files, &mut binder);
+    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
+
+    let function = find_contract_function(files[0].ir_root(), "Test", "test");
+    let expression_types = expression_statement_types(function, &binder, &types);
+
+    // In source order:
+    //  - `bs;` — internal access to a `bytes` storage variable: `bytes storage`.
+    //  - `foo.xs;` — `xs` is declared with `Inherited` location inside the
+    //    struct; the member access propagates the operand's storage location.
+    //  - `t.bs();` — external call to the auto-generated getter of `bytes bs`;
+    //    the returned reference type lives in memory.
+    //  - `t.foo();` — external call to the auto-generated getter of `Foo foo`.
+    //    `Foo` has a single returnable field (`bytes xs`), so the getter
+    //    returns just `bytes`, again in memory.
+    let expected = vec![
+        Type::Bytes {
+            location: DataLocation::Storage,
+        },
+        Type::Bytes {
+            location: DataLocation::Storage,
+        },
+        Type::Bytes {
+            location: DataLocation::Memory,
+        },
+        Type::Bytes {
+            location: DataLocation::Memory,
+        },
+    ];
+    assert_eq!(expression_types, expected);
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -529,7 +529,7 @@ fn test_array_literal_unifies_element_types() {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
     assert_eq!(size, 2);
-    assert_eq!(element_type, types.string());
+    assert_eq!(element_type, types.string_memory());
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -31,7 +31,7 @@ pub struct TypeRegistry {
     bytes20_type_id: TypeId,
     bytes32_type_id: TypeId,
     bytes4_type_id: TypeId,
-    string_type_id: TypeId,
+    string_memory_type_id: TypeId,
     uint256_type_id: TypeId,
     uint8_type_id: TypeId,
     void_type_id: TypeId,
@@ -54,7 +54,7 @@ impl Default for TypeRegistry {
         let (bytes20_type, _) = types.insert_full(Type::ByteArray { width: 20 });
         let (bytes32_type, _) = types.insert_full(Type::ByteArray { width: 32 });
         let (bytes4_type, _) = types.insert_full(Type::ByteArray { width: 4 });
-        let (string_type, _) = types.insert_full(Type::String {
+        let (string_memory_type, _) = types.insert_full(Type::String {
             location: DataLocation::Memory,
         });
         let (uint256_type, _) = types.insert_full(Type::Integer {
@@ -85,7 +85,7 @@ impl Default for TypeRegistry {
             bytes20_type_id: TypeId(bytes20_type),
             bytes32_type_id: TypeId(bytes32_type),
             bytes4_type_id: TypeId(bytes4_type),
-            string_type_id: TypeId(string_type),
+            string_memory_type_id: TypeId(string_memory_type),
             uint256_type_id: TypeId(uint256_type),
             uint8_type_id: TypeId(uint8_type),
             void_type_id: TypeId(void_type),
@@ -744,8 +744,8 @@ impl TypeRegistry {
     pub(crate) fn bytes4(&self) -> TypeId {
         self.bytes4_type_id
     }
-    pub(crate) fn string(&self) -> TypeId {
-        self.string_type_id
+    pub(crate) fn string_memory(&self) -> TypeId {
+        self.string_memory_type_id
     }
     pub(crate) fn uint256(&self) -> TypeId {
         self.uint256_type_id


### PR DESCRIPTION
In public getters, struct members are returned as a tuple in getters and it's possible to return reference types (bytes/string). Ensure data location is memory in all cases, since the data is copied and always received by memory. 

This also fixes the one instance where an expression node can return `DataLocation::Inherited` which essentially means _still unresolved_.
