### PR TITLE
[v2] Implement comptime evaluation of `erc7201`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "ruint",
+ "sha3 0.11.0",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",
  "slang_solidity_v2_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
 name = "slang_solidity_v2"
 version = "1.3.5"
 dependencies = [
+ "ruint",
  "serde_json",
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4070,6 +4071,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "paste",
+ "ruint",
  "serde",
  "sha3 0.11.0",
  "slang_solidity_v2_common",
@@ -4123,6 +4125,7 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
+ "ruint",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",
  "slang_solidity_v2_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ quote = { version = "1.0.40" }
 rayon = { version = "1.11.0" }
 regex = { version = "1.11.1" }
 reqwest = { version = "0.13.0", features = ["blocking"] }
+ruint = { version = "1.17.2" }
 rustdoc-json = { version = "0.9.5" }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["compilers", "utilities"]
 num-bigint = { workspace = true }
 num-rational = { workspace = true }
 paste = { workspace = true }
+ruint = { workspace = true }
 serde = { workspace = true }
 sha3 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -118,7 +118,7 @@ impl slang_solidity_v2_ast::abi::StorageItem
 pub fn slang_solidity_v2_ast::abi::StorageItem::label(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::StorageItem::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::abi::StorageItem::offset(&self) -> usize
-pub fn slang_solidity_v2_ast::abi::StorageItem::slot(&self) -> usize
+pub fn slang_solidity_v2_ast::abi::StorageItem::slot(&self) -> ruint::aliases::U256
 pub fn slang_solidity_v2_ast::abi::StorageItem::type_name(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ast::abi::StorageItem
 pub fn slang_solidity_v2_ast::abi::StorageItem::clone(&self) -> slang_solidity_v2_ast::abi::StorageItem

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
@@ -313,7 +314,7 @@ impl AbiParameter {
 pub struct StorageItem {
     node_id: NodeId,
     label: String,
-    slot: usize,
+    slot: U256,
     offset: usize,
     type_name: String,
 }
@@ -327,7 +328,7 @@ impl StorageItem {
         &self.label
     }
 
-    pub fn slot(&self) -> usize {
+    pub fn slot(&self) -> U256 {
         self.slot
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
@@ -1,5 +1,4 @@
-use std::ops::Div;
-
+use ruint::aliases::U256;
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::SemanticContext;
 
@@ -53,7 +52,7 @@ impl ContractDefinitionStruct {
     /// Retrieves the custom base slot for this contract, if specified. This is
     /// used for computing the base of the storage layout for non-transient
     /// state variables.
-    fn base_slot(&self) -> Option<usize> {
+    fn base_slot(&self) -> Option<U256> {
         let binder::Definition::Contract(definition) = self
             .semantic
             .binder()
@@ -71,7 +70,7 @@ impl ContractDefinitionStruct {
         // TODO(validation): it is an error if any contract in the hierarchy
         // other than the leaf has a custom offset layout
         let storage_layout = self.lay_out_state_variables(
-            self.base_slot().unwrap_or_default() * SemanticContext::SLOT_SIZE,
+            self.base_slot().unwrap_or(U256::ZERO),
             all_state_variables.iter().filter(|state_variable| {
                 matches!(
                     state_variable.mutability(),
@@ -80,7 +79,7 @@ impl ContractDefinitionStruct {
             }),
         )?;
         let transient_storage_layout = self.lay_out_state_variables(
-            0usize,
+            U256::ZERO,
             all_state_variables.iter().filter(|state_variable| {
                 matches!(
                     state_variable.mutability(),
@@ -93,36 +92,39 @@ impl ContractDefinitionStruct {
 
     fn lay_out_state_variables<'a>(
         &self,
-        base_ptr: usize,
+        base_slot: U256,
         variables: impl Iterator<Item = &'a StateVariableDefinition>,
     ) -> Option<Vec<StorageItem>> {
         let mut storage_layout = Vec::new();
-        let mut ptr: usize = base_ptr;
+        let mut current_slot: U256 = base_slot;
+        let mut byte_offset_in_slot: usize = 0;
         for state_variable in variables {
             let node_id = state_variable.ir_node.id();
             let variable_type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;
             let variable_size = self.semantic.storage_size_of_type_id(variable_type_id)?;
 
-            // check if we can pack the variable in the previous slot
-            let remaining_bytes = SemanticContext::SLOT_SIZE - (ptr % SemanticContext::SLOT_SIZE);
-            if remaining_bytes < SemanticContext::SLOT_SIZE && variable_size > remaining_bytes {
-                ptr += remaining_bytes;
+            // Check if we can pack the variable in the current slot, otherwise
+            // we start at the beginning of the next slot.
+            let remaining_bytes = SemanticContext::SLOT_SIZE - byte_offset_in_slot;
+            if byte_offset_in_slot > 0 && variable_size > remaining_bytes {
+                current_slot += U256::from(1u64);
+                byte_offset_in_slot = 0;
             }
 
             let label = state_variable.ir_node.name.unparse().to_string();
-            let slot = ptr.div(SemanticContext::SLOT_SIZE);
-            let offset = ptr % SemanticContext::SLOT_SIZE;
             let type_name = self.semantic.type_internal_name(variable_type_id);
             storage_layout.push(StorageItem {
                 node_id,
                 label,
-                slot,
-                offset,
+                slot: current_slot,
+                offset: byte_offset_in_slot,
                 type_name,
             });
 
-            // ready pointer for the next variable
-            ptr += variable_size;
+            // Ready slot and offset for the next variable
+            byte_offset_in_slot += variable_size;
+            current_slot += U256::from(byte_offset_in_slot / SemanticContext::SLOT_SIZE);
+            byte_offset_in_slot %= SemanticContext::SLOT_SIZE;
         }
         Some(storage_layout)
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
@@ -24,6 +24,7 @@ num-bigint = { workspace = true }
 num-integer = { workspace = true }
 num-rational = { workspace = true }
 num-traits = { workspace = true }
+ruint = { workspace = true, features = ["num-bigint"] }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
@@ -25,6 +25,7 @@ num-integer = { workspace = true }
 num-rational = { workspace = true }
 num-traits = { workspace = true }
 ruint = { workspace = true, features = ["num-bigint"] }
+sha3 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ruint::aliases::U256;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -47,8 +48,7 @@ pub struct ContractDefinition {
     pub ir_node: ir::ContractDefinition,
     pub bases: Option<Vec<NodeId>>,
     pub(crate) constructor_parameters_scope_id: Option<ScopeId>,
-    // TODO: this should be `Option<u256>`
-    pub base_slot: Option<usize>,
+    pub base_slot: Option<U256>,
 }
 
 #[derive(Debug)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -40,7 +40,9 @@ pub enum Definition {
 #[derive(Debug)]
 pub struct ConstantDefinition {
     pub ir_node: ir::ConstantDefinition,
-    pub(crate) scope_id: ScopeId,
+    // This is the scope the constant is defined in, and is used to change the
+    // resolution context in the `CompileConstantEvaluator`.
+    pub(crate) enclosing_scope_id: ScopeId,
 }
 
 #[derive(Debug)]
@@ -289,12 +291,15 @@ impl Definition {
         }
     }
 
-    pub(crate) fn new_constant(ir_node: &ir::ConstantDefinition, scope_id: ScopeId) -> Self {
+    pub(crate) fn new_constant(
+        ir_node: &ir::ConstantDefinition,
+        enclosing_scope_id: ScopeId,
+    ) -> Self {
         // for constants we store the scope_id where it's defined to use for
         // evaluation of compile-time constants (eg. fixed arrays size)
         Self::Constant(ConstantDefinition {
             ir_node: Arc::clone(ir_node),
-            scope_id,
+            enclosing_scope_id,
         })
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -64,7 +64,7 @@ impl SemanticContext {
 
         p1_collect_definitions::run(files, &mut binder);
         p2_linearise_contracts::run(files, &mut binder);
-        p3_type_definitions::run(files, &mut binder, &mut types);
+        p3_type_definitions::run(files, &mut binder, &mut types, language_version);
         p4_resolve_references::run(files, &mut binder, &mut types, language_version);
 
         let file_node_mapper = FileNodeMapper::build_from(files);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -1,14 +1,24 @@
+use num_bigint::BigInt;
 use slang_solidity_v2_ir::ir;
 
 use crate::types::Number;
 
-pub(crate) fn evaluate_compile_time_uint_constant<Scope>(
+pub(crate) fn evaluate_compile_time_usize_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
 ) -> Option<usize> {
     evaluate_compile_time_number_constant(expression, start_scope, identifier_resolver)
         .and_then(|value| value.as_usize())
+}
+
+pub(crate) fn evaluate_compile_time_integer_constant<Scope>(
+    expression: &ir::Expression,
+    start_scope: Scope,
+    identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
+) -> Option<BigInt> {
+    evaluate_compile_time_number_constant(expression, start_scope, identifier_resolver)
+        .and_then(Number::into_integer)
 }
 
 fn evaluate_compile_time_number_constant<Scope>(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -1,7 +1,10 @@
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Sign};
+use ruint::aliases::U256;
+use sha3::{Digest, Keccak256};
 use slang_solidity_v2_ir::ir;
 
-use crate::types::Number;
+use crate::built_ins::BuiltIn;
+use crate::types::{literals, Number};
 
 pub(crate) fn evaluate_compile_time_usize_constant<Scope>(
     expression: &ir::Expression,
@@ -33,6 +36,15 @@ fn evaluate_compile_time_number_constant<Scope>(
     evaluator.evaluate_expression_in_scope(expression, start_scope)
 }
 
+pub(crate) enum ComptimeResolution<Scope> {
+    Unresolved,
+    Constant {
+        value: ir::Expression,
+        target_scope: Scope,
+    },
+    BuiltIn(BuiltIn),
+}
+
 pub(crate) trait ConstantIdentifierResolver<Scope> {
     /// Resolve an identifier to a constant in the given context, returning the
     /// value expression of the constant and the scope in which the value
@@ -42,7 +54,7 @@ pub(crate) trait ConstantIdentifierResolver<Scope> {
         &self,
         identifier: &str,
         scope: &Scope,
-    ) -> Option<(ir::Expression, Scope)>;
+    ) -> ComptimeResolution<Scope>;
 }
 
 struct CompileConstantEvaluator<'a, Scope> {
@@ -105,6 +117,9 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             ir::Expression::Identifier(identifier) => self.evaluate_identifier(identifier),
             ir::Expression::TupleExpression(tuple_expression) => {
                 self.evaluate_tuple_expression(tuple_expression)
+            }
+            ir::Expression::FunctionCallExpression(call) => {
+                self.evaluate_function_call_expression(call)
             }
             _ => {
                 // all other variants of expression cannot be evaluated at
@@ -204,9 +219,15 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
 
     fn evaluate_identifier(&mut self, identifier: &ir::Identifier) -> Option<Number> {
         let current_scope = self.scope_stack.last().expect("scope stack is empty");
-        let (target_expression, target_scope) = self
+        let ComptimeResolution::Constant {
+            value: target_expression,
+            target_scope,
+        } = self
             .identifier_resolver
-            .resolve_identifier_in_scope(identifier.unparse(), current_scope)?;
+            .resolve_identifier_in_scope(identifier.unparse(), current_scope)
+        else {
+            return None;
+        };
         self.evaluate_expression_in_scope(&target_expression, target_scope)
     }
 
@@ -221,6 +242,103 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             None
         }
     }
+
+    /// Compile-time evaluation of a built-in function call. Only `erc7201`
+    /// is supported as of Solidity 0.8.35. Everything else returns `None`.
+    fn evaluate_function_call_expression(
+        &mut self,
+        call: &ir::FunctionCallExpression,
+    ) -> Option<Number> {
+        let ir::Expression::Identifier(operand) = &call.operand else {
+            return None;
+        };
+        let scope = self.scope_stack.last().expect("scope stack is empty");
+        let resolution = self
+            .identifier_resolver
+            .resolve_identifier_in_scope(operand.unparse(), scope);
+        match resolution {
+            ComptimeResolution::BuiltIn(BuiltIn::Erc7201) => {
+                self.evaluate_erc7201_built_in_call(&call.arguments)
+            }
+            _ => None,
+        }
+    }
+
+    fn evaluate_erc7201_built_in_call(
+        &mut self,
+        arguments: &ir::ArgumentsDeclaration,
+    ) -> Option<Number> {
+        let ir::ArgumentsDeclaration::PositionalArguments(arguments) = arguments else {
+            return None;
+        };
+        let [argument] = arguments.as_slice() else {
+            // Reject other arities
+            return None;
+        };
+        let value = self.evaluate_expression_as_string(argument)?;
+        Some(Number::Integer(compute_erc7201(&value)))
+    }
+
+    fn evaluate_expression_as_string(&mut self, expression: &ir::Expression) -> Option<Vec<u8>> {
+        match expression {
+            ir::Expression::StringExpression(string_expression) => {
+                let value = match string_expression {
+                    ir::StringExpression::StringLiterals(literals) => {
+                        literals::value_of_string_literals(literals)
+                    }
+                    ir::StringExpression::HexStringLiterals(literals) => {
+                        literals::value_of_hex_string_literals(literals)
+                    }
+                    ir::StringExpression::UnicodeStringLiterals(literals) => {
+                        literals::value_of_unicode_string_literals(literals)
+                    }
+                };
+                Some(value)
+            }
+            ir::Expression::Identifier(identifier) => {
+                self.evaluate_identifier_as_string(identifier)
+            }
+            _ => None,
+        }
+    }
+
+    fn evaluate_identifier_as_string(&mut self, identifier: &ir::Identifier) -> Option<Vec<u8>> {
+        let current_scope = self.scope_stack.last().expect("scope stack is empty");
+        let ComptimeResolution::Constant {
+            value: target_expression,
+            target_scope,
+        } = self
+            .identifier_resolver
+            .resolve_identifier_in_scope(identifier.unparse(), current_scope)
+        else {
+            return None;
+        };
+        if self.scope_stack.len() >= Self::MAX_SCOPE_DEPTH {
+            // TODO(validation): cyclic dependency in constant resolution or max depth reached
+            return None;
+        }
+        self.scope_stack.push(target_scope);
+        let result = self.evaluate_expression_as_string(&target_expression);
+        self.scope_stack
+            .pop()
+            .expect("scope stack should not be empty");
+        result
+    }
+}
+
+/// Computes the storage slot defined by ERC-7201 for the given value bytes:
+/// `keccak256(abi.encode(uint256(keccak256(value)) - 1)) & ~bytes32(uint256(0xff))`.
+fn compute_erc7201(value: &[u8]) -> BigInt {
+    let inner: [u8; 32] = Keccak256::digest(value).into();
+    // Wrapping subtraction matches Solidity's `uint256(...) - 1` semantics —
+    // the inner hash being zero is negligibly rare but well-defined.
+    let minus_one = U256::from_be_bytes(inner).wrapping_sub(U256::from(1u8));
+    // `abi.encode(uint256(...))` is the value's 32-byte big-endian encoding.
+    let encoded = minus_one.to_be_bytes::<32>();
+    let mut outer: [u8; 32] = Keccak256::digest(encoded).into();
+    // Mask off the lowest byte (`& ~bytes32(uint256(0xff))`).
+    outer[31] = 0;
+    BigInt::from_bytes_be(Sign::Plus, &outer)
 }
 
 #[cfg(test)]
@@ -229,16 +347,20 @@ mod tests {
 
     use num_bigint::{BigInt, ToBigInt};
     use num_rational::BigRational;
+    use num_traits::Num;
     use slang_solidity_v2_common::versions::LanguageVersion;
     use slang_solidity_v2_parser::{ParseOutput, Parser};
 
     use super::*;
 
-    #[derive(Default)]
     struct MapResolver {
         // qualified identifier => (target expression, target scope)
         // qualified identifier is the concatenation of the scope and identifier
         context: HashMap<String, (ir::Expression, String)>,
+        // Tests that exercise the erc7201 evaluation path opt in by toggling
+        // this flag, mirroring what the production resolver does when the
+        // language version enables the built-in and it isn't shadowed.
+        recognise_erc7201: bool,
     }
 
     impl ConstantIdentifierResolver<String> for MapResolver {
@@ -246,14 +368,56 @@ mod tests {
             &self,
             identifier: &str,
             scope: &String,
-        ) -> Option<(ir::Expression, String)> {
-            self.context.get(&format!("{scope}{identifier}")).cloned()
+        ) -> ComptimeResolution<String> {
+            if let Some((target_expression, target_scope)) =
+                self.context.get(&format!("{scope}{identifier}"))
+            {
+                ComptimeResolution::Constant {
+                    value: target_expression.clone(),
+                    target_scope: target_scope.clone(),
+                }
+            } else if self.recognise_erc7201 && identifier == "erc7201" {
+                ComptimeResolution::BuiltIn(BuiltIn::Erc7201)
+            } else {
+                ComptimeResolution::Unresolved
+            }
+        }
+    }
+
+    impl MapResolver {
+        fn build_context(
+            context: &[(&str, &str, &str)],
+        ) -> HashMap<String, (ir::Expression, String)> {
+            context
+                .iter()
+                .map(|(name, input, target_scope)| {
+                    (
+                        (*name).to_string(),
+                        (parse_expression(input), (*target_scope).to_string()),
+                    )
+                })
+                .collect()
+        }
+
+        fn with_context(context: &[(&str, &str, &str)]) -> Self {
+            Self {
+                context: Self::build_context(context),
+                recognise_erc7201: false,
+            }
+        }
+
+        fn recognise_erc7201_with_context(context: &[(&str, &str, &str)]) -> Self {
+            Self {
+                context: Self::build_context(context),
+                recognise_erc7201: true,
+            }
         }
     }
 
     fn parse_expression(input: &str) -> ir::Expression {
+        // NB. the declaration is only a harness to contain the expression
         let source = format!("uint constant x = {input};");
-        let version = LanguageVersion::V0_8_30;
+        let version = LanguageVersion::V0_8_35;
 
         let ParseOutput {
             source_unit,
@@ -286,29 +450,20 @@ mod tests {
         }
     }
 
-    fn eval_string(input: &str) -> Option<Number> {
-        let expression = parse_expression(input);
-        evaluate_compile_time_number_constant(&expression, String::new(), &MapResolver::default())
-    }
-
     // `context` is given as a list of constants defined as:
     // - the qualified identifier
     // - the target expression (to be parsed)
     // - the target scope
     // Resolution always starts at the empty string scope in these tests.
     fn eval_string_with_context(input: &str, context: &[(&str, &str, &str)]) -> Option<Number> {
-        let context: HashMap<String, (ir::Expression, String)> = context
-            .iter()
-            .map(|(name, input, target_scope)| {
-                (
-                    (*name).to_string(),
-                    (parse_expression(input), (*target_scope).to_string()),
-                )
-            })
-            .collect();
+        let resolver = MapResolver::with_context(context);
         let expression = parse_expression(input);
 
-        evaluate_compile_time_number_constant(&expression, String::new(), &MapResolver { context })
+        evaluate_compile_time_number_constant(&expression, String::new(), &resolver)
+    }
+
+    fn eval_string(input: &str) -> Option<Number> {
+        eval_string_with_context(input, &[])
     }
 
     #[test]
@@ -489,5 +644,81 @@ mod tests {
             &[("FOO", "BAR", "CTX."), ("CTX.BAR", "42", "CTX.")]
         )
         .is_some_and(|value| value == Number::Integer(42.to_bigint().unwrap())));
+    }
+
+    fn eval_string_with_erc7201_and_context(
+        input: &str,
+        context: &[(&str, &str, &str)],
+    ) -> Option<Number> {
+        let expression = parse_expression(input);
+        let resolver = MapResolver::recognise_erc7201_with_context(context);
+        evaluate_compile_time_number_constant(&expression, String::new(), &resolver)
+    }
+
+    fn eval_string_with_erc7201(input: &str) -> Option<Number> {
+        eval_string_with_erc7201_and_context(input, &[])
+    }
+
+    #[test]
+    fn test_erc7201_reference_vector() {
+        // EIP-7201 test vector: `erc7201("example.main")` →
+        // 0x183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500
+        let expected = BigInt::from_str_radix(
+            "183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500",
+            16,
+        )
+        .map(Number::Integer)
+        .unwrap();
+
+        assert!(eval_string_with_erc7201(r#"erc7201("example.main")"#)
+            .is_some_and(|value| value == expected));
+        assert!(
+            eval_string_with_erc7201(r#"erc7201(unicode"example.main")"#)
+                .is_some_and(|value| value == expected)
+        );
+        assert!(
+            eval_string_with_erc7201(r#"erc7201(hex"6578616D706C652E6D61696E")"#)
+                .is_some_and(|value| value == expected)
+        );
+    }
+
+    #[test]
+    fn test_erc7201_folds_inside_arithmetic() {
+        // Confirms the function-call result feeds further folding
+        let expected = BigInt::from_str_radix("b500", 16).unwrap();
+        assert!(
+            eval_string_with_erc7201(r#"erc7201("example.main") & 0xffff"#)
+                .is_some_and(|value| value == Number::Integer(expected))
+        );
+    }
+
+    #[test]
+    fn test_erc7201_not_recognised_without_resolver_opt_in() {
+        // Same expression, but the default resolver doesn't claim "erc7201"
+        // is the built-in; evaluation falls through to `None`.
+        assert!(eval_string(r#"erc7201("example.main")"#).is_none());
+    }
+
+    #[test]
+    fn test_erc7201_rejects_wrong_arity() {
+        assert!(eval_string_with_erc7201(r#"erc7201()"#).is_none());
+        assert!(eval_string_with_erc7201(r#"erc7201("a", "b")"#).is_none());
+    }
+
+    #[test]
+    fn test_erc7201_resolves_identifier_arguments() {
+        let expected = BigInt::from_str_radix(
+            "183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500",
+            16,
+        )
+        .unwrap();
+        assert!(eval_string_with_erc7201_and_context(
+            r#"erc7201(NAME)"#,
+            &[
+                ("NAME", "NAME", "SUB."),
+                ("SUB.NAME", "\"example.main\"", "")
+            ],
+        )
+        .is_some_and(|value| value == Number::Integer(expected)));
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,7 +1,9 @@
 use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
+use crate::built_ins::BuiltInsResolver;
 use crate::context::SemanticFile;
 use crate::types::{Type, TypeId, TypeRegistry};
 
@@ -19,16 +21,22 @@ mod visitor;
 /// Finally, public state variables will be assigned an equivalent getter
 /// function type. This happens after the main typing pass to ensure all types
 /// are already registered.
-pub fn run(files: &[impl SemanticFile], binder: &mut Binder, types: &mut TypeRegistry) {
+pub fn run(
+    files: &[impl SemanticFile],
+    binder: &mut Binder,
+    types: &mut TypeRegistry,
+    language_version: LanguageVersion,
+) {
     for file in files {
-        Pass::visit_file(file, binder, types);
+        Pass::visit_file(file, binder, types, language_version);
     }
     for file in files {
-        Pass::visit_file_type_getters(file, binder, types);
+        Pass::visit_file_type_getters(file, binder, types, language_version);
     }
 }
 
 struct Pass<'a> {
+    language_version: LanguageVersion,
     scope_stack: Vec<ScopeId>,
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
@@ -36,8 +44,14 @@ struct Pass<'a> {
 }
 
 impl<'a> Pass<'a> {
-    fn visit_file(file: &impl SemanticFile, binder: &'a mut Binder, types: &'a mut TypeRegistry) {
+    fn visit_file(
+        file: &impl SemanticFile,
+        binder: &'a mut Binder,
+        types: &'a mut TypeRegistry,
+        language_version: LanguageVersion,
+    ) {
         let mut pass = Self {
+            language_version,
             scope_stack: Vec::new(),
             binder,
             types,
@@ -57,14 +71,20 @@ impl<'a> Pass<'a> {
         file: &impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
+        language_version: LanguageVersion,
     ) {
         let mut pass = Self {
+            language_version,
             scope_stack: Vec::new(),
             binder,
             types,
             current_receiver_type: None,
         };
         pass.type_getters_from(file.ir_root());
+    }
+
+    fn built_ins_resolver(&self) -> BuiltInsResolver<'_> {
+        BuiltInsResolver::new(self.language_version, self.binder, self.types)
     }
 
     fn type_getters_from(&mut self, source_unit: &ir::SourceUnit) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -1,8 +1,10 @@
 use slang_solidity_v2_ir::ir;
 
-use super::evaluator::{evaluate_compile_time_usize_constant, ConstantIdentifierResolver};
+use super::evaluator::{
+    evaluate_compile_time_usize_constant, ComptimeResolution, ConstantIdentifierResolver,
+};
 use super::Pass;
-use crate::binder::{Definition, Resolution, ScopeId};
+use crate::binder::{Definition, Resolution, Scope, ScopeId};
 use crate::passes::common::resolve_identifier_path_in_scope;
 use crate::types::{DataLocation, FunctionType, Type, TypeId};
 
@@ -142,16 +144,56 @@ impl ConstantIdentifierResolver<ScopeId> for Pass<'_> {
         &self,
         identifier: &str,
         scope_id: &ScopeId,
-    ) -> Option<(ir::Expression, ScopeId)> {
-        let resolution = self.binder.resolve_in_scope(*scope_id, identifier);
-        let definition_id = resolution.as_definition_id()?;
-        match self.binder.find_definition_by_id(definition_id)? {
-            Definition::Constant(constant_definition) => constant_definition
-                .ir_node
-                .value
-                .as_ref()
-                .map(|value| (value.clone(), constant_definition.scope_id)),
-            _ => None,
+    ) -> ComptimeResolution<ScopeId> {
+        match self.binder.resolve_in_scope(*scope_id, identifier) {
+            Resolution::Definition(definition_id) => {
+                match self
+                    .binder
+                    .find_definition_by_id(definition_id)
+                    .expect("resolved definition is found")
+                {
+                    Definition::Constant(constant_definition) => {
+                        if let Some(value) = &constant_definition.ir_node.value {
+                            ComptimeResolution::Constant {
+                                value: value.clone(),
+                                target_scope: constant_definition.enclosing_scope_id,
+                            }
+                        } else {
+                            // TODO(validation): this is a constant state
+                            // variable for which the grammar allows an absent
+                            // value expression but it's a semantic error
+                            ComptimeResolution::Unresolved
+                        }
+                    }
+                    _ => ComptimeResolution::Unresolved,
+                }
+            }
+            Resolution::Ambiguous(_) => {
+                // TODO(validation): multiple definitions found which is an error
+                ComptimeResolution::Unresolved
+            }
+            Resolution::BuiltIn(_) => unreachable!("the binder doesn't resolve to built-ins"),
+
+            Resolution::Unresolved => {
+                // Try to resolve a built-in using the scope as context
+                let resolver = self.built_ins_resolver();
+                let built_in = match self.binder.get_scope_by_id(*scope_id) {
+                    Scope::Block(_)
+                    | Scope::Contract(_)
+                    | Scope::File(_)
+                    | Scope::Function(_)
+                    | Scope::Modifier(_) => resolver.lookup_global(identifier),
+
+                    Scope::Enum(_) | Scope::Parameters(_) | Scope::Struct(_) | Scope::Using(_) => {
+                        None
+                    }
+
+                    Scope::YulBlock(_) | Scope::YulFunction(_) => {
+                        resolver.lookup_yul_global(identifier)
+                    }
+                };
+                built_in.map_or(ComptimeResolution::Unresolved, ComptimeResolution::BuiltIn)
+            }
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -1,6 +1,6 @@
 use slang_solidity_v2_ir::ir;
 
-use super::evaluator::{evaluate_compile_time_uint_constant, ConstantIdentifierResolver};
+use super::evaluator::{evaluate_compile_time_usize_constant, ConstantIdentifierResolver};
 use super::Pass;
 use crate::binder::{Definition, Resolution, ScopeId};
 use crate::passes::common::resolve_identifier_path_in_scope;
@@ -44,9 +44,9 @@ impl Pass<'_> {
                         .map(|element_type| {
                             if let Some(size_expression) = &array_type_name.index {
                                 // TODO(validation): if the size of the array
-                                // cannot be evaluated, it's not a compile-time
-                                // constant
-                                let size = evaluate_compile_time_uint_constant(
+                                // cannot be evaluated it's not a compile-time
+                                // constant, or it doesn't fit in `usize`.
+                                let size = evaluate_compile_time_usize_constant(
                                     size_expression,
                                     self.current_contract_or_file_scope_id(),
                                     self,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ruint::aliases::U256;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
-use super::evaluator::evaluate_compile_time_uint_constant;
+use super::evaluator::evaluate_compile_time_integer_constant;
 use super::Pass;
 use crate::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
 use crate::built_ins::BuiltIn;
@@ -47,17 +48,24 @@ impl Visitor for Pass<'_> {
             // TODO(validation): if the base slot expression cannot be computed
             // at this time, it's not a compile time constant and hence it's an
             // error
-            if let Some(base_slot) = evaluate_compile_time_uint_constant(
+            let base_slot = evaluate_compile_time_integer_constant(
                 base_slot_expression,
                 self.current_contract_or_file_scope_id(),
                 self,
-            ) {
+            )
+            .and_then(|base_slot| {
+                // TODO(validation): if conversion fails the constant is
+                // negative or exceeds the 256 bit range
+                U256::try_from(base_slot).ok()
+            });
+
+            if base_slot.is_some() {
                 let Definition::Contract(contract_definition) =
                     self.binder.get_definition_mut(node.id())
                 else {
                     unreachable!("the definition is not a contract");
                 };
-                contract_definition.base_slot = Some(base_slot);
+                contract_definition.base_slot = base_slot;
             }
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -18,7 +18,12 @@ contract Test is Base layout at 0 {}
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let file = build_file(
+        "test.sol",
+        CONTENTS,
+        &mut id_generator,
+        LanguageVersion::V0_8_35,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -71,7 +76,12 @@ interface A is C {}
 "#;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let file = build_file(
+        "test.sol",
+        CONTENTS,
+        &mut id_generator,
+        LanguageVersion::V0_8_35,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -111,7 +121,12 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
 "#;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let file = build_file(
+        "test.sol",
+        CONTENTS,
+        &mut id_generator,
+        LanguageVersion::V0_8_35,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -158,7 +173,12 @@ contract Test is Base {
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let file = build_file(
+        "test.sol",
+        CONTENTS,
+        &mut id_generator,
+        LanguageVersion::V0_8_35,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -211,12 +231,12 @@ contract Test is Base {
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let language_version = LanguageVersion::V0_8_35;
+    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
 
     let files = [file];
     let mut binder = Binder::default();
     let mut types = TypeRegistry::default();
-    let language_version = LanguageVersion::V0_8_30;
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -173,12 +173,8 @@ contract Test is Base {
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file(
-        "test.sol",
-        CONTENTS,
-        &mut id_generator,
-        LanguageVersion::V0_8_35,
-    );
+    let language_version = LanguageVersion::V0_8_35;
+    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
 
     let files = [file];
     let mut binder = Binder::default();
@@ -188,7 +184,7 @@ contract Test is Base {
     p2_linearise_contracts::run(&files, &mut binder);
 
     let types_before = types.iter_types().count();
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     let types_after = types.iter_types().count();
 
     // The pass registers new types for: contracts, mappings, structs, enums,
@@ -240,7 +236,7 @@ contract Test is Base {
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 
     // Verify that references were created and most are resolved

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -27,11 +27,16 @@ impl SemanticFile for TestFile {
     }
 }
 
-fn build_file(name: &str, contents: &str, id_generator: &mut NodeIdGenerator) -> TestFile {
+fn build_file(
+    name: &str,
+    contents: &str,
+    id_generator: &mut NodeIdGenerator,
+    language_version: LanguageVersion,
+) -> TestFile {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse(name, contents, LanguageVersion::V0_8_30);
+    } = Parser::parse(name, contents, language_version);
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -36,7 +36,7 @@ fn try_type_of_value_expression(input: &str) -> (Option<Type>, TypeRegistry) {
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 
     let value_expr = match files[0].ir_root().members.first().unwrap() {
@@ -689,7 +689,7 @@ contract Test {
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
-    p3_type_definitions::run(&files, &mut binder, &mut types);
+    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 
     let function = find_contract_function(files[0].ir_root(), "Test", "test");

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -27,12 +27,12 @@ fn type_of_value_expression(input: &str) -> (Type, TypeRegistry) {
 fn try_type_of_value_expression(input: &str) -> (Option<Type>, TypeRegistry) {
     let source = format!("uint constant x = {input};");
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", &source, &mut id_generator);
+    let language_version = LanguageVersion::V0_8_35;
+    let file = build_file("test.sol", &source, &mut id_generator, language_version);
     let files = [file];
 
     let mut binder = Binder::default();
     let mut types = TypeRegistry::default();
-    let language_version = LanguageVersion::V0_8_30;
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);
@@ -680,12 +680,12 @@ contract Test {
 "#;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator);
+    let language_version = LanguageVersion::V0_8_35;
+    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
     let files = [file];
 
     let mut binder = Binder::default();
     let mut types = TypeRegistry::default();
-    let language_version = LanguageVersion::V0_8_30;
 
     p1_collect_definitions::run(&files, &mut binder);
     p2_linearise_contracts::run(&files, &mut binder);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -30,6 +30,7 @@ slang_solidity_v2_parser = { workspace = true }
 slang_solidity_v2_semantic = { workspace = true }
 
 [dev-dependencies]
+ruint = { workspace = true }
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -1,3 +1,5 @@
+use ruint::uint;
+
 use super::fixtures;
 use crate::abi::AbiEntry;
 
@@ -62,7 +64,7 @@ macro_rules! assert_layout_item_eq {
     ($item:expr, $name:expr, $slot:expr, $offset:expr, $type:expr) => {
         assert_eq!($item.label(), $name);
         assert_eq!($item.type_name(), $type);
-        assert_eq!($item.slot(), $slot);
+        assert_eq!($item.slot(), uint!($slot));
         assert_eq!($item.offset(), $offset);
     };
 }
@@ -81,18 +83,18 @@ fn test_storage_layout() {
 
     assert_eq!(layout.len(), 12);
 
-    assert_layout_item_eq!(layout[0], "a", 0, 0, "uint256");
-    assert_layout_item_eq!(layout[1], "e", 1, 0, "uint8[]");
-    assert_layout_item_eq!(layout[2], "f", 2, 0, "mapping(uint256 => S)");
-    assert_layout_item_eq!(layout[3], "g", 3, 0, "uint16");
-    assert_layout_item_eq!(layout[4], "h", 3, 2, "uint16");
-    assert_layout_item_eq!(layout[5], "s", 4, 0, "S");
-    assert_layout_item_eq!(layout[6], "k", 5, 0, "int8");
-    assert_layout_item_eq!(layout[7], "l", 5, 1, "bytes21");
-    assert_layout_item_eq!(layout[8], "m", 6, 0, "uint8[10]");
-    assert_layout_item_eq!(layout[9], "n", 7, 0, "bytes5[8]");
-    assert_layout_item_eq!(layout[10], "t", 9, 0, "T[2]");
-    assert_layout_item_eq!(layout[11], "o", 13, 0, "bytes5");
+    assert_layout_item_eq!(layout[0], "a", 0_U256, 0, "uint256");
+    assert_layout_item_eq!(layout[1], "e", 1_U256, 0, "uint8[]");
+    assert_layout_item_eq!(layout[2], "f", 2_U256, 0, "mapping(uint256 => S)");
+    assert_layout_item_eq!(layout[3], "g", 3_U256, 0, "uint16");
+    assert_layout_item_eq!(layout[4], "h", 3_U256, 2, "uint16");
+    assert_layout_item_eq!(layout[5], "s", 4_U256, 0, "S");
+    assert_layout_item_eq!(layout[6], "k", 5_U256, 0, "int8");
+    assert_layout_item_eq!(layout[7], "l", 5_U256, 1, "bytes21");
+    assert_layout_item_eq!(layout[8], "m", 6_U256, 0, "uint8[10]");
+    assert_layout_item_eq!(layout[9], "n", 7_U256, 0, "bytes5[8]");
+    assert_layout_item_eq!(layout[10], "t", 9_U256, 0, "T[2]");
+    assert_layout_item_eq!(layout[11], "o", 13_U256, 0, "bytes5");
 
     let transient_layout = counter_abi.transient_storage_layout();
     assert!(transient_layout.is_empty());

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -64,7 +64,7 @@ macro_rules! assert_layout_item_eq {
     ($item:expr, $name:expr, $slot:expr, $offset:expr, $type:expr) => {
         assert_eq!($item.label(), $name);
         assert_eq!($item.type_name(), $type);
-        assert_eq!($item.slot(), uint!($slot));
+        assert_eq!($item.slot(), $slot);
         assert_eq!($item.offset(), $offset);
     };
 }
@@ -83,18 +83,18 @@ fn test_storage_layout() {
 
     assert_eq!(layout.len(), 12);
 
-    assert_layout_item_eq!(layout[0], "a", 0_U256, 0, "uint256");
-    assert_layout_item_eq!(layout[1], "e", 1_U256, 0, "uint8[]");
-    assert_layout_item_eq!(layout[2], "f", 2_U256, 0, "mapping(uint256 => S)");
-    assert_layout_item_eq!(layout[3], "g", 3_U256, 0, "uint16");
-    assert_layout_item_eq!(layout[4], "h", 3_U256, 2, "uint16");
-    assert_layout_item_eq!(layout[5], "s", 4_U256, 0, "S");
-    assert_layout_item_eq!(layout[6], "k", 5_U256, 0, "int8");
-    assert_layout_item_eq!(layout[7], "l", 5_U256, 1, "bytes21");
-    assert_layout_item_eq!(layout[8], "m", 6_U256, 0, "uint8[10]");
-    assert_layout_item_eq!(layout[9], "n", 7_U256, 0, "bytes5[8]");
-    assert_layout_item_eq!(layout[10], "t", 9_U256, 0, "T[2]");
-    assert_layout_item_eq!(layout[11], "o", 13_U256, 0, "bytes5");
+    assert_layout_item_eq!(layout[0], "a", uint!(0_U256), 0, "uint256");
+    assert_layout_item_eq!(layout[1], "e", uint!(1_U256), 0, "uint8[]");
+    assert_layout_item_eq!(layout[2], "f", uint!(2_U256), 0, "mapping(uint256 => S)");
+    assert_layout_item_eq!(layout[3], "g", uint!(3_U256), 0, "uint16");
+    assert_layout_item_eq!(layout[4], "h", uint!(3_U256), 2, "uint16");
+    assert_layout_item_eq!(layout[5], "s", uint!(4_U256), 0, "S");
+    assert_layout_item_eq!(layout[6], "k", uint!(5_U256), 0, "int8");
+    assert_layout_item_eq!(layout[7], "l", uint!(5_U256), 1, "bytes21");
+    assert_layout_item_eq!(layout[8], "m", uint!(6_U256), 0, "uint8[10]");
+    assert_layout_item_eq!(layout[9], "n", uint!(7_U256), 0, "bytes5[8]");
+    assert_layout_item_eq!(layout[10], "t", uint!(9_U256), 0, "T[2]");
+    assert_layout_item_eq!(layout[11], "o", uint!(13_U256), 0, "bytes5");
 
     let transient_layout = counter_abi.transient_storage_layout();
     assert!(transient_layout.is_empty());
@@ -132,6 +132,27 @@ fn test_transient_and_custom_storage_layout() {
     assert_eq!(e_transient_layout.len(), 2);
     assert_layout_item_eq!(e_transient_layout[0], "qt", 0, 0, "int8");
     assert_layout_item_eq!(e_transient_layout[1], "rt", 0, 1, "bytes5");
+}
+
+#[test]
+fn test_erc7201_storage_layout() {
+    let unit = fixtures::StorageLayout::build_compilation_unit();
+
+    let f_contract = unit
+        .find_contract_by_name("F")
+        .expect("contract can be found");
+    let f_abi = f_contract
+        .compute_abi_with_file_id("main.sol".to_string())
+        .expect("can compute ABI");
+    let f_layout = f_abi.storage_layout();
+
+    // EIP-7201 test vector: `erc7201("example.main")` →
+    // 0x183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500.
+    let base_slot = uint!(0x183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500_U256);
+
+    assert_eq!(f_layout.len(), 2);
+    assert_layout_item_eq!(f_layout[0], "u", base_slot, 0, "uint256");
+    assert_layout_item_eq!(f_layout[1], "v", base_slot + uint!(1_U256), 0, "uint256");
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -76,7 +76,7 @@ impl CompilationBuilderConfig for FixtureBuildConfig<'_> {
 pub(super) fn build_compilation_unit_from_fixture(
     files: &[FixtureFile<'_>],
 ) -> Arc<CompilationUnit> {
-    let version = LanguageVersion::V0_8_30;
+    let version = LanguageVersion::V0_8_35;
     let mut builder = CompilationBuilder::create(version, FixtureBuildConfig { files });
 
     for file in files {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/storage_layout.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/storage_layout.rs
@@ -48,5 +48,10 @@ contract E layout at BASE * 2 + 10 {
     bytes5 r;
     bytes5 transient rt;
 }
+
+contract F layout at erc7201("example.main") {
+    uint256 u;
+    uint256 v;
+}
 "#,
 );


### PR DESCRIPTION
Closes #1747 

This PR also introduces the `U256` type from the `ruint` crate to represent base slot addresses for contracts in the EVM.