### PR TITLE
[v2] Minor API fixes

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -129,7 +129,7 @@ impl core::fmt::Debug for slang_solidity_v2_ast::abi::StorageItem
 pub fn slang_solidity_v2_ast::abi::StorageItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ast::abi::StorageItem
 pub fn slang_solidity_v2_ast::abi::selector_from_signature(signature: &str) -> u32
-pub type slang_solidity_v2_ast::abi::AbiMutability = slang_solidity_v2_semantic::types::FunctionMutability
+pub type slang_solidity_v2_ast::abi::AbiMutability = slang_solidity_v2_semantic::types::FunctionTypeMutability
 pub mod slang_solidity_v2_ast::ast
 pub use slang_solidity_v2_ast::ast::LiteralKind
 pub use slang_solidity_v2_ast::ast::Number
@@ -1724,10 +1724,10 @@ impl slang_solidity_v2_ast::ast::FunctionType
 pub fn slang_solidity_v2_ast::ast::FunctionType::associated_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::FunctionType::implicit_receiver_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FunctionType::is_externally_visible(&self) -> bool
-pub fn slang_solidity_v2_ast::ast::FunctionType::mutability(&self) -> slang_solidity_v2_semantic::types::FunctionMutability
+pub fn slang_solidity_v2_ast::ast::FunctionType::mutability(&self) -> slang_solidity_v2_semantic::types::FunctionTypeMutability
 pub fn slang_solidity_v2_ast::ast::FunctionType::parameter_types(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FunctionType::return_type(&self) -> slang_solidity_v2_ast::ast::Type
-pub fn slang_solidity_v2_ast::ast::FunctionType::visibility(&self) -> slang_solidity_v2_semantic::types::FunctionVisibility
+pub fn slang_solidity_v2_ast::ast::FunctionType::visibility(&self) -> slang_solidity_v2_semantic::types::FunctionTypeVisibility
 impl core::clone::Clone for slang_solidity_v2_ast::ast::FunctionType
 pub fn slang_solidity_v2_ast::ast::FunctionType::clone(&self) -> slang_solidity_v2_ast::ast::FunctionType
 pub struct slang_solidity_v2_ast::ast::FunctionTypeStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -9,7 +9,7 @@ use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use slang_solidity_v2_semantic::types::{FunctionMutability, Type, TypeId};
+use slang_solidity_v2_semantic::types::{FunctionTypeMutability, Type, TypeId};
 
 pub struct ContractAbi {
     node_id: NodeId,
@@ -46,7 +46,7 @@ impl ContractAbi {
     }
 }
 
-pub type AbiMutability = FunctionMutability;
+pub type AbiMutability = FunctionTypeMutability;
 
 #[derive(Clone, Debug)]
 pub struct AbiConstructor {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -5,7 +5,7 @@ use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{
-    self, DataLocation, FunctionMutability, FunctionVisibility, TypeId,
+    self, DataLocation, FunctionTypeMutability, FunctionTypeVisibility, TypeId,
 };
 pub use slang_solidity_v2_semantic::types::{LiteralKind, Number};
 
@@ -321,14 +321,14 @@ impl FunctionType {
         function_type.is_externally_visible()
     }
 
-    pub fn visibility(&self) -> FunctionVisibility {
+    pub fn visibility(&self) -> FunctionTypeVisibility {
         let types::Type::Function(function_type) = self.internal_type() else {
             unreachable!("invalid function type");
         };
         function_type.visibility
     }
 
-    pub fn mutability(&self) -> FunctionMutability {
+    pub fn mutability(&self) -> FunctionTypeMutability {
         let types::Type::Function(function_type) = self.internal_type() else {
             unreachable!("invalid function type");
         };

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -818,6 +818,8 @@ pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_6
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_7
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_8
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_9
+impl slang_solidity_v2_common::versions::LanguageVersion
+pub const slang_solidity_v2_common::versions::LanguageVersion::LATEST: Self
 impl core::clone::Clone for slang_solidity_v2_common::versions::LanguageVersion
 pub fn slang_solidity_v2_common::versions::LanguageVersion::clone(&self) -> slang_solidity_v2_common::versions::LanguageVersion
 impl core::cmp::Eq for slang_solidity_v2_common::versions::LanguageVersion

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/language_versions.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/language_versions.generated.rs
@@ -48,6 +48,10 @@ pub enum LanguageVersion {
     V0_8_35,
 }
 
+impl LanguageVersion {
+    pub const LATEST: Self = Self::V0_8_35;
+}
+
 #[derive(Debug, Error, PartialEq)]
 pub enum FromSemverError {
     #[error("provided version is not supported")]

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/language_versions.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/language_versions.rs.jinja2
@@ -13,6 +13,10 @@ pub enum LanguageVersion {
     {%- endfor -%}
 }
 
+impl LanguageVersion {
+    pub const LATEST: Self = Self::V{{ model.language.versions | last | split(pat=".") | join(sep="_") }};
+}
+
 #[derive(Debug, Error, PartialEq)]
 pub enum FromSemverError {
     #[error("provided version is not supported")]

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -23,7 +23,7 @@ contract MyContract {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::V0_8_30);
+    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -101,7 +101,7 @@ contract Test is Base layout at 0 {}
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::V0_8_30);
+    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
@@ -79,7 +79,7 @@ contract Counter is Ownable {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::V0_8_30);
+    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -305,42 +305,42 @@ impl core::hash::Hash for slang_solidity_v2_semantic::types::DataLocation
 pub fn slang_solidity_v2_semantic::types::DataLocation::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for slang_solidity_v2_semantic::types::DataLocation
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::DataLocation
-pub enum slang_solidity_v2_semantic::types::FunctionMutability
-pub slang_solidity_v2_semantic::types::FunctionMutability::NonPayable
-pub slang_solidity_v2_semantic::types::FunctionMutability::Payable
-pub slang_solidity_v2_semantic::types::FunctionMutability::Pure
-pub slang_solidity_v2_semantic::types::FunctionMutability::View
-impl core::clone::Clone for slang_solidity_v2_semantic::types::FunctionMutability
-pub fn slang_solidity_v2_semantic::types::FunctionMutability::clone(&self) -> slang_solidity_v2_semantic::types::FunctionMutability
-impl core::cmp::Eq for slang_solidity_v2_semantic::types::FunctionMutability
-impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FunctionMutability
-pub fn slang_solidity_v2_semantic::types::FunctionMutability::eq(&self, other: &slang_solidity_v2_semantic::types::FunctionMutability) -> bool
-impl core::convert::From<&slang_solidity_v2_ir::ir::nodes::FunctionMutability> for slang_solidity_v2_semantic::types::FunctionMutability
-pub fn slang_solidity_v2_semantic::types::FunctionMutability::from(value: &slang_solidity_v2_ir::ir::nodes::FunctionMutability) -> Self
-impl core::fmt::Debug for slang_solidity_v2_semantic::types::FunctionMutability
-pub fn slang_solidity_v2_semantic::types::FunctionMutability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for slang_solidity_v2_semantic::types::FunctionMutability
-pub fn slang_solidity_v2_semantic::types::FunctionMutability::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionMutability
-impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionMutability
-pub enum slang_solidity_v2_semantic::types::FunctionVisibility
-pub slang_solidity_v2_semantic::types::FunctionVisibility::External
-pub slang_solidity_v2_semantic::types::FunctionVisibility::Internal
-pub slang_solidity_v2_semantic::types::FunctionVisibility::Private
-pub slang_solidity_v2_semantic::types::FunctionVisibility::Public
-impl core::clone::Clone for slang_solidity_v2_semantic::types::FunctionVisibility
-pub fn slang_solidity_v2_semantic::types::FunctionVisibility::clone(&self) -> slang_solidity_v2_semantic::types::FunctionVisibility
-impl core::cmp::Eq for slang_solidity_v2_semantic::types::FunctionVisibility
-impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FunctionVisibility
-pub fn slang_solidity_v2_semantic::types::FunctionVisibility::eq(&self, other: &slang_solidity_v2_semantic::types::FunctionVisibility) -> bool
-impl core::convert::From<&slang_solidity_v2_ir::ir::nodes::FunctionVisibility> for slang_solidity_v2_semantic::types::FunctionVisibility
-pub fn slang_solidity_v2_semantic::types::FunctionVisibility::from(value: &slang_solidity_v2_ir::ir::nodes::FunctionVisibility) -> Self
-impl core::fmt::Debug for slang_solidity_v2_semantic::types::FunctionVisibility
-pub fn slang_solidity_v2_semantic::types::FunctionVisibility::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for slang_solidity_v2_semantic::types::FunctionVisibility
-pub fn slang_solidity_v2_semantic::types::FunctionVisibility::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionVisibility
-impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionVisibility
+pub enum slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub slang_solidity_v2_semantic::types::FunctionTypeMutability::NonPayable
+pub slang_solidity_v2_semantic::types::FunctionTypeMutability::Payable
+pub slang_solidity_v2_semantic::types::FunctionTypeMutability::Pure
+pub slang_solidity_v2_semantic::types::FunctionTypeMutability::View
+impl core::clone::Clone for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub fn slang_solidity_v2_semantic::types::FunctionTypeMutability::clone(&self) -> slang_solidity_v2_semantic::types::FunctionTypeMutability
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::FunctionTypeMutability
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub fn slang_solidity_v2_semantic::types::FunctionTypeMutability::eq(&self, other: &slang_solidity_v2_semantic::types::FunctionTypeMutability) -> bool
+impl core::convert::From<&slang_solidity_v2_ir::ir::nodes::FunctionMutability> for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub fn slang_solidity_v2_semantic::types::FunctionTypeMutability::from(value: &slang_solidity_v2_ir::ir::nodes::FunctionMutability) -> Self
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub fn slang_solidity_v2_semantic::types::FunctionTypeMutability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub fn slang_solidity_v2_semantic::types::FunctionTypeMutability::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionTypeMutability
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionTypeMutability
+pub enum slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub slang_solidity_v2_semantic::types::FunctionTypeVisibility::External
+pub slang_solidity_v2_semantic::types::FunctionTypeVisibility::Internal
+pub slang_solidity_v2_semantic::types::FunctionTypeVisibility::Private
+pub slang_solidity_v2_semantic::types::FunctionTypeVisibility::Public
+impl core::clone::Clone for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub fn slang_solidity_v2_semantic::types::FunctionTypeVisibility::clone(&self) -> slang_solidity_v2_semantic::types::FunctionTypeVisibility
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub fn slang_solidity_v2_semantic::types::FunctionTypeVisibility::eq(&self, other: &slang_solidity_v2_semantic::types::FunctionTypeVisibility) -> bool
+impl core::convert::From<&slang_solidity_v2_ir::ir::nodes::FunctionVisibility> for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub fn slang_solidity_v2_semantic::types::FunctionTypeVisibility::from(value: &slang_solidity_v2_ir::ir::nodes::FunctionVisibility) -> Self
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub fn slang_solidity_v2_semantic::types::FunctionTypeVisibility::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+pub fn slang_solidity_v2_semantic::types::FunctionTypeVisibility::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionTypeVisibility
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionTypeVisibility
 pub enum slang_solidity_v2_semantic::types::LiteralKind
 pub slang_solidity_v2_semantic::types::LiteralKind::Address
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger
@@ -447,10 +447,10 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Ty
 pub struct slang_solidity_v2_semantic::types::FunctionType
 pub slang_solidity_v2_semantic::types::FunctionType::definition_id: core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub slang_solidity_v2_semantic::types::FunctionType::implicit_receiver_type: core::option::Option<slang_solidity_v2_semantic::types::TypeId>
-pub slang_solidity_v2_semantic::types::FunctionType::mutability: slang_solidity_v2_semantic::types::FunctionMutability
+pub slang_solidity_v2_semantic::types::FunctionType::mutability: slang_solidity_v2_semantic::types::FunctionTypeMutability
 pub slang_solidity_v2_semantic::types::FunctionType::parameter_types: alloc::vec::Vec<slang_solidity_v2_semantic::types::TypeId>
 pub slang_solidity_v2_semantic::types::FunctionType::return_type: slang_solidity_v2_semantic::types::TypeId
-pub slang_solidity_v2_semantic::types::FunctionType::visibility: slang_solidity_v2_semantic::types::FunctionVisibility
+pub slang_solidity_v2_semantic::types::FunctionType::visibility: slang_solidity_v2_semantic::types::FunctionTypeVisibility
 impl slang_solidity_v2_semantic::types::FunctionType
 pub fn slang_solidity_v2_semantic::types::FunctionType::is_externally_visible(&self) -> bool
 impl core::clone::Clone for slang_solidity_v2_semantic::types::FunctionType

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -417,7 +417,7 @@ mod tests {
     fn parse_expression(input: &str) -> ir::Expression {
         // NB. the declaration is only a harness to contain the expression
         let source = format!("uint constant x = {input};");
-        let version = LanguageVersion::V0_8_35;
+        let version = LanguageVersion::LATEST;
 
         let ParseOutput {
             source_unit,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::{Definition, Scope};
 use crate::types::{
-    DataLocation, FunctionMutability, FunctionType, FunctionVisibility, Type, TypeId,
+    DataLocation, FunctionType, FunctionTypeMutability, FunctionTypeVisibility, Type, TypeId,
 };
 
 impl Pass<'_> {
@@ -260,8 +260,8 @@ impl Pass<'_> {
             implicit_receiver_type: Some(receiver_type_id),
             parameter_types,
             return_type,
-            visibility: FunctionVisibility::Public,
-            mutability: FunctionMutability::View,
+            visibility: FunctionTypeVisibility::Public,
+            mutability: FunctionTypeMutability::View,
         });
         Some(self.types.register_type(getter_type))
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -22,7 +22,7 @@ contract Test is Base layout at 0 {}
         "test.sol",
         CONTENTS,
         &mut id_generator,
-        LanguageVersion::V0_8_35,
+        LanguageVersion::LATEST,
     );
 
     let files = [file];
@@ -80,7 +80,7 @@ interface A is C {}
         "test.sol",
         CONTENTS,
         &mut id_generator,
-        LanguageVersion::V0_8_35,
+        LanguageVersion::LATEST,
     );
 
     let files = [file];
@@ -125,7 +125,7 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
         "test.sol",
         CONTENTS,
         &mut id_generator,
-        LanguageVersion::V0_8_35,
+        LanguageVersion::LATEST,
     );
 
     let files = [file];
@@ -173,7 +173,7 @@ contract Test is Base {
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let language_version = LanguageVersion::V0_8_35;
+    let language_version = LanguageVersion::LATEST;
     let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
 
     let files = [file];
@@ -227,7 +227,7 @@ contract Test is Base {
     "###;
 
     let mut id_generator = NodeIdGenerator::default();
-    let language_version = LanguageVersion::V0_8_35;
+    let language_version = LanguageVersion::LATEST;
     let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
 
     let files = [file];

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -43,7 +43,7 @@ fn try_type_of_value_expression_in_context(
 ) -> (Option<Type>, TypeRegistry) {
     let source = format!("{setup}\nuint constant x = {input};");
     let mut id_generator = NodeIdGenerator::default();
-    let language_version = LanguageVersion::V0_8_35;
+    let language_version = LanguageVersion::LATEST;
     let file = build_file("test.sol", &source, &mut id_generator, language_version);
     let files = [file];
 
@@ -772,7 +772,7 @@ contract Test {
 "#;
 
     let mut id_generator = NodeIdGenerator::default();
-    let language_version = LanguageVersion::V0_8_35;
+    let language_version = LanguageVersion::LATEST;
     let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
     let files = [file];
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -109,29 +109,29 @@ pub struct FunctionType {
     pub implicit_receiver_type: Option<TypeId>,
     pub parameter_types: Vec<TypeId>,
     pub return_type: TypeId,
-    pub visibility: FunctionVisibility,
-    pub mutability: FunctionMutability,
+    pub visibility: FunctionTypeVisibility,
+    pub mutability: FunctionTypeMutability,
 }
 
 impl FunctionType {
     pub fn is_externally_visible(&self) -> bool {
         matches!(
             self.visibility,
-            FunctionVisibility::External | FunctionVisibility::Public
+            FunctionTypeVisibility::External | FunctionTypeVisibility::Public
         )
     }
 }
 
 // Mirrors `ir::FunctionVisibility`
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum FunctionVisibility {
+pub enum FunctionTypeVisibility {
     Public,
     Private,
     Internal,
     External,
 }
 
-impl From<&ir::FunctionVisibility> for FunctionVisibility {
+impl From<&ir::FunctionVisibility> for FunctionTypeVisibility {
     fn from(value: &ir::FunctionVisibility) -> Self {
         match value {
             ir::FunctionVisibility::Public => Self::Public,
@@ -144,14 +144,14 @@ impl From<&ir::FunctionVisibility> for FunctionVisibility {
 
 // Mirrors `ir::FunctionMutability`
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum FunctionMutability {
+pub enum FunctionTypeMutability {
     Pure,
     View,
     NonPayable,
     Payable,
 }
 
-impl From<&ir::FunctionMutability> for FunctionMutability {
+impl From<&ir::FunctionMutability> for FunctionTypeMutability {
     fn from(value: &ir::FunctionMutability) -> Self {
         match value {
             ir::FunctionMutability::Pure => Self::Pure,
@@ -166,50 +166,50 @@ pub(crate) trait ImplicitlyConvertible<T> {
     fn implicitly_convertible_to(&self, target: T) -> bool;
 }
 
-impl ImplicitlyConvertible<FunctionVisibility> for FunctionVisibility {
+impl ImplicitlyConvertible<FunctionTypeVisibility> for FunctionTypeVisibility {
     fn implicitly_convertible_to(&self, target: Self) -> bool {
         matches!(
             (self, target),
             // public can convert to public, external or internal (if called
             // internally)
             (
-                FunctionVisibility::Public,
-                FunctionVisibility::Public
-                    | FunctionVisibility::Internal
-                    | FunctionVisibility::External,
+                FunctionTypeVisibility::Public,
+                FunctionTypeVisibility::Public
+                    | FunctionTypeVisibility::Internal
+                    | FunctionTypeVisibility::External,
             )
                 // private converts to private or internal
                 | (
-                    FunctionVisibility::Private,
-                    FunctionVisibility::Private | FunctionVisibility::Internal,
+                    FunctionTypeVisibility::Private,
+                    FunctionTypeVisibility::Private | FunctionTypeVisibility::Internal,
                 )
                 // internal and external only convert to themselves
-                | (FunctionVisibility::Internal, FunctionVisibility::Internal)
-                | (FunctionVisibility::External, FunctionVisibility::External)
+                | (FunctionTypeVisibility::Internal, FunctionTypeVisibility::Internal)
+                | (FunctionTypeVisibility::External, FunctionTypeVisibility::External)
         )
     }
 }
 
-impl ImplicitlyConvertible<FunctionMutability> for FunctionMutability {
+impl ImplicitlyConvertible<FunctionTypeMutability> for FunctionTypeMutability {
     fn implicitly_convertible_to(&self, target: Self) -> bool {
         matches!(
             (self, target),
             // pure converts to view or non-payable
             (
-                FunctionMutability::Pure,
-                FunctionMutability::Pure | FunctionMutability::View | FunctionMutability::NonPayable,
+                FunctionTypeMutability::Pure,
+                FunctionTypeMutability::Pure | FunctionTypeMutability::View | FunctionTypeMutability::NonPayable,
             )
                 // view converts to non-payable
                 | (
-                FunctionMutability::View,
-                FunctionMutability::View | FunctionMutability::NonPayable
+                FunctionTypeMutability::View,
+                FunctionTypeMutability::View | FunctionTypeMutability::NonPayable
             )
                 // non-payable does not implicitly convert to any other kind
-                | (FunctionMutability::NonPayable, FunctionMutability::NonPayable)
+                | (FunctionTypeMutability::NonPayable, FunctionTypeMutability::NonPayable)
                 // payable converts to non-payable
                 | (
-                    FunctionMutability::Payable,
-                    FunctionMutability::Payable | FunctionMutability::NonPayable,
+                    FunctionTypeMutability::Payable,
+                    FunctionTypeMutability::Payable | FunctionTypeMutability::NonPayable,
                 )
         )
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -5,7 +5,9 @@ use num_traits::Zero;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::literals::numbers;
-use super::{DataLocation, FunctionType, FunctionVisibility, LiteralKind, Number, Type, TypeId};
+use super::{
+    DataLocation, FunctionType, FunctionTypeVisibility, LiteralKind, Number, Type, TypeId,
+};
 use crate::types::ImplicitlyConvertible;
 
 /// The `TypeRegistry` stores an index of registered types, both elementary
@@ -408,7 +410,7 @@ impl TypeRegistry {
         function_type: FunctionType,
     ) -> FunctionType {
         FunctionType {
-            visibility: FunctionVisibility::External,
+            visibility: FunctionTypeVisibility::External,
             parameter_types: function_type
                 .parameter_types
                 .into_iter()
@@ -596,10 +598,10 @@ impl TypeRegistry {
         // The exception is if the `other` function is external which allows
         // changing the data location of parameters from `memory` to `calldata`
         // (or viceversa) if the visibility of `ftype` is external or public.
-        } else if matches!(other.visibility, FunctionVisibility::External)
+        } else if matches!(other.visibility, FunctionTypeVisibility::External)
             && matches!(
                 ftype.visibility,
-                FunctionVisibility::External | FunctionVisibility::Public
+                FunctionTypeVisibility::External | FunctionTypeVisibility::Public
             )
         {
             ftype

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -29,6 +29,13 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) 
 pub trait slang_solidity_v2::compilation::CompilationBuilderConfig
 pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::read_file(&mut self, file_id: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
 pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::resolve_import(&mut self, source_file_id: &str, import_path: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
+pub mod slang_solidity_v2::diagnostics
+pub use slang_solidity_v2::diagnostics::Diagnostic
+pub use slang_solidity_v2::diagnostics::DiagnosticCollection
+pub use slang_solidity_v2::diagnostics::DiagnosticExtensions
+pub use slang_solidity_v2::diagnostics::DiagnosticKind
+pub use slang_solidity_v2::diagnostics::DiagnosticSeverity
+pub use slang_solidity_v2::diagnostics::kinds
 pub mod slang_solidity_v2::utils
 pub use slang_solidity_v2::utils::FromSemverError
 pub use slang_solidity_v2::utils::LanguageVersion

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -7,6 +7,8 @@ pub mod slang_solidity_v2::ast
 pub use slang_solidity_v2::ast::<<slang_solidity_v2_ast::ast::*>>
 pub use slang_solidity_v2::ast::BuiltIn
 pub use slang_solidity_v2::ast::DataLocation
+pub use slang_solidity_v2::ast::FunctionTypeMutability
+pub use slang_solidity_v2::ast::FunctionTypeVisibility
 pub use slang_solidity_v2::ast::NodeId
 pub use slang_solidity_v2::ast::TypeId
 pub mod slang_solidity_v2::compilation

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/ast.rs
@@ -1,4 +1,6 @@
 pub use slang_solidity_v2_ast::ast::*;
 pub use slang_solidity_v2_common::built_ins::BuiltIn;
 pub use slang_solidity_v2_common::nodes::NodeId;
-pub use slang_solidity_v2_semantic::types::{DataLocation, TypeId};
+pub use slang_solidity_v2_semantic::types::{
+    DataLocation, FunctionTypeMutability, FunctionTypeVisibility, TypeId,
+};

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/diagnostics.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/diagnostics.rs
@@ -1,0 +1,4 @@
+pub use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
+pub use slang_solidity_v2_common::diagnostics::{
+    kinds, Diagnostic, DiagnosticCollection, DiagnosticExtensions, DiagnosticSeverity,
+};

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod abi;
 pub mod ast;
 pub mod compilation;
+pub mod diagnostics;
 pub mod utils;
 
 #[cfg(test)]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -76,7 +76,7 @@ impl CompilationBuilderConfig for FixtureBuildConfig<'_> {
 pub(super) fn build_compilation_unit_from_fixture(
     files: &[FixtureFile<'_>],
 ) -> Arc<CompilationUnit> {
-    let version = LanguageVersion::V0_8_35;
+    let version = LanguageVersion::LATEST;
     let mut builder = CompilationBuilder::create(version, FixtureBuildConfig { files });
 
     for file in files {


### PR DESCRIPTION
This PR fixes part of the issues identified in nomicFoundation/solx#453.

- Export a `LanguageVersion::LATEST` with the more recent version of Solidity supported
- Export a `diagnostics` module with the Diagnostic API types
- Fix function type mutability and visibility for exporting in the public API
