### PR TITLE
widen versions used in snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,7 +4483,6 @@ dependencies = [
  "slang_solidity_v2_ir",
  "slang_solidity_v2_parser",
  "slang_solidity_v2_semantic",
- "solidity_v2_language",
  "solidity_v2_testing_utils",
 ]
 

--- a/crates/language-v2/definition/src/model/manifest.rs
+++ b/crates/language-v2/definition/src/model/manifest.rs
@@ -1,11 +1,9 @@
-use std::collections::BTreeSet;
-
 use indexmap::IndexSet;
 use language_v2_internal_macros::{derive_spanned_type, ParseInputTokens, WriteOutputTokens};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BuiltInContext, Field, Identifier, Item, VersionSpecifier};
+use crate::model::{BuiltInContext, Identifier, Item};
 
 /// A representation of a Language definition
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -32,91 +30,6 @@ impl Language {
     /// Returns every item in the language definition (across all contexts).
     pub fn items(&self) -> impl Iterator<Item = &Item> {
         self.contexts.iter().flat_map(|context| context.items())
-    }
-
-    /// Collects all versions that change the language syntax in a breaking way.
-    ///
-    /// Includes the first supported version. Only considers grammar items
-    /// (structs, enums, tokens, etc.), not built-in definitions.
-    pub fn collect_syntax_breaking_versions(&self) -> BTreeSet<Version> {
-        let first = self.versions.first().unwrap().clone();
-        let mut res = BTreeSet::from_iter([first]);
-
-        let mut add_spec = |spec: &Option<VersionSpecifier>| {
-            if let Some(spec) = spec {
-                res.extend(spec.breaking_versions().cloned());
-            }
-        };
-
-        for item in self.items() {
-            match item {
-                Item::Struct { item } => {
-                    add_spec(&item.enabled);
-                    for field in item.fields.values() {
-                        match field {
-                            Field::Required { .. } => (),
-                            Field::Optional { enabled, .. } => add_spec(enabled),
-                        }
-                    }
-                }
-                Item::Enum { item } => {
-                    add_spec(&item.enabled);
-                    for variant in &item.variants {
-                        add_spec(&variant.enabled);
-                    }
-                }
-                Item::Repeated { item } => add_spec(&item.enabled),
-                Item::Separated { item } => add_spec(&item.enabled),
-                Item::Precedence { item } => {
-                    add_spec(&item.enabled);
-                    for prec in &item.precedence_expressions {
-                        for op in &prec.operators {
-                            add_spec(&op.enabled);
-                            for field in op.fields.values() {
-                                match field {
-                                    Field::Required { .. } => (),
-                                    Field::Optional { enabled, .. } => add_spec(enabled),
-                                }
-                            }
-                        }
-                    }
-                    for prim in &item.primary_expressions {
-                        add_spec(&prim.enabled);
-                    }
-                }
-                Item::Keyword { item } => {
-                    add_spec(&item.enabled);
-                    add_spec(&item.reserved);
-                }
-                Item::Token { item } => {
-                    add_spec(&item.enabled);
-                }
-                Item::Fragment { item } => add_spec(&item.enabled),
-                Item::Trivia { .. } => {}
-            }
-        }
-
-        res
-    }
-
-    /// Collects all versions that change the language semantics in a breaking way.
-    ///
-    /// Includes the first supported version. Considers both grammar items and
-    /// built-in definitions.
-    pub fn collect_semantic_breaking_versions(&self) -> BTreeSet<Version> {
-        let mut res = self.collect_syntax_breaking_versions();
-
-        for context in &self.built_ins {
-            for scope in &context.scopes {
-                for definition in &scope.definitions {
-                    if let Some(spec) = &definition.enabled {
-                        res.extend(spec.breaking_versions().cloned());
-                    }
-                }
-            }
-        }
-
-        res
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -819,6 +819,8 @@ pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_7
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_8
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_9
 impl slang_solidity_v2_common::versions::LanguageVersion
+pub const slang_solidity_v2_common::versions::LanguageVersion::ALL: &'static [slang_solidity_v2_common::versions::LanguageVersion]
+pub const slang_solidity_v2_common::versions::LanguageVersion::EARLIEST: Self
 pub const slang_solidity_v2_common::versions::LanguageVersion::LATEST: Self
 impl core::clone::Clone for slang_solidity_v2_common::versions::LanguageVersion
 pub fn slang_solidity_v2_common::versions::LanguageVersion::clone(&self) -> slang_solidity_v2_common::versions::LanguageVersion

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/mod.rs
@@ -1,32 +1,9 @@
-#[path = "language_versions.generated.rs"]
-mod language_versions;
+mod specifier;
+#[path = "version.generated.rs"]
+mod version;
 
-pub use language_versions::{FromSemverError, LanguageVersion};
-use serde::Serialize;
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub enum LanguageVersionSpecifier {
-    From {
-        from: LanguageVersion,
-    },
-    Till {
-        till: LanguageVersion,
-    },
-    Range {
-        from: LanguageVersion,
-        till: LanguageVersion,
-    },
-}
-
-impl LanguageVersionSpecifier {
-    pub fn contains(&self, other: LanguageVersion) -> bool {
-        match self {
-            LanguageVersionSpecifier::From { from } => other >= *from,
-            LanguageVersionSpecifier::Till { till } => other < *till,
-            LanguageVersionSpecifier::Range { from, till } => other >= *from && other < *till,
-        }
-    }
-}
+pub use specifier::LanguageVersionSpecifier;
+pub use version::{FromSemverError, LanguageVersion};
 
 #[cfg(test)]
 mod tests;

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/specifier.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/specifier.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+
+use crate::versions::LanguageVersion;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub enum LanguageVersionSpecifier {
+    From {
+        from: LanguageVersion,
+    },
+    Till {
+        till: LanguageVersion,
+    },
+    Range {
+        from: LanguageVersion,
+        till: LanguageVersion,
+    },
+}
+
+impl LanguageVersionSpecifier {
+    pub fn contains(&self, other: LanguageVersion) -> bool {
+        match self {
+            LanguageVersionSpecifier::From { from } => other >= *from,
+            LanguageVersionSpecifier::Till { till } => other < *till,
+            LanguageVersionSpecifier::Range { from, till } => other >= *from && other < *till,
+        }
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/tests.rs
@@ -1,4 +1,4 @@
-use crate::versions::language_versions::{FromSemverError, LanguageVersion};
+use crate::versions::version::{FromSemverError, LanguageVersion};
 
 #[test]
 fn test_correct_version() {

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/version.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/version.generated.rs
@@ -49,7 +49,51 @@ pub enum LanguageVersion {
 }
 
 impl LanguageVersion {
+    /// The earliest supported version of `Solidity`.
+    pub const EARLIEST: Self = Self::V0_8_0;
+
+    /// The latest supported version of `Solidity`.
     pub const LATEST: Self = Self::V0_8_35;
+
+    /// All supported versions of `Solidity`, in order.
+    pub const ALL: &'static [LanguageVersion] = &[
+        LanguageVersion::V0_8_0,
+        LanguageVersion::V0_8_1,
+        LanguageVersion::V0_8_2,
+        LanguageVersion::V0_8_3,
+        LanguageVersion::V0_8_4,
+        LanguageVersion::V0_8_5,
+        LanguageVersion::V0_8_6,
+        LanguageVersion::V0_8_7,
+        LanguageVersion::V0_8_8,
+        LanguageVersion::V0_8_9,
+        LanguageVersion::V0_8_10,
+        LanguageVersion::V0_8_11,
+        LanguageVersion::V0_8_12,
+        LanguageVersion::V0_8_13,
+        LanguageVersion::V0_8_14,
+        LanguageVersion::V0_8_15,
+        LanguageVersion::V0_8_16,
+        LanguageVersion::V0_8_17,
+        LanguageVersion::V0_8_18,
+        LanguageVersion::V0_8_19,
+        LanguageVersion::V0_8_20,
+        LanguageVersion::V0_8_21,
+        LanguageVersion::V0_8_22,
+        LanguageVersion::V0_8_23,
+        LanguageVersion::V0_8_24,
+        LanguageVersion::V0_8_25,
+        LanguageVersion::V0_8_26,
+        LanguageVersion::V0_8_27,
+        LanguageVersion::V0_8_28,
+        LanguageVersion::V0_8_29,
+        LanguageVersion::V0_8_30,
+        LanguageVersion::V0_8_31,
+        LanguageVersion::V0_8_32,
+        LanguageVersion::V0_8_33,
+        LanguageVersion::V0_8_34,
+        LanguageVersion::V0_8_35,
+    ];
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/version.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/version.rs.jinja2
@@ -5,16 +5,27 @@ use semver::Version;
 use serde::Serialize;
 use thiserror::Error;
 
-/// All supported versions of `{{ model.language.name }}`. 
+/// All supported versions of `{{ model.language.name }}`.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum LanguageVersion {
-    {% for version in model.language.versions %}    
+    {% for version in model.language.versions %}
         V{{ version | split(pat=".") | join(sep="_") }},
     {%- endfor -%}
 }
 
 impl LanguageVersion {
+    /// The earliest supported version of `{{ model.language.name }}`.
+    pub const EARLIEST: Self = Self::V{{ model.language.versions | first | split(pat=".") | join(sep="_") }};
+
+    /// The latest supported version of `{{ model.language.name }}`.
     pub const LATEST: Self = Self::V{{ model.language.versions | last | split(pat=".") | join(sep="_") }};
+
+    /// All supported versions of `{{ model.language.name }}`, in order.
+    pub const ALL: &'static [LanguageVersion] = &[
+        {%- for version in model.language.versions %}
+            LanguageVersion::V{{ version | split(pat=".") | join(sep="_") }},
+        {%- endfor %}
+    ];
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/crates/solidity-v2/outputs/cargo/parser/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/parser/generated/public_api.txt
@@ -11,6 +11,6 @@ pub fn slang_solidity_v2_parser::ParseOutput::fmt(&self, f: &mut core::fmt::Form
 impl core::marker::StructuralPartialEq for slang_solidity_v2_parser::ParseOutput
 pub struct slang_solidity_v2_parser::Parser
 impl slang_solidity_v2_parser::Parser
-pub fn slang_solidity_v2_parser::Parser::parse(file_id: &str, source: &str, language_version: slang_solidity_v2_common::versions::language_versions::LanguageVersion) -> slang_solidity_v2_parser::ParseOutput
+pub fn slang_solidity_v2_parser::Parser::parse(file_id: &str, source: &str, language_version: slang_solidity_v2_common::versions::version::LanguageVersion) -> slang_solidity_v2_parser::ParseOutput
 impl core::default::Default for slang_solidity_v2_parser::Parser
 pub fn slang_solidity_v2_parser::Parser::default() -> slang_solidity_v2_parser::Parser

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -272,7 +272,7 @@ impl slang_solidity_v2_semantic::context::SemanticContext
 pub fn slang_solidity_v2_semantic::context::SemanticContext::all_definitions(&self) -> impl core::iter::traits::iterator::Iterator<Item = &slang_solidity_v2_semantic::binder::Definition> + use<'_>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::all_references(&self) -> impl core::iter::traits::iterator::Iterator<Item = &slang_solidity_v2_semantic::binder::Reference> + use<'_>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::binder(&self) -> &slang_solidity_v2_semantic::binder::Binder
-pub fn slang_solidity_v2_semantic::context::SemanticContext::build_from(language_version: slang_solidity_v2_common::versions::language_versions::LanguageVersion, files: &[impl slang_solidity_v2_semantic::context::SemanticFile]) -> Self
+pub fn slang_solidity_v2_semantic::context::SemanticContext::build_from(language_version: slang_solidity_v2_common::versions::version::LanguageVersion, files: &[impl slang_solidity_v2_semantic::context::SemanticFile]) -> Self
 pub fn slang_solidity_v2_semantic::context::SemanticContext::find_contract_by_name(&self, name: &str) -> core::option::Option<slang_solidity_v2_ir::ir::nodes::ContractDefinition>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::types(&self) -> &slang_solidity_v2_semantic::types::TypeRegistry
 pub trait slang_solidity_v2_semantic::context::SemanticFile

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -17,7 +17,7 @@ pub slang_solidity_v2::compilation::CompilationBuilder::config: C
 impl<C: slang_solidity_v2::compilation::CompilationBuilderConfig> slang_solidity_v2::compilation::CompilationBuilder<C>
 pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::add_file(&mut self, file_id: alloc::string::String)
 pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::build(self) -> slang_solidity_v2::compilation::CompilationUnit
-pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::create(language_version: slang_solidity_v2_common::versions::language_versions::LanguageVersion, config: C) -> slang_solidity_v2::compilation::CompilationBuilder<C>
+pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::create(language_version: slang_solidity_v2_common::versions::version::LanguageVersion, config: C) -> slang_solidity_v2::compilation::CompilationBuilder<C>
 pub struct slang_solidity_v2::compilation::CompilationUnit
 impl slang_solidity_v2::compilation::CompilationUnit
 pub fn slang_solidity_v2::compilation::CompilationUnit::all_definitions(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::definitions::Definition> + use<'_>
@@ -28,7 +28,7 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::file(&self, id: &str) ->
 pub fn slang_solidity_v2::compilation::CompilationUnit::file_ids(&self) -> alloc::vec::Vec<alloc::string::String>
 pub fn slang_solidity_v2::compilation::CompilationUnit::files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
 pub fn slang_solidity_v2::compilation::CompilationUnit::find_contract_by_name(&self, name: &str) -> core::option::Option<slang_solidity_v2_ast::ast::nodes::ContractDefinition>
-pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::language_versions::LanguageVersion
+pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::version::LanguageVersion
 pub struct slang_solidity_v2::compilation::FileStruct
 impl slang_solidity_v2::compilation::FileStruct
 pub fn slang_solidity_v2::compilation::FileStruct::ast(&self) -> slang_solidity_v2_ast::ast::nodes::SourceUnit

--- a/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
@@ -16,7 +16,6 @@ slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_ir = { workspace = true }
 slang_solidity_v2_parser = { workspace = true }
 slang_solidity_v2_semantic = { workspace = true }
-solidity_v2_language = { workspace = true }
 solidity_v2_testing_utils = { workspace = true }
 
 [lints]

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
@@ -6,7 +6,6 @@ use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
 use slang_solidity_v2_common::versions::LanguageVersion;
-use solidity_v2_language::SolidityDefinition;
 
 use super::report::binder_report;
 use super::report_data::ReportData;
@@ -53,15 +52,9 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
         .map(|part| (part.name.to_string(), part.contents.to_string()))
         .collect();
 
-    let tested_versions: Vec<LanguageVersion> = SolidityDefinition::create()
-        .collect_semantic_breaking_versions()
-        .into_iter()
-        .filter_map(|version| LanguageVersion::try_from(version).ok())
-        .collect();
-
     let mut last_report = None;
 
-    for &version in &tested_versions {
+    for &version in LanguageVersion::ALL {
         let config = TestConfig {
             files: files.clone(),
         };

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/runner.rs
@@ -4,7 +4,6 @@ use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_parser::Parser as V2Parser;
-use solidity_v2_language::SolidityDefinition;
 
 pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
     let test_dir = CargoWorkspace::locate_source_crate("solidity_v2_testing_snapshots")?
@@ -20,13 +19,7 @@ pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
 
     let mut last_output = None;
 
-    let tested_versions: Vec<LanguageVersion> = SolidityDefinition::create()
-        .collect_syntax_breaking_versions()
-        .into_iter()
-        .map(|v| LanguageVersion::try_from(v).unwrap())
-        .collect();
-
-    for &lang_version in &tested_versions {
+    for &lang_version in LanguageVersion::ALL {
         let v2_output = V2Parser::parse(&source_id, &source, lang_version);
 
         match last_output {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
@@ -7,7 +7,6 @@ use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
 use slang_solidity_v2_common::versions::LanguageVersion;
-use solidity_v2_language::SolidityDefinition;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use crate::utils::multi_part_file::split_multi_file;
@@ -54,15 +53,9 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
         .map(|part| (part.name.to_string(), part.contents.to_string()))
         .collect();
 
-    let tested_versions: Vec<LanguageVersion> = SolidityDefinition::create()
-        .collect_semantic_breaking_versions()
-        .into_iter()
-        .filter_map(|version| LanguageVersion::try_from(version).ok())
-        .collect();
-
     let mut last_report = None;
 
-    for &version in &tested_versions {
+    for &version in LanguageVersion::ALL {
         let config = TestConfig {
             files: files.clone(),
         };


### PR DESCRIPTION
Noticed this gap in our tests, as we collect only the version breaks from the grammar, instead of testing all versions. This is no longer sufficient, and may result in missing coverage in the future:

- `cst_output` tests: both the lexer and parser have post-processing that is not derived directly from the grammar.
- `binder_output` and `diagnostics_output` tests: the v2 binder/validation are mostly hand written, and very little is derived from the grammar.