### PR TITLE
[v2] Rename `compute_abi_with_file_id` to `compute_abi` and get the file from the contract node

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1425,7 +1425,7 @@ impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::compute_abi_with_file_id(&self, file_id: alloc::string::String) -> core::option::Option<slang_solidity_v2_ast::abi::ContractAbi>
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::compute_abi(&self) -> core::option::Option<slang_solidity_v2_ast::abi::ContractAbi>
 impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::compute_linearised_bases(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::ContractBase>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::compute_linearised_errors(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::ErrorDefinition>

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
@@ -6,11 +6,9 @@ use crate::abi::{AbiEntry, ContractAbi, StorageItem};
 use crate::ast::{ContractDefinitionStruct, StateVariableDefinition, StateVariableMutability};
 
 impl ContractDefinitionStruct {
-    // TODO: ideally the user wouldn't need to provide the file_id and we should
-    // be able to obtain it here, but for that we need bi-directional tree
-    // navigation
-    pub fn compute_abi_with_file_id(&self, file_id: String) -> Option<ContractAbi> {
+    pub fn compute_abi(&self) -> Option<ContractAbi> {
         let name = self.ir_node.name.unparse().to_string();
+        let file_id = self.get_file_id().to_string();
         let entries = self.compute_abi_entries()?;
         let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
         Some(ContractAbi {

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
@@ -3,14 +3,13 @@ use crate::ast::SourceUnitStruct;
 
 impl SourceUnitStruct {
     pub fn compute_contracts_abi(&self) -> Vec<abi::ContractAbi> {
-        let file_id = self.file_id();
         self.contracts()
             .iter()
             .filter_map(|contract| {
                 if contract.abstract_keyword().is_some() {
                     None
                 } else {
-                    contract.compute_abi_with_file_id(file_id.to_string())
+                    contract.compute_abi()
                 }
             })
             .collect()

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -76,9 +76,7 @@ fn test_storage_layout() {
     let counter = unit
         .find_contract_by_name("C")
         .expect("contract can be found");
-    let counter_abi = counter
-        .compute_abi_with_file_id("main.sol".to_string())
-        .expect("can compute ABI");
+    let counter_abi = counter.compute_abi().expect("can compute ABI");
     let layout = counter_abi.storage_layout();
 
     assert_eq!(layout.len(), 12);
@@ -107,9 +105,7 @@ fn test_transient_and_custom_storage_layout() {
     let d_contract = unit
         .find_contract_by_name("D")
         .expect("contract can be found");
-    let d_abi = d_contract
-        .compute_abi_with_file_id("main.sol".to_string())
-        .expect("can compute ABI");
+    let d_abi = d_contract.compute_abi().expect("can compute ABI");
     let d_layout = d_abi.storage_layout();
 
     assert_eq!(d_layout.len(), 2);
@@ -119,9 +115,7 @@ fn test_transient_and_custom_storage_layout() {
     let e_contract = unit
         .find_contract_by_name("E")
         .expect("contract can be found");
-    let e_abi = e_contract
-        .compute_abi_with_file_id("main.sol".to_string())
-        .expect("can compute ABI");
+    let e_abi = e_contract.compute_abi().expect("can compute ABI");
     let e_layout = e_abi.storage_layout();
     let e_transient_layout = e_abi.transient_storage_layout();
 
@@ -141,9 +135,7 @@ fn test_erc7201_storage_layout() {
     let f_contract = unit
         .find_contract_by_name("F")
         .expect("contract can be found");
-    let f_abi = f_contract
-        .compute_abi_with_file_id("main.sol".to_string())
-        .expect("can compute ABI");
+    let f_abi = f_contract.compute_abi().expect("can compute ABI");
     let f_layout = f_abi.storage_layout();
 
     // EIP-7201 test vector: `erc7201("example.main")` →


### PR DESCRIPTION
Minor API change to improve ergonomics. Extract `file_id` from the contract node when computing ABI, remove the extra parameter and rename the function for consistency. We used to require the parameter because we didn't have node->file mapping available.

