### PR TITLE
Diagnose duplicate overrides

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -241,6 +241,7 @@ pub mod slang_solidity_v2_common::diagnostics::kinds::syntax
 pub enum slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExtraTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleMutabilitySpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers)
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleOverrideSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedEof(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnsupportedSyntax(slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax)
@@ -253,6 +254,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
@@ -309,6 +312,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::expected: alloc::collections::btree::set::BTreeSet<slang_solidity_v2_common::terminals::TerminalKind>
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
@@ -388,6 +410,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -493,6 +517,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
@@ -1,11 +1,13 @@
 mod extra_terminal;
 mod multiple_mutability_specifiers;
+mod multiple_override_specifiers;
 mod unexpected_eof;
 mod unexpected_terminal;
 mod unsupported_syntax;
 
 pub use extra_terminal::ExtraTerminal;
 pub use multiple_mutability_specifiers::MultipleMutabilitySpecifiers;
+pub use multiple_override_specifiers::MultipleOverrideSpecifiers;
 use serde::Serialize;
 pub use unexpected_eof::UnexpectedEof;
 pub use unexpected_terminal::UnexpectedTerminal;
@@ -32,5 +34,8 @@ define_diagnostic_kind! {
 
         /// More than one mutability specifier was provided on a definition.
         MultipleMutabilitySpecifiers(MultipleMutabilitySpecifiers),
+
+        /// More than one override specifier was provided on a definition.
+        MultipleOverrideSpecifiers(MultipleOverrideSpecifiers),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_override_specifiers.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_override_specifiers.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a definition carries more than one override
+/// specifier.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MultipleOverrideSpecifiers;
+
+impl DiagnosticExtensions for MultipleOverrideSpecifiers {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "syntax/multiple-override-specifiers"
+    }
+
+    fn message(&self) -> String {
+        "Only a single override specifier can be provided.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers;
+use slang_solidity_v2_common::diagnostics::kinds::syntax::{
+    MultipleMutabilitySpecifiers, MultipleOverrideSpecifiers,
+};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
@@ -222,7 +224,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                 None
             }
         });
-        // TODO(validation): function definitions can have only a single override specifier
         let override_specifier = self.function_override_specifier(&source.attributes);
         let modifier_invocations = self.function_modifier_invocations(&source.attributes);
         let returns = source
@@ -466,9 +467,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::FunctionAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_override_specifier(&attributes.elements, |attribute| {
             if let input::FunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
@@ -611,7 +612,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                 None
             }
         });
-        let override_specifier = self.fallback_function_override_specifier(&source.attributes);
+        let override_specifier =
+            self.extract_override_specifier(&source.attributes.elements, |attribute| {
+                if let input::FallbackFunctionAttribute::OverrideSpecifier(specifier) = attribute {
+                    Some(specifier)
+                } else {
+                    None
+                }
+            });
         let modifier_invocations = self.fallback_function_modifier_invocations(&source.attributes);
         let returns = source
             .returns
@@ -632,19 +640,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             modifier_invocations,
             returns,
             body,
-        })
-    }
-
-    fn fallback_function_override_specifier(
-        &mut self,
-        attributes: &input::FallbackFunctionAttributes,
-    ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
-            if let input::FallbackFunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
-            } else {
-                None
-            }
         })
     }
 
@@ -712,9 +707,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::ReceiveFunctionAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_override_specifier(&attributes.elements, |attribute| {
             if let input::ReceiveFunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
@@ -760,7 +755,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                 None
             }
         });
-        let override_specifier = self.modifier_override_specifier(&source.attributes);
+        let override_specifier =
+            self.extract_override_specifier(&source.attributes.elements, |attribute| {
+                if let input::ModifierAttribute::OverrideSpecifier(specifier) = attribute {
+                    Some(specifier)
+                } else {
+                    None
+                }
+            });
         let modifier_invocations = Vec::new();
         let returns = None;
         let body = self.build_function_body(&source.body);
@@ -778,19 +780,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             modifier_invocations,
             returns,
             body,
-        })
-    }
-
-    fn modifier_override_specifier(
-        &mut self,
-        attributes: &input::ModifierAttributes,
-    ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
-            if let input::ModifierAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
-            } else {
-                None
-            }
         })
     }
 
@@ -823,10 +812,9 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::StateVariableAttributes,
     ) -> Option<output::OverridePaths> {
-        // TODO(validation): only one override specifier is allowed
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_override_specifier(&attributes.elements, |attribute| {
             if let input::StateVariableAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
@@ -993,6 +981,33 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                     );
                 } else {
                     result = Some(current);
+                }
+            }
+        }
+
+        result
+    }
+
+    fn extract_override_specifier<'a, Input>(
+        &mut self,
+        attributes: impl IntoIterator<Item = &'a Input>,
+        override_specifier_of: impl Fn(&'a Input) -> Option<&'a input::OverrideSpecifier>,
+    ) -> Option<output::OverridePaths>
+    where
+        Input: TextRange + 'a,
+    {
+        let mut result: Option<output::OverridePaths> = None;
+
+        for attribute in attributes {
+            if let Some(specifier) = override_specifier_of(attribute) {
+                if result.is_some() {
+                    self.diagnostics.push(
+                        self.file_id.to_owned(),
+                        attribute.calculate_text_range().unwrap(),
+                        MultipleOverrideSpecifiers,
+                    );
+                } else {
+                    result = Some(self.build_override_specifier_as_paths(specifier));
                 }
             }
         }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -59,6 +59,11 @@ mod syntax {
     }
 
     #[test]
+    fn multiple_override_specifiers() -> Result<()> {
+        run("syntax", "multiple_override_specifiers")
+    }
+
+    #[test]
     fn unexpected_eof() -> Result<()> {
         run("syntax", "unexpected_eof")
     }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/generated/0.8.0-failure.txt
@@ -1,0 +1,43 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 5
+
+Error: Only a single override specifier can be provided.
+    ╭─[input.sol:12:36]
+    │
+ 12 │     function foo() public override override {}
+    │                                    ────┬───  
+    │                                        ╰───── Error occurred here.
+────╯
+
+Error: Only a single override specifier can be provided.
+    ╭─[input.sol:13:34]
+    │
+ 13 │     fallback() external override override payable {}
+    │                                  ────┬───  
+    │                                      ╰───── Error occurred here.
+────╯
+
+Error: Only a single override specifier can be provided.
+    ╭─[input.sol:14:33]
+    │
+ 14 │     receive() external override override payable {}
+    │                                 ────┬───  
+    │                                     ╰───── Error occurred here.
+────╯
+
+Error: Only a single override specifier can be provided.
+    ╭─[input.sol:15:26]
+    │
+ 15 │     uint public override override x;
+    │                          ────┬───  
+    │                              ╰───── Error occurred here.
+────╯
+
+Error: Only a single override specifier can be provided.
+    ╭─[input.sol:16:35]
+    │
+ 16 │     modifier onlyOwner() override override {}
+    │                                   ────┬───  
+    │                                       ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/input.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+contract A {
+    uint public x;
+    function foo() public virtual {}
+    fallback() external virtual payable {}
+    receive() external virtual payable {}
+    modifier onlyOwner() virtual {}
+}
+
+contract B is A {
+    function foo() public override override {}
+    fallback() external override override payable {}
+    receive() external override override payable {}
+    uint public override override x;
+    modifier onlyOwner() override override {}
+}
+contract C is A {
+    function foo() public override {}
+    fallback() external override payable {}
+    receive() external override payable {}
+    uint public override x;
+    modifier onlyOwner() override {}
+}
+// (removed duplicate B and C)


### PR DESCRIPTION
This patch introduces a generic extractor for override attributes and applies it to methods, state variables, fallback, receive, and modifiers, ensuring duplicate override checks are performed consistently across all these constructs.