### PR TITLE
[v2] Strip quotes from paths for resolving imports

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -764,6 +764,9 @@ impl core::marker::Copy for slang_solidity_v2_common::terminals::TerminalKind
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::terminals::TerminalKind
 impl serde_core::ser::Serialize for slang_solidity_v2_common::terminals::TerminalKind
 pub fn slang_solidity_v2_common::terminals::TerminalKind::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+pub mod slang_solidity_v2_common::utils
+pub fn slang_solidity_v2_common::utils::strip_string_literal_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str
+pub fn slang_solidity_v2_common::utils::strip_string_literal_quotes(text: &str) -> &str
 pub mod slang_solidity_v2_common::versions
 pub enum slang_solidity_v2_common::versions::FromSemverError
 pub slang_solidity_v2_common::versions::FromSemverError::UnexpectedMetadata

--- a/crates/solidity-v2/outputs/cargo/common/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/lib.rs
@@ -2,4 +2,5 @@ pub mod built_ins;
 pub mod diagnostics;
 pub mod nodes;
 pub mod terminals;
+pub mod utils;
 pub mod versions;

--- a/crates/solidity-v2/outputs/cargo/common/src/utils/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/utils/mod.rs
@@ -1,0 +1,85 @@
+/// Strips a prefix and removes quotes from a parsed string literal. Prefix can
+/// be the empty string. Panics if the string is not quoted or the prefix
+/// doesn't match.
+pub fn strip_string_literal_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
+    text.strip_prefix(prefix)
+        .and_then(|stripped| {
+            stripped
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .or_else(|| {
+                    stripped
+                        .strip_prefix('\'')
+                        .and_then(|s| s.strip_suffix('\''))
+                })
+        })
+        .expect("string literal prefix mismatch or not quoted")
+}
+
+/// Strips quotes from a parsed string literal. Panics if the string is not
+/// quoted.
+pub fn strip_string_literal_quotes(text: &str) -> &str {
+    strip_string_literal_prefix_and_quotes(text, "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_string_literal_prefix_and_quotes;
+
+    #[test]
+    fn strip_double_quotes_no_prefix() {
+        assert_eq!(
+            strip_string_literal_prefix_and_quotes(r#""hello""#, ""),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn strip_single_quotes_no_prefix() {
+        assert_eq!(
+            strip_string_literal_prefix_and_quotes("'hello'", ""),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn strip_hex_prefix_double_quotes() {
+        assert_eq!(
+            strip_string_literal_prefix_and_quotes(r#"hex"414243""#, "hex"),
+            "414243"
+        );
+    }
+
+    #[test]
+    fn strip_hex_prefix_single_quotes() {
+        assert_eq!(
+            strip_string_literal_prefix_and_quotes("hex'414243'", "hex"),
+            "414243"
+        );
+    }
+
+    #[test]
+    fn strip_unicode_prefix() {
+        assert_eq!(
+            strip_string_literal_prefix_and_quotes(r#"unicode"ñ""#, "unicode"),
+            "ñ"
+        );
+    }
+
+    #[test]
+    fn strip_empty_content() {
+        assert_eq!(strip_string_literal_prefix_and_quotes(r#""""#, ""), "");
+    }
+
+    #[test]
+    #[should_panic(expected = "string literal prefix mismatch or not quoted")]
+    fn strip_panics_when_not_quoted() {
+        strip_string_literal_prefix_and_quotes("unquoted", "");
+    }
+
+    #[test]
+    #[should_panic(expected = "string literal prefix mismatch or not quoted")]
+    fn strip_panics_on_prefix_mismatch() {
+        strip_string_literal_prefix_and_quotes("hex'1234'", "unicode");
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use file_node_mapper::FileNodeMapper;
 use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::utils::strip_string_literal_quotes;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
 
@@ -35,16 +36,17 @@ pub fn extract_import_paths_from_source_unit(
         let ir::SourceUnitMember::ImportClause(import_clause) = member else {
             continue;
         };
-        let (node_id, path) = match import_clause {
+        let (node_id, path_string_literal) = match import_clause {
             ir::ImportClause::PathImport(path_import) => {
-                (path_import.id(), path_import.path.unparse().to_owned())
+                (path_import.id(), path_import.path.unparse())
             }
             ir::ImportClause::ImportDeconstruction(import_deconstruction) => (
                 import_deconstruction.id(),
-                import_deconstruction.path.unparse().to_owned(),
+                import_deconstruction.path.unparse(),
             ),
         };
-        import_paths.push((node_id, path));
+        let import_path = strip_string_literal_quotes(path_string_literal).to_owned();
+        import_paths.push((node_id, import_path));
     }
     import_paths
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/strings.rs
@@ -1,3 +1,4 @@
+use slang_solidity_v2_common::utils::strip_string_literal_prefix_and_quotes;
 use slang_solidity_v2_ir::ir;
 
 /// Decodes the concatenated value of a collection of `StringLiteral` to its raw bytes.
@@ -6,7 +7,7 @@ use slang_solidity_v2_ir::ir;
 pub fn value_of_string_literals(literals: &[ir::StringLiteral]) -> Vec<u8> {
     let mut result = Vec::new();
     for literal in literals {
-        let content = strip_prefix_and_quotes(&literal.text, "");
+        let content = strip_string_literal_prefix_and_quotes(&literal.text, "");
         result.extend(decode_escape_sequences(content));
     }
     result
@@ -18,7 +19,7 @@ pub fn value_of_string_literals(literals: &[ir::StringLiteral]) -> Vec<u8> {
 pub fn value_of_hex_string_literals(literals: &[ir::HexStringLiteral]) -> Vec<u8> {
     let mut result = Vec::new();
     for literal in literals {
-        let content = strip_prefix_and_quotes(&literal.text, "hex");
+        let content = strip_string_literal_prefix_and_quotes(&literal.text, "hex");
         result.extend(decode_hex_string(content));
     }
     result
@@ -31,25 +32,10 @@ pub fn value_of_hex_string_literals(literals: &[ir::HexStringLiteral]) -> Vec<u8
 pub fn value_of_unicode_string_literals(literals: &[ir::UnicodeStringLiteral]) -> Vec<u8> {
     let mut result = Vec::new();
     for literal in literals {
-        let content = strip_prefix_and_quotes(&literal.text, "unicode");
+        let content = strip_string_literal_prefix_and_quotes(&literal.text, "unicode");
         result.extend(decode_escape_sequences(content));
     }
     result
-}
-
-fn strip_prefix_and_quotes<'a>(text: &'a str, prefix: &str) -> &'a str {
-    text.strip_prefix(prefix)
-        .and_then(|stripped| {
-            stripped
-                .strip_prefix('"')
-                .and_then(|s| s.strip_suffix('"'))
-                .or_else(|| {
-                    stripped
-                        .strip_prefix('\'')
-                        .and_then(|s| s.strip_suffix('\''))
-                })
-        })
-        .expect("string prefix mismatch or not quoted")
 }
 
 fn decode_hex_string(content: &str) -> Vec<u8> {
@@ -124,7 +110,7 @@ fn decode_escape_sequences(content: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_escape_sequences, decode_hex_string, strip_prefix_and_quotes};
+    use super::{decode_escape_sequences, decode_hex_string};
 
     // ----- decode_hex_string ------
 
@@ -244,49 +230,5 @@ mod tests {
         // Raw multibyte input (legal in unicode strings) passes through as
         // its UTF-8 encoding.
         assert_eq!(decode_escape_sequences("ñ"), &[0xC3, 0xB1]);
-    }
-
-    // ----- strip_prefix_and_quotes -----
-
-    #[test]
-    fn strip_double_quotes_no_prefix() {
-        assert_eq!(strip_prefix_and_quotes(r#""hello""#, ""), "hello");
-    }
-
-    #[test]
-    fn strip_single_quotes_no_prefix() {
-        assert_eq!(strip_prefix_and_quotes("'hello'", ""), "hello");
-    }
-
-    #[test]
-    fn strip_hex_prefix_double_quotes() {
-        assert_eq!(strip_prefix_and_quotes(r#"hex"414243""#, "hex"), "414243");
-    }
-
-    #[test]
-    fn strip_hex_prefix_single_quotes() {
-        assert_eq!(strip_prefix_and_quotes("hex'414243'", "hex"), "414243");
-    }
-
-    #[test]
-    fn strip_unicode_prefix() {
-        assert_eq!(strip_prefix_and_quotes(r#"unicode"ñ""#, "unicode"), "ñ");
-    }
-
-    #[test]
-    fn strip_empty_content() {
-        assert_eq!(strip_prefix_and_quotes(r#""""#, ""), "");
-    }
-
-    #[test]
-    #[should_panic(expected = "string prefix mismatch or not quoted")]
-    fn strip_panics_when_not_quoted() {
-        strip_prefix_and_quotes("unquoted", "");
-    }
-
-    #[test]
-    #[should_panic(expected = "string prefix mismatch or not quoted")]
-    fn strip_panics_on_prefix_mismatch() {
-        strip_prefix_and_quotes("hex'1234'", "unicode");
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::utils::strip_string_literal_quotes;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_cst::structured_cst::nodes as cst;
 use slang_solidity_v2_ir::ir::{self, BuildOutput};
@@ -29,8 +30,8 @@ pub trait CompilationBuilderConfig {
     /// import {Foo} from "foo.sol";
     /// ```
     ///
-    /// Then the API will invoke the callback with the value of the `"foo.sol"`
-    /// string literal, including the surrounding quotes.
+    /// Then the API will invoke the callback with the value `foo.sol` (the
+    /// contents of the string literal, with the surrounding quotes stripped).
     ///
     /// The user is responsible for resolving it to a file in the compilation,
     /// and returning its ID. Any error returned is surfaced as a compilation
@@ -192,7 +193,8 @@ fn extract_import_paths_from_cst(
                 &import_deconstruction.path.range
             }
         };
-        import_paths.insert(contents[range.clone()].to_owned());
+        let literal = &contents[range.clone()];
+        import_paths.insert(strip_string_literal_quotes(literal).to_owned());
     }
     import_paths
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -69,11 +69,7 @@ impl CompilationBuilderConfig for FixtureBuildConfig<'_> {
         _source_file_id: &str,
         import_path: &str,
     ) -> Result<String, String> {
-        import_path
-            .strip_prefix(|c: char| matches!(c, '"' | '\''))
-            .and_then(|p| p.strip_suffix(|c: char| matches!(c, '"' | '\'')))
-            .map(|p| p.to_owned())
-            .ok_or_else(|| format!("failed to resolve import: {import_path}"))
+        Ok(import_path.to_owned())
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
@@ -1,16 +1,12 @@
 /// Resolve an import path relative to a source file.
 ///
-/// `import_path` is the raw string literal text from the source (with quotes),
-/// as provided by the v2 `CompilationBuilderConfig::resolve_import` callback.
+/// `import_path` is the unquoted import path as provided by the v2
+/// `CompilationBuilderConfig::resolve_import` callback.
 pub(crate) fn resolve_import(source_file_id: &str, import_path: &str) -> Option<String> {
-    let path = import_path
-        .strip_prefix(|c| matches!(c, '"' | '\''))?
-        .strip_suffix(|c| matches!(c, '"' | '\''))?;
-
-    if is_relative_path(path) {
-        normalize_path(path, get_parent_path(source_file_id))
+    if is_relative_path(import_path) {
+        normalize_path(import_path, get_parent_path(source_file_id))
     } else {
-        Some(path.to_owned())
+        Some(import_path.to_owned())
     }
 }
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/unresolved_import/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/unresolved_import/generated/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-Error: Unresolved import: unresolved import: "../../oops.sol" (from input.sol)
+Error: Unresolved import: unresolved import: ../../oops.sol (from input.sol)
    ╭─[input.sol:1:1]
    │
  1 │ // Our test resolver only resolves files in the same directory:

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -55,18 +55,9 @@ pub fn build_files(
             let resolved_imports = import_paths
                 .iter()
                 .map(|(node_id, import_path)| {
-                    // Import paths come from the IR as the unparsed string
-                    // literal, including the surrounding quotes; strip them
-                    // before delegating to the resolver (which expects the
-                    // unquoted path).
-                    let stripped = import_path
-                        .strip_prefix(|c: char| matches!(c, '"' | '\''))
-                        .and_then(|p| p.strip_suffix(|c: char| matches!(c, '"' | '\'')))
-                        .expect("import path should be a quoted string literal")
-                        .trim();
                     let resolved_file_id = project
                         .import_resolver
-                        .resolve_import(file_id, stripped)
+                        .resolve_import(file_id, import_path)
                         .expect("files to be resolved");
                     (*node_id, resolved_file_id)
                 })


### PR DESCRIPTION
Spawned from reviewing #1769 ([comment](https://github.com/NomicFoundation/slang/pull/1769#pullrequestreview-4291950827)).

- Pass import paths with stripped quotes to the user-provided import resolver for the `CompilationUnit` builder.
- Add a `utils` module in `common` with prefix and quote stripping for parsed string literals. This is used both for stripping import paths and for computing values of string/hex strings/unicode literals.
