### PR TITLE
[v2] Simplify AST `Type` implementation to add `LiteralType::mobile_type()`

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -2104,6 +2104,7 @@ pub fn slang_solidity_v2_ast::ast::LibraryMembersStruct::serialize<S: serde_core
 pub struct slang_solidity_v2_ast::ast::LiteralType
 impl slang_solidity_v2_ast::ast::LiteralType
 pub fn slang_solidity_v2_ast::ast::LiteralType::kind(&self) -> slang_solidity_v2_semantic::types::LiteralKind
+pub fn slang_solidity_v2_ast::ast::LiteralType::mobile_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl core::clone::Clone for slang_solidity_v2_ast::ast::LiteralType
 pub fn slang_solidity_v2_ast::ast::LiteralType::clone(&self) -> slang_solidity_v2_ast::ast::LiteralType
 pub struct slang_solidity_v2_ast::ast::MappingType

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -928,11 +928,9 @@ pub slang_solidity_v2_ast::ast::Type::Tuple(slang_solidity_v2_ast::ast::TupleTyp
 pub slang_solidity_v2_ast::ast::Type::UserDefinedValue(slang_solidity_v2_ast::ast::UserDefinedValueType)
 pub slang_solidity_v2_ast::ast::Type::Void(slang_solidity_v2_ast::ast::VoidType)
 impl slang_solidity_v2_ast::ast::Type
-pub fn slang_solidity_v2_ast::ast::Type::create(type_id: slang_solidity_v2_semantic::types::TypeId, semantic: &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> Self
 pub fn slang_solidity_v2_ast::ast::Type::data_location(&self) -> core::option::Option<slang_solidity_v2_semantic::types::DataLocation>
 pub fn slang_solidity_v2_ast::ast::Type::is_reference_type(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::Type::try_create_for_node_id(node_id: slang_solidity_v2_common::nodes::NodeId, semantic: &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> core::option::Option<Self>
-pub fn slang_solidity_v2_ast::ast::Type::type_id(&self) -> slang_solidity_v2_semantic::types::TypeId
 impl core::clone::Clone for slang_solidity_v2_ast::ast::Type
 pub fn slang_solidity_v2_ast::ast::Type::clone(&self) -> slang_solidity_v2_ast::ast::Type
 pub enum slang_solidity_v2_ast::ast::TypeName

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1679,7 +1679,7 @@ pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::serialize<S: serde_core::
 pub struct slang_solidity_v2_ast::ast::FixedPointNumberType
 impl slang_solidity_v2_ast::ast::FixedPointNumberType
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::bits(&self) -> u32
-pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::precision_bits(&self) -> u32
+pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::decimal_places(&self) -> u32
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::signed(&self) -> bool
 impl core::clone::Clone for slang_solidity_v2_ast::ast::FixedPointNumberType
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::clone(&self) -> slang_solidity_v2_ast::ast::FixedPointNumberType

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -9,7 +9,9 @@ use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use slang_solidity_v2_semantic::types::{FunctionTypeMutability, Type, TypeId};
+use slang_solidity_v2_semantic::types::{
+    ArrayType, FunctionTypeMutability, StructType, Type, TypeId,
+};
 
 pub struct ContractAbi {
     node_id: NodeId,
@@ -392,12 +394,12 @@ fn type_as_abi_parameter_impl(
     visited_structs: &mut HashSet<NodeId>,
 ) -> Option<(String, Vec<ParameterComponent>)> {
     match semantic.types().get_type_by_id(type_id) {
-        Type::Array { element_type, .. } => {
+        Type::Array(ArrayType { element_type, .. }) => {
             let (element_type_name, element_components) =
                 type_as_abi_parameter_impl(semantic, *element_type, visited_structs)?;
             Some((format!("{element_type_name}[]"), element_components))
         }
-        Type::Struct { definition_id, .. } => {
+        Type::Struct(StructType { definition_id, .. }) => {
             // Recursive structs are not valid Solidity, but guard against cycles
             // to avoid unbounded recursion if malformed types reach this point.
             // TODO(validation) SDR[1]: The recursion should be detected in the

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -89,29 +89,29 @@ impl Type {
         let type_ = semantic.types().get_type_by_id(type_id);
         let semantic = Arc::clone(semantic);
         match type_ {
-            types::Type::Address { .. } => Self::Address(AddressType { type_id, semantic }),
-            types::Type::Array { .. } => Self::Array(ArrayType { type_id, semantic }),
+            types::Type::Address(_) => Self::Address(AddressType { type_id, semantic }),
+            types::Type::Array(_) => Self::Array(ArrayType { type_id, semantic }),
             types::Type::Boolean => Self::Boolean(BooleanType { type_id, semantic }),
-            types::Type::ByteArray { .. } => Self::ByteArray(ByteArrayType { type_id, semantic }),
-            types::Type::Bytes { .. } => Self::Bytes(BytesType { type_id, semantic }),
-            types::Type::Contract { .. } => Self::Contract(ContractType { type_id, semantic }),
-            types::Type::Enum { .. } => Self::Enum(EnumType { type_id, semantic }),
-            types::Type::FixedSizeArray { .. } => {
+            types::Type::ByteArray(_) => Self::ByteArray(ByteArrayType { type_id, semantic }),
+            types::Type::Bytes(_) => Self::Bytes(BytesType { type_id, semantic }),
+            types::Type::Contract(_) => Self::Contract(ContractType { type_id, semantic }),
+            types::Type::Enum(_) => Self::Enum(EnumType { type_id, semantic }),
+            types::Type::FixedSizeArray(_) => {
                 Self::FixedSizeArray(FixedSizeArrayType { type_id, semantic })
             }
-            types::Type::FixedPointNumber { .. } => {
+            types::Type::FixedPointNumber(_) => {
                 Self::FixedPointNumber(FixedPointNumberType { type_id, semantic })
             }
             types::Type::Function(_) => Self::Function(FunctionType { type_id, semantic }),
-            types::Type::Integer { .. } => Self::Integer(IntegerType { type_id, semantic }),
-            types::Type::Interface { .. } => Self::Interface(InterfaceType { type_id, semantic }),
-            types::Type::Library { .. } => Self::Library(LibraryType { type_id, semantic }),
+            types::Type::Integer(_) => Self::Integer(IntegerType { type_id, semantic }),
+            types::Type::Interface(_) => Self::Interface(InterfaceType { type_id, semantic }),
+            types::Type::Library(_) => Self::Library(LibraryType { type_id, semantic }),
             types::Type::Literal(_) => Self::Literal(LiteralType { type_id, semantic }),
-            types::Type::Mapping { .. } => Self::Mapping(MappingType { type_id, semantic }),
-            types::Type::String { .. } => Self::String(StringType { type_id, semantic }),
-            types::Type::Struct { .. } => Self::Struct(StructType { type_id, semantic }),
-            types::Type::Tuple { .. } => Self::Tuple(TupleType { type_id, semantic }),
-            types::Type::UserDefinedValue { .. } => {
+            types::Type::Mapping(_) => Self::Mapping(MappingType { type_id, semantic }),
+            types::Type::String(_) => Self::String(StringType { type_id, semantic }),
+            types::Type::Struct(_) => Self::Struct(StructType { type_id, semantic }),
+            types::Type::Tuple(_) => Self::Tuple(TupleType { type_id, semantic }),
+            types::Type::UserDefinedValue(_) => {
                 Self::UserDefinedValue(UserDefinedValueType { type_id, semantic })
             }
             types::Type::Void => Self::Void(VoidType { type_id, semantic }),
@@ -178,25 +178,25 @@ impl Type {
 
 impl AddressType {
     pub fn payable(&self) -> bool {
-        let types::Type::Address { payable } = self.internal_type() else {
+        let types::Type::Address(details) = self.internal_type() else {
             unreachable!("invalid address type");
         };
-        *payable
+        details.payable
     }
 }
 
 impl ArrayType {
     pub fn element_type(&self) -> Type {
-        let types::Type::Array { element_type, .. } = self.internal_type() else {
+        let types::Type::Array(details) = self.internal_type() else {
             unreachable!("invalid array type");
         };
-        Type::create(*element_type, &self.semantic)
+        Type::create(details.element_type, &self.semantic)
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::Array { location, .. } = self.internal_type() else {
+        let types::Type::Array(details) = self.internal_type() else {
             unreachable!("invalid array type");
         };
-        *location
+        details.location
     }
 }
 
@@ -204,79 +204,81 @@ impl BooleanType {}
 
 impl ByteArrayType {
     pub fn width(&self) -> u32 {
-        let types::Type::ByteArray { width } = self.internal_type() else {
+        let types::Type::ByteArray(details) = self.internal_type() else {
             unreachable!("invalid byte array type");
         };
-        *width
+        details.width
     }
 }
 
 impl BytesType {
     pub fn location(&self) -> DataLocation {
-        let types::Type::Bytes { location } = self.internal_type() else {
+        let types::Type::Bytes(details) = self.internal_type() else {
             unreachable!("invalid bytes type");
         };
-        *location
+        details.location
     }
 }
 
 impl ContractType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Contract { definition_id } = self.internal_type() else {
+        let types::Type::Contract(details) = self.internal_type() else {
             unreachable!("invalid contract type");
         };
-        Definition::try_create(*definition_id, &self.semantic).expect("invalid contract definition")
+        Definition::try_create(details.definition_id, &self.semantic)
+            .expect("invalid contract definition")
     }
 }
 
 impl EnumType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Enum { definition_id } = self.internal_type() else {
+        let types::Type::Enum(details) = self.internal_type() else {
             unreachable!("invalid enum type");
         };
-        Definition::try_create(*definition_id, &self.semantic).expect("invalid enum definition")
+        Definition::try_create(details.definition_id, &self.semantic)
+            .expect("invalid enum definition")
     }
 }
 
 impl FixedSizeArrayType {
     pub fn element_type(&self) -> Type {
-        let types::Type::FixedSizeArray { element_type, .. } = self.internal_type() else {
+        let types::Type::FixedSizeArray(details) = self.internal_type() else {
             unreachable!("invalid fixed-size array type");
         };
-        Type::create(*element_type, &self.semantic)
+        Type::create(details.element_type, &self.semantic)
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::FixedSizeArray { location, .. } = self.internal_type() else {
+        let types::Type::FixedSizeArray(details) = self.internal_type() else {
             unreachable!("invalid fixed-size array type");
         };
-        *location
+        details.location
     }
     pub fn size(&self) -> usize {
-        let types::Type::FixedSizeArray { size, .. } = self.internal_type() else {
+        let types::Type::FixedSizeArray(details) = self.internal_type() else {
             unreachable!("invalid fixed-size array type");
         };
-        *size
+        details.size
     }
 }
 
 impl FixedPointNumberType {
     pub fn signed(&self) -> bool {
-        let types::Type::FixedPointNumber { signed, .. } = self.internal_type() else {
+        let types::Type::FixedPointNumber(details) = self.internal_type() else {
             unreachable!("invalid fixed point number type");
         };
-        *signed
+        details.signed
     }
     pub fn bits(&self) -> u32 {
-        let types::Type::FixedPointNumber { bits, .. } = self.internal_type() else {
+        let types::Type::FixedPointNumber(details) = self.internal_type() else {
             unreachable!("invalid fixed point number type");
         };
-        *bits
+        details.bits
     }
     pub fn precision_bits(&self) -> u32 {
-        let types::Type::FixedPointNumber { precision_bits, .. } = self.internal_type() else {
+        let types::Type::FixedPointNumber(details) = self.internal_type() else {
             unreachable!("invalid fixed point number type");
         };
-        *precision_bits
+        details.precision_bits
     }
 }
 
@@ -342,35 +344,36 @@ impl FunctionType {
 
 impl IntegerType {
     pub fn signed(&self) -> bool {
-        let types::Type::Integer { signed, .. } = self.internal_type() else {
+        let types::Type::Integer(details) = self.internal_type() else {
             unreachable!("invalid integer type");
         };
-        *signed
+        details.signed
     }
     pub fn bits(&self) -> u32 {
-        let types::Type::Integer { bits, .. } = self.internal_type() else {
+        let types::Type::Integer(details) = self.internal_type() else {
             unreachable!("invalid integer type");
         };
-        *bits
+        details.bits
     }
 }
 
 impl InterfaceType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Interface { definition_id } = self.internal_type() else {
+        let types::Type::Interface(details) = self.internal_type() else {
             unreachable!("invalid interface type");
         };
-        Definition::try_create(*definition_id, &self.semantic)
+        Definition::try_create(details.definition_id, &self.semantic)
             .expect("invalid interface definition")
     }
 }
 
 impl LibraryType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Library { definition_id } = self.internal_type() else {
+        let types::Type::Library(details) = self.internal_type() else {
             unreachable!("invalid library type");
         };
-        Definition::try_create(*definition_id, &self.semantic).expect("invalid library definition")
+        Definition::try_create(details.definition_id, &self.semantic)
+            .expect("invalid library definition")
     }
 }
 
@@ -386,49 +389,51 @@ impl LiteralType {
 
 impl MappingType {
     pub fn key_type(&self) -> Type {
-        let types::Type::Mapping { key_type_id, .. } = self.internal_type() else {
+        let types::Type::Mapping(details) = self.internal_type() else {
             unreachable!("invalid mapping type");
         };
-        Type::create(*key_type_id, &self.semantic)
+        Type::create(details.key_type_id, &self.semantic)
     }
     pub fn value_type(&self) -> Type {
-        let types::Type::Mapping { value_type_id, .. } = self.internal_type() else {
+        let types::Type::Mapping(details) = self.internal_type() else {
             unreachable!("invalid mapping type");
         };
-        Type::create(*value_type_id, &self.semantic)
+        Type::create(details.value_type_id, &self.semantic)
     }
 }
 
 impl StringType {
     pub fn location(&self) -> DataLocation {
-        let types::Type::String { location } = self.internal_type() else {
+        let types::Type::String(details) = self.internal_type() else {
             unreachable!("invalid string type");
         };
-        *location
+        details.location
     }
 }
 
 impl StructType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Struct { definition_id, .. } = self.internal_type() else {
+        let types::Type::Struct(details) = self.internal_type() else {
             unreachable!("invalid struct type");
         };
-        Definition::try_create(*definition_id, &self.semantic).expect("invalid struct definition")
+        Definition::try_create(details.definition_id, &self.semantic)
+            .expect("invalid struct definition")
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::Struct { location, .. } = self.internal_type() else {
+        let types::Type::Struct(details) = self.internal_type() else {
             unreachable!("invalid struct type");
         };
-        *location
+        details.location
     }
 }
 
 impl TupleType {
     pub fn types(&self) -> Vec<Type> {
-        let types::Type::Tuple { types } = self.internal_type() else {
+        let types::Type::Tuple(details) = self.internal_type() else {
             unreachable!("invalid tuple type");
         };
-        types
+        details
+            .types
             .iter()
             .map(|type_id| Type::create(*type_id, &self.semantic))
             .collect()
@@ -437,10 +442,10 @@ impl TupleType {
 
 impl UserDefinedValueType {
     pub fn definition(&self) -> Definition {
-        let types::Type::UserDefinedValue { definition_id } = self.internal_type() else {
+        let types::Type::UserDefinedValue(details) = self.internal_type() else {
             unreachable!("invalid user defined value type");
         };
-        Definition::try_create(*definition_id, &self.semantic)
+        Definition::try_create(details.definition_id, &self.semantic)
             .expect("invalid user defined value definition")
     }
 
@@ -448,13 +453,13 @@ impl UserDefinedValueType {
     /// if the binder did not resolve a target type (e.g., the declaration is
     /// ill-formed or references an unsupported elementary type).
     pub fn target_type(&self) -> Option<Type> {
-        let types::Type::UserDefinedValue { definition_id } = self.internal_type() else {
+        let types::Type::UserDefinedValue(details) = self.internal_type() else {
             unreachable!("invalid user defined value type");
         };
         let binder_definition = self
             .semantic
             .binder()
-            .find_definition_by_id(*definition_id)?;
+            .find_definition_by_id(details.definition_id)?;
         let binder::Definition::UserDefinedValueType(udvt_definition) = binder_definition else {
             unreachable!("UDVT type id should map to UDVT definition");
         };

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -36,45 +36,61 @@ pub enum Type {
     Void(VoidType),
 }
 
-macro_rules! define_type_variant {
+macro_rules! define_value_type_variant {
     ($type:ident) => {
         paste! {
             #[derive(Clone)]
             pub struct [<$type Type>] {
-                type_id: TypeId,
-                semantic: Arc<SemanticContext>,
-            }
-
-            impl [<$type Type>] {
-                #[allow(unused)]
-                fn internal_type(&self) -> &types::Type {
-                    self.semantic.types().get_type_by_id(self.type_id)
-                }
+                inner: types::[<$type Type>],
             }
         }
     };
 }
 
-define_type_variant!(Address);
+macro_rules! define_type_variant {
+    ($type:ident) => {
+        paste! {
+            #[derive(Clone)]
+            pub struct [<$type Type>] {
+                inner: types::[<$type Type>],
+                semantic: Arc<SemanticContext>,
+            }
+        }
+    };
+}
+
+// Variants whose accessors only read fields from the inner struct.
+define_value_type_variant!(Address);
+define_value_type_variant!(ByteArray);
+define_value_type_variant!(Bytes);
+define_value_type_variant!(FixedPointNumber);
+define_value_type_variant!(Integer);
+define_value_type_variant!(String);
+
+// Variants that need the semantic context to resolve nested types or
+// definitions.
 define_type_variant!(Array);
-define_type_variant!(Boolean);
-define_type_variant!(ByteArray);
-define_type_variant!(Bytes);
 define_type_variant!(Contract);
 define_type_variant!(Enum);
 define_type_variant!(FixedSizeArray);
-define_type_variant!(FixedPointNumber);
 define_type_variant!(Function);
-define_type_variant!(Integer);
 define_type_variant!(Interface);
 define_type_variant!(Library);
-define_type_variant!(Literal);
 define_type_variant!(Mapping);
-define_type_variant!(String);
 define_type_variant!(Struct);
 define_type_variant!(Tuple);
 define_type_variant!(UserDefinedValue);
-define_type_variant!(Void);
+
+#[derive(Clone)]
+pub struct LiteralType {
+    inner: LiteralKind,
+}
+
+#[derive(Clone)]
+pub struct BooleanType;
+
+#[derive(Clone)]
+pub struct VoidType;
 
 impl Type {
     pub fn try_create_for_node_id(
@@ -86,35 +102,35 @@ impl Type {
     }
 
     pub(crate) fn create(type_id: TypeId, semantic: &Arc<SemanticContext>) -> Self {
-        let type_ = semantic.types().get_type_by_id(type_id);
+        let type_ = semantic.types().get_type_by_id(type_id).clone();
         let semantic = Arc::clone(semantic);
         match type_ {
-            types::Type::Address(_) => Self::Address(AddressType { type_id, semantic }),
-            types::Type::Array(_) => Self::Array(ArrayType { type_id, semantic }),
-            types::Type::Boolean => Self::Boolean(BooleanType { type_id, semantic }),
-            types::Type::ByteArray(_) => Self::ByteArray(ByteArrayType { type_id, semantic }),
-            types::Type::Bytes(_) => Self::Bytes(BytesType { type_id, semantic }),
-            types::Type::Contract(_) => Self::Contract(ContractType { type_id, semantic }),
-            types::Type::Enum(_) => Self::Enum(EnumType { type_id, semantic }),
-            types::Type::FixedSizeArray(_) => {
-                Self::FixedSizeArray(FixedSizeArrayType { type_id, semantic })
+            types::Type::Address(inner) => Self::Address(AddressType { inner }),
+            types::Type::Array(inner) => Self::Array(ArrayType { inner, semantic }),
+            types::Type::Boolean => Self::Boolean(BooleanType),
+            types::Type::ByteArray(inner) => Self::ByteArray(ByteArrayType { inner }),
+            types::Type::Bytes(inner) => Self::Bytes(BytesType { inner }),
+            types::Type::Contract(inner) => Self::Contract(ContractType { inner, semantic }),
+            types::Type::Enum(inner) => Self::Enum(EnumType { inner, semantic }),
+            types::Type::FixedSizeArray(inner) => {
+                Self::FixedSizeArray(FixedSizeArrayType { inner, semantic })
             }
-            types::Type::FixedPointNumber(_) => {
-                Self::FixedPointNumber(FixedPointNumberType { type_id, semantic })
+            types::Type::FixedPointNumber(inner) => {
+                Self::FixedPointNumber(FixedPointNumberType { inner })
             }
-            types::Type::Function(_) => Self::Function(FunctionType { type_id, semantic }),
-            types::Type::Integer(_) => Self::Integer(IntegerType { type_id, semantic }),
-            types::Type::Interface(_) => Self::Interface(InterfaceType { type_id, semantic }),
-            types::Type::Library(_) => Self::Library(LibraryType { type_id, semantic }),
-            types::Type::Literal(_) => Self::Literal(LiteralType { type_id, semantic }),
-            types::Type::Mapping(_) => Self::Mapping(MappingType { type_id, semantic }),
-            types::Type::String(_) => Self::String(StringType { type_id, semantic }),
-            types::Type::Struct(_) => Self::Struct(StructType { type_id, semantic }),
-            types::Type::Tuple(_) => Self::Tuple(TupleType { type_id, semantic }),
-            types::Type::UserDefinedValue(_) => {
-                Self::UserDefinedValue(UserDefinedValueType { type_id, semantic })
+            types::Type::Function(inner) => Self::Function(FunctionType { inner, semantic }),
+            types::Type::Integer(inner) => Self::Integer(IntegerType { inner }),
+            types::Type::Interface(inner) => Self::Interface(InterfaceType { inner, semantic }),
+            types::Type::Library(inner) => Self::Library(LibraryType { inner, semantic }),
+            types::Type::Literal(inner) => Self::Literal(LiteralType { inner }),
+            types::Type::Mapping(inner) => Self::Mapping(MappingType { inner, semantic }),
+            types::Type::String(inner) => Self::String(StringType { inner }),
+            types::Type::Struct(inner) => Self::Struct(StructType { inner, semantic }),
+            types::Type::Tuple(inner) => Self::Tuple(TupleType { inner, semantic }),
+            types::Type::UserDefinedValue(inner) => {
+                Self::UserDefinedValue(UserDefinedValueType { inner, semantic })
             }
-            types::Type::Void => Self::Void(VoidType { type_id, semantic }),
+            types::Type::Void => Self::Void(VoidType),
         }
     }
 
@@ -153,25 +169,16 @@ impl Type {
 
 impl AddressType {
     pub fn payable(&self) -> bool {
-        let types::Type::Address(details) = self.internal_type() else {
-            unreachable!("invalid address type");
-        };
-        details.payable
+        self.inner.payable
     }
 }
 
 impl ArrayType {
     pub fn element_type(&self) -> Type {
-        let types::Type::Array(details) = self.internal_type() else {
-            unreachable!("invalid array type");
-        };
-        Type::create(details.element_type, &self.semantic)
+        Type::create(self.inner.element_type, &self.semantic)
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::Array(details) = self.internal_type() else {
-            unreachable!("invalid array type");
-        };
-        details.location
+        self.inner.location
     }
 }
 
@@ -179,109 +186,70 @@ impl BooleanType {}
 
 impl ByteArrayType {
     pub fn width(&self) -> u32 {
-        let types::Type::ByteArray(details) = self.internal_type() else {
-            unreachable!("invalid byte array type");
-        };
-        details.width
+        self.inner.width
     }
 }
 
 impl BytesType {
     pub fn location(&self) -> DataLocation {
-        let types::Type::Bytes(details) = self.internal_type() else {
-            unreachable!("invalid bytes type");
-        };
-        details.location
+        self.inner.location
     }
 }
 
 impl ContractType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Contract(details) = self.internal_type() else {
-            unreachable!("invalid contract type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid contract definition")
     }
 }
 
 impl EnumType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Enum(details) = self.internal_type() else {
-            unreachable!("invalid enum type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid enum definition")
     }
 }
 
 impl FixedSizeArrayType {
     pub fn element_type(&self) -> Type {
-        let types::Type::FixedSizeArray(details) = self.internal_type() else {
-            unreachable!("invalid fixed-size array type");
-        };
-        Type::create(details.element_type, &self.semantic)
+        Type::create(self.inner.element_type, &self.semantic)
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::FixedSizeArray(details) = self.internal_type() else {
-            unreachable!("invalid fixed-size array type");
-        };
-        details.location
+        self.inner.location
     }
     pub fn size(&self) -> usize {
-        let types::Type::FixedSizeArray(details) = self.internal_type() else {
-            unreachable!("invalid fixed-size array type");
-        };
-        details.size
+        self.inner.size
     }
 }
 
 impl FixedPointNumberType {
     pub fn signed(&self) -> bool {
-        let types::Type::FixedPointNumber(details) = self.internal_type() else {
-            unreachable!("invalid fixed point number type");
-        };
-        details.signed
+        self.inner.signed
     }
     pub fn bits(&self) -> u32 {
-        let types::Type::FixedPointNumber(details) = self.internal_type() else {
-            unreachable!("invalid fixed point number type");
-        };
-        details.bits
+        self.inner.bits
     }
     pub fn precision_bits(&self) -> u32 {
-        let types::Type::FixedPointNumber(details) = self.internal_type() else {
-            unreachable!("invalid fixed point number type");
-        };
-        details.precision_bits
+        self.inner.precision_bits
     }
 }
 
 impl FunctionType {
     pub fn associated_definition(&self) -> Option<Definition> {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type.definition_id.map(|definition_id| {
+        self.inner.definition_id.map(|definition_id| {
             Definition::try_create(definition_id, &self.semantic)
                 .expect("invalid function definition")
         })
     }
 
     pub fn implicit_receiver_type(&self) -> Option<Type> {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type
+        self.inner
             .implicit_receiver_type
             .map(|type_id| Type::create(type_id, &self.semantic))
     }
 
     pub fn parameter_types(&self) -> Vec<Type> {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type
+        self.inner
             .parameter_types
             .iter()
             .map(|type_id| Type::create(*type_id, &self.semantic))
@@ -289,65 +257,41 @@ impl FunctionType {
     }
 
     pub fn return_type(&self) -> Type {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        Type::create(function_type.return_type, &self.semantic)
+        Type::create(self.inner.return_type, &self.semantic)
     }
 
     pub fn is_externally_visible(&self) -> bool {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type.is_externally_visible()
+        self.inner.is_externally_visible()
     }
 
     pub fn visibility(&self) -> FunctionTypeVisibility {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type.visibility
+        self.inner.visibility
     }
 
     pub fn mutability(&self) -> FunctionTypeMutability {
-        let types::Type::Function(function_type) = self.internal_type() else {
-            unreachable!("invalid function type");
-        };
-        function_type.mutability
+        self.inner.mutability
     }
 }
 
 impl IntegerType {
     pub fn signed(&self) -> bool {
-        let types::Type::Integer(details) = self.internal_type() else {
-            unreachable!("invalid integer type");
-        };
-        details.signed
+        self.inner.signed
     }
     pub fn bits(&self) -> u32 {
-        let types::Type::Integer(details) = self.internal_type() else {
-            unreachable!("invalid integer type");
-        };
-        details.bits
+        self.inner.bits
     }
 }
 
 impl InterfaceType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Interface(details) = self.internal_type() else {
-            unreachable!("invalid interface type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid interface definition")
     }
 }
 
 impl LibraryType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Library(details) = self.internal_type() else {
-            unreachable!("invalid library type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid library definition")
     }
 }
@@ -355,59 +299,38 @@ impl LibraryType {
 impl LiteralType {
     /// Returns the narrowed kind of this literal type.
     pub fn kind(&self) -> LiteralKind {
-        let types::Type::Literal(kind) = self.internal_type() else {
-            unreachable!("LiteralType wraps a literal variant by construction")
-        };
-        kind.clone()
+        self.inner.clone()
     }
 }
 
 impl MappingType {
     pub fn key_type(&self) -> Type {
-        let types::Type::Mapping(details) = self.internal_type() else {
-            unreachable!("invalid mapping type");
-        };
-        Type::create(details.key_type_id, &self.semantic)
+        Type::create(self.inner.key_type_id, &self.semantic)
     }
     pub fn value_type(&self) -> Type {
-        let types::Type::Mapping(details) = self.internal_type() else {
-            unreachable!("invalid mapping type");
-        };
-        Type::create(details.value_type_id, &self.semantic)
+        Type::create(self.inner.value_type_id, &self.semantic)
     }
 }
 
 impl StringType {
     pub fn location(&self) -> DataLocation {
-        let types::Type::String(details) = self.internal_type() else {
-            unreachable!("invalid string type");
-        };
-        details.location
+        self.inner.location
     }
 }
 
 impl StructType {
     pub fn definition(&self) -> Definition {
-        let types::Type::Struct(details) = self.internal_type() else {
-            unreachable!("invalid struct type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid struct definition")
     }
     pub fn location(&self) -> DataLocation {
-        let types::Type::Struct(details) = self.internal_type() else {
-            unreachable!("invalid struct type");
-        };
-        details.location
+        self.inner.location
     }
 }
 
 impl TupleType {
     pub fn types(&self) -> Vec<Type> {
-        let types::Type::Tuple(details) = self.internal_type() else {
-            unreachable!("invalid tuple type");
-        };
-        details
+        self.inner
             .types
             .iter()
             .map(|type_id| Type::create(*type_id, &self.semantic))
@@ -417,10 +340,7 @@ impl TupleType {
 
 impl UserDefinedValueType {
     pub fn definition(&self) -> Definition {
-        let types::Type::UserDefinedValue(details) = self.internal_type() else {
-            unreachable!("invalid user defined value type");
-        };
-        Definition::try_create(details.definition_id, &self.semantic)
+        Definition::try_create(self.inner.definition_id, &self.semantic)
             .expect("invalid user defined value definition")
     }
 
@@ -428,13 +348,10 @@ impl UserDefinedValueType {
     /// if the binder did not resolve a target type (e.g., the declaration is
     /// ill-formed or references an unsupported elementary type).
     pub fn target_type(&self) -> Option<Type> {
-        let types::Type::UserDefinedValue(details) = self.internal_type() else {
-            unreachable!("invalid user defined value type");
-        };
         let binder_definition = self
             .semantic
             .binder()
-            .find_definition_by_id(details.definition_id)?;
+            .find_definition_by_id(self.inner.definition_id)?;
         let binder::Definition::UserDefinedValueType(udvt_definition) = binder_definition else {
             unreachable!("UDVT type id should map to UDVT definition");
         };

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -303,17 +303,19 @@ impl LiteralType {
     }
 
     /// Returns the non-literal mobile type this literal can flow into (e.g.,
-    /// the smallest integer type that fits an integer literal, or
-    /// `string memory` for a string literal). Returns `None` for literals
-    /// without a mobile type (e.g., non-reducing rationals).
+    /// the smallest integer type that fits an integer literal, the smallest
+    /// fixed-point type that fits a rational literal, or `string memory`
+    /// for a string literal). Returns `None` when the literal cannot be
+    /// represented (eg. integer would require more than 256 bits).
     // __SLANG_MOBILE_TYPE__ keep in sync with `LiteralKind::mobile_type`
     pub fn mobile_type(&self) -> Option<Type> {
         self.inner.mobile_type().and_then(|mobile| match mobile {
             types::Type::Integer(inner) => Some(Type::Integer(IntegerType { inner })),
+            types::Type::FixedPointNumber(inner) => {
+                Some(Type::FixedPointNumber(FixedPointNumberType { inner }))
+            }
             types::Type::String(inner) => Some(Type::String(StringType { inner })),
             types::Type::Address(inner) => Some(Type::Address(AddressType { inner })),
-            // Other mobile types (e.g., future fixed-point for rational
-            // literals) are not yet surfaced to the AST.
             _ => None,
         })
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -301,6 +301,22 @@ impl LiteralType {
     pub fn kind(&self) -> LiteralKind {
         self.inner.clone()
     }
+
+    /// Returns the non-literal mobile type this literal can flow into (e.g.,
+    /// the smallest integer type that fits an integer literal, or
+    /// `string memory` for a string literal). Returns `None` for literals
+    /// without a mobile type (e.g., non-reducing rationals).
+    // __SLANG_MOBILE_TYPE__ keep in sync with `LiteralKind::mobile_type`
+    pub fn mobile_type(&self) -> Option<Type> {
+        self.inner.mobile_type().and_then(|mobile| match mobile {
+            types::Type::Integer(inner) => Some(Type::Integer(IntegerType { inner })),
+            types::Type::String(inner) => Some(Type::String(StringType { inner })),
+            types::Type::Address(inner) => Some(Type::Address(AddressType { inner })),
+            // Other mobile types (e.g., future fixed-point for rational
+            // literals) are not yet surfaced to the AST.
+            _ => None,
+        })
+    }
 }
 
 impl MappingType {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -85,7 +85,7 @@ impl Type {
         Some(Self::create(type_id, semantic))
     }
 
-    pub fn create(type_id: TypeId, semantic: &Arc<SemanticContext>) -> Self {
+    pub(crate) fn create(type_id: TypeId, semantic: &Arc<SemanticContext>) -> Self {
         let type_ = semantic.types().get_type_by_id(type_id);
         let semantic = Arc::clone(semantic);
         match type_ {
@@ -115,31 +115,6 @@ impl Type {
                 Self::UserDefinedValue(UserDefinedValueType { type_id, semantic })
             }
             types::Type::Void => Self::Void(VoidType { type_id, semantic }),
-        }
-    }
-
-    pub fn type_id(&self) -> TypeId {
-        match self {
-            Type::Address(details) => details.type_id,
-            Type::Array(details) => details.type_id,
-            Type::Boolean(details) => details.type_id,
-            Type::ByteArray(details) => details.type_id,
-            Type::Bytes(details) => details.type_id,
-            Type::Contract(details) => details.type_id,
-            Type::Enum(details) => details.type_id,
-            Type::FixedSizeArray(details) => details.type_id,
-            Type::FixedPointNumber(details) => details.type_id,
-            Type::Function(details) => details.type_id,
-            Type::Integer(details) => details.type_id,
-            Type::Interface(details) => details.type_id,
-            Type::Library(details) => details.type_id,
-            Type::Literal(details) => details.type_id,
-            Type::Mapping(details) => details.type_id,
-            Type::String(details) => details.type_id,
-            Type::Struct(details) => details.type_id,
-            Type::Tuple(details) => details.type_id,
-            Type::UserDefinedValue(details) => details.type_id,
-            Type::Void(details) => details.type_id,
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -229,8 +229,8 @@ impl FixedPointNumberType {
     pub fn bits(&self) -> u32 {
         self.inner.bits
     }
-    pub fn precision_bits(&self) -> u32 {
-        self.inner.precision_bits
+    pub fn decimal_places(&self) -> u32 {
+        self.inner.decimal_places
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -355,6 +355,8 @@ pub slang_solidity_v2_semantic::types::LiteralKind::Rational
 pub slang_solidity_v2_semantic::types::LiteralKind::Rational::value: num_rational::BigRational
 pub slang_solidity_v2_semantic::types::LiteralKind::String
 pub slang_solidity_v2_semantic::types::LiteralKind::String::bytes: usize
+impl slang_solidity_v2_semantic::types::LiteralKind
+pub fn slang_solidity_v2_semantic::types::LiteralKind::mobile_type(&self) -> core::option::Option<slang_solidity_v2_semantic::types::Type>
 impl core::clone::Clone for slang_solidity_v2_semantic::types::LiteralKind
 pub fn slang_solidity_v2_semantic::types::LiteralKind::clone(&self) -> slang_solidity_v2_semantic::types::LiteralKind
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::LiteralKind

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -346,7 +346,7 @@ pub slang_solidity_v2_semantic::types::LiteralKind::Address
 pub slang_solidity_v2_semantic::types::LiteralKind::Address::value: ruint::aliases::U160
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::bytes: u32
-pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::value: num_bigint::bigint::BigInt
+pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::value: num_bigint::biguint::BigUint
 pub slang_solidity_v2_semantic::types::LiteralKind::HexString
 pub slang_solidity_v2_semantic::types::LiteralKind::HexString::bytes: usize
 pub slang_solidity_v2_semantic::types::LiteralKind::Integer

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -380,49 +380,25 @@ impl core::fmt::Debug for slang_solidity_v2_semantic::types::Number
 pub fn slang_solidity_v2_semantic::types::Number::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Number
 pub enum slang_solidity_v2_semantic::types::Type
-pub slang_solidity_v2_semantic::types::Type::Address
-pub slang_solidity_v2_semantic::types::Type::Address::payable: bool
-pub slang_solidity_v2_semantic::types::Type::Array
-pub slang_solidity_v2_semantic::types::Type::Array::element_type: slang_solidity_v2_semantic::types::TypeId
-pub slang_solidity_v2_semantic::types::Type::Array::location: slang_solidity_v2_semantic::types::DataLocation
+pub slang_solidity_v2_semantic::types::Type::Address(slang_solidity_v2_semantic::types::AddressType)
+pub slang_solidity_v2_semantic::types::Type::Array(slang_solidity_v2_semantic::types::ArrayType)
 pub slang_solidity_v2_semantic::types::Type::Boolean
-pub slang_solidity_v2_semantic::types::Type::ByteArray
-pub slang_solidity_v2_semantic::types::Type::ByteArray::width: u32
-pub slang_solidity_v2_semantic::types::Type::Bytes
-pub slang_solidity_v2_semantic::types::Type::Bytes::location: slang_solidity_v2_semantic::types::DataLocation
-pub slang_solidity_v2_semantic::types::Type::Contract
-pub slang_solidity_v2_semantic::types::Type::Contract::definition_id: slang_solidity_v2_common::nodes::NodeId
-pub slang_solidity_v2_semantic::types::Type::Enum
-pub slang_solidity_v2_semantic::types::Type::Enum::definition_id: slang_solidity_v2_common::nodes::NodeId
-pub slang_solidity_v2_semantic::types::Type::FixedPointNumber
-pub slang_solidity_v2_semantic::types::Type::FixedPointNumber::bits: u32
-pub slang_solidity_v2_semantic::types::Type::FixedPointNumber::precision_bits: u32
-pub slang_solidity_v2_semantic::types::Type::FixedPointNumber::signed: bool
-pub slang_solidity_v2_semantic::types::Type::FixedSizeArray
-pub slang_solidity_v2_semantic::types::Type::FixedSizeArray::element_type: slang_solidity_v2_semantic::types::TypeId
-pub slang_solidity_v2_semantic::types::Type::FixedSizeArray::location: slang_solidity_v2_semantic::types::DataLocation
-pub slang_solidity_v2_semantic::types::Type::FixedSizeArray::size: usize
+pub slang_solidity_v2_semantic::types::Type::ByteArray(slang_solidity_v2_semantic::types::ByteArrayType)
+pub slang_solidity_v2_semantic::types::Type::Bytes(slang_solidity_v2_semantic::types::BytesType)
+pub slang_solidity_v2_semantic::types::Type::Contract(slang_solidity_v2_semantic::types::ContractType)
+pub slang_solidity_v2_semantic::types::Type::Enum(slang_solidity_v2_semantic::types::EnumType)
+pub slang_solidity_v2_semantic::types::Type::FixedPointNumber(slang_solidity_v2_semantic::types::FixedPointNumberType)
+pub slang_solidity_v2_semantic::types::Type::FixedSizeArray(slang_solidity_v2_semantic::types::FixedSizeArrayType)
 pub slang_solidity_v2_semantic::types::Type::Function(slang_solidity_v2_semantic::types::FunctionType)
-pub slang_solidity_v2_semantic::types::Type::Integer
-pub slang_solidity_v2_semantic::types::Type::Integer::bits: u32
-pub slang_solidity_v2_semantic::types::Type::Integer::signed: bool
-pub slang_solidity_v2_semantic::types::Type::Interface
-pub slang_solidity_v2_semantic::types::Type::Interface::definition_id: slang_solidity_v2_common::nodes::NodeId
-pub slang_solidity_v2_semantic::types::Type::Library
-pub slang_solidity_v2_semantic::types::Type::Library::definition_id: slang_solidity_v2_common::nodes::NodeId
+pub slang_solidity_v2_semantic::types::Type::Integer(slang_solidity_v2_semantic::types::IntegerType)
+pub slang_solidity_v2_semantic::types::Type::Interface(slang_solidity_v2_semantic::types::InterfaceType)
+pub slang_solidity_v2_semantic::types::Type::Library(slang_solidity_v2_semantic::types::LibraryType)
 pub slang_solidity_v2_semantic::types::Type::Literal(slang_solidity_v2_semantic::types::LiteralKind)
-pub slang_solidity_v2_semantic::types::Type::Mapping
-pub slang_solidity_v2_semantic::types::Type::Mapping::key_type_id: slang_solidity_v2_semantic::types::TypeId
-pub slang_solidity_v2_semantic::types::Type::Mapping::value_type_id: slang_solidity_v2_semantic::types::TypeId
-pub slang_solidity_v2_semantic::types::Type::String
-pub slang_solidity_v2_semantic::types::Type::String::location: slang_solidity_v2_semantic::types::DataLocation
-pub slang_solidity_v2_semantic::types::Type::Struct
-pub slang_solidity_v2_semantic::types::Type::Struct::definition_id: slang_solidity_v2_common::nodes::NodeId
-pub slang_solidity_v2_semantic::types::Type::Struct::location: slang_solidity_v2_semantic::types::DataLocation
-pub slang_solidity_v2_semantic::types::Type::Tuple
-pub slang_solidity_v2_semantic::types::Type::Tuple::types: alloc::vec::Vec<slang_solidity_v2_semantic::types::TypeId>
-pub slang_solidity_v2_semantic::types::Type::UserDefinedValue
-pub slang_solidity_v2_semantic::types::Type::UserDefinedValue::definition_id: slang_solidity_v2_common::nodes::NodeId
+pub slang_solidity_v2_semantic::types::Type::Mapping(slang_solidity_v2_semantic::types::MappingType)
+pub slang_solidity_v2_semantic::types::Type::String(slang_solidity_v2_semantic::types::StringType)
+pub slang_solidity_v2_semantic::types::Type::Struct(slang_solidity_v2_semantic::types::StructType)
+pub slang_solidity_v2_semantic::types::Type::Tuple(slang_solidity_v2_semantic::types::TupleType)
+pub slang_solidity_v2_semantic::types::Type::UserDefinedValue(slang_solidity_v2_semantic::types::UserDefinedValueType)
 pub slang_solidity_v2_semantic::types::Type::Void
 impl slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::can_return_from_getter_directly(&self) -> bool
@@ -447,6 +423,107 @@ pub fn slang_solidity_v2_semantic::types::Type::fmt(&self, f: &mut core::fmt::Fo
 impl core::hash::Hash for slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Type
+pub struct slang_solidity_v2_semantic::types::AddressType
+pub slang_solidity_v2_semantic::types::AddressType::payable: bool
+impl core::clone::Clone for slang_solidity_v2_semantic::types::AddressType
+pub fn slang_solidity_v2_semantic::types::AddressType::clone(&self) -> slang_solidity_v2_semantic::types::AddressType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::AddressType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::AddressType
+pub fn slang_solidity_v2_semantic::types::AddressType::eq(&self, other: &slang_solidity_v2_semantic::types::AddressType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::AddressType
+pub fn slang_solidity_v2_semantic::types::AddressType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::AddressType
+pub fn slang_solidity_v2_semantic::types::AddressType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::AddressType
+pub struct slang_solidity_v2_semantic::types::ArrayType
+pub slang_solidity_v2_semantic::types::ArrayType::element_type: slang_solidity_v2_semantic::types::TypeId
+pub slang_solidity_v2_semantic::types::ArrayType::location: slang_solidity_v2_semantic::types::DataLocation
+impl core::clone::Clone for slang_solidity_v2_semantic::types::ArrayType
+pub fn slang_solidity_v2_semantic::types::ArrayType::clone(&self) -> slang_solidity_v2_semantic::types::ArrayType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::ArrayType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::ArrayType
+pub fn slang_solidity_v2_semantic::types::ArrayType::eq(&self, other: &slang_solidity_v2_semantic::types::ArrayType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::ArrayType
+pub fn slang_solidity_v2_semantic::types::ArrayType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::ArrayType
+pub fn slang_solidity_v2_semantic::types::ArrayType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::ArrayType
+pub struct slang_solidity_v2_semantic::types::ByteArrayType
+pub slang_solidity_v2_semantic::types::ByteArrayType::width: u32
+impl core::clone::Clone for slang_solidity_v2_semantic::types::ByteArrayType
+pub fn slang_solidity_v2_semantic::types::ByteArrayType::clone(&self) -> slang_solidity_v2_semantic::types::ByteArrayType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::ByteArrayType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::ByteArrayType
+pub fn slang_solidity_v2_semantic::types::ByteArrayType::eq(&self, other: &slang_solidity_v2_semantic::types::ByteArrayType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::ByteArrayType
+pub fn slang_solidity_v2_semantic::types::ByteArrayType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::ByteArrayType
+pub fn slang_solidity_v2_semantic::types::ByteArrayType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::ByteArrayType
+pub struct slang_solidity_v2_semantic::types::BytesType
+pub slang_solidity_v2_semantic::types::BytesType::location: slang_solidity_v2_semantic::types::DataLocation
+impl core::clone::Clone for slang_solidity_v2_semantic::types::BytesType
+pub fn slang_solidity_v2_semantic::types::BytesType::clone(&self) -> slang_solidity_v2_semantic::types::BytesType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::BytesType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::BytesType
+pub fn slang_solidity_v2_semantic::types::BytesType::eq(&self, other: &slang_solidity_v2_semantic::types::BytesType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::BytesType
+pub fn slang_solidity_v2_semantic::types::BytesType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::BytesType
+pub fn slang_solidity_v2_semantic::types::BytesType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::BytesType
+pub struct slang_solidity_v2_semantic::types::ContractType
+pub slang_solidity_v2_semantic::types::ContractType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::ContractType
+pub fn slang_solidity_v2_semantic::types::ContractType::clone(&self) -> slang_solidity_v2_semantic::types::ContractType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::ContractType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::ContractType
+pub fn slang_solidity_v2_semantic::types::ContractType::eq(&self, other: &slang_solidity_v2_semantic::types::ContractType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::ContractType
+pub fn slang_solidity_v2_semantic::types::ContractType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::ContractType
+pub fn slang_solidity_v2_semantic::types::ContractType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::ContractType
+pub struct slang_solidity_v2_semantic::types::EnumType
+pub slang_solidity_v2_semantic::types::EnumType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::EnumType
+pub fn slang_solidity_v2_semantic::types::EnumType::clone(&self) -> slang_solidity_v2_semantic::types::EnumType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::EnumType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::EnumType
+pub fn slang_solidity_v2_semantic::types::EnumType::eq(&self, other: &slang_solidity_v2_semantic::types::EnumType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::EnumType
+pub fn slang_solidity_v2_semantic::types::EnumType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::EnumType
+pub fn slang_solidity_v2_semantic::types::EnumType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::EnumType
+pub struct slang_solidity_v2_semantic::types::FixedPointNumberType
+pub slang_solidity_v2_semantic::types::FixedPointNumberType::bits: u32
+pub slang_solidity_v2_semantic::types::FixedPointNumberType::precision_bits: u32
+pub slang_solidity_v2_semantic::types::FixedPointNumberType::signed: bool
+impl core::clone::Clone for slang_solidity_v2_semantic::types::FixedPointNumberType
+pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::clone(&self) -> slang_solidity_v2_semantic::types::FixedPointNumberType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::FixedPointNumberType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FixedPointNumberType
+pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::eq(&self, other: &slang_solidity_v2_semantic::types::FixedPointNumberType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::FixedPointNumberType
+pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::FixedPointNumberType
+pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FixedPointNumberType
+pub struct slang_solidity_v2_semantic::types::FixedSizeArrayType
+pub slang_solidity_v2_semantic::types::FixedSizeArrayType::element_type: slang_solidity_v2_semantic::types::TypeId
+pub slang_solidity_v2_semantic::types::FixedSizeArrayType::location: slang_solidity_v2_semantic::types::DataLocation
+pub slang_solidity_v2_semantic::types::FixedSizeArrayType::size: usize
+impl core::clone::Clone for slang_solidity_v2_semantic::types::FixedSizeArrayType
+pub fn slang_solidity_v2_semantic::types::FixedSizeArrayType::clone(&self) -> slang_solidity_v2_semantic::types::FixedSizeArrayType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::FixedSizeArrayType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::FixedSizeArrayType
+pub fn slang_solidity_v2_semantic::types::FixedSizeArrayType::eq(&self, other: &slang_solidity_v2_semantic::types::FixedSizeArrayType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::FixedSizeArrayType
+pub fn slang_solidity_v2_semantic::types::FixedSizeArrayType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::FixedSizeArrayType
+pub fn slang_solidity_v2_semantic::types::FixedSizeArrayType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FixedSizeArrayType
 pub struct slang_solidity_v2_semantic::types::FunctionType
 pub slang_solidity_v2_semantic::types::FunctionType::definition_id: core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub slang_solidity_v2_semantic::types::FunctionType::implicit_receiver_type: core::option::Option<slang_solidity_v2_semantic::types::TypeId>
@@ -466,6 +543,93 @@ pub fn slang_solidity_v2_semantic::types::FunctionType::fmt(&self, f: &mut core:
 impl core::hash::Hash for slang_solidity_v2_semantic::types::FunctionType
 pub fn slang_solidity_v2_semantic::types::FunctionType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionType
+pub struct slang_solidity_v2_semantic::types::IntegerType
+pub slang_solidity_v2_semantic::types::IntegerType::bits: u32
+pub slang_solidity_v2_semantic::types::IntegerType::signed: bool
+impl core::clone::Clone for slang_solidity_v2_semantic::types::IntegerType
+pub fn slang_solidity_v2_semantic::types::IntegerType::clone(&self) -> slang_solidity_v2_semantic::types::IntegerType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::IntegerType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::IntegerType
+pub fn slang_solidity_v2_semantic::types::IntegerType::eq(&self, other: &slang_solidity_v2_semantic::types::IntegerType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::IntegerType
+pub fn slang_solidity_v2_semantic::types::IntegerType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::IntegerType
+pub fn slang_solidity_v2_semantic::types::IntegerType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::IntegerType
+pub struct slang_solidity_v2_semantic::types::InterfaceType
+pub slang_solidity_v2_semantic::types::InterfaceType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::InterfaceType
+pub fn slang_solidity_v2_semantic::types::InterfaceType::clone(&self) -> slang_solidity_v2_semantic::types::InterfaceType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::InterfaceType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::InterfaceType
+pub fn slang_solidity_v2_semantic::types::InterfaceType::eq(&self, other: &slang_solidity_v2_semantic::types::InterfaceType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::InterfaceType
+pub fn slang_solidity_v2_semantic::types::InterfaceType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::InterfaceType
+pub fn slang_solidity_v2_semantic::types::InterfaceType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::InterfaceType
+pub struct slang_solidity_v2_semantic::types::LibraryType
+pub slang_solidity_v2_semantic::types::LibraryType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::LibraryType
+pub fn slang_solidity_v2_semantic::types::LibraryType::clone(&self) -> slang_solidity_v2_semantic::types::LibraryType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::LibraryType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::LibraryType
+pub fn slang_solidity_v2_semantic::types::LibraryType::eq(&self, other: &slang_solidity_v2_semantic::types::LibraryType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::LibraryType
+pub fn slang_solidity_v2_semantic::types::LibraryType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::LibraryType
+pub fn slang_solidity_v2_semantic::types::LibraryType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::LibraryType
+pub struct slang_solidity_v2_semantic::types::MappingType
+pub slang_solidity_v2_semantic::types::MappingType::key_type_id: slang_solidity_v2_semantic::types::TypeId
+pub slang_solidity_v2_semantic::types::MappingType::value_type_id: slang_solidity_v2_semantic::types::TypeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::MappingType
+pub fn slang_solidity_v2_semantic::types::MappingType::clone(&self) -> slang_solidity_v2_semantic::types::MappingType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::MappingType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::MappingType
+pub fn slang_solidity_v2_semantic::types::MappingType::eq(&self, other: &slang_solidity_v2_semantic::types::MappingType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::MappingType
+pub fn slang_solidity_v2_semantic::types::MappingType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::MappingType
+pub fn slang_solidity_v2_semantic::types::MappingType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::MappingType
+pub struct slang_solidity_v2_semantic::types::StringType
+pub slang_solidity_v2_semantic::types::StringType::location: slang_solidity_v2_semantic::types::DataLocation
+impl core::clone::Clone for slang_solidity_v2_semantic::types::StringType
+pub fn slang_solidity_v2_semantic::types::StringType::clone(&self) -> slang_solidity_v2_semantic::types::StringType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::StringType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::StringType
+pub fn slang_solidity_v2_semantic::types::StringType::eq(&self, other: &slang_solidity_v2_semantic::types::StringType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::StringType
+pub fn slang_solidity_v2_semantic::types::StringType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::StringType
+pub fn slang_solidity_v2_semantic::types::StringType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::StringType
+pub struct slang_solidity_v2_semantic::types::StructType
+pub slang_solidity_v2_semantic::types::StructType::definition_id: slang_solidity_v2_common::nodes::NodeId
+pub slang_solidity_v2_semantic::types::StructType::location: slang_solidity_v2_semantic::types::DataLocation
+impl core::clone::Clone for slang_solidity_v2_semantic::types::StructType
+pub fn slang_solidity_v2_semantic::types::StructType::clone(&self) -> slang_solidity_v2_semantic::types::StructType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::StructType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::StructType
+pub fn slang_solidity_v2_semantic::types::StructType::eq(&self, other: &slang_solidity_v2_semantic::types::StructType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::StructType
+pub fn slang_solidity_v2_semantic::types::StructType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::StructType
+pub fn slang_solidity_v2_semantic::types::StructType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::StructType
+pub struct slang_solidity_v2_semantic::types::TupleType
+pub slang_solidity_v2_semantic::types::TupleType::types: alloc::vec::Vec<slang_solidity_v2_semantic::types::TypeId>
+impl core::clone::Clone for slang_solidity_v2_semantic::types::TupleType
+pub fn slang_solidity_v2_semantic::types::TupleType::clone(&self) -> slang_solidity_v2_semantic::types::TupleType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::TupleType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::TupleType
+pub fn slang_solidity_v2_semantic::types::TupleType::eq(&self, other: &slang_solidity_v2_semantic::types::TupleType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::TupleType
+pub fn slang_solidity_v2_semantic::types::TupleType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::TupleType
+pub fn slang_solidity_v2_semantic::types::TupleType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::TupleType
 pub struct slang_solidity_v2_semantic::types::TypeId(_)
 impl core::clone::Clone for slang_solidity_v2_semantic::types::TypeId
 pub fn slang_solidity_v2_semantic::types::TypeId::clone(&self) -> slang_solidity_v2_semantic::types::TypeId
@@ -485,3 +649,15 @@ pub fn slang_solidity_v2_semantic::types::TypeRegistry::number_value_of_type_id(
 pub fn slang_solidity_v2_semantic::types::TypeRegistry::type_id_is_function_and_overrides(&self, type_id: slang_solidity_v2_semantic::types::TypeId, other_type_id: slang_solidity_v2_semantic::types::TypeId) -> bool
 impl core::default::Default for slang_solidity_v2_semantic::types::TypeRegistry
 pub fn slang_solidity_v2_semantic::types::TypeRegistry::default() -> Self
+pub struct slang_solidity_v2_semantic::types::UserDefinedValueType
+pub slang_solidity_v2_semantic::types::UserDefinedValueType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::UserDefinedValueType
+pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::clone(&self) -> slang_solidity_v2_semantic::types::UserDefinedValueType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::UserDefinedValueType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::UserDefinedValueType
+pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::eq(&self, other: &slang_solidity_v2_semantic::types::UserDefinedValueType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::UserDefinedValueType
+pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::UserDefinedValueType
+pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::UserDefinedValueType

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -500,7 +500,7 @@ pub fn slang_solidity_v2_semantic::types::EnumType::hash<__H: core::hash::Hasher
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::EnumType
 pub struct slang_solidity_v2_semantic::types::FixedPointNumberType
 pub slang_solidity_v2_semantic::types::FixedPointNumberType::bits: u32
-pub slang_solidity_v2_semantic::types::FixedPointNumberType::precision_bits: u32
+pub slang_solidity_v2_semantic::types::FixedPointNumberType::decimal_places: u32
 pub slang_solidity_v2_semantic::types::FixedPointNumberType::signed: bool
 impl core::clone::Clone for slang_solidity_v2_semantic::types::FixedPointNumberType
 pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::clone(&self) -> slang_solidity_v2_semantic::types::FixedPointNumberType

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,7 +1,10 @@
 use slang_solidity_v2_common::versions::LanguageVersion;
 
 use super::binder::{Binder, Definition, Typing};
-use super::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
+use super::types::{
+    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, Type, TypeId, TypeRegistry,
+    UserDefinedValueType,
+};
 
 #[path = "internal.generated.rs"]
 mod internal;
@@ -207,18 +210,18 @@ impl<'a> BuiltInsResolver<'a> {
                 _ => None,
             },
             BuiltIn::Type(type_id) => match self.types.get_type_by_id(*type_id) {
-                Type::Contract { .. } | Type::Library { .. } => match symbol {
+                Type::Contract(_) | Type::Library(_) => match symbol {
                     "name" => Some(BuiltIn::TypeName),
                     "creationCode" => Some(BuiltIn::TypeCreationCode),
                     "runtimeCode" => Some(BuiltIn::TypeRuntimeCode),
                     _ => None,
                 },
-                Type::Interface { .. } => match symbol {
+                Type::Interface(_) => match symbol {
                     "name" => Some(BuiltIn::TypeName),
                     "interfaceId" => Some(BuiltIn::TypeInterfaceId),
                     _ => None,
                 },
-                Type::Enum { .. } => match symbol {
+                Type::Enum(_) => match symbol {
                     "min" if BuiltIn::TYPE_ENUM_MIN_VERSIONS.contains(self.language_version) => {
                         Some(BuiltIn::TypeEnumMin(*type_id))
                     }
@@ -227,7 +230,7 @@ impl<'a> BuiltInsResolver<'a> {
                     }
                     _ => None,
                 },
-                Type::Integer { .. } => match symbol {
+                Type::Integer(_) => match symbol {
                     "min" => Some(BuiltIn::TypeMin(*type_id)),
                     "max" => Some(BuiltIn::TypeMax(*type_id)),
                     _ => None,
@@ -283,11 +286,11 @@ impl<'a> BuiltInsResolver<'a> {
         symbol: &str,
     ) -> Option<BuiltIn> {
         match parent_type {
-            Type::Bytes { .. } => match symbol {
+            Type::Bytes(_) => match symbol {
                 "concat" => Some(BuiltIn::BytesConcat),
                 _ => None,
             },
-            Type::String { .. } => match symbol {
+            Type::String(_) => match symbol {
                 "concat" => Some(BuiltIn::StringConcat),
                 _ => None,
             },
@@ -317,19 +320,21 @@ impl<'a> BuiltInsResolver<'a> {
     ) -> Option<BuiltIn> {
         let type_ = self.types.get_type_by_id(type_id);
         match type_ {
-            Type::Address { payable } => Self::lookup_member_of_address(symbol, *payable),
-            Type::Array { element_type, .. } => match symbol {
+            Type::Address(AddressType { payable }) => {
+                Self::lookup_member_of_address(symbol, *payable)
+            }
+            Type::Array(ArrayType { element_type, .. }) => match symbol {
                 "length" => Some(BuiltIn::Length),
                 "pop" => Some(BuiltIn::ArrayPop),
                 "push" => Some(BuiltIn::ArrayPush(*element_type)),
                 _ => None,
             },
             Type::Boolean => None,
-            Type::ByteArray { .. } => match symbol {
+            Type::ByteArray(_) => match symbol {
                 "length" => Some(BuiltIn::Length),
                 _ => None,
             },
-            Type::Bytes { location } => match symbol {
+            Type::Bytes(BytesType { location }) => match symbol {
                 "length" => Some(BuiltIn::Length),
                 "pop" if *location == DataLocation::Storage => Some(BuiltIn::ArrayPop),
                 "push" if *location == DataLocation::Storage => {
@@ -337,10 +342,10 @@ impl<'a> BuiltInsResolver<'a> {
                 }
                 _ => None,
             },
-            Type::Contract { .. } | Type::Interface { .. } | Type::Library { .. } => None,
-            Type::Enum { .. } => None,
-            Type::FixedPointNumber { .. } => None,
-            Type::FixedSizeArray { .. } => match symbol {
+            Type::Contract(_) | Type::Interface(_) | Type::Library(_) => None,
+            Type::Enum(_) => None,
+            Type::FixedPointNumber(_) => None,
+            Type::FixedSizeArray(_) => match symbol {
                 "length" => Some(BuiltIn::Length),
                 _ => None,
             },
@@ -360,19 +365,19 @@ impl<'a> BuiltInsResolver<'a> {
                     None
                 }
             }
-            Type::Integer { .. } => None,
+            Type::Integer(_) => None,
             Type::Literal(LiteralKind::Address { .. }) => {
                 Self::lookup_member_of_address(symbol, false)
             }
             Type::Literal(_) => None,
-            Type::Mapping { .. } => None,
-            Type::String { .. } => match symbol {
+            Type::Mapping(_) => None,
+            Type::String(_) => match symbol {
                 "length" => Some(BuiltIn::Length),
                 _ => None,
             },
-            Type::Struct { .. } => None,
-            Type::Tuple { .. } => None,
-            Type::UserDefinedValue { .. } => None,
+            Type::Struct(_) => None,
+            Type::Tuple(_) => None,
+            Type::UserDefinedValue(_) => None,
             Type::Void => None,
         }
     }
@@ -552,9 +557,9 @@ impl<'a> BuiltInsResolver<'a> {
                 };
                 Typing::Resolved(
                     self.types
-                        .find_type(&Type::UserDefinedValue {
+                        .find_type(&Type::UserDefinedValue(UserDefinedValueType {
                             definition_id: *definition_id,
-                        })
+                        }))
                         .unwrap(),
                 )
             }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -11,7 +11,11 @@ use crate::binder::{Binder, Definition, Reference};
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
-use crate::types::{Type, TypeId, TypeRegistry};
+use crate::types::{
+    ArrayType, ByteArrayType, ContractType, EnumType, FixedPointNumberType, FixedSizeArrayType,
+    IntegerType, InterfaceType, LibraryType, MappingType, StructType, TupleType, Type, TypeId,
+    TypeRegistry, UserDefinedValueType,
+};
 
 mod file_node_mapper;
 
@@ -143,48 +147,48 @@ impl SemanticContext {
 
     pub fn type_internal_name(&self, type_id: TypeId) -> String {
         match self.types.get_type_by_id(type_id) {
-            Type::Address { .. } => "address".to_string(),
-            Type::Array { element_type, .. } => {
+            Type::Address(_) => "address".to_string(),
+            Type::Array(ArrayType { element_type, .. }) => {
                 format!(
                     "{element}[]",
                     element = self.type_internal_name(*element_type)
                 )
             }
             Type::Boolean => "bool".to_string(),
-            Type::ByteArray { width } => format!("bytes{width}"),
-            Type::Bytes { .. } => "bytes".to_string(),
-            Type::FixedPointNumber {
+            Type::ByteArray(ByteArrayType { width }) => format!("bytes{width}"),
+            Type::Bytes(_) => "bytes".to_string(),
+            Type::FixedPointNumber(FixedPointNumberType {
                 signed,
                 bits,
                 precision_bits,
-            } => format!(
+            }) => format!(
                 "{prefix}{bits}x{precision_bits}",
                 prefix = if *signed { "fixed" } else { "ufixed" },
             ),
-            Type::FixedSizeArray {
+            Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
-            } => {
+            }) => {
                 format!(
                     "{element}[{size}]",
                     element = self.type_internal_name(*element_type),
                 )
             }
             Type::Function(_) => "function".to_string(),
-            Type::Integer { signed, bits } => format!(
+            Type::Integer(IntegerType { signed, bits }) => format!(
                 "{prefix}{bits}",
                 prefix = if *signed { "int" } else { "uint" }
             ),
             Type::Literal(_) => "literal".to_string(),
-            Type::Mapping {
+            Type::Mapping(MappingType {
                 key_type_id,
                 value_type_id,
-            } => format!(
+            }) => format!(
                 "mapping({key_type} => {value_type})",
                 key_type = self.type_internal_name(*key_type_id),
                 value_type = self.type_internal_name(*value_type_id)
             ),
-            Type::String { .. } => "string".to_string(),
-            Type::Tuple { types } => format!(
+            Type::String(_) => "string".to_string(),
+            Type::Tuple(TupleType { types }) => format!(
                 "({types})",
                 types = types
                     .iter()
@@ -192,12 +196,14 @@ impl SemanticContext {
                     .collect::<Vec<_>>()
                     .join(",")
             ),
-            Type::Contract { definition_id }
-            | Type::Enum { definition_id }
-            | Type::Interface { definition_id }
-            | Type::Struct { definition_id, .. }
-            | Type::UserDefinedValue { definition_id }
-            | Type::Library { definition_id } => self.definition_canonical_name(*definition_id),
+            Type::Contract(ContractType { definition_id })
+            | Type::Enum(EnumType { definition_id })
+            | Type::Interface(InterfaceType { definition_id })
+            | Type::Library(LibraryType { definition_id })
+            | Type::Struct(StructType { definition_id, .. })
+            | Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
+                self.definition_canonical_name(*definition_id)
+            }
             Type::Void => "void".to_string(),
         }
     }
@@ -212,29 +218,29 @@ impl SemanticContext {
         visited_structs: &mut HashSet<NodeId>,
     ) -> Option<String> {
         match self.types.get_type_by_id(type_id) {
-            Type::Address { .. }
+            Type::Address(_)
             | Type::Boolean
-            | Type::ByteArray { .. }
-            | Type::Bytes { .. }
-            | Type::FixedPointNumber { .. }
+            | Type::ByteArray(_)
+            | Type::Bytes(_)
+            | Type::FixedPointNumber(_)
             | Type::Function(_)
-            | Type::Integer { .. }
-            | Type::String { .. } => Some(self.type_internal_name(type_id)),
+            | Type::Integer(_)
+            | Type::String(_) => Some(self.type_internal_name(type_id)),
 
-            Type::Array { element_type, .. } => self
+            Type::Array(ArrayType { element_type, .. }) => self
                 .type_canonical_name_impl(*element_type, visited_structs)
                 .map(|element| format!("{element}[]",)),
-            Type::FixedSizeArray {
+            Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
-            } => self
+            }) => self
                 .type_canonical_name_impl(*element_type, visited_structs)
                 .map(|element| format!("{element}[{size}]",)),
 
-            Type::Contract { .. } | Type::Interface { .. } => Some("address".to_string()),
+            Type::Contract(_) | Type::Interface(_) => Some("address".to_string()),
 
-            Type::Enum { .. } => Some("uint8".to_string()),
+            Type::Enum(_) => Some("uint8".to_string()),
 
-            Type::Struct { definition_id, .. } => {
+            Type::Struct(StructType { definition_id, .. }) => {
                 // Recursive structs are not valid Solidity, but guard against cycles
                 // to avoid unbounded recursion if malformed types reach this point.
                 // TODO(validation) SDR[19]: The recursion should be detected in the
@@ -260,7 +266,7 @@ impl SemanticContext {
                 Some(format!("({fields})", fields = fields.join(",")))
             }
 
-            Type::UserDefinedValue { definition_id } => {
+            Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
                 let Definition::UserDefinedValueType(udvt) = self
                     .binder
                     .find_definition_by_id(*definition_id)
@@ -272,11 +278,11 @@ impl SemanticContext {
                     .and_then(|type_id| self.type_canonical_name_impl(type_id, visited_structs))
             }
 
-            Type::Literal(_)
-            | Type::Mapping { .. }
-            | Type::Tuple { .. }
-            | Type::Void
-            | Type::Library { .. } => None,
+            Type::Library(_)
+            | Type::Literal(_)
+            | Type::Mapping(_)
+            | Type::Tuple(_)
+            | Type::Void => None,
         }
     }
 
@@ -294,22 +300,23 @@ impl SemanticContext {
         visited_structs: &mut HashSet<NodeId>,
     ) -> Option<usize> {
         match self.types.get_type_by_id(type_id) {
-            Type::Address { .. } | Type::Contract { .. } | Type::Interface { .. } => {
+            Type::Address(_) | Type::Contract(_) | Type::Interface(_) => {
                 Some(Self::ADDRESS_BYTE_SIZE)
             }
             Type::Boolean => Some(1),
-            Type::FixedPointNumber { bits, .. } | Type::Integer { bits, .. } => {
+            Type::FixedPointNumber(FixedPointNumberType { bits, .. })
+            | Type::Integer(IntegerType { bits, .. }) => {
                 Some((bits.div_ceil(8)).try_into().unwrap())
             }
-            Type::ByteArray { width } => Some((*width).try_into().unwrap()),
-            Type::Enum { .. } => Some(1),
-            Type::Bytes { .. } | Type::String { .. } => Some(Self::SLOT_SIZE),
-            Type::Mapping { .. } => Some(Self::SLOT_SIZE),
+            Type::ByteArray(ByteArrayType { width }) => Some((*width).try_into().unwrap()),
+            Type::Enum(_) => Some(1),
+            Type::Bytes(_) | Type::String(_) => Some(Self::SLOT_SIZE),
+            Type::Mapping(_) => Some(Self::SLOT_SIZE),
 
-            Type::Array { .. } => Some(Self::SLOT_SIZE),
-            Type::FixedSizeArray {
+            Type::Array(_) => Some(Self::SLOT_SIZE),
+            Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
-            } => {
+            }) => {
                 let element_size =
                     self.storage_size_of_type_id_impl(*element_type, visited_structs)?;
                 if element_size > Self::SLOT_SIZE {
@@ -331,7 +338,7 @@ impl SemanticContext {
                     Some(8)
                 }
             }
-            Type::Struct { definition_id, .. } => {
+            Type::Struct(StructType { definition_id, .. }) => {
                 // Recursive structs are not valid Solidity, but guard against cycles
                 // to avoid unbounded recursion if malformed types reach this point.
                 // TODO(validation) SDR[19]: The recursion should be detected in the
@@ -361,7 +368,7 @@ impl SemanticContext {
                 ptr = ptr.div_ceil(Self::SLOT_SIZE) * Self::SLOT_SIZE;
                 Some(ptr)
             }
-            Type::UserDefinedValue { definition_id } => {
+            Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
                 let Definition::UserDefinedValueType(user_defined_value) =
                     self.binder.find_definition_by_id(*definition_id)?
                 else {
@@ -373,7 +380,7 @@ impl SemanticContext {
                 )
             }
 
-            Type::Literal(_) | Type::Tuple { .. } | Type::Void | Type::Library { .. } => None,
+            Type::Library(_) | Type::Literal(_) | Type::Tuple(_) | Type::Void => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -160,9 +160,9 @@ impl SemanticContext {
             Type::FixedPointNumber(FixedPointNumberType {
                 signed,
                 bits,
-                precision_bits,
+                decimal_places,
             }) => format!(
-                "{prefix}{bits}x{precision_bits}",
+                "{prefix}{bits}x{decimal_places}",
                 prefix = if *signed { "fixed" } else { "ufixed" },
             ),
             Type::FixedSizeArray(FixedSizeArrayType {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -5,7 +5,7 @@ use slang_solidity_v2_ir::ir;
 use crate::binder::{Binder, Definition, Scope, ScopeId};
 use crate::built_ins::BuiltInsResolver;
 use crate::context::SemanticFile;
-use crate::types::{Type, TypeId, TypeRegistry};
+use crate::types::{ContractType, Type, TypeId, TypeRegistry};
 
 mod evaluator;
 mod resolution;
@@ -93,9 +93,9 @@ impl<'a> Pass<'a> {
             else {
                 continue;
             };
-            let receiver_type_id = self.types.register_type(Type::Contract {
+            let receiver_type_id = self.types.register_type(Type::Contract(ContractType {
                 definition_id: contract_definition.id(),
-            });
+            }));
             for contract_member in &contract_definition.members {
                 let ir::ContractMember::StateVariableDefinition(state_var_definition) =
                     contract_member

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -6,7 +6,9 @@ use super::evaluator::{
 use super::Pass;
 use crate::binder::{Definition, Resolution, Scope, ScopeId};
 use crate::passes::common::resolve_identifier_path_in_scope;
-use crate::types::{DataLocation, FunctionType, Type, TypeId};
+use crate::types::{
+    ArrayType, DataLocation, FixedSizeArrayType, FunctionType, MappingType, TupleType, Type, TypeId,
+};
 
 impl Pass<'_> {
     // Resolves an IdentifierPath starting at the "contract" scope level, or at
@@ -54,16 +56,17 @@ impl Pass<'_> {
                                     self,
                                 )
                                 .unwrap_or_default();
-                                self.types.register_type(Type::FixedSizeArray {
-                                    element_type,
-                                    size,
-                                    location: data_location,
-                                })
+                                self.types
+                                    .register_type(Type::FixedSizeArray(FixedSizeArrayType {
+                                        element_type,
+                                        size,
+                                        location: data_location,
+                                    }))
                             } else {
-                                self.types.register_type(Type::Array {
+                                self.types.register_type(Type::Array(ArrayType {
                                     element_type,
                                     location: data_location,
-                                })
+                                }))
                             }
                         })
                 })
@@ -76,9 +79,9 @@ impl Pass<'_> {
                     if return_types.len() == 1 {
                         return_types.first().copied().unwrap()
                     } else {
-                        self.types.register_type(Type::Tuple {
+                        self.types.register_type(Type::Tuple(TupleType {
                             types: return_types,
-                        })
+                        }))
                     }
                 } else {
                     self.types.void()
@@ -99,10 +102,10 @@ impl Pass<'_> {
                     self.resolve_type_name(&mapping_type.key_type.type_name, data_location)?;
                 let value_type_id =
                     self.resolve_type_name(&mapping_type.value_type.type_name, data_location)?;
-                Some(self.types.register_type(Type::Mapping {
+                Some(self.types.register_type(Type::Mapping(MappingType {
                     key_type_id,
                     value_type_id,
-                }))
+                })))
             }
             ir::TypeName::ElementaryType(elementary_type) => {
                 self.type_of_elementary_type(elementary_type, data_location)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -4,7 +4,9 @@ use slang_solidity_v2_ir::ir;
 use super::Pass;
 use crate::binder::Definition;
 use crate::types::{
-    DataLocation, FunctionType, FunctionTypeMutability, FunctionTypeVisibility, Type, TypeId,
+    AddressType, ArrayType, ContractType, DataLocation, EnumType, FixedSizeArrayType, FunctionType,
+    FunctionTypeMutability, FunctionTypeVisibility, InterfaceType, LibraryType, MappingType,
+    StringType, StructType, TupleType, Type, TypeId, UserDefinedValueType,
 };
 
 impl Pass<'_> {
@@ -37,29 +39,34 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         if let Some(definition) = self.binder.find_definition_by_id(definition_id) {
             match definition {
-                Definition::Contract(_) => {
-                    Some(self.types.register_type(Type::Contract { definition_id }))
-                }
-                Definition::Library(_) => {
-                    Some(self.types.register_type(Type::Library { definition_id }))
-                }
-                Definition::Enum(_) => Some(self.types.register_type(Type::Enum { definition_id })),
-                Definition::Interface(_) => {
-                    Some(self.types.register_type(Type::Interface { definition_id }))
-                }
+                Definition::Contract(_) => Some(
+                    self.types
+                        .register_type(Type::Contract(ContractType { definition_id })),
+                ),
+                Definition::Library(_) => Some(
+                    self.types
+                        .register_type(Type::Library(LibraryType { definition_id })),
+                ),
+                Definition::Enum(_) => Some(
+                    self.types
+                        .register_type(Type::Enum(EnumType { definition_id })),
+                ),
+                Definition::Interface(_) => Some(
+                    self.types
+                        .register_type(Type::Interface(InterfaceType { definition_id })),
+                ),
                 Definition::Struct(_) => data_location.map(|data_location| {
-                    self.types.register_type(Type::Struct {
+                    self.types.register_type(Type::Struct(StructType {
                         definition_id,
                         location: data_location,
-                    })
+                    }))
                 }),
                 Definition::TypeParameter(_) => {
                     unreachable!("type parameter names don't have a type")
                 }
-                Definition::UserDefinedValueType(_) => Some(
-                    self.types
-                        .register_type(Type::UserDefinedValue { definition_id }),
-                ),
+                Definition::UserDefinedValueType(_) => Some(self.types.register_type(
+                    Type::UserDefinedValue(UserDefinedValueType { definition_id }),
+                )),
 
                 Definition::Constant(_)
                 | Definition::EnumMember(_)
@@ -89,9 +96,9 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         match elementary_type {
             ir::ElementaryType::AddressType(address_type) => {
-                Some(self.types.register_type(Type::Address {
+                Some(self.types.register_type(Type::Address(AddressType {
                     payable: address_type.payable_keyword.is_some(),
-                }))
+                })))
             }
             ir::ElementaryType::BytesKeyword(bytes_keyword) => {
                 Type::from_bytes_keyword(bytes_keyword.unparse(), data_location)
@@ -116,9 +123,9 @@ impl Pass<'_> {
             ir::ElementaryType::BoolKeyword(_) => Some(self.types.boolean()),
             // No ByteKeyword in v2 (removed since Solidity >= 0.8.0)
             ir::ElementaryType::StringKeyword(_) => data_location.map(|data_location| {
-                self.types.register_type(Type::String {
+                self.types.register_type(Type::String(StringType {
                     location: data_location,
-                })
+                }))
             }),
         }
     }
@@ -138,9 +145,9 @@ impl Pass<'_> {
                 // typing of function call expressions
                 return_types.first().copied().unwrap()
             } else {
-                self.types.register_type(Type::Tuple {
+                self.types.register_type(Type::Tuple(TupleType {
                     types: return_types,
-                })
+                }))
             }
         } else {
             self.types.void()
@@ -167,29 +174,29 @@ impl Pass<'_> {
         loop {
             match self.types.get_type_by_id(return_type) {
                 // scalar types
-                Type::Address { .. }
+                Type::Address(_)
                 | Type::Boolean
-                | Type::ByteArray { .. }
-                | Type::Contract { .. }
-                | Type::Enum { .. }
-                | Type::FixedPointNumber { .. }
-                | Type::Function { .. }
-                | Type::Integer { .. }
-                | Type::Interface { .. }
-                | Type::UserDefinedValue { .. } => break,
+                | Type::ByteArray(_)
+                | Type::Contract(_)
+                | Type::Enum(_)
+                | Type::FixedPointNumber(_)
+                | Type::Function(_)
+                | Type::Integer(_)
+                | Type::Interface(_)
+                | Type::UserDefinedValue(_) => break,
 
-                Type::Bytes { .. } => {
+                Type::Bytes(_) => {
                     // getters will always return values in memory
                     return_type = self.types.bytes_memory();
                     break;
                 }
-                Type::String { .. } => {
+                Type::String(_) => {
                     // getters will always return values in memory
                     return_type = self.types.string_memory();
                     break;
                 }
 
-                Type::Struct { definition_id, .. } => {
+                Type::Struct(StructType { definition_id, .. }) => {
                     // For structs the getter will return a tuple with all value
                     // type and string/bytes fields, in declaration order. It
                     // won't return nested mappings or arrays.
@@ -235,26 +242,27 @@ impl Pass<'_> {
                     return_type = match types.len() {
                         0 => return None,
                         1 => types[0],
-                        _ => self.types.register_type(Type::Tuple { types }),
+                        _ => self.types.register_type(Type::Tuple(TupleType { types })),
                     };
                     break;
                 }
 
                 // non-scalar types
-                Type::Array { element_type, .. } | Type::FixedSizeArray { element_type, .. } => {
+                Type::Array(ArrayType { element_type, .. })
+                | Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) => {
                     return_type = *element_type;
                     parameter_types.push(self.types.uint256());
                 }
-                Type::Mapping {
+                Type::Mapping(MappingType {
                     key_type_id,
                     value_type_id,
-                } => {
+                }) => {
                     return_type = *value_type_id;
                     parameter_types.push(*key_type_id);
                 }
 
                 // invalid types
-                Type::Literal(_) | Type::Library { .. } | Type::Tuple { .. } | Type::Void => {
+                Type::Library(_) | Type::Literal(_) | Type::Tuple(_) | Type::Void => {
                     unreachable!("cannot compute the getter type for {type_id:?}")
                 }
             }
@@ -290,12 +298,12 @@ impl Pass<'_> {
                     unreachable!("base for {base_id:?} does not exist");
                 };
                 let base_type = match base {
-                    Definition::Contract(_) => Type::Contract {
+                    Definition::Contract(_) => Type::Contract(ContractType {
                         definition_id: *base_id,
-                    },
-                    Definition::Interface(_) => Type::Interface {
+                    }),
+                    Definition::Interface(_) => Type::Interface(InterfaceType {
                         definition_id: *base_id,
-                    },
+                    }),
                     _ => return None,
                 };
                 Some(self.types.register_type(base_type))

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -9,7 +9,7 @@ use super::evaluator::evaluate_compile_time_integer_constant;
 use super::Pass;
 use crate::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
 use crate::built_ins::BuiltIn;
-use crate::types::{DataLocation, Type};
+use crate::types::{ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -24,9 +24,9 @@ impl Visitor for Pass<'_> {
     fn enter_contract_definition(&mut self, node: &ir::ContractDefinition) -> bool {
         self.enter_scope_for_node_id(node.id());
 
-        let type_id = self.types.register_type(Type::Contract {
+        let type_id = self.types.register_type(Type::Contract(ContractType {
             definition_id: node.id(),
-        });
+        }));
         self.current_receiver_type = Some(type_id);
 
         if let Some(bases) = self.binder.get_linearised_bases(node.id()) {
@@ -73,9 +73,9 @@ impl Visitor for Pass<'_> {
     fn enter_interface_definition(&mut self, node: &ir::InterfaceDefinition) -> bool {
         self.enter_scope_for_node_id(node.id());
 
-        let type_id = self.types.register_type(Type::Interface {
+        let type_id = self.types.register_type(Type::Interface(InterfaceType {
             definition_id: node.id(),
-        });
+        }));
         self.current_receiver_type = Some(type_id);
 
         if let Some(bases) = self.binder.get_linearised_bases(node.id()) {
@@ -97,9 +97,9 @@ impl Visitor for Pass<'_> {
     fn enter_library_definition(&mut self, node: &ir::LibraryDefinition) -> bool {
         self.enter_scope_for_node_id(node.id());
 
-        self.types.register_type(Type::Library {
+        self.types.register_type(Type::Library(LibraryType {
             definition_id: node.id(),
-        });
+        }));
 
         true
     }
@@ -295,9 +295,9 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_enum_definition(&mut self, node: &ir::EnumDefinition) {
-        let type_id = self.types.register_type(Type::Enum {
+        let type_id = self.types.register_type(Type::Enum(EnumType {
             definition_id: node.id(),
-        });
+        }));
         for member in &node.members {
             self.binder.set_node_type(member.id(), Some(type_id));
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -8,7 +8,7 @@ use super::{Pass, ScopeFrame};
 use crate::binder::{
     Definition, Reference, Resolution, ResolveOptions, ScopeId, Typing, UsingDirective,
 };
-use crate::types::{FunctionType, Type, TypeId};
+use crate::types::{ContractType, FunctionType, InterfaceType, StructType, Type, TypeId};
 
 /// Lexical style resolution of symbols
 impl Pass<'_> {
@@ -162,9 +162,11 @@ impl Pass<'_> {
                     if matches!(typing, Typing::This) {
                         // Consider active `using` directives for `this`
                         // TODO(this-typing): Once `This` carries a type, use that and check it's a contract
-                        if let Some(receiver_type_id) = self.types.find_type(&Type::Contract {
-                            definition_id: node_id,
-                        }) {
+                        if let Some(receiver_type_id) =
+                            self.types.find_type(&Type::Contract(ContractType {
+                                definition_id: node_id,
+                            }))
+                        {
                             self.add_attached_functions_for_type(
                                 receiver_type_id,
                                 symbol,
@@ -239,7 +241,8 @@ impl Pass<'_> {
 
         // Resolve direct members of the type first
         let mut definition_ids = match type_ {
-            Type::Contract { definition_id, .. } | Type::Interface { definition_id, .. } => {
+            Type::Contract(ContractType { definition_id })
+            | Type::Interface(InterfaceType { definition_id }) => {
                 // A `Type::Library` doesn't belong here, since values of type `library` (ie `this`)
                 // can't be used to access to library members.
                 let scope_id = self.binder.scope_id_for_node_id(*definition_id).unwrap();
@@ -251,7 +254,7 @@ impl Pass<'_> {
                             .into()
                     })
             }
-            Type::Struct { definition_id, .. } => {
+            Type::Struct(StructType { definition_id, .. }) => {
                 let scope_id = self.binder.scope_id_for_node_id(*definition_id).unwrap();
                 self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
             }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -643,7 +643,9 @@ impl Pass<'_> {
         }
         let value = Number::from_hex_number_expression(hex_number_expression)?
             .into_integer()
-            .expect("hex literal must parse to an integer");
+            .expect("hex literal must parse to an integer")
+            .to_biguint()
+            .expect("hex literal must be non-negative");
         // Each pair of hex digits is one byte (with odd digit counts rounded up).
         let bytes = digits.div_ceil(2).max(1);
         Some(LiteralKind::HexInteger { value, bytes })

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -6,7 +6,11 @@ use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::built_ins::BuiltIn;
 use crate::passes::common::node_id_for_expression_typing;
-use crate::types::{literals, DataLocation, FunctionType, LiteralKind, Number, Type, TypeId};
+use crate::types::{
+    literals, AddressType, ContractType, DataLocation, EnumType, FixedSizeArrayType, FunctionType,
+    IntegerType, InterfaceType, LibraryType, LiteralKind, Number, StringType, StructType, Type,
+    TypeId, UserDefinedValueType,
+};
 
 impl Pass<'_> {
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
@@ -25,7 +29,9 @@ impl Pass<'_> {
             }
 
             // Other special cases
-            ir::Expression::PayableKeyword(_) => Typing::MetaType(Type::Address { payable: true }),
+            ir::Expression::PayableKeyword(_) => {
+                Typing::MetaType(Type::Address(AddressType { payable: true }))
+            }
             ir::Expression::ThisKeyword(_) => Typing::This,
             ir::Expression::SuperKeyword(_) => Typing::Super,
 
@@ -41,9 +47,9 @@ impl Pass<'_> {
 
     fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
         match elementary_type {
-            ir::ElementaryType::AddressType(address_type) => Type::Address {
+            ir::ElementaryType::AddressType(address_type) => Type::Address(AddressType {
                 payable: address_type.payable_keyword.is_some(),
-            },
+            }),
             ir::ElementaryType::BytesKeyword(terminal) => {
                 Type::from_bytes_keyword(terminal.unparse(), Some(DataLocation::Memory)).unwrap()
             }
@@ -58,24 +64,28 @@ impl Pass<'_> {
                 Type::from_ufixed_keyword(terminal.unparse())
             }
             ir::ElementaryType::BoolKeyword(_) => Type::Boolean,
-            ir::ElementaryType::StringKeyword(_) => Type::String {
+            ir::ElementaryType::StringKeyword(_) => Type::String(StringType {
                 location: DataLocation::Memory,
-            },
+            }),
         }
     }
 
     pub(super) fn type_of_definition(&mut self, definition_id: NodeId) -> Option<Type> {
         let definition = self.binder.find_definition_by_id(definition_id)?;
         match definition {
-            Definition::Contract(_) => Some(Type::Contract { definition_id }),
-            Definition::Enum(_) => Some(Type::Enum { definition_id }),
-            Definition::Interface(_) => Some(Type::Interface { definition_id }),
-            Definition::Library(_) => Some(Type::Library { definition_id }),
-            Definition::Struct(_) => Some(Type::Struct {
+            Definition::Contract(_) => Some(Type::Contract(ContractType { definition_id })),
+            Definition::Enum(_) => Some(Type::Enum(EnumType { definition_id })),
+            Definition::Interface(_) => Some(Type::Interface(InterfaceType { definition_id })),
+            Definition::Library(_) => Some(Type::Library(LibraryType { definition_id })),
+            Definition::Struct(_) => Some(Type::Struct(StructType {
                 definition_id,
                 location: DataLocation::Memory,
-            }),
-            Definition::UserDefinedValueType(_) => Some(Type::UserDefinedValue { definition_id }),
+            })),
+            Definition::UserDefinedValueType(_) => {
+                Some(Type::UserDefinedValue(UserDefinedValueType {
+                    definition_id,
+                }))
+            }
             _ => None,
         }
     }
@@ -171,11 +181,14 @@ impl Pass<'_> {
             item_type_ids.push(self.typing_of_expression(item).as_type_id()?);
         }
         let element_type = self.types.type_of_array_literal(&item_type_ids)?;
-        Some(self.types.register_type(Type::FixedSizeArray {
-            element_type,
-            size: array.items.len(),
-            location: DataLocation::Memory,
-        }))
+        Some(
+            self.types
+                .register_type(Type::FixedSizeArray(FixedSizeArrayType {
+                    element_type,
+                    size: array.items.len(),
+                    location: DataLocation::Memory,
+                })),
+        )
     }
 
     pub(super) fn type_of_left_typed_binary_operator_expression<F>(
@@ -204,10 +217,10 @@ impl Pass<'_> {
             // the result is either a `uint256` or an `int256` depending on the
             // sign of `left_operand`.
             if left_value.is_negative() {
-                Some(self.types.register_type(Type::Integer {
+                Some(self.types.register_type(Type::Integer(IntegerType {
                     signed: true,
                     bits: 256,
-                }))
+                })))
             } else {
                 Some(self.types.uint256())
             }
@@ -241,7 +254,7 @@ impl Pass<'_> {
             Typing::This => true,
             Typing::Resolved(type_id) => matches!(
                 self.types.get_type_by_id(*type_id),
-                Type::Contract { .. } | Type::Interface { .. }
+                Type::Contract(_) | Type::Interface(_)
             ),
             _ => false,
         }
@@ -312,7 +325,7 @@ impl Pass<'_> {
             }
             Typing::This => {
                 // special case: "this" can be cast to an address
-                if let Type::Address { .. } = target_type {
+                if let Type::Address(_) = target_type {
                     Typing::Resolved(self.types.address())
                 } else {
                     Typing::Unresolved
@@ -389,7 +402,7 @@ impl Pass<'_> {
             }
             Typing::NewExpression(type_id) => {
                 match self.types.get_type_by_id(type_id) {
-                    Type::Array { .. } | Type::Contract { .. } => Typing::Resolved(type_id),
+                    Type::Array(_) | Type::Contract(_) => Typing::Resolved(type_id),
                     _ => {
                         // only contracts can be created with `new`
                         Typing::Unresolved
@@ -403,31 +416,31 @@ impl Pass<'_> {
                 match self.binder.find_definition_by_id(node_id) {
                     Some(Definition::Contract(_)) => {
                         // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Contract {
+                        let type_id = self.types.register_type(Type::Contract(ContractType {
                             definition_id: node_id,
-                        });
+                        }));
                         Typing::Resolved(type_id)
                     }
                     Some(Definition::Interface(_)) => {
                         // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Interface {
+                        let type_id = self.types.register_type(Type::Interface(InterfaceType {
                             definition_id: node_id,
-                        });
+                        }));
                         Typing::Resolved(type_id)
                     }
                     Some(Definition::Library(_)) => {
                         // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Library {
+                        let type_id = self.types.register_type(Type::Library(LibraryType {
                             definition_id: node_id,
-                        });
+                        }));
                         Typing::Resolved(type_id)
                     }
                     Some(Definition::Struct(_)) => {
                         // struct construction
-                        let type_id = self.types.register_type(Type::Struct {
+                        let type_id = self.types.register_type(Type::Struct(StructType {
                             definition_id: node_id,
                             location: DataLocation::Memory,
-                        });
+                        }));
                         Typing::Resolved(type_id)
                     }
                     _ => Typing::Unresolved,
@@ -535,7 +548,9 @@ impl Pass<'_> {
                 (Typing::Unresolved, None)
             }
             Typing::NewExpression(type_id) => {
-                if let Type::Contract { definition_id } = self.types.get_type_by_id(type_id) {
+                if let Type::Contract(ContractType { definition_id }) =
+                    self.types.get_type_by_id(type_id)
+                {
                     (Typing::Resolved(type_id), Some(*definition_id))
                 } else {
                     // only contracts can be created with `new`
@@ -549,10 +564,10 @@ impl Pass<'_> {
                 match self.binder.find_definition_by_id(node_id) {
                     Some(Definition::Struct(_)) => {
                         // struct construction
-                        let type_id = self.types.register_type(Type::Struct {
+                        let type_id = self.types.register_type(Type::Struct(StructType {
                             definition_id: node_id,
                             location: DataLocation::Memory,
-                        });
+                        }));
                         (Typing::Resolved(type_id), Some(node_id))
                     }
                     Some(Definition::Event(_)) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/visitor.rs
@@ -7,7 +7,9 @@ use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::BuiltIn;
 use crate::passes::common::node_id_for_string_expression_typing;
-use crate::types::{DataLocation, Number, Type};
+use crate::types::{
+    ArrayType, DataLocation, FixedSizeArrayType, MappingType, Number, TupleType, Type,
+};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -316,7 +318,7 @@ impl Visitor for Pass<'_> {
                     .unwrap_or(self.types.void());
                 types.push(type_id);
             }
-            let type_id = self.types.register_type(Type::Tuple { types });
+            let type_id = self.types.register_type(Type::Tuple(TupleType { types }));
             Typing::Resolved(type_id)
         };
         self.binder.set_node_typing(node.id(), typing);
@@ -371,8 +373,8 @@ impl Visitor for Pass<'_> {
                 let range_access = node.end.is_some();
                 let operand_type = self.types.get_type_by_id(operand_type_id);
                 match operand_type {
-                    Type::Array { element_type, .. }
-                    | Type::FixedSizeArray { element_type, .. } => {
+                    Type::Array(ArrayType { element_type, .. })
+                    | Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) => {
                         // TODO(validation) SDR[58]: for fixed-size arrays, if the range
                         // is resolvable at compile time we should check for out
                         // of bounds accesses.
@@ -386,21 +388,21 @@ impl Visitor for Pass<'_> {
                             Typing::Resolved(*element_type)
                         }
                     }
-                    Type::ByteArray { .. } => {
+                    Type::ByteArray(_) => {
                         if range_access {
                             Typing::Unresolved
                         } else {
                             Typing::Resolved(self.types.bytes1())
                         }
                     }
-                    Type::Bytes { .. } => {
+                    Type::Bytes(_) => {
                         if range_access {
                             Typing::Resolved(operand_type_id)
                         } else {
                             Typing::Resolved(self.types.bytes1())
                         }
                     }
-                    Type::Mapping { value_type_id, .. } => {
+                    Type::Mapping(MappingType { value_type_id, .. }) => {
                         if range_access {
                             Typing::Unresolved
                         } else {
@@ -416,19 +418,19 @@ impl Visitor for Pass<'_> {
             Typing::MetaType(operand_type) => {
                 // indexing a meta-type creates a new meta-type of the array
                 let operand_type_id = self.types.register_type(operand_type);
-                Typing::MetaType(Type::Array {
+                Typing::MetaType(Type::Array(ArrayType {
                     element_type: operand_type_id,
                     location: DataLocation::Memory,
-                })
+                }))
             }
             Typing::UserMetaType(definition_id) => {
                 // indexing a user meta-type creates a new meta-type of the array
                 if let Some(operand_type) = self.type_of_definition(definition_id) {
                     let operand_type_id = self.types.register_type(operand_type);
-                    Typing::MetaType(Type::Array {
+                    Typing::MetaType(Type::Array(ArrayType {
                         element_type: operand_type_id,
                         location: DataLocation::Memory,
-                    })
+                    }))
                 } else {
                     Typing::Unresolved
                 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -10,7 +10,10 @@ use crate::passes::common::node_id_for_expression_typing;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
-use crate::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
+use crate::types::{
+    ByteArrayType, BytesType, DataLocation, FixedSizeArrayType, IntegerType, LiteralKind,
+    MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
+};
 
 struct TypeAnalysis {
     file: TestFile,
@@ -178,10 +181,10 @@ fn try_type_of_expression_in_context(context: &str, expr: &str) -> (Option<Type>
 }
 
 fn register_uint_type(types: &mut TypeRegistry, bits: u32) -> TypeId {
-    types.register_type(Type::Integer {
+    types.register_type(Type::Integer(IntegerType {
         signed: false,
         bits,
-    })
+    }))
 }
 
 #[test]
@@ -426,10 +429,10 @@ fn test_bitwise_operations_unresolved_for_rationals() {
 fn test_implicit_conversion_uses_literal_value() {
     let (_, mut types) = type_of_expression("0");
 
-    let int8 = types.register_type(Type::Integer {
+    let int8 = types.register_type(Type::Integer(IntegerType {
         signed: true,
         bits: 8,
-    });
+    }));
     let uint8 = types.uint8();
     let uint256 = types.uint256();
 
@@ -494,9 +497,9 @@ fn test_implicit_conversion_uses_literal_value() {
 fn test_hex_literal_to_byte_array_conversion() {
     let (_, mut types) = type_of_expression("0");
 
-    let bytes1 = types.register_type(Type::ByteArray { width: 1 });
-    let bytes2 = types.register_type(Type::ByteArray { width: 2 });
-    let bytes4 = types.register_type(Type::ByteArray { width: 4 });
+    let bytes1 = types.register_type(Type::ByteArray(ByteArrayType { width: 1 }));
+    let bytes2 = types.register_type(Type::ByteArray(ByteArrayType { width: 2 }));
+    let bytes4 = types.register_type(Type::ByteArray(ByteArrayType { width: 4 }));
 
     // Hex source literal: byte-width must match the target exactly.
     let hex_0x12 = types.register_type(Type::Literal(LiteralKind::HexInteger {
@@ -553,39 +556,39 @@ fn test_conditional_expression_unifies_branch_types() {
     let (type_, _) = type_of_expression("true ? 1 : 2");
     assert_eq!(
         type_,
-        Type::Integer {
+        Type::Integer(IntegerType {
             signed: false,
             bits: 8,
-        }
+        })
     );
 
     // uint8 (1) widens to uint16 (256).
     let (type_, _) = type_of_expression("true ? 1 : 256");
     assert_eq!(
         type_,
-        Type::Integer {
+        Type::Integer(IntegerType {
             signed: false,
             bits: 16,
-        }
+        })
     );
 
     // int8 (-1) and int8 (1) — common type is int8.
     let (type_, _) = type_of_expression("true ? -1 : -128");
     assert_eq!(
         type_,
-        Type::Integer {
+        Type::Integer(IntegerType {
             signed: true,
             bits: 8,
-        }
+        })
     );
 
     // Both branches are string literals — both reify to `string memory`.
     let (type_, _) = type_of_expression(r#"true ? "abc" : "x""#);
     assert_eq!(
         type_,
-        Type::String {
+        Type::String(StringType {
             location: DataLocation::Memory,
-        }
+        })
     );
 }
 
@@ -606,11 +609,11 @@ fn test_conditional_expression_unresolved_when_branches_incompatible() {
 fn test_array_literal_unifies_element_types() {
     // Homogeneous uint8 elements.
     let (expr_type, types) = type_of_expression("[1, 2, 3]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type,
         size,
         location,
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -620,9 +623,9 @@ fn test_array_literal_unifies_element_types() {
 
     // Mixed widths widen to the largest required.
     let (expr_type, mut types) = type_of_expression("[1, 256, 3]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type, size, ..
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -631,22 +634,22 @@ fn test_array_literal_unifies_element_types() {
 
     // Negative values force the result to a signed type.
     let (expr_type, mut types) = type_of_expression("[-1, -2]");
-    let Type::FixedSizeArray { element_type, .. } = expr_type else {
+    let Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) = expr_type else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
     assert_eq!(
         element_type,
-        types.register_type(Type::Integer {
+        types.register_type(Type::Integer(IntegerType {
             signed: true,
             bits: 8,
-        })
+        }))
     );
 
     // String literal arrays reify each element to `string memory`.
     let (expr_type, types) = type_of_expression(r#"["abc", "x"]"#);
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type, size, ..
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -683,11 +686,11 @@ fn test_conditional_expression_widens_byte_arrays() {
 #[test]
 fn test_array_literal_unifies_byte_array_elements() {
     let (expr_type, types) = type_of_expression("[bytes32(0), bytes32(1)]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type,
         size,
         location,
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -699,11 +702,11 @@ fn test_array_literal_unifies_byte_array_elements() {
 #[test]
 fn test_array_literal_unifies_byte_array_and_literal_zero() {
     let (expr_type, types) = type_of_expression("[bytes32(0), 0]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type,
         size,
         location,
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -729,9 +732,9 @@ fn test_array_literal_does_not_unify_when_literal_is_first_and_byte_array_follow
 #[test]
 fn test_array_literal_widens_past_first_element_integer_type() {
     let (expr_type, mut types) = type_of_expression("[uint8(0), 256]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type, size, ..
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -742,9 +745,9 @@ fn test_array_literal_widens_past_first_element_integer_type() {
 #[test]
 fn test_array_literal_unifies_byte_array_and_matching_hex_literal() {
     let (expr_type, types) = type_of_expression("[bytes1(0x01), 0x01]");
-    let Type::FixedSizeArray {
+    let Type::FixedSizeArray(FixedSizeArrayType {
         element_type, size, ..
-    } = expr_type
+    }) = expr_type
     else {
         panic!("expected FixedSizeArray, got {expr_type:?}");
     };
@@ -773,10 +776,10 @@ fn test_conditional_expression_unifies_mappings() {
         "mapping(uint => uint) m1; mapping(uint => uint) m2;",
         "true ? m1 : m2",
     );
-    let Some(Type::Mapping {
+    let Some(Type::Mapping(MappingType {
         key_type_id,
         value_type_id,
-    }) = expr_type
+    })) = expr_type
     else {
         panic!("expected Mapping, got {expr_type:?}");
     };
@@ -787,7 +790,7 @@ fn test_conditional_expression_unifies_mappings() {
 #[test]
 fn test_conditional_expression_unifies_literal_tuples() {
     let (expr_type, types) = type_of_expression("true ? (1, 2) : (3, 4)");
-    let Type::Tuple { types: tuple_types } = expr_type else {
+    let Type::Tuple(TupleType { types: tuple_types }) = expr_type else {
         panic!("expected Tuple, got {expr_type:?}");
     };
 
@@ -839,10 +842,10 @@ fn test_overload_resolution_widens_byte_array_argument() {
     let (type_, _) = type_of_expression_in_context(setup, "pick(bytes20(0))");
     assert_eq!(
         type_,
-        Type::Integer {
+        Type::Integer(IntegerType {
             signed: false,
             bits: 8,
-        }
+        })
     );
 }
 
@@ -944,18 +947,18 @@ fn test_data_locations_of_state_variable_and_getter_accesses() {
         &["bs", "foo.xs", "t.bs()", "t.foo()"],
     );
     let expected = vec![
-        Some(Type::Bytes {
+        Some(Type::Bytes(BytesType {
             location: DataLocation::Storage,
-        }),
-        Some(Type::Bytes {
+        })),
+        Some(Type::Bytes(BytesType {
             location: DataLocation::Storage,
-        }),
-        Some(Type::Bytes {
+        })),
+        Some(Type::Bytes(BytesType {
             location: DataLocation::Memory,
-        }),
-        Some(Type::Bytes {
+        })),
+        Some(Type::Bytes(BytesType {
             location: DataLocation::Memory,
-        }),
+        })),
     ];
     assert_eq!(typings, expected);
 }
@@ -1015,7 +1018,7 @@ fn test_getter_of_struct_with_function_member() {
         "other.s()",
     );
 
-    let Type::Tuple { types: elements } = getter_type else {
+    let Type::Tuple(TupleType { types: elements }) = getter_type else {
         panic!("expected the getter to return a tuple, got {getter_type:?}");
     };
     let element_types: Vec<&Type> = elements
@@ -1027,10 +1030,10 @@ fn test_getter_of_struct_with_function_member() {
         matches!(
             element_types.as_slice(),
             [
-                Type::Integer {
+                Type::Integer(IntegerType {
                     signed: false,
                     bits: 256
-                },
+                }),
                 Type::Function(_),
             ]
         ),
@@ -1052,7 +1055,7 @@ fn test_getter_of_struct_with_struct_member() {
         "other.s()",
     );
 
-    let Type::Tuple { types: elements } = getter_type else {
+    let Type::Tuple(TupleType { types: elements }) = getter_type else {
         panic!("expected the getter to return a tuple, got {getter_type:?}");
     };
     let element_types: Vec<&Type> = elements
@@ -1064,11 +1067,11 @@ fn test_getter_of_struct_with_struct_member() {
         matches!(
             element_types.as_slice(),
             [
-                Type::Struct { .. },
-                Type::Integer {
+                Type::Struct(_),
+                Type::Integer(IntegerType {
                     signed: false,
                     bits: 256
-                },
+                }),
             ]
         ),
         "expected getter tuple `(Struct, uint256)`, got {element_types:?}",

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use num_bigint::{BigInt, BigUint};
 use num_rational::BigRational;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
@@ -211,7 +211,7 @@ fn test_value_bearing_integer_literal_types() {
     assert_eq!(
         type_,
         Type::Literal(LiteralKind::HexInteger {
-            value: BigInt::from(255),
+            value: BigUint::from(255u32),
             bytes: 1,
         })
     );
@@ -221,7 +221,7 @@ fn test_value_bearing_integer_literal_types() {
     assert_eq!(
         type_,
         Type::Literal(LiteralKind::HexInteger {
-            value: BigInt::from(18),
+            value: BigUint::from(18u32),
             bytes: 2,
         })
     );
@@ -503,15 +503,15 @@ fn test_hex_literal_to_byte_array_conversion() {
 
     // Hex source literal: byte-width must match the target exactly.
     let hex_0x12 = types.register_type(Type::Literal(LiteralKind::HexInteger {
-        value: BigInt::from(0x12),
+        value: BigUint::from(0x12u32),
         bytes: 1,
     }));
     let hex_0x0012 = types.register_type(Type::Literal(LiteralKind::HexInteger {
-        value: BigInt::from(0x12),
+        value: BigUint::from(0x12u32),
         bytes: 2,
     }));
     let hex_0x10203040 = types.register_type(Type::Literal(LiteralKind::HexInteger {
-        value: BigInt::from(0x1020_3040u32),
+        value: BigUint::from(0x1020_3040u32),
         bytes: 4,
     }));
 
@@ -537,11 +537,11 @@ fn test_hex_literal_to_byte_array_conversion() {
         value: BigInt::from(0),
     }));
     let hex_0x0 = types.register_type(Type::Literal(LiteralKind::HexInteger {
-        value: BigInt::from(0),
+        value: BigUint::from(0u32),
         bytes: 1,
     }));
     let hex_0x0000 = types.register_type(Type::Literal(LiteralKind::HexInteger {
-        value: BigInt::from(0),
+        value: BigUint::from(0u32),
         bytes: 2,
     }));
     assert!(types.implicitly_convertible_to(dec_0, bytes1));

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -348,14 +348,14 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
     // Factor the denominator as `2^a * 5^b * r`. The natural precision of
     // an exact representation is `max(a, b)`; if `r > 1` the rational has
     // a periodic fractional part and no exact representation exists.
-    let two = BigInt::from(2u32);
     let five = BigInt::from(5u32);
     let mut remaining_denominator = denominator.clone();
-    let mut factors_of_two: u32 = 0;
-    while remaining_denominator.is_multiple_of(&two) {
-        remaining_denominator /= &two;
-        factors_of_two += 1;
-    }
+    let factors_of_two: u32 = remaining_denominator
+        .trailing_zeros()
+        .unwrap_or(0)
+        .try_into()
+        .unwrap();
+    remaining_denominator >>= factors_of_two;
     let mut factors_of_five: u32 = 0;
     while remaining_denominator.is_multiple_of(&five) {
         remaining_denominator /= &five;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -348,7 +348,7 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
 
     // Factor the denominator as `2^a * 5^b * r`. The natural precision of
     // an exact representation is `max(a, b)`; if `r > 1` the rational has
-    // a periodic fractional part and no exact precision exists.
+    // a periodic fractional part and no exact representation exists.
     let two = BigInt::from(2u32);
     let five = BigInt::from(5u32);
     let mut remaining_denominator = denominator.clone();
@@ -365,10 +365,46 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
     let has_finite_expansion = remaining_denominator.is_one();
     let natural_decimal_places = factors_of_two.max(factors_of_five);
 
-    // Binary search the maximum precision in `[0, MAX_DECIMAL_PLACES]` for
-    // which the scaled magnitude still fits `max_magnitude`. Equivalent
-    // condition: `|p| * 10^d < (max_magnitude + 1) * q`.
+    // The scaled magnitude `floor(|p| * 10^d / q)` fits the 256-bit range
+    // iff `|p| * 10^d < (max_magnitude + 1) * q`; both the fast path and
+    // the binary-search probe below use this `threshold` comparison.
     let threshold = (max_magnitude + BigInt::from(1u32)) * denominator;
+
+    let build_result = |scaled_magnitude: BigInt, decimal_places: u32| -> Type {
+        let scaled = if signed {
+            -scaled_magnitude
+        } else {
+            scaled_magnitude
+        };
+        let bits = integer_bits_required(&scaled, signed);
+        debug_assert!(bits <= 256, "scaled value must fit 256 bits at this point");
+        let bits = bits.next_multiple_of(8).max(8);
+        Type::FixedPointNumber(FixedPointNumberType {
+            signed,
+            bits,
+            decimal_places,
+        })
+    };
+
+    // Fast path: a finite expansion whose natural precision is within the
+    // 80-place cap and whose scaled magnitude already fits — the common
+    // shape for typical decimal literals (`1/2`, `1/4`, `1.2`, …). One
+    // `pow` + multiply + compare here saves the binary search's ~7 probes.
+    if has_finite_expansion && natural_decimal_places <= MAX_DECIMAL_PLACES {
+        let scaled_numerator =
+            &numerator_magnitude * BigInt::from(10u32).pow(natural_decimal_places);
+        if scaled_numerator < threshold {
+            return Some(build_result(
+                scaled_numerator / denominator,
+                natural_decimal_places,
+            ));
+        }
+    }
+
+    // Slow path: truncate at the largest precision in `[0, MAX_DECIMAL_PLACES]`
+    // whose scaled magnitude still fits. Reached when the rational is
+    // periodic, when its natural precision exceeds 80 places, or when its
+    // natural precision yields a scaled value over 256 bits.
     let mut lower_bound: u32 = 0;
     let mut upper_bound: u32 = MAX_DECIMAL_PLACES;
     while lower_bound < upper_bound {
@@ -379,38 +415,11 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
             upper_bound = midpoint - 1;
         }
     }
-    let max_decimal_places = lower_bound;
-
-    // Prefer the natural precision when an exact representation fits;
-    // otherwise truncate at the largest precision that does. Since the
-    // scaled magnitude grows monotonically with `d`,
-    // `natural_decimal_places <= max_decimal_places` is exactly the
-    // "exact fit" condition (and also enforces `natural <= 80`).
-    let decimal_places = if has_finite_expansion && natural_decimal_places <= max_decimal_places {
-        natural_decimal_places
-    } else {
-        max_decimal_places
-    };
+    let decimal_places = lower_bound;
 
     let scaled_magnitude =
         &numerator_magnitude * BigInt::from(10u32).pow(decimal_places) / denominator;
-    let scaled = if signed {
-        -scaled_magnitude
-    } else {
-        scaled_magnitude
-    };
-
-    let bits = integer_bits_required(&scaled, signed);
-    debug_assert!(
-        bits <= 256,
-        "binary search guarantees the scaled value fits"
-    );
-    let bits = bits.next_multiple_of(8).max(8);
-    Some(Type::FixedPointNumber(FixedPointNumberType {
-        signed,
-        bits,
-        decimal_places,
-    }))
+    Some(build_result(scaled_magnitude, decimal_places))
 }
 
 #[cfg(test)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -7,7 +7,7 @@ use num_traits::cast::ToPrimitive;
 use num_traits::{Num, One, Signed, Zero};
 use slang_solidity_v2_ir::ir;
 
-use crate::types::{LiteralKind, Type};
+use crate::types::{IntegerType, LiteralKind, Type};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Number {
@@ -305,5 +305,5 @@ pub(crate) fn smallest_integer_type_to_fit(value: &BigInt) -> Option<Type> {
         return None;
     }
     let bits = bits.next_multiple_of(8).max(8);
-    Some(Type::Integer { signed, bits })
+    Some(Type::Integer(IntegerType { signed, bits }))
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -67,10 +67,9 @@ impl Number {
 
     pub fn from_literal_kind(kind: &LiteralKind) -> Option<Self> {
         match kind {
-            LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
-                Some(Self::Integer(value.clone()))
-            }
             LiteralKind::Address { value } => Some(Self::Integer(value.into())),
+            LiteralKind::Integer { value } => Some(Self::Integer(value.clone())),
+            LiteralKind::HexInteger { value, .. } => Some(Self::Integer(value.clone().into())),
             LiteralKind::Rational { value } => Some(Self::Rational(value.clone())),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => None,
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -7,7 +7,7 @@ use num_traits::cast::ToPrimitive;
 use num_traits::{Num, One, Signed, Zero};
 use slang_solidity_v2_ir::ir;
 
-use crate::types::{IntegerType, LiteralKind, Type};
+use crate::types::{FixedPointNumberType, IntegerType, LiteralKind, Type};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Number {
@@ -306,4 +306,257 @@ pub(crate) fn smallest_integer_type_to_fit(value: &BigInt) -> Option<Type> {
     }
     let bits = bits.next_multiple_of(8).max(8);
     Some(Type::Integer(IntegerType { signed, bits }))
+}
+
+/// Returns the smallest fixed-point type that holds `value`.
+///
+/// For rationals with a finite decimal expansion (`q = 2^a * 5^b` in
+/// lowest terms) the natural precision `max(a, b)` gives an exact
+/// representation; that's what we pick when it doesn't exceed 80 and the
+/// scaled value still fits in 256 bits — so `1/2` becomes `ufixed8x1`,
+/// `1/4` becomes `ufixed8x2`, `6/5` becomes `ufixed8x1`, etc.
+///
+/// Otherwise — periodic fractional part, natural precision over 80, or
+/// natural precision yielding a scaled value over 256 bits — we truncate
+/// at the largest precision `N` in `[0, 80]` that keeps
+/// `floor(|p| * 10^N / q)` within the chosen 256-bit range (`2^256 - 1`
+/// unsigned, `2^255` signed). `M` is then the smallest multiple of 8 in
+/// `[8, 256]` that holds the scaled value. Returns `None` only when the
+/// integer part alone overflows the range, since for any rational a
+/// low-enough `N` (down to 0) would otherwise let it fit.
+pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Type> {
+    const MAX_DECIMAL_PLACES: u32 = 80;
+
+    let signed = value.is_negative();
+    let numerator_magnitude = value.numer().abs();
+    // `BigRational` normalises to a positive denominator, so `denom()` is
+    // always > 0 and carries no sign information.
+    let denominator = value.denom();
+
+    // Maximum scaled magnitude that fits in 256 bits with the chosen
+    // signedness: `2^255` for signed (reachable by `INT256_MIN`), and
+    // `2^256 - 1` for unsigned.
+    let max_magnitude = if signed {
+        BigInt::from(1u32) << 255
+    } else {
+        (BigInt::from(1u32) << 256) - BigInt::from(1u32)
+    };
+
+    if &numerator_magnitude / denominator > max_magnitude {
+        return None;
+    }
+
+    // Factor the denominator as `2^a * 5^b * r`. The natural precision of
+    // an exact representation is `max(a, b)`; if `r > 1` the rational has
+    // a periodic fractional part and no exact precision exists.
+    let two = BigInt::from(2u32);
+    let five = BigInt::from(5u32);
+    let mut remaining_denominator = denominator.clone();
+    let mut factors_of_two: u32 = 0;
+    while remaining_denominator.is_multiple_of(&two) {
+        remaining_denominator /= &two;
+        factors_of_two += 1;
+    }
+    let mut factors_of_five: u32 = 0;
+    while remaining_denominator.is_multiple_of(&five) {
+        remaining_denominator /= &five;
+        factors_of_five += 1;
+    }
+    let has_finite_expansion = remaining_denominator.is_one();
+    let natural_decimal_places = factors_of_two.max(factors_of_five);
+
+    // Binary search the maximum precision in `[0, MAX_DECIMAL_PLACES]` for
+    // which the scaled magnitude still fits `max_magnitude`. Equivalent
+    // condition: `|p| * 10^d < (max_magnitude + 1) * q`.
+    let threshold = (max_magnitude + BigInt::from(1u32)) * denominator;
+    let mut lower_bound: u32 = 0;
+    let mut upper_bound: u32 = MAX_DECIMAL_PLACES;
+    while lower_bound < upper_bound {
+        let midpoint = lower_bound + (upper_bound - lower_bound).div_ceil(2);
+        if &numerator_magnitude * BigInt::from(10u32).pow(midpoint) < threshold {
+            lower_bound = midpoint;
+        } else {
+            upper_bound = midpoint - 1;
+        }
+    }
+    let max_decimal_places = lower_bound;
+
+    // Prefer the natural precision when an exact representation fits;
+    // otherwise truncate at the largest precision that does. Since the
+    // scaled magnitude grows monotonically with `d`,
+    // `natural_decimal_places <= max_decimal_places` is exactly the
+    // "exact fit" condition (and also enforces `natural <= 80`).
+    let decimal_places = if has_finite_expansion && natural_decimal_places <= max_decimal_places {
+        natural_decimal_places
+    } else {
+        max_decimal_places
+    };
+
+    let scaled_magnitude =
+        &numerator_magnitude * BigInt::from(10u32).pow(decimal_places) / denominator;
+    let scaled = if signed {
+        -scaled_magnitude
+    } else {
+        scaled_magnitude
+    };
+
+    let bits = integer_bits_required(&scaled, signed);
+    debug_assert!(
+        bits <= 256,
+        "binary search guarantees the scaled value fits"
+    );
+    let bits = bits.next_multiple_of(8).max(8);
+    Some(Type::FixedPointNumber(FixedPointNumberType {
+        signed,
+        bits,
+        decimal_places,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigInt;
+    use num_rational::BigRational;
+
+    use super::{smallest_fixed_point_type_to_fit, Type};
+    use crate::types::FixedPointNumberType;
+
+    fn fit(numerator: BigInt, denominator: BigInt) -> Option<FixedPointNumberType> {
+        match smallest_fixed_point_type_to_fit(&BigRational::new(numerator, denominator))? {
+            Type::FixedPointNumber(inner) => Some(inner),
+            other => panic!("expected FixedPointNumber, got {other:?}"),
+        }
+    }
+
+    fn unsigned_fixed(bits: u32, decimal_places: u32) -> FixedPointNumberType {
+        FixedPointNumberType {
+            signed: false,
+            bits,
+            decimal_places,
+        }
+    }
+
+    fn signed_fixed(bits: u32, decimal_places: u32) -> FixedPointNumberType {
+        FixedPointNumberType {
+            signed: true,
+            bits,
+            decimal_places,
+        }
+    }
+
+    fn pow2(exponent: u32) -> BigInt {
+        BigInt::from(2u32).pow(exponent)
+    }
+
+    fn pow10(exponent: u32) -> BigInt {
+        BigInt::from(10u32).pow(exponent)
+    }
+
+    // 1/2 = 0.5: terminating, denom = 2^1, natural d = 1. Scaled = 5
+    // (3 bits, rounded to M = 8).
+    #[test]
+    fn terminating_one_half() {
+        assert_eq!(
+            fit(BigInt::from(1u32), BigInt::from(2u32)),
+            Some(unsigned_fixed(8, 1)),
+        );
+    }
+
+    // 1/4 = 0.25: terminating, denom = 2^2, natural d = 2. Scaled = 25
+    // (5 bits → M = 8).
+    #[test]
+    fn terminating_one_quarter() {
+        assert_eq!(
+            fit(BigInt::from(1u32), BigInt::from(4u32)),
+            Some(unsigned_fixed(8, 2)),
+        );
+    }
+
+    // 6/5 = 1.2: terminating, denom = 5^1, natural d = 1. Scaled = 12
+    // (4 bits → M = 8).
+    #[test]
+    fn terminating_one_point_two() {
+        assert_eq!(
+            fit(BigInt::from(6u32), BigInt::from(5u32)),
+            Some(unsigned_fixed(8, 1)),
+        );
+    }
+
+    // -1/2: terminating negative — natural d = 1, scaled = -5
+    // (signed bits required = 4 → M = 8).
+    #[test]
+    fn terminating_signed_negative_one_half() {
+        assert_eq!(
+            fit(-BigInt::from(1u32), BigInt::from(2u32)),
+            Some(signed_fixed(8, 1)),
+        );
+    }
+
+    // 1/3: periodic — algorithm falls back to truncation, maximising d
+    // within the unsigned 256-bit range. d = 77 since `10^77 / 3` fits
+    // but `10^78 / 3` would not.
+    #[test]
+    fn non_terminating_one_third_truncates() {
+        assert_eq!(
+            fit(BigInt::from(1u32), BigInt::from(3u32)),
+            Some(unsigned_fixed(256, 77)),
+        );
+    }
+
+    // -1/3: signed variant of the truncation case. The signed bound
+    // `2^255` still admits d = 77 (`10^77 / 3 ≈ 3.33 * 10^76 < 2^255`).
+    #[test]
+    fn non_terminating_signed_negative_one_third_truncates() {
+        assert_eq!(
+            fit(-BigInt::from(1u32), BigInt::from(3u32)),
+            Some(signed_fixed(256, 77)),
+        );
+    }
+
+    // (2^256 - 1) / 2: terminating with natural d = 1, but the scaled
+    // value `5 * (2^256 - 1)` overflows 256 bits. Falls back to d = 0
+    // (which truncates the .5 fractional part).
+    #[test]
+    fn terminating_natural_precision_overflows_falls_back_to_truncation() {
+        let numerator = pow2(256) - BigInt::from(1u32);
+        assert_eq!(
+            fit(numerator, BigInt::from(2u32)),
+            Some(unsigned_fixed(256, 0)),
+        );
+    }
+
+    // 5 / 10^80: terminating, reduces to `1 / (2^80 * 5^79)`, natural
+    // d = 80. Scaled = 5, fits in the smallest M = 8.
+    #[test]
+    fn terminating_natural_precision_at_maximum() {
+        assert_eq!(
+            fit(BigInt::from(5u32), pow10(80)),
+            Some(unsigned_fixed(8, 80)),
+        );
+    }
+
+    // 1 / 10^100: natural d = 100 exceeds the 80-place cap, so we
+    // truncate. At d = 80 the scaled magnitude floors to 0.
+    #[test]
+    fn terminating_natural_precision_over_cap_truncates_to_zero() {
+        assert_eq!(
+            fit(BigInt::from(1u32), pow10(100)),
+            Some(unsigned_fixed(8, 80)),
+        );
+    }
+
+    // 2^260 / 3: integer part alone exceeds `2^256 - 1`, so no unsigned
+    // fixed-point type can hold this value.
+    #[test]
+    fn unsigned_integer_part_overflows() {
+        assert_eq!(fit(pow2(260), BigInt::from(3u32)), None);
+    }
+
+    // -2^257 / 3: signed bound is `2^255`, but `|2^257 / 3| ≈ 7.7 * 10^76`
+    // overflows it. The same magnitude as a positive value would fit
+    // unsigned, but signedness is fixed by the negative sign.
+    #[test]
+    fn signed_integer_part_overflows() {
+        assert_eq!(fit(-pow2(257), BigInt::from(3u32)), None);
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -75,7 +75,7 @@ pub struct EnumType {
 pub struct FixedPointNumberType {
     pub signed: bool,
     pub bits: u32,
-    pub precision_bits: u32,
+    pub decimal_places: u32,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,5 +1,5 @@
 use literals::numbers;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, BigUint};
 use num_rational::BigRational;
 use ruint::aliases::U160;
 use slang_solidity_v2_common::nodes::NodeId;
@@ -138,9 +138,10 @@ pub enum LiteralKind {
     /// source-text byte width (number of hex digits / 2, rounded up). The
     /// width is what determines convertibility with `bytesN` and is preserved
     /// distinctly from the value because `0x0012` and `0x12` share value `18`
-    /// but convert to `bytes2` and `bytes1` respectively.
+    /// but convert to `bytes2` and `bytes1` respectively. The value is
+    /// `BigUint` since hex literals are always non-negative.
     HexInteger {
-        value: BigInt,
+        value: BigUint,
         bytes: u32,
     },
     Rational {
@@ -166,8 +167,9 @@ impl LiteralKind {
     // __SLANG_MOBILE_TYPE__ keep in sync with `ast::LiteralType::mobile_type`
     pub fn mobile_type(&self) -> Option<Type> {
         match self {
-            LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
-                numbers::smallest_integer_type_to_fit(value)
+            LiteralKind::Integer { value } => numbers::smallest_integer_type_to_fit(value),
+            LiteralKind::HexInteger { value, .. } => {
+                numbers::smallest_integer_type_to_fit(&BigInt::from(value.clone()))
             }
             LiteralKind::Rational { value } => numbers::smallest_fixed_point_type_to_fit(value),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -159,20 +159,17 @@ pub enum LiteralKind {
 
 impl LiteralKind {
     /// Returns the non-literal `Type` this literal can flow into (e.g., the
-    /// smallest integer type that fits an integer literal, or `string memory`
-    /// for a string literal). Returns `None` for literals without a mobile
-    /// type (e.g., non-reducing rationals).
+    /// smallest integer type that fits an integer literal, the smallest
+    /// fixed-point type that fits a rational literal, or `string memory`
+    /// for a string literal). Returns `None` when the literal cannot be
+    /// represented (eg. integer would require more than 256 bits).
     // __SLANG_MOBILE_TYPE__ keep in sync with `ast::LiteralType::mobile_type`
     pub fn mobile_type(&self) -> Option<Type> {
         match self {
             LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
                 numbers::smallest_integer_type_to_fit(value)
             }
-            LiteralKind::Rational { .. } => {
-                // TODO: not supported yet, but narrow the rational type to the
-                // smallest fixed/ufixed available (eg. 1.2 -> ufixed8x1).
-                None
-            }
+            LiteralKind::Rational { value } => numbers::smallest_fixed_point_type_to_fit(value),
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => {
                 Some(Type::String(StringType {
                     location: DataLocation::Memory,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -18,67 +18,115 @@ pub struct TypeId(usize);
 // __SLANG_TYPE_TYPES__ keep in sync with AST types
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Type {
-    Address {
-        payable: bool,
-    },
-    Array {
-        element_type: TypeId,
-        location: DataLocation,
-    },
+    Address(AddressType),
+    Array(ArrayType),
     Boolean,
-    ByteArray {
-        width: u32,
-    },
-    Bytes {
-        location: DataLocation,
-    },
-    Contract {
-        definition_id: NodeId,
-    },
-    Enum {
-        definition_id: NodeId,
-    },
-    FixedPointNumber {
-        signed: bool,
-        bits: u32,
-        precision_bits: u32,
-    },
-    FixedSizeArray {
-        element_type: TypeId,
-        location: DataLocation,
-        // TODO: this should be u256, although in practice usize should suffice
-        size: usize,
-    },
+    ByteArray(ByteArrayType),
+    Bytes(BytesType),
+    Contract(ContractType),
+    Enum(EnumType),
+    FixedPointNumber(FixedPointNumberType),
+    FixedSizeArray(FixedSizeArrayType),
     Function(FunctionType),
-    Integer {
-        signed: bool,
-        bits: u32,
-    },
-    Interface {
-        definition_id: NodeId,
-    },
-    Library {
-        definition_id: NodeId,
-    },
+    Integer(IntegerType),
+    Interface(InterfaceType),
+    Library(LibraryType),
     Literal(LiteralKind),
-    Mapping {
-        key_type_id: TypeId,
-        value_type_id: TypeId,
-    },
-    String {
-        location: DataLocation,
-    },
-    Struct {
-        definition_id: NodeId,
-        location: DataLocation,
-    },
-    Tuple {
-        types: Vec<TypeId>,
-    },
-    UserDefinedValue {
-        definition_id: NodeId,
-    },
+    Mapping(MappingType),
+    String(StringType),
+    Struct(StructType),
+    Tuple(TupleType),
+    UserDefinedValue(UserDefinedValueType),
     Void,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct AddressType {
+    pub payable: bool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ArrayType {
+    pub element_type: TypeId,
+    pub location: DataLocation,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ByteArrayType {
+    pub width: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BytesType {
+    pub location: DataLocation,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ContractType {
+    pub definition_id: NodeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct EnumType {
+    pub definition_id: NodeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FixedPointNumberType {
+    pub signed: bool,
+    pub bits: u32,
+    pub precision_bits: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FixedSizeArrayType {
+    pub element_type: TypeId,
+    pub location: DataLocation,
+    // TODO: this should be u256, although in practice usize should suffice
+    pub size: usize,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct IntegerType {
+    pub signed: bool,
+    pub bits: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct InterfaceType {
+    pub definition_id: NodeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LibraryType {
+    pub definition_id: NodeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MappingType {
+    pub key_type_id: TypeId,
+    pub value_type_id: TypeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct StringType {
+    pub location: DataLocation,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct StructType {
+    pub definition_id: NodeId,
+    pub location: DataLocation,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TupleType {
+    pub types: Vec<TypeId>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UserDefinedValueType {
+    pub definition_id: NodeId,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -117,13 +165,17 @@ impl LiteralKind {
             LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
                 numbers::smallest_integer_type_to_fit(value)
             }
-            // TODO: not supported yet, but narrow the rational type to the
-            // smallest fixed/ufixed available (eg. 1.2 -> ufixed8x1).
-            LiteralKind::Rational { .. } => None,
-            LiteralKind::HexString { .. } | LiteralKind::String { .. } => Some(Type::String {
-                location: DataLocation::Memory,
-            }),
-            LiteralKind::Address { .. } => Some(Type::Address { payable: false }),
+            LiteralKind::Rational { .. } => {
+                // TODO: not supported yet, but narrow the rational type to the
+                // smallest fixed/ufixed available (eg. 1.2 -> ufixed8x1).
+                None
+            }
+            LiteralKind::HexString { .. } | LiteralKind::String { .. } => {
+                Some(Type::String(StringType {
+                    location: DataLocation::Memory,
+                }))
+            }
+            LiteralKind::Address { .. } => Some(Type::Address(AddressType { payable: false })),
         }
     }
 }
@@ -286,12 +338,12 @@ impl ImplicitlyConvertible<DataLocation> for DataLocation {
 impl Type {
     pub fn data_location(&self) -> Option<DataLocation> {
         match self {
-            Self::Array { location, .. }
-            | Self::Bytes { location }
-            | Self::FixedSizeArray { location, .. }
-            | Self::String { location }
-            | Self::Struct { location, .. } => Some(*location),
-            Self::Mapping { .. } => Some(DataLocation::Storage),
+            Self::Array(ArrayType { location, .. })
+            | Self::Bytes(BytesType { location })
+            | Self::FixedSizeArray(FixedSizeArrayType { location, .. })
+            | Self::String(StringType { location })
+            | Self::Struct(StructType { location, .. }) => Some(*location),
+            Self::Mapping(_) => Some(DataLocation::Storage),
             _ => None,
         }
     }
@@ -307,33 +359,33 @@ impl Type {
     /// Arrays and mapping can't
     pub fn can_return_from_getter_directly(&self) -> bool {
         match self {
-            Type::Address { .. }
+            Type::Address(_)
             | Type::Boolean
-            | Type::ByteArray { .. }
-            | Type::Bytes { .. }
-            | Type::Contract { .. }
-            | Type::Enum { .. }
-            | Type::FixedPointNumber { .. }
-            | Type::Integer { .. }
-            | Type::Interface { .. }
-            | Type::String { .. }
-            | Type::Struct { .. }
-            | Type::UserDefinedValue { .. } => true,
+            | Type::ByteArray(_)
+            | Type::Bytes(_)
+            | Type::Contract(_)
+            | Type::Enum(_)
+            | Type::FixedPointNumber(_)
+            | Type::Integer(_)
+            | Type::Interface(_)
+            | Type::String(_)
+            | Type::Struct(_)
+            | Type::UserDefinedValue(_) => true,
             Type::Function(FunctionType { visibility, .. }) => {
                 // Function types can only be returned if they're external
                 visibility == &FunctionTypeVisibility::External
             }
 
             // Can be returned, just not inside a struct
-            Type::Array { .. }
-            | Type::FixedSizeArray { .. }
-            | Type::Mapping { .. }
+            Type::Array(_)
+            | Type::FixedSizeArray(_)
+            | Type::Mapping(_)
             // Actually can't return from a getter
             // TODO(validation) SDR[1394]: Not sure if this is the best place for this check,
             // but it's related.
             | Type::Literal(_)
-            | Type::Library { .. }
-            | Type::Tuple { .. }
+            | Type::Library(_)
+            | Type::Tuple(_)
             | Type::Void => false,
         }
     }
@@ -358,17 +410,19 @@ impl Type {
     }
 
     pub fn is_contract_or_interface(&self) -> bool {
-        matches!(self, Type::Contract { .. } | Type::Interface { .. })
+        matches!(self, Type::Contract(_) | Type::Interface(_))
     }
 
     pub(crate) fn get_definition_id(&self) -> Option<NodeId> {
         match self {
-            Type::Contract { definition_id }
-            | Type::Enum { definition_id }
-            | Type::Interface { definition_id }
-            | Type::Struct { definition_id, .. }
-            | Type::UserDefinedValue { definition_id }
-            | Type::Library { definition_id } => Some(*definition_id),
+            Type::Contract(ContractType { definition_id })
+            | Type::Enum(EnumType { definition_id })
+            | Type::Interface(InterfaceType { definition_id })
+            | Type::Library(LibraryType { definition_id })
+            | Type::Struct(StructType { definition_id, .. })
+            | Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
+                Some(*definition_id)
+            }
             _ => None,
         }
     }
@@ -377,6 +431,6 @@ impl Type {
     ///
     /// TODO: This probably has a better way to resolve it, looking at the storage location
     pub(crate) fn can_be_array_element(&self) -> bool {
-        !matches!(self, Type::Mapping { .. } | Type::Tuple { .. } | Type::Void)
+        !matches!(self, Type::Mapping(_) | Type::Tuple(_) | Type::Void)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -158,9 +158,12 @@ pub enum LiteralKind {
 }
 
 impl LiteralKind {
-    /// Returns the non-literal `Type` this literal flows into when its source
-    /// position needs a concrete EVM type.
-    pub(crate) fn mobile_type(&self) -> Option<Type> {
+    /// Returns the non-literal `Type` this literal can flow into (e.g., the
+    /// smallest integer type that fits an integer literal, or `string memory`
+    /// for a string literal). Returns `None` for literals without a mobile
+    /// type (e.g., non-reducing rationals).
+    // __SLANG_MOBILE_TYPE__ keep in sync with `ast::LiteralType::mobile_type`
+    pub fn mobile_type(&self) -> Option<Type> {
         match self {
             LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
                 numbers::smallest_integer_type_to_fit(value)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
@@ -1,14 +1,16 @@
-use super::{DataLocation, Type};
+use super::{ByteArrayType, BytesType, DataLocation, FixedPointNumberType, IntegerType, Type};
 
 // Type instantiation from language keywords, eg. `uint64`
 impl Type {
     pub fn from_bytes_keyword(keyword: &str, data_location: Option<DataLocation>) -> Option<Self> {
         let width = keyword.strip_prefix("bytes").unwrap().parse::<u32>();
         if let Ok(width) = width {
-            Some(Self::ByteArray { width })
+            Some(Self::ByteArray(ByteArrayType { width }))
         } else {
-            data_location.map(|data_location| Self::Bytes {
-                location: data_location,
+            data_location.map(|data_location| {
+                Self::Bytes(BytesType {
+                    location: data_location,
+                })
             })
         }
     }
@@ -19,7 +21,7 @@ impl Type {
             .unwrap()
             .parse::<u32>()
             .unwrap_or(256);
-        Self::Integer { signed: true, bits }
+        Self::Integer(IntegerType { signed: true, bits })
     }
 
     pub fn from_uint_keyword(keyword: &str) -> Self {
@@ -28,10 +30,10 @@ impl Type {
             .unwrap()
             .parse::<u32>()
             .unwrap_or(256);
-        Self::Integer {
+        Self::Integer(IntegerType {
             signed: false,
             bits,
-        }
+        })
     }
 
     pub fn from_fixed_keyword(keyword: &str) -> Self {
@@ -42,11 +44,11 @@ impl Type {
             .map(|part| part.parse::<u32>().unwrap());
         let bits = parts.next().unwrap();
         let precision_bits = parts.next().unwrap_or(0);
-        Self::FixedPointNumber {
+        Self::FixedPointNumber(FixedPointNumberType {
             signed: true,
             bits,
             precision_bits,
-        }
+        })
     }
 
     pub fn from_ufixed_keyword(keyword: &str) -> Self {
@@ -57,10 +59,10 @@ impl Type {
             .map(|part| part.parse::<u32>().unwrap());
         let bits = parts.next().unwrap();
         let precision_bits = parts.next().unwrap_or(0);
-        Self::FixedPointNumber {
+        Self::FixedPointNumber(FixedPointNumberType {
             signed: false,
             bits,
             precision_bits,
-        }
+        })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
@@ -43,11 +43,11 @@ impl Type {
             .split('x')
             .map(|part| part.parse::<u32>().unwrap());
         let bits = parts.next().unwrap();
-        let precision_bits = parts.next().unwrap_or(0);
+        let decimal_places = parts.next().unwrap_or(0);
         Self::FixedPointNumber(FixedPointNumberType {
             signed: true,
             bits,
-            precision_bits,
+            decimal_places,
         })
     }
 
@@ -58,11 +58,11 @@ impl Type {
             .split('x')
             .map(|part| part.parse::<u32>().unwrap());
         let bits = parts.next().unwrap();
-        let precision_bits = parts.next().unwrap_or(0);
+        let decimal_places = parts.next().unwrap_or(0);
         Self::FixedPointNumber(FixedPointNumberType {
             signed: false,
             bits,
-            precision_bits,
+            decimal_places,
         })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -6,7 +6,9 @@ use slang_solidity_v2_common::nodes::NodeId;
 
 use super::literals::numbers;
 use super::{
-    DataLocation, FunctionType, FunctionTypeVisibility, LiteralKind, Number, Type, TypeId,
+    AddressType, ArrayType, ByteArrayType, BytesType, ContractType, DataLocation,
+    FixedSizeArrayType, FunctionType, FunctionTypeVisibility, IntegerType, InterfaceType,
+    LiteralKind, Number, StringType, StructType, TupleType, Type, TypeId,
 };
 use crate::types::ImplicitlyConvertible;
 
@@ -43,35 +45,36 @@ impl Default for TypeRegistry {
     #[allow(clippy::similar_names)]
     fn default() -> Self {
         let mut types = IndexSet::new();
-        let (address_type, _) = types.insert_full(Type::Address { payable: false });
-        let (address_payable_type, _) = types.insert_full(Type::Address { payable: true });
+        let (address_type, _) = types.insert_full(Type::Address(AddressType { payable: false }));
+        let (address_payable_type, _) =
+            types.insert_full(Type::Address(AddressType { payable: true }));
         let (boolean_type, _) = types.insert_full(Type::Boolean);
-        let (bytes_calldata_type, _) = types.insert_full(Type::Bytes {
+        let (bytes_calldata_type, _) = types.insert_full(Type::Bytes(BytesType {
             location: DataLocation::Calldata,
-        });
-        let (bytes_memory_type, _) = types.insert_full(Type::Bytes {
+        }));
+        let (bytes_memory_type, _) = types.insert_full(Type::Bytes(BytesType {
             location: DataLocation::Memory,
-        });
-        let (bytes1_type, _) = types.insert_full(Type::ByteArray { width: 1 });
-        let (bytes20_type, _) = types.insert_full(Type::ByteArray { width: 20 });
-        let (bytes32_type, _) = types.insert_full(Type::ByteArray { width: 32 });
-        let (bytes4_type, _) = types.insert_full(Type::ByteArray { width: 4 });
-        let (string_memory_type, _) = types.insert_full(Type::String {
+        }));
+        let (bytes1_type, _) = types.insert_full(Type::ByteArray(ByteArrayType { width: 1 }));
+        let (bytes20_type, _) = types.insert_full(Type::ByteArray(ByteArrayType { width: 20 }));
+        let (bytes32_type, _) = types.insert_full(Type::ByteArray(ByteArrayType { width: 32 }));
+        let (bytes4_type, _) = types.insert_full(Type::ByteArray(ByteArrayType { width: 4 }));
+        let (string_memory_type, _) = types.insert_full(Type::String(StringType {
             location: DataLocation::Memory,
-        });
-        let (uint256_type, _) = types.insert_full(Type::Integer {
+        }));
+        let (uint256_type, _) = types.insert_full(Type::Integer(IntegerType {
             signed: false,
             bits: 256,
-        });
-        let (uint8_type, _) = types.insert_full(Type::Integer {
+        }));
+        let (uint8_type, _) = types.insert_full(Type::Integer(IntegerType {
             signed: false,
             bits: 8,
-        });
+        }));
         let (void_type, _) = types.insert_full(Type::Void);
 
-        let (boolean_bytes_tuple_type, _) = types.insert_full(Type::Tuple {
+        let (boolean_bytes_tuple_type, _) = types.insert_full(Type::Tuple(TupleType {
             types: vec![TypeId(boolean_type), TypeId(bytes_memory_type)],
-        });
+        }));
 
         Self {
             types,
@@ -144,21 +147,21 @@ impl TypeRegistry {
 
         match (from_type, to_type) {
             (
-                Type::Address {
+                Type::Address(AddressType {
                     payable: from_payable,
-                },
-                Type::Address { .. },
+                }),
+                Type::Address(_),
             ) => *from_payable,
 
             (
-                Type::Integer {
+                Type::Integer(IntegerType {
                     signed: from_signed,
                     bits: from_bits,
-                },
-                Type::Integer {
+                }),
+                Type::Integer(IntegerType {
                     signed: to_signed,
                     bits: to_bits,
-                },
+                }),
             ) => {
                 if from_signed == to_signed {
                     from_bits <= to_bits
@@ -173,21 +176,21 @@ impl TypeRegistry {
                 Type::Literal(
                     LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
                 ),
-                Type::Integer { signed, bits },
+                Type::Integer(IntegerType { signed, bits }),
             ) => numbers::integer_literal_fits(value, *signed, *bits),
 
             // Non-integer rational literals never implicitly convert to an
             // integer type — if a rational reduced to an integer it would have
             // been normalised to `LiteralKind::Integer` at construction time.
-            (Type::Literal(LiteralKind::Rational { .. }), Type::Integer { .. }) => false,
+            (Type::Literal(LiteralKind::Rational { .. }), Type::Integer(_)) => false,
 
             // TODO: Rational -> FixedPointNumber once v2 models implicit
             // conversion of rational literals to fixed-point types.
-            (Type::Integer { .. }, Type::Literal(_)) => false,
+            (Type::Integer(_), Type::Literal(_)) => false,
 
             (
                 Type::Literal(LiteralKind::HexString { .. } | LiteralKind::String { .. }),
-                Type::String { location } | Type::Bytes { location },
+                Type::String(StringType { location }) | Type::Bytes(BytesType { location }),
             ) if *location == DataLocation::Memory || *location == DataLocation::Calldata => true,
 
             // Zero (any source — decimal, hex, or folded) is always
@@ -196,49 +199,48 @@ impl TypeRegistry {
                 Type::Literal(
                     LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
                 ),
-                Type::ByteArray { .. },
+                Type::ByteArray(_),
             ) if value.is_zero() => true,
 
             // Non-zero hex-source literals convert to `bytesN` of exactly
             // matching source byte width. Plain `Integer` literals (decimal
             // source or any folded result) do NOT — folding any operation
             // erases the hex provenance and disables this conversion.
-            (Type::Literal(LiteralKind::HexInteger { bytes, .. }), Type::ByteArray { width })
-                if *bytes == *width =>
-            {
-                true
-            }
+            (
+                Type::Literal(LiteralKind::HexInteger { bytes, .. }),
+                Type::ByteArray(ByteArrayType { width }),
+            ) if *bytes == *width => true,
 
             (
                 Type::Literal(LiteralKind::HexString { bytes } | LiteralKind::String { bytes }),
-                Type::ByteArray { width },
+                Type::ByteArray(ByteArrayType { width }),
             ) if *bytes == *width as usize => true,
 
             (
-                Type::Array {
+                Type::Array(ArrayType {
                     element_type: from_element_type,
                     location: from_location,
-                },
-                Type::Array {
+                }),
+                Type::Array(ArrayType {
                     element_type: to_element_type,
                     location: to_location,
-                },
+                }),
             ) => {
                 from_location.implicitly_convertible_to(*to_location)
                     && self.implicitly_convertible_to(*from_element_type, *to_element_type)
             }
 
             (
-                Type::FixedSizeArray {
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: from_element_type,
                     location: from_location,
                     size: from_size,
-                },
-                Type::FixedSizeArray {
+                }),
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: to_element_type,
                     location: to_location,
                     size: to_size,
-                },
+                }),
             ) => {
                 // conversion rules are strict and only allow changing data
                 // location (from storage/calldata to memory)
@@ -248,40 +250,41 @@ impl TypeRegistry {
             }
 
             (
-                Type::Struct {
+                Type::Struct(StructType {
                     definition_id: from_definition,
                     location: from_location,
-                },
-                Type::Struct {
+                }),
+                Type::Struct(StructType {
                     definition_id: to_definition,
                     location: to_location,
-                },
+                }),
             ) => {
                 from_location.implicitly_convertible_to(*to_location)
                     && from_definition == to_definition
             }
 
             (
-                Type::Bytes {
+                Type::Bytes(BytesType {
                     location: from_location,
-                },
-                Type::Bytes {
+                }),
+                Type::Bytes(BytesType {
                     location: to_location,
-                },
+                }),
             )
             | (
-                Type::String {
+                Type::String(StringType {
                     location: from_location,
-                },
-                Type::String {
+                }),
+                Type::String(StringType {
                     location: to_location,
-                },
+                }),
             ) => from_location.implicitly_convertible_to(*to_location),
 
             // `bytesN` widens to `bytesM` when `M >= N`.
-            (Type::ByteArray { width: from_width }, Type::ByteArray { width: to_width }) => {
-                from_width <= to_width
-            }
+            (
+                Type::ByteArray(ByteArrayType { width: from_width }),
+                Type::ByteArray(ByteArrayType { width: to_width }),
+            ) => from_width <= to_width,
 
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
                 // This is full equality except for visibility and mutability
@@ -298,28 +301,23 @@ impl TypeRegistry {
 
             // Contracts and interfaces are implicitly converted to their super types
             (
-                Type::Contract {
+                Type::Contract(ContractType {
                     definition_id: from_node_id,
-                    ..
-                },
-                Type::Contract {
+                }),
+                Type::Contract(ContractType {
                     definition_id: to_node_id,
-                    ..
-                }
-                | Type::Interface {
+                })
+                | Type::Interface(InterfaceType {
                     definition_id: to_node_id,
-                    ..
-                },
+                }),
             )
             | (
-                Type::Interface {
+                Type::Interface(InterfaceType {
                     definition_id: from_node_id,
-                    ..
-                },
-                Type::Interface {
+                }),
+                Type::Interface(InterfaceType {
                     definition_id: to_node_id,
-                    ..
-                },
+                }),
             ) => self
                 .super_types
                 .get(from_node_id)
@@ -349,43 +347,42 @@ impl TypeRegistry {
         // this assumption.
         match (from_type, to_type) {
             (
-                Type::Array {
+                Type::Array(ArrayType {
                     element_type: from_element_type,
                     ..
-                },
-                Type::Array {
+                }),
+                Type::Array(ArrayType {
                     element_type: to_element_type,
                     ..
-                },
+                }),
             ) => self
                 .implicitly_convertible_to_for_external_call(*from_element_type, *to_element_type),
 
             (
-                Type::FixedSizeArray {
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: from_element_type,
                     size: from_size,
                     ..
-                },
-                Type::FixedSizeArray {
+                }),
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: to_element_type,
                     size: to_size,
                     ..
-                },
+                }),
             ) => from_size == to_size && from_element_type == to_element_type,
 
             (
-                Type::Struct {
+                Type::Struct(StructType {
                     definition_id: from_definition,
                     ..
-                },
-                Type::Struct {
+                }),
+                Type::Struct(StructType {
                     definition_id: to_definition,
                     ..
-                },
+                }),
             ) => from_definition == to_definition,
 
-            (Type::Bytes { .. }, Type::Bytes { .. })
-            | (Type::String { .. }, Type::String { .. }) => true,
+            (Type::Bytes(_), Type::Bytes(_)) | (Type::String(_), Type::String(_)) => true,
 
             _ => self.implicitly_convertible_to(from_type_id, to_type_id),
         }
@@ -423,33 +420,33 @@ impl TypeRegistry {
 
     pub(crate) fn find_canonical_type_id(&self, type_id: TypeId) -> Option<TypeId> {
         let canonical_type = match self.get_type_by_id(type_id) {
-            Type::Array { element_type, .. } => {
+            Type::Array(ArrayType { element_type, .. }) => {
                 let element_type = self.find_canonical_type_id(*element_type)?;
-                Type::Array {
+                Type::Array(ArrayType {
                     element_type,
                     location: DataLocation::Inherited,
-                }
+                })
             }
-            Type::Bytes { .. } => Type::Bytes {
+            Type::Bytes(_) => Type::Bytes(BytesType {
                 location: DataLocation::Inherited,
-            },
-            Type::FixedSizeArray {
+            }),
+            Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
-            } => {
+            }) => {
                 let element_type = self.find_canonical_type_id(*element_type)?;
-                Type::FixedSizeArray {
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type,
                     size: *size,
                     location: DataLocation::Inherited,
-                }
+                })
             }
-            Type::String { .. } => Type::String {
+            Type::String(_) => Type::String(StringType {
                 location: DataLocation::Inherited,
-            },
-            Type::Struct { definition_id, .. } => Type::Struct {
+            }),
+            Type::Struct(StructType { definition_id, .. }) => Type::Struct(StructType {
                 definition_id: *definition_id,
                 location: DataLocation::Inherited,
-            },
+            }),
             Type::Function(FunctionType {
                 parameter_types,
                 return_type,
@@ -465,19 +462,19 @@ impl TypeRegistry {
                 mutability: *mutability,
             }),
 
-            Type::Address { .. }
+            Type::Address(_)
             | Type::Boolean
-            | Type::ByteArray { .. }
-            | Type::Contract { .. }
-            | Type::Enum { .. }
-            | Type::FixedPointNumber { .. }
-            | Type::Integer { .. }
-            | Type::Interface { .. }
-            | Type::Library { .. }
+            | Type::ByteArray(_)
+            | Type::Contract(_)
+            | Type::Enum(_)
+            | Type::FixedPointNumber(_)
+            | Type::Integer(_)
+            | Type::Interface(_)
+            | Type::Library(_)
             | Type::Literal(_)
-            | Type::Mapping { .. }
-            | Type::Tuple { .. }
-            | Type::UserDefinedValue { .. }
+            | Type::Mapping(_)
+            | Type::Tuple(_)
+            | Type::UserDefinedValue(_)
             | Type::Void => return Some(type_id),
         };
         self.find_type(&canonical_type)
@@ -498,45 +495,45 @@ impl TypeRegistry {
         location: DataLocation,
     ) -> TypeId {
         let type_with_location = match type_ {
-            Type::Array { element_type, .. } => Type::Array {
+            Type::Array(ArrayType { element_type, .. }) => Type::Array(ArrayType {
                 element_type: self.register_type_id_with_data_location(element_type, location),
                 location,
-            },
-            Type::Bytes { .. } => Type::Bytes { location },
-            Type::FixedSizeArray {
+            }),
+            Type::Bytes(_) => Type::Bytes(BytesType { location }),
+            Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
-            } => Type::FixedSizeArray {
+            }) => Type::FixedSizeArray(FixedSizeArrayType {
                 element_type: self.register_type_id_with_data_location(element_type, location),
                 size,
                 location,
-            },
-            Type::String { .. } => Type::String { location },
-            Type::Struct { definition_id, .. } => Type::Struct {
+            }),
+            Type::String(_) => Type::String(StringType { location }),
+            Type::Struct(StructType { definition_id, .. }) => Type::Struct(StructType {
                 definition_id,
                 location,
-            },
-            Type::Tuple { types } => {
+            }),
+            Type::Tuple(TupleType { types }) => {
                 let types_with_location = types
                     .iter()
                     .map(|id| self.register_type_id_with_data_location(*id, location))
                     .collect();
-                Type::Tuple {
+                Type::Tuple(TupleType {
                     types: types_with_location,
-                }
+                })
             }
-            Type::Address { .. }
+            Type::Address(_)
             | Type::Boolean
-            | Type::ByteArray { .. }
-            | Type::Contract { .. }
-            | Type::Enum { .. }
-            | Type::FixedPointNumber { .. }
+            | Type::ByteArray(_)
+            | Type::Contract(_)
+            | Type::Enum(_)
+            | Type::FixedPointNumber(_)
             | Type::Function(_)
-            | Type::Integer { .. }
-            | Type::Interface { .. }
-            | Type::Library { .. }
+            | Type::Integer(_)
+            | Type::Interface(_)
+            | Type::Library(_)
             | Type::Literal(_)
-            | Type::Mapping { .. }
-            | Type::UserDefinedValue { .. }
+            | Type::Mapping(_)
+            | Type::UserDefinedValue(_)
             | Type::Void => type_,
         };
         self.register_type(type_with_location)
@@ -549,12 +546,12 @@ impl TypeRegistry {
                 let mobile = kind.mobile_type()?;
                 Some(self.register_type(mobile))
             }
-            Type::Tuple { types: element_ids } => {
+            Type::Tuple(TupleType { types: element_ids }) => {
                 let mobile_ids: Option<Vec<TypeId>> = element_ids
                     .iter()
                     .map(|id| self.compute_mobile_type(*id))
                     .collect();
-                Some(self.register_type(Type::Tuple { types: mobile_ids? }))
+                Some(self.register_type(Type::Tuple(TupleType { types: mobile_ids? })))
             }
             _ => Some(type_id),
         }
@@ -663,14 +660,14 @@ impl TypeRegistry {
         let type_right = self.get_type_by_id(right);
         match (type_left, type_right) {
             (
-                Type::Array {
+                Type::Array(ArrayType {
                     element_type: element_type_left,
                     location: location_left,
-                },
-                Type::Array {
+                }),
+                Type::Array(ArrayType {
                     element_type: element_type_right,
                     location: location_right,
-                },
+                }),
             ) => {
                 location_left.overrides_in_external_function(*location_right)
                     && self.parameter_type_overrides_in_external_function(
@@ -679,16 +676,16 @@ impl TypeRegistry {
                     )
             }
             (
-                Type::FixedSizeArray {
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: element_type_left,
                     size: size_left,
                     location: location_left,
-                },
-                Type::FixedSizeArray {
+                }),
+                Type::FixedSizeArray(FixedSizeArrayType {
                     element_type: element_type_right,
                     size: size_right,
                     location: location_right,
-                },
+                }),
             ) => {
                 size_left == size_right
                     && location_left.overrides_in_external_function(*location_right)
@@ -698,30 +695,30 @@ impl TypeRegistry {
                     )
             }
             (
-                Type::Bytes {
+                Type::Bytes(BytesType {
                     location: location_left,
-                },
-                Type::Bytes {
+                }),
+                Type::Bytes(BytesType {
                     location: location_right,
-                },
+                }),
             )
             | (
-                Type::String {
+                Type::String(StringType {
                     location: location_left,
-                },
-                Type::String {
+                }),
+                Type::String(StringType {
                     location: location_right,
-                },
+                }),
             ) => location_left.overrides_in_external_function(*location_right),
             (
-                Type::Struct {
+                Type::Struct(StructType {
                     definition_id: definition_id_left,
                     location: location_left,
-                },
-                Type::Struct {
+                }),
+                Type::Struct(StructType {
                     definition_id: definition_id_right,
                     location: location_right,
-                },
+                }),
             ) => {
                 definition_id_left == definition_id_right
                     && location_left.overrides_in_external_function(*location_right)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use indexmap::IndexSet;
+use num_bigint::BigInt;
 use num_traits::Zero;
 use slang_solidity_v2_common::nodes::NodeId;
 
@@ -173,11 +174,14 @@ impl TypeRegistry {
             }
 
             (
-                Type::Literal(
-                    LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
-                ),
+                Type::Literal(LiteralKind::Integer { value }),
                 Type::Integer(IntegerType { signed, bits }),
             ) => numbers::integer_literal_fits(value, *signed, *bits),
+
+            (
+                Type::Literal(LiteralKind::HexInteger { value, .. }),
+                Type::Integer(IntegerType { signed, bits }),
+            ) => numbers::integer_literal_fits(&BigInt::from(value.clone()), *signed, *bits),
 
             // Non-integer rational literals never implicitly convert to an
             // integer type — if a rational reduced to an integer it would have
@@ -195,12 +199,16 @@ impl TypeRegistry {
 
             // Zero (any source — decimal, hex, or folded) is always
             // implicitly convertible to any byte-array type.
-            (
-                Type::Literal(
-                    LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. },
-                ),
-                Type::ByteArray(_),
-            ) if value.is_zero() => true,
+            (Type::Literal(LiteralKind::Integer { value }), Type::ByteArray(_))
+                if value.is_zero() =>
+            {
+                true
+            }
+            (Type::Literal(LiteralKind::HexInteger { value, .. }), Type::ByteArray(_))
+                if value.is_zero() =>
+            {
+                true
+            }
 
             // Non-zero hex-source literals convert to `bytesN` of exactly
             // matching source byte width. Plain `Integer` literals (decimal

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -407,7 +407,7 @@ fn type_display(type_: &Type) -> String {
                 "{signed}fixed{bits}x{precision_bits}",
                 signed = if fixed.signed() { "" } else { "u" },
                 bits = fixed.bits(),
-                precision_bits = fixed.precision_bits(),
+                precision_bits = fixed.decimal_places(),
             )
         }
         Type::FixedSizeArray(fixed_size_array) => format!(


### PR DESCRIPTION
We want to add `LiteralType::mobile_type()` as a service for `solx` to easily type literal constants. This PR modifies `Type` to store the type details instead of the `TypeId`. We still need a reference to the `SemanticContext` for some types because of nested types and definitions. To do that, we create named structs for semantic types variants, to use them in place of the current anonymous ones.

Most importantly, it allows us to compute the mobile type for literal variants and return them as AST types without having to register new types (which would require a mutable `SemanticContext`).

Also implements mobile type conversion for rationals to fixed-point number types.
