### PR TITLE
[v2] Wrap compilation unit's `File` with `SemanticContext`

### DIFF
--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -27,10 +27,17 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::diagnostics(&self) -> &s
 pub fn slang_solidity_v2::compilation::CompilationUnit::file_ids(&self) -> alloc::vec::Vec<alloc::string::String>
 pub fn slang_solidity_v2::compilation::CompilationUnit::find_contract_by_name(&self, name: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::ContractDefinition>
 pub fn slang_solidity_v2::compilation::CompilationUnit::get_file_ast_root(&self, file_id: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::SourceUnit>
+pub fn slang_solidity_v2::compilation::CompilationUnit::get_file_by_id(&self, id: &str) -> core::option::Option<slang_solidity_v2::compilation::File>
+pub fn slang_solidity_v2::compilation::CompilationUnit::iter_files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::language_versions::LanguageVersion
+pub struct slang_solidity_v2::compilation::FileStruct
+impl slang_solidity_v2::compilation::FileStruct
+pub fn slang_solidity_v2::compilation::FileStruct::ast_root(&self) -> slang_solidity_v2_ast::ast::nodes::SourceUnit
+pub fn slang_solidity_v2::compilation::FileStruct::id(&self) -> &str
 pub trait slang_solidity_v2::compilation::CompilationBuilderConfig
 pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::read_file(&mut self, file_id: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
 pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::resolve_import(&mut self, source_file_id: &str, import_path: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
+pub type slang_solidity_v2::compilation::File = alloc::sync::Arc<slang_solidity_v2::compilation::FileStruct>
 pub mod slang_solidity_v2::diagnostics
 pub use slang_solidity_v2::diagnostics::Diagnostic
 pub use slang_solidity_v2::diagnostics::DiagnosticCollection

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -26,7 +26,6 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::compute_contracts_abi(&s
 pub fn slang_solidity_v2::compilation::CompilationUnit::diagnostics(&self) -> &slang_solidity_v2_common::diagnostics::collection::DiagnosticCollection
 pub fn slang_solidity_v2::compilation::CompilationUnit::file_ids(&self) -> alloc::vec::Vec<alloc::string::String>
 pub fn slang_solidity_v2::compilation::CompilationUnit::find_contract_by_name(&self, name: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::ContractDefinition>
-pub fn slang_solidity_v2::compilation::CompilationUnit::get_file_ast_root(&self, file_id: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::SourceUnit>
 pub fn slang_solidity_v2::compilation::CompilationUnit::get_file_by_id(&self, id: &str) -> core::option::Option<slang_solidity_v2::compilation::File>
 pub fn slang_solidity_v2::compilation::CompilationUnit::iter_files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::language_versions::LanguageVersion

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -24,14 +24,14 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::all_definitions(&self) -
 pub fn slang_solidity_v2::compilation::CompilationUnit::all_references(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::references::Reference> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::compute_contracts_abi(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::abi::ContractAbi>
 pub fn slang_solidity_v2::compilation::CompilationUnit::diagnostics(&self) -> &slang_solidity_v2_common::diagnostics::collection::DiagnosticCollection
+pub fn slang_solidity_v2::compilation::CompilationUnit::file(&self, id: &str) -> core::option::Option<slang_solidity_v2::compilation::File>
 pub fn slang_solidity_v2::compilation::CompilationUnit::file_ids(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn slang_solidity_v2::compilation::CompilationUnit::files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::find_contract_by_name(&self, name: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::ContractDefinition>
-pub fn slang_solidity_v2::compilation::CompilationUnit::get_file_by_id(&self, id: &str) -> core::option::Option<slang_solidity_v2::compilation::File>
-pub fn slang_solidity_v2::compilation::CompilationUnit::iter_files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::language_versions::LanguageVersion
 pub struct slang_solidity_v2::compilation::FileStruct
 impl slang_solidity_v2::compilation::FileStruct
-pub fn slang_solidity_v2::compilation::FileStruct::ast_root(&self) -> slang_solidity_v2_ast::ast::nodes::SourceUnit
+pub fn slang_solidity_v2::compilation::FileStruct::ast(&self) -> slang_solidity_v2_ast::ast::nodes::SourceUnit
 pub fn slang_solidity_v2::compilation::FileStruct::id(&self) -> &str
 pub trait slang_solidity_v2::compilation::CompilationBuilderConfig
 pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::read_file(&mut self, file_id: &str) -> core::result::Result<alloc::string::String, alloc::string::String>

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -11,7 +11,7 @@ use slang_solidity_v2_semantic::context::{
     extract_import_paths_from_source_unit, SemanticContext, SemanticFile,
 };
 
-use super::file::File;
+use super::file::InternalFile;
 use super::unit::CompilationUnit;
 
 /// User-provided callbacks necessary for the `CompilationBuilder` to perform its job.
@@ -39,7 +39,7 @@ pub trait CompilationBuilderConfig {
         -> Result<String, String>;
 }
 
-struct InternalFile {
+struct BuilderFile {
     source_unit: cst::SourceUnit,
     contents: String,
     resolved_imports: BTreeMap<String, String>,
@@ -54,7 +54,7 @@ pub struct CompilationBuilder<C: CompilationBuilderConfig> {
     language_version: LanguageVersion,
     diagnostics: DiagnosticCollection,
 
-    files: BTreeMap<String, InternalFile>,
+    files: BTreeMap<String, BuilderFile>,
     seen_files: HashSet<String>,
 }
 
@@ -129,7 +129,7 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
 
         self.files.insert(
             file_id,
-            InternalFile {
+            BuilderFile {
                 source_unit,
                 contents: source,
                 resolved_imports,
@@ -143,7 +143,7 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
         let mut diagnostics = self.diagnostics;
 
         let mut id_generator = ir::NodeIdGenerator::default();
-        let files: Vec<File> = self
+        let files: Vec<InternalFile> = self
             .files
             .into_iter()
             .map(|(file_id, internal_file)| {
@@ -158,7 +158,7 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
                 );
                 diagnostics.extend(ir_diagnostics);
 
-                let mut file = File::new(file_id, ir_root);
+                let mut file = InternalFile::new(file_id, ir_root);
                 for (node_id, import_path) in extract_import_paths_from_source_unit(file.ir_root())
                 {
                     if let Some(target_file_id) = internal_file.resolved_imports.get(&import_path) {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -64,4 +64,10 @@ impl FileStruct {
     pub fn ast_root(&self) -> ast::SourceUnit {
         ast::create_source_unit(&self.file.ir_root, &self.semantic)
     }
+
+    #[cfg(feature = "__private_testing_utils")]
+    #[doc(hidden)]
+    pub fn ir_root(&self) -> ir::SourceUnit {
+        Arc::clone(&self.file.ir_root)
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -61,13 +61,13 @@ impl FileStruct {
         &self.file.id
     }
 
-    pub fn ast_root(&self) -> ast::SourceUnit {
+    pub fn ast(&self) -> ast::SourceUnit {
         ast::create_source_unit(&self.file.ir_root, &self.semantic)
     }
 
     #[cfg(feature = "__private_testing_utils")]
     #[doc(hidden)]
-    pub fn ir_root(&self) -> ir::SourceUnit {
+    pub fn ir(&self) -> ir::SourceUnit {
         Arc::clone(&self.file.ir_root)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -1,17 +1,20 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_semantic::context::SemanticFile;
+use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
 
-pub struct File {
+use crate::ast;
+
+pub(crate) struct InternalFile {
     // TODO(v2): abstract this into a `FileId` type
     id: String,
     ir_root: ir::SourceUnit,
     resolved_imports: HashMap<NodeId, String>,
 }
 
-impl File {
+impl InternalFile {
     pub(crate) fn new(id: String, ir_root: ir::SourceUnit) -> Self {
         Self {
             id,
@@ -25,7 +28,7 @@ impl File {
     }
 }
 
-impl SemanticFile for File {
+impl SemanticFile for InternalFile {
     fn id(&self) -> &str {
         &self.id
     }
@@ -36,5 +39,29 @@ impl SemanticFile for File {
 
     fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String> {
         self.resolved_imports.get(&node_id)
+    }
+}
+
+pub struct FileStruct {
+    file: Arc<InternalFile>,
+    semantic: Arc<SemanticContext>,
+}
+
+pub type File = Arc<FileStruct>;
+
+impl FileStruct {
+    pub(crate) fn create(file: &Arc<InternalFile>, semantic: &Arc<SemanticContext>) -> File {
+        Arc::new(Self {
+            file: Arc::clone(file),
+            semantic: Arc::clone(semantic),
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.file.id
+    }
+
+    pub fn ast_root(&self) -> ast::SourceUnit {
+        ast::create_source_unit(&self.file.ir_root, &self.semantic)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
@@ -3,4 +3,5 @@ mod file;
 mod unit;
 
 pub use builder::{CompilationBuilder, CompilationBuilderConfig};
+pub use file::{File, FileStruct};
 pub use unit::CompilationUnit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -50,13 +50,13 @@ impl CompilationUnit {
         self.files.keys().cloned().collect()
     }
 
-    pub fn iter_files(&self) -> impl Iterator<Item = File> + use<'_> {
+    pub fn files(&self) -> impl Iterator<Item = File> + use<'_> {
         self.files
             .values()
             .map(|internal_file| FileStruct::create(internal_file, &self.semantic))
     }
 
-    pub fn get_file_by_id(&self, id: &str) -> Option<File> {
+    pub fn file(&self, id: &str) -> Option<File> {
         self.files
             .get(id)
             .map(|internal_file| FileStruct::create(internal_file, &self.semantic))

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -68,14 +68,6 @@ impl CompilationUnit {
         &self.semantic
     }
 
-    #[cfg(feature = "__private_testing_utils")]
-    #[doc(hidden)]
-    pub fn get_file_ir_root(&self, file_id: &str) -> Option<slang_solidity_v2_ir::ir::SourceUnit> {
-        self.files
-            .get(file_id)
-            .map(|file| Arc::clone(file.ir_root()))
-    }
-
     pub fn all_definitions(&self) -> impl Iterator<Item = ast::Definition> + use<'_> {
         self.semantic.all_definitions().map(|definition| {
             ast::Definition::try_create(definition.node_id(), &self.semantic).unwrap()

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -68,12 +68,6 @@ impl CompilationUnit {
         &self.semantic
     }
 
-    pub fn get_file_ast_root(&self, file_id: &str) -> Option<ast::SourceUnit> {
-        self.files
-            .get(file_id)
-            .map(|file| ast::create_source_unit(file.ir_root(), &self.semantic))
-    }
-
     #[cfg(feature = "__private_testing_utils")]
     #[doc(hidden)]
     pub fn get_file_ir_root(&self, file_id: &str) -> Option<slang_solidity_v2_ir::ir::SourceUnit> {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -6,11 +6,12 @@ use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
 
-use super::file::File;
+use super::file::InternalFile;
+use super::{File, FileStruct};
 
 pub struct CompilationUnit {
     language_version: LanguageVersion,
-    files: BTreeMap<String, Arc<File>>,
+    files: BTreeMap<String, Arc<InternalFile>>,
     semantic: Arc<SemanticContext>,
     diagnostics: DiagnosticCollection,
 }
@@ -18,11 +19,11 @@ pub struct CompilationUnit {
 impl CompilationUnit {
     pub(super) fn create(
         language_version: LanguageVersion,
-        files: Vec<File>,
+        files: Vec<InternalFile>,
         semantic: SemanticContext,
         diagnostics: DiagnosticCollection,
     ) -> Self {
-        let files: BTreeMap<String, Arc<File>> = files
+        let files: BTreeMap<String, Arc<InternalFile>> = files
             .into_iter()
             .map(|file| (file.id().to_string(), Arc::new(file)))
             .collect();
@@ -47,6 +48,18 @@ impl CompilationUnit {
     /// Returns a list of all file IDs in the compilation unit.
     pub fn file_ids(&self) -> Vec<String> {
         self.files.keys().cloned().collect()
+    }
+
+    pub fn iter_files(&self) -> impl Iterator<Item = File> + use<'_> {
+        self.files
+            .values()
+            .map(|internal_file| FileStruct::create(internal_file, &self.semantic))
+    }
+
+    pub fn get_file_by_id(&self, id: &str) -> Option<File> {
+        self.files
+            .get(id)
+            .map(|internal_file| FileStruct::create(internal_file, &self.semantic))
     }
 
     #[cfg(feature = "__private_testing_utils")]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -24,7 +24,7 @@ impl ast::visitor::Visitor for IdentifierCounter {
 fn test_ast_visitor() {
     let unit = fixtures::Counter::build_compilation_unit();
 
-    let main_ast = unit.get_file_by_id("main.sol").unwrap().ast_root();
+    let main_ast = unit.file("main.sol").unwrap().ast();
 
     let mut main_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&main_ast, &mut main_visitor);
@@ -33,7 +33,7 @@ fn test_ast_visitor() {
     assert_eq!(main_visitor.definitions, 9);
     assert_eq!(main_visitor.references, 18);
 
-    let ownable_ast = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
+    let ownable_ast = unit.file("ownable.sol").unwrap().ast();
 
     let mut ownable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut ownable_visitor);
@@ -42,7 +42,7 @@ fn test_ast_visitor() {
     assert_eq!(ownable_visitor.definitions, 3);
     assert_eq!(ownable_visitor.references, 8);
 
-    let activatable_ast = unit.get_file_by_id("activatable.sol").unwrap().ast_root();
+    let activatable_ast = unit.file("activatable.sol").unwrap().ast();
 
     let mut activatable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&activatable_ast, &mut activatable_visitor);
@@ -392,7 +392,7 @@ fn test_resolve_to_built_in() {
 
     // Collect all identifiers that resolve to built-ins from the ownable.sol file,
     // which contains `msg.sender` and `require`.
-    let ownable_ast = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
+    let ownable_ast = unit.file("ownable.sol").unwrap().ast();
 
     let mut built_in_collector = BuiltInCollector::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut built_in_collector);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -24,7 +24,7 @@ impl ast::visitor::Visitor for IdentifierCounter {
 fn test_ast_visitor() {
     let unit = fixtures::Counter::build_compilation_unit();
 
-    let main_ast = unit.get_file_ast_root("main.sol").unwrap();
+    let main_ast = unit.get_file_by_id("main.sol").unwrap().ast_root();
 
     let mut main_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&main_ast, &mut main_visitor);
@@ -33,7 +33,7 @@ fn test_ast_visitor() {
     assert_eq!(main_visitor.definitions, 9);
     assert_eq!(main_visitor.references, 18);
 
-    let ownable_ast = unit.get_file_ast_root("ownable.sol").unwrap();
+    let ownable_ast = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
 
     let mut ownable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut ownable_visitor);
@@ -42,7 +42,7 @@ fn test_ast_visitor() {
     assert_eq!(ownable_visitor.definitions, 3);
     assert_eq!(ownable_visitor.references, 8);
 
-    let activatable_ast = unit.get_file_ast_root("activatable.sol").unwrap();
+    let activatable_ast = unit.get_file_by_id("activatable.sol").unwrap().ast_root();
 
     let mut activatable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&activatable_ast, &mut activatable_visitor);
@@ -392,7 +392,7 @@ fn test_resolve_to_built_in() {
 
     // Collect all identifiers that resolve to built-ins from the ownable.sol file,
     // which contains `msg.sender` and `require`.
-    let ownable_ast = unit.get_file_ast_root("ownable.sol").unwrap();
+    let ownable_ast = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
 
     let mut built_in_collector = BuiltInCollector::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut built_in_collector);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/json.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/json.rs
@@ -5,7 +5,7 @@ use super::fixtures;
 #[test]
 fn source_unit_serializes_to_json_with_expected_shape() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.get_file_ast_root("main.sol").unwrap();
+    let source_unit = unit.get_file_by_id("main.sol").unwrap().ast_root();
 
     let json = serde_json::to_value(&source_unit).expect("serialization succeeds");
 
@@ -37,7 +37,7 @@ fn source_unit_serializes_to_json_with_expected_shape() {
 #[test]
 fn function_definition_field_kind_does_not_collide_with_discriminator() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.get_file_ast_root("ownable.sol").unwrap();
+    let source_unit = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
 
     let json = serde_json::to_value(&source_unit).unwrap();
     let function =

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/json.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/json.rs
@@ -5,7 +5,7 @@ use super::fixtures;
 #[test]
 fn source_unit_serializes_to_json_with_expected_shape() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.get_file_by_id("main.sol").unwrap().ast_root();
+    let source_unit = unit.file("main.sol").unwrap().ast();
 
     let json = serde_json::to_value(&source_unit).expect("serialization succeeds");
 
@@ -37,7 +37,7 @@ fn source_unit_serializes_to_json_with_expected_shape() {
 #[test]
 fn function_definition_field_kind_does_not_collide_with_discriminator() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.get_file_by_id("ownable.sol").unwrap().ast_root();
+    let source_unit = unit.file("ownable.sol").unwrap().ast();
 
     let json = serde_json::to_value(&source_unit).unwrap();
     let function =

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -51,9 +51,9 @@ fn parallel_access_via_arc_consistent_with_serial_baseline() {
                 // so the AST node `Arc<…Struct>` handles are cloned across threads.
                 for file_id in &expected_file_ids {
                     let root = unit
-                        .get_file_by_id(file_id)
+                        .file(file_id)
                         .unwrap_or_else(|| panic!("missing {file_id}"))
-                        .ast_root();
+                        .ast();
                     let members = root.members();
                     assert!(!members.is_empty());
                     let _collected: Vec<_> = members.iter().collect();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -51,8 +51,9 @@ fn parallel_access_via_arc_consistent_with_serial_baseline() {
                 // so the AST node `Arc<…Struct>` handles are cloned across threads.
                 for file_id in &expected_file_ids {
                     let root = unit
-                        .get_file_ast_root(file_id)
-                        .unwrap_or_else(|| panic!("missing AST root for {file_id}"));
+                        .get_file_by_id(file_id)
+                        .unwrap_or_else(|| panic!("missing {file_id}"))
+                        .ast_root();
                     let members = root.members();
                     assert!(!members.is_empty());
                     let _collected: Vec<_> = members.iter().collect();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -8,17 +8,17 @@ fn test_get_file_ast_root() {
     assert_eq!(unit.file_ids().len(), 3);
 
     let main_ast = unit
-        .get_file_by_id("main.sol")
+        .file("main.sol")
         .expect("main.sol is a file of the compilation unit")
-        .ast_root();
+        .ast();
     let ownable_ast = unit
-        .get_file_by_id("ownable.sol")
+        .file("ownable.sol")
         .expect("ownable.sol is a file in the compilation unit")
-        .ast_root();
+        .ast();
     let activatable_ast = unit
-        .get_file_by_id("activatable.sol")
+        .file("activatable.sol")
         .expect("activatable.sol is a file in the compilation unit")
-        .ast_root();
+        .ast();
 
     assert_eq!(main_ast.file_id(), "main.sol");
     assert_eq!(ownable_ast.file_id(), "ownable.sol");

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -8,14 +8,17 @@ fn test_get_file_ast_root() {
     assert_eq!(unit.file_ids().len(), 3);
 
     let main_ast = unit
-        .get_file_ast_root("main.sol")
-        .expect("main.sol is a file of the compilation unit");
+        .get_file_by_id("main.sol")
+        .expect("main.sol is a file of the compilation unit")
+        .ast_root();
     let ownable_ast = unit
-        .get_file_ast_root("ownable.sol")
-        .expect("ownable.sol is a file in the compilation unit");
+        .get_file_by_id("ownable.sol")
+        .expect("ownable.sol is a file in the compilation unit")
+        .ast_root();
     let activatable_ast = unit
-        .get_file_ast_root("activatable.sol")
-        .expect("activatable.sol is a file in the compilation unit");
+        .get_file_by_id("activatable.sol")
+        .expect("activatable.sol is a file in the compilation unit")
+        .ast_root();
 
     assert_eq!(main_ast.file_id(), "main.sol");
     assert_eq!(ownable_ast.file_id(), "ownable.sol");

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -144,9 +144,9 @@ fn collect_all_identifiers(
         collector.current_file = files.get_key_value(file_id);
         accept_source_unit(
             &compilation
-                .get_file_by_id(file_id)
+                .file(file_id)
                 .expect("file is in the compilation unit")
-                .ir_root(),
+                .ir(),
             &mut collector,
         );
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -144,8 +144,9 @@ fn collect_all_identifiers(
         collector.current_file = files.get_key_value(file_id);
         accept_source_unit(
             &compilation
-                .get_file_ir_root(file_id)
-                .expect("file has IR root"),
+                .get_file_by_id(file_id)
+                .expect("file is in the compilation unit")
+                .ir_root(),
             &mut collector,
         );
     }


### PR DESCRIPTION
Closes #1765 

This PR exposes a `File` object from the `CompilationUnit` that wraps the internal representation with the semantic context, following a similar pattern to AST nodes. This allows encapsulating access to the AST to the `File`, improving the ergonomics of the API.
