### PR TITLE
[v2] Add `unparse` to all IR terminals

### DIFF
--- a/crates/codegen-v2/semantic/src/ir/builder.rs
+++ b/crates/codegen-v2/semantic/src/ir/builder.rs
@@ -42,7 +42,9 @@ fn remove_redundant_terminal_nodes(cst_model: &IrModel, mutator: &mut IrModelMut
         for field in &sequence.fields {
             if !field.is_optional
                 && field.field_type.is_terminal()
-                && cst_model.terminals[field.field_type.as_identifier()].is_unique
+                && cst_model.terminals[field.field_type.as_identifier()]
+                    .unique_symbol
+                    .is_some()
             {
                 mutator.remove_sequence_field(sequence_id, &field.label);
             }

--- a/crates/codegen-v2/semantic/src/ir/model.rs
+++ b/crates/codegen-v2/semantic/src/ir/model.rs
@@ -23,7 +23,7 @@ pub struct IrModel {
 
 #[derive(Clone, Serialize)]
 pub struct Terminal {
-    pub is_unique: bool,
+    pub unique_symbol: Option<String>,
     pub is_identifier: bool,
 }
 
@@ -201,7 +201,7 @@ impl IrModelBuilder {
                     // These items are skipped by the parser.
                 }
                 model::Item::Keyword { item } => {
-                    let node_type = if item.is_unique() {
+                    let node_type = if item.unique_symbol().is_some() {
                         NodeType::UniqueTerminal(item.name.clone())
                     } else {
                         NodeType::Terminal(item.name.clone())
@@ -209,7 +209,7 @@ impl IrModelBuilder {
                     self.node_types.insert(item.name.clone(), node_type);
                 }
                 model::Item::Token { item } => {
-                    let node_type = if item.is_unique() {
+                    let node_type = if item.unique_symbol().is_some() {
                         NodeType::UniqueTerminal(item.name.clone())
                     } else {
                         NodeType::Terminal(item.name.clone())
@@ -258,7 +258,7 @@ impl IrModelBuilder {
                     self.terminals.insert(
                         item.name.clone(),
                         Terminal {
-                            is_unique: item.is_unique(),
+                            unique_symbol: item.unique_symbol(),
                             is_identifier: false,
                         },
                     );
@@ -267,7 +267,7 @@ impl IrModelBuilder {
                     self.terminals.insert(
                         item.name.clone(),
                         Terminal {
-                            is_unique: item.is_unique(),
+                            unique_symbol: item.unique_symbol(),
                             is_identifier: identifier_tokens.contains(&item.name),
                         },
                     );

--- a/crates/codegen-v2/semantic/src/ir/mutator.rs
+++ b/crates/codegen-v2/semantic/src/ir/mutator.rs
@@ -187,7 +187,7 @@ impl From<&MutatedCollection> for Collection {
 
 #[derive(Clone, Serialize)]
 pub struct MutatedTerminal {
-    pub is_unique: bool,
+    pub unique_symbol: Option<String>,
     pub is_identifier: bool,
 
     // Indicates this is a new terminal, created in this language.
@@ -197,7 +197,7 @@ pub struct MutatedTerminal {
 impl From<&Terminal> for MutatedTerminal {
     fn from(terminal: &Terminal) -> Self {
         Self {
-            is_unique: terminal.is_unique,
+            unique_symbol: terminal.unique_symbol.clone(),
             is_identifier: terminal.is_identifier,
             is_new: false,
         }
@@ -207,7 +207,7 @@ impl From<&Terminal> for MutatedTerminal {
 impl From<&MutatedTerminal> for Terminal {
     fn from(value: &MutatedTerminal) -> Self {
         Self {
-            is_unique: value.is_unique,
+            unique_symbol: value.unique_symbol.clone(),
             is_identifier: value.is_identifier,
         }
     }
@@ -414,7 +414,7 @@ impl IrModelMutator {
 
     fn find_node_type(&self, identifier: &model::Identifier) -> NodeType {
         if let Some(terminal) = self.terminals.get(identifier) {
-            if terminal.is_unique {
+            if terminal.unique_symbol.is_some() {
                 NodeType::UniqueTerminal(identifier.clone())
             } else {
                 NodeType::Terminal(identifier.clone())
@@ -560,7 +560,7 @@ impl IrModelMutator {
         let target_id: model::Identifier = target.into();
         if let Some(terminal) = self.terminals.get(&target_id) {
             assert!(
-                !terminal.is_unique,
+                terminal.unique_symbol.is_none(),
                 "Cannot collapse choice {choice_id} to unique terminal {target}",
             );
         } else {
@@ -568,7 +568,7 @@ impl IrModelMutator {
             self.terminals.insert(
                 target_id.clone(),
                 MutatedTerminal {
-                    is_unique: false,
+                    unique_symbol: None,
                     is_identifier: false,
                     is_new: true,
                 },
@@ -622,11 +622,11 @@ impl IrModelMutator {
             .unwrap_or_else(|| panic!("Target terminal {target} not found"));
 
         assert_eq!(
-            source_terminal.is_unique, target_terminal.is_unique,
-            "Source and target terminals must have the same uniqueness"
+            source_terminal.unique_symbol, target_terminal.unique_symbol,
+            "Source and target terminals must have the same unique symbol"
         );
 
-        let is_unique = source_terminal.is_unique;
+        let is_unique = source_terminal.unique_symbol.is_some();
         let target_is_identifier = target_terminal.is_identifier;
         let source_type = self.find_node_type(&source_id);
         let target_type = self.find_node_type(&target_id);

--- a/crates/language-v2/definition/src/model/terminals/keyword.rs
+++ b/crates/language-v2/definition/src/model/terminals/keyword.rs
@@ -21,8 +21,13 @@ pub struct KeywordItem {
 }
 
 impl KeywordItem {
-    pub fn is_unique(&self) -> bool {
-        self.scanner.collect_variations().len() == 1
+    pub fn unique_symbol(&self) -> Option<String> {
+        let variations = self.scanner.collect_variations();
+        if variations.len() == 1 {
+            Some(variations.into_iter().next().unwrap())
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/language-v2/definition/src/model/terminals/scanner.rs
+++ b/crates/language-v2/definition/src/model/terminals/scanner.rs
@@ -39,17 +39,197 @@ pub enum TokenScanner {
 }
 
 impl TokenScanner {
-    pub fn is_unique(&self) -> bool {
+    /// Calculate the unique symbol for this token scanner if it exists. Returns `None` if it couldn't calculate it.
+    ///
+    /// This is a best effort approach, in particular:
+    /// - We don't consider empty scanners, this means that a `Choice` without any scanners is
+    ///   not considered to have a unique symbol (this is ok), but a `Choice` containing that empty
+    ///   `Choice` and an atom is also not considered to have a unique symbol, even though it could
+    ///   be considered to have the same unique symbol as the atom.
+    /// - `Fragments` are not considered to be unique symbols, even though they could.
+    pub fn unique_symbol(&self) -> Option<String> {
         match self {
-            Self::Sequence { scanners } => scanners.iter().all(|scanner| scanner.is_unique()),
-            Self::Atom { .. } => true,
-            Self::Choice { .. }
+            Self::Sequence { scanners } if !scanners.is_empty() => scanners
+                .iter()
+                .map(|s| s.unique_symbol())
+                .collect::<Option<Vec<String>>>()
+                .map(|s| s.join("")),
+            Self::Atom { atom } => Some(atom.clone()),
+            Self::Choice { scanners } if scanners.len() == 1 => scanners[0].unique_symbol(),
+            Self::Range {
+                inclusive_start,
+                inclusive_end,
+            } if *inclusive_start == *inclusive_end => Some(inclusive_start.to_string()),
+            Self::Sequence { .. }
+            | Self::Choice { .. }
             | Self::Optional { .. }
             | Self::ZeroOrMore { .. }
             | Self::OneOrMore { .. }
             | Self::Not { .. }
             | Self::Range { .. }
-            | Self::Fragment { .. } => false,
+            | Self::Fragment { .. } => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_atom_is_unique_symbol() {
+        let scanner = TokenScanner::Atom {
+            atom: "&a".to_string(),
+        };
+        assert_eq!(scanner.unique_symbol(), Some("&a".to_string()));
+    }
+
+    #[test]
+    fn test_empty_sequence_is_not_unique() {
+        let scanner = TokenScanner::Sequence { scanners: vec![] };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_sequence_of_unique_symbols_is_unique() {
+        let scanner = TokenScanner::Sequence {
+            scanners: vec![
+                TokenScanner::Atom {
+                    atom: "a".to_string(),
+                },
+                TokenScanner::Choice {
+                    scanners: vec![TokenScanner::Atom {
+                        atom: "b".to_string(),
+                    }],
+                },
+                TokenScanner::Range {
+                    inclusive_start: 'c',
+                    inclusive_end: 'c',
+                },
+            ],
+        };
+        assert_eq!(scanner.unique_symbol(), Some("abc".to_string()));
+    }
+
+    #[test]
+    fn test_sequence_of_non_unique_is_not_unique() {
+        let scanner = TokenScanner::Sequence {
+            scanners: vec![
+                TokenScanner::Atom {
+                    atom: "a".to_string(),
+                },
+                TokenScanner::Choice {
+                    scanners: vec![
+                        TokenScanner::Atom {
+                            atom: "b".to_string(),
+                        },
+                        TokenScanner::Atom {
+                            atom: "c".to_string(),
+                        },
+                    ],
+                },
+            ],
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_choice_of_one_unique_is_unique() {
+        let scanner = TokenScanner::Choice {
+            scanners: vec![TokenScanner::Atom {
+                atom: "a".to_string(),
+            }],
+        };
+        assert_eq!(scanner.unique_symbol(), Some("a".to_string()));
+    }
+
+    #[test]
+    fn test_choice_of_multiple_is_not_unique() {
+        let scanner = TokenScanner::Choice {
+            scanners: vec![
+                TokenScanner::Atom {
+                    atom: "a".to_string(),
+                },
+                TokenScanner::Atom {
+                    atom: "b".to_string(),
+                },
+            ],
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_choice_of_non_unique_is_not_unique() {
+        let scanner = TokenScanner::Choice {
+            scanners: vec![TokenScanner::Range {
+                inclusive_start: 'a',
+                inclusive_end: 'b',
+            }],
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_range_of_single_char_is_unique() {
+        let scanner = TokenScanner::Range {
+            inclusive_start: 'a',
+            inclusive_end: 'a',
+        };
+        assert_eq!(scanner.unique_symbol(), Some("a".to_string()));
+    }
+
+    #[test]
+    fn test_range_of_different_chars_is_not_unique() {
+        let scanner = TokenScanner::Range {
+            inclusive_start: 'a',
+            inclusive_end: 'b',
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_not_is_not_unique() {
+        let scanner = TokenScanner::Not {
+            chars: IndexSet::from_iter(vec!['a', 'b', 'c']),
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_optional_is_not_unique() {
+        let scanner = TokenScanner::Optional {
+            scanner: Box::new(TokenScanner::Atom {
+                atom: "a".to_string(),
+            }),
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_zero_or_more_is_not_unique() {
+        let scanner = TokenScanner::ZeroOrMore {
+            scanner: Box::new(TokenScanner::Atom {
+                atom: "a".to_string(),
+            }),
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_one_or_more_is_not_unique() {
+        let scanner = TokenScanner::OneOrMore {
+            scanner: Box::new(TokenScanner::Atom {
+                atom: "a".to_string(),
+            }),
+        };
+        assert_eq!(scanner.unique_symbol(), None);
+    }
+
+    #[test]
+    fn test_fragment_is_not_unique() {
+        let scanner = TokenScanner::Fragment {
+            reference: "fragment".into(),
+        };
+        assert_eq!(scanner.unique_symbol(), None);
     }
 }

--- a/crates/language-v2/definition/src/model/terminals/token.rs
+++ b/crates/language-v2/definition/src/model/terminals/token.rs
@@ -20,7 +20,7 @@ pub struct TokenItem {
 }
 
 impl TokenItem {
-    pub fn is_unique(&self) -> bool {
-        self.scanner.is_unique()
+    pub fn unique_symbol(&self) -> Option<String> {
+        self.scanner.unique_symbol()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1035,6 +1035,7 @@ pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_file_id(&self)
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderPragmaStruct
@@ -1052,6 +1053,7 @@ pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_file_id(&self) -
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
@@ -1060,6 +1062,7 @@ pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_file_id(&self) -
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbstractKeywordStruct
@@ -1068,6 +1071,7 @@ pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_file_id(&self) -> 
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbstractKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AdditiveExpressionStruct
@@ -1101,6 +1105,7 @@ pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandEqualStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AmpersandStruct
@@ -1109,6 +1114,7 @@ pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AmpersandStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AndExpressionStruct
@@ -1127,6 +1133,7 @@ pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_file_id(&self) ->
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AnonymousKeywordStruct
 pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ArrayExpressionStruct
@@ -1189,6 +1196,7 @@ pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskEqualStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AsteriskStruct
@@ -1197,6 +1205,7 @@ pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::AsteriskStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangEqualStruct
@@ -1205,6 +1214,7 @@ pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BangEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangEqualStruct
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangStruct
@@ -1213,6 +1223,7 @@ pub fn slang_solidity_v2_ast::ast::BangStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BangStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BangStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangStruct
 pub fn slang_solidity_v2_ast::ast::BangStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarEqualStruct
@@ -1221,6 +1232,7 @@ pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BarEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarEqualStruct
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarStruct
@@ -1229,6 +1241,7 @@ pub fn slang_solidity_v2_ast::ast::BarStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BarStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BarStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarStruct
 pub fn slang_solidity_v2_ast::ast::BarStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
@@ -1276,6 +1289,7 @@ pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BoolKeywordStruct
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BooleanType
@@ -1314,6 +1328,7 @@ pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_file_id(&self) -> 
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CallDataKeywordStruct
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CallOptionsExpressionStruct
@@ -1339,6 +1354,7 @@ pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretEqualStruct
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CaretStruct
@@ -1347,6 +1363,7 @@ pub fn slang_solidity_v2_ast::ast::CaretStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::CaretStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretStruct
 pub fn slang_solidity_v2_ast::ast::CaretStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CatchClauseErrorStruct
@@ -1459,6 +1476,7 @@ pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DaysKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DecimalLiteralStruct
@@ -1490,6 +1508,7 @@ pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DeleteKeywordStruct
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DoWhileStatementStruct
@@ -1543,6 +1562,7 @@ pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualEqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualStruct
@@ -1551,6 +1571,7 @@ pub fn slang_solidity_v2_ast::ast::EqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualityExpressionStruct
@@ -1588,6 +1609,7 @@ pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EtherKeywordStruct
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EventDefinitionStruct
@@ -1643,6 +1665,7 @@ pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FalseKeywordStruct
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::FixedKeywordStruct
@@ -1748,6 +1771,7 @@ pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GlobalKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanEqualStruct
@@ -1756,6 +1780,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_file_id(&self) ->
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
@@ -1764,6 +1789,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_file_i
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
@@ -1772,6 +1798,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct:
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
@@ -1780,6 +1807,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
@@ -1788,6 +1816,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_file_id(&se
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanStruct
@@ -1796,6 +1825,7 @@ pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GweiKeywordStruct
@@ -1804,6 +1834,7 @@ pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GweiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HexLiteralStruct
@@ -1851,6 +1882,7 @@ pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HoursKeywordStruct
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::IdentifierPathStruct
@@ -1941,6 +1973,7 @@ pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IndexedKeywordStruct
 pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::InequalityExpressionStruct
@@ -2018,6 +2051,7 @@ pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
@@ -2026,6 +2060,7 @@ pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_file_id(&sel
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanStruct
@@ -2034,6 +2069,7 @@ pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_file_id(&self) ->
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanStruct
@@ -2042,6 +2078,7 @@ pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::LessThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanStruct
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LibraryDefinitionStruct
@@ -2101,6 +2138,7 @@ pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MemoryKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusEqualStruct
@@ -2109,6 +2147,7 @@ pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusEqualStruct
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusMinusStruct
@@ -2117,6 +2156,7 @@ pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusMinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusStruct
@@ -2125,6 +2165,7 @@ pub fn slang_solidity_v2_ast::ast::MinusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinusStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinutesKeywordStruct
@@ -2133,6 +2174,7 @@ pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinutesKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ModifierInvocationStruct
@@ -2273,6 +2315,7 @@ pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PayableKeywordStruct
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentEqualStruct
@@ -2281,6 +2324,7 @@ pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentEqualStruct
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentStruct
@@ -2289,6 +2333,7 @@ pub fn slang_solidity_v2_ast::ast::PercentStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PercentStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PercentStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentStruct
 pub fn slang_solidity_v2_ast::ast::PercentStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusEqualStruct
@@ -2297,6 +2342,7 @@ pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusEqualStruct
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusPlusStruct
@@ -2305,6 +2351,7 @@ pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusPlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusStruct
@@ -2313,6 +2360,7 @@ pub fn slang_solidity_v2_ast::ast::PlusStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PlusStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PositionalArgumentsStruct
@@ -2338,6 +2386,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaCaretStruct
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaDirectiveStruct
@@ -2355,6 +2404,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
@@ -2363,6 +2413,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_file_id(&se
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
@@ -2371,6 +2422,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_file_id(&self) -
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
@@ -2379,6 +2431,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_file_id(&self)
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanStruct
@@ -2387,6 +2440,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanStruct
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaTildeStruct
@@ -2395,6 +2449,7 @@ pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaTildeStruct
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PrefixExpressionStruct
@@ -2439,6 +2494,7 @@ pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_file_id(&self) -
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SecondsKeywordStruct
@@ -2447,6 +2503,7 @@ pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SecondsKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SemicolonStruct
@@ -2455,6 +2512,7 @@ pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SemicolonStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SemicolonStruct
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ShiftExpressionStruct
@@ -2491,6 +2549,7 @@ pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SlashEqualStruct
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SlashStruct
@@ -2499,6 +2558,7 @@ pub fn slang_solidity_v2_ast::ast::SlashStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SlashStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SlashStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SlashStruct
 pub fn slang_solidity_v2_ast::ast::SlashStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SourceUnitMembersStruct
@@ -2558,6 +2618,7 @@ pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StorageKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringKeywordStruct
@@ -2566,6 +2627,7 @@ pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_file_id(&self) -> &s
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StringKeywordStruct
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringLiteralStruct
@@ -2636,6 +2698,7 @@ pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SuperKeywordStruct
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ThisKeywordStruct
@@ -2644,6 +2707,7 @@ pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ThisKeywordStruct
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TildeStruct
@@ -2652,6 +2716,7 @@ pub fn slang_solidity_v2_ast::ast::TildeStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::TildeStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TildeStruct
 pub fn slang_solidity_v2_ast::ast::TildeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TrueKeywordStruct
@@ -2660,6 +2725,7 @@ pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TrueKeywordStruct
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TryStatementStruct
@@ -2895,6 +2961,7 @@ pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_file_id(&self) -> &
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VirtualKeywordStruct
 pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VoidType
@@ -2906,6 +2973,7 @@ pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_file_id(&self) -> &st
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::WeeksKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WeiKeywordStruct
@@ -2914,6 +2982,7 @@ pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::WeiKeywordStruct
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WhileStatementStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -6754,6 +6754,10 @@ impl ABIEncoderV2KeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -6787,6 +6791,10 @@ pub(crate) fn create_abicoder_v1_keyword(
 impl AbicoderV1KeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -6824,6 +6832,10 @@ impl AbicoderV2KeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -6857,6 +6869,10 @@ pub(crate) fn create_abstract_keyword(
 impl AbstractKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -6894,6 +6910,10 @@ impl AmpersandStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -6927,6 +6947,10 @@ pub(crate) fn create_ampersand_equal(
 impl AmpersandEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -6964,6 +6988,10 @@ impl AnonymousKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -6994,6 +7022,10 @@ pub(crate) fn create_asterisk(ir_node: &ir::Asterisk, semantic: &Arc<SemanticCon
 impl AsteriskStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7031,6 +7063,10 @@ impl AsteriskEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7061,6 +7097,10 @@ pub(crate) fn create_bang(ir_node: &ir::Bang, semantic: &Arc<SemanticContext>) -
 impl BangStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7098,6 +7138,10 @@ impl BangEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7128,6 +7172,10 @@ pub(crate) fn create_bar(ir_node: &ir::Bar, semantic: &Arc<SemanticContext>) -> 
 impl BarStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7165,6 +7213,10 @@ impl BarEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7198,6 +7250,10 @@ pub(crate) fn create_bool_keyword(
 impl BoolKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7234,6 +7290,7 @@ impl BytesKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -7273,6 +7330,10 @@ impl CallDataKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7303,6 +7364,10 @@ pub(crate) fn create_caret(ir_node: &ir::Caret, semantic: &Arc<SemanticContext>)
 impl CaretStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7340,6 +7405,10 @@ impl CaretEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7373,6 +7442,10 @@ pub(crate) fn create_days_keyword(
 impl DaysKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7409,6 +7482,7 @@ impl DecimalLiteralStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -7448,6 +7522,10 @@ impl DeleteKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7478,6 +7556,10 @@ pub(crate) fn create_equal(ir_node: &ir::Equal, semantic: &Arc<SemanticContext>)
 impl EqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7515,6 +7597,10 @@ impl EqualEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7548,6 +7634,10 @@ pub(crate) fn create_ether_keyword(
 impl EtherKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7585,6 +7675,10 @@ impl FalseKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7619,6 +7713,7 @@ impl FixedKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -7658,6 +7753,10 @@ impl GlobalKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7691,6 +7790,10 @@ pub(crate) fn create_greater_than(
 impl GreaterThanStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7728,6 +7831,10 @@ impl GreaterThanEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7761,6 +7868,10 @@ pub(crate) fn create_greater_than_greater_than(
 impl GreaterThanGreaterThanStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7798,6 +7909,10 @@ impl GreaterThanGreaterThanEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7831,6 +7946,10 @@ pub(crate) fn create_greater_than_greater_than_greater_than(
 impl GreaterThanGreaterThanGreaterThanStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7868,6 +7987,10 @@ impl GreaterThanGreaterThanGreaterThanEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -7901,6 +8024,10 @@ pub(crate) fn create_gwei_keyword(
 impl GweiKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -7937,6 +8064,7 @@ impl HexLiteralStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -7975,6 +8103,7 @@ impl HexStringLiteralStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -8014,6 +8143,10 @@ impl HoursKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8048,6 +8181,7 @@ impl IdentifierStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -8087,6 +8221,10 @@ impl IndexedKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8121,6 +8259,7 @@ impl IntKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -8160,6 +8299,10 @@ impl LessThanStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8193,6 +8336,10 @@ pub(crate) fn create_less_than_equal(
 impl LessThanEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8230,6 +8377,10 @@ impl LessThanLessThanStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8263,6 +8414,10 @@ pub(crate) fn create_less_than_less_than_equal(
 impl LessThanLessThanEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8300,6 +8455,10 @@ impl MemoryKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8330,6 +8489,10 @@ pub(crate) fn create_minus(ir_node: &ir::Minus, semantic: &Arc<SemanticContext>)
 impl MinusStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8367,6 +8530,10 @@ impl MinusEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8400,6 +8567,10 @@ pub(crate) fn create_minus_minus(
 impl MinusMinusStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8437,6 +8608,10 @@ impl MinutesKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8472,6 +8647,10 @@ impl PayableKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8502,6 +8681,10 @@ pub(crate) fn create_percent(ir_node: &ir::Percent, semantic: &Arc<SemanticConte
 impl PercentStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8539,6 +8722,10 @@ impl PercentEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8569,6 +8756,10 @@ pub(crate) fn create_plus(ir_node: &ir::Plus, semantic: &Arc<SemanticContext>) -
 impl PlusStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8606,6 +8797,10 @@ impl PlusEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8639,6 +8834,10 @@ pub(crate) fn create_plus_plus(
 impl PlusPlusStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8676,6 +8875,10 @@ impl PragmaCaretStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8709,6 +8912,10 @@ pub(crate) fn create_pragma_equal(
 impl PragmaEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8746,6 +8953,10 @@ impl PragmaGreaterThanStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8779,6 +8990,10 @@ pub(crate) fn create_pragma_greater_than_equal(
 impl PragmaGreaterThanEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8816,6 +9031,10 @@ impl PragmaLessThanStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8849,6 +9068,10 @@ pub(crate) fn create_pragma_less_than_equal(
 impl PragmaLessThanEqualStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8886,6 +9109,10 @@ impl PragmaTildeStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8919,6 +9146,10 @@ pub(crate) fn create_smt_checker_keyword(
 impl SMTCheckerKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -8956,6 +9187,10 @@ impl SecondsKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -8991,6 +9226,10 @@ impl SemicolonStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9021,6 +9260,10 @@ pub(crate) fn create_slash(ir_node: &ir::Slash, semantic: &Arc<SemanticContext>)
 impl SlashStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -9058,6 +9301,10 @@ impl SlashEqualStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9091,6 +9338,10 @@ pub(crate) fn create_storage_keyword(
 impl StorageKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -9128,6 +9379,10 @@ impl StringKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9162,6 +9417,7 @@ impl StringLiteralStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -9201,6 +9457,10 @@ impl SuperKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9236,6 +9496,10 @@ impl ThisKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9266,6 +9530,10 @@ pub(crate) fn create_tilde(ir_node: &ir::Tilde, semantic: &Arc<SemanticContext>)
 impl TildeStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -9303,6 +9571,10 @@ impl TrueKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9337,6 +9609,7 @@ impl UfixedKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -9375,6 +9648,7 @@ impl UintKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -9413,6 +9687,7 @@ impl UnicodeStringLiteralStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -9451,6 +9726,7 @@ impl VersionSpecifierStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
+
     pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
     }
@@ -9490,6 +9766,10 @@ impl VirtualKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9525,6 +9805,10 @@ impl WeeksKeywordStruct {
         self.ir_node.id()
     }
 
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
@@ -9558,6 +9842,10 @@ pub(crate) fn create_wei_keyword(
 impl WeiKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
+    }
+
+    pub fn unparse(&self) -> &str {
+        self.ir_node.unparse()
     }
 
     pub fn get_type(&self) -> Option<Type> {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -176,7 +176,7 @@ use super::types::Type;
       self.ir_node.id()
     }
 
-    {%- if not terminal.is_unique %}
+    {%- if not terminal.unique_symbol %}
       pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
       }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -176,11 +176,9 @@ use super::types::Type;
       self.ir_node.id()
     }
 
-    {%- if not terminal.unique_symbol %}
       pub fn unparse(&self) -> &str {
         self.ir_node.unparse()
       }
-    {%- endif %}
 
     pub fn get_type(&self) -> Option<Type> {
       Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.rs.jinja2
@@ -89,12 +89,12 @@ impl Serialize for {{ parent_type }}Struct {
 {% for terminal_type, terminal in target.terminals %}
 impl Serialize for {{ terminal_type }}Struct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some({% if terminal.is_unique %}4{% else %}5{% endif %}))?;
+        let mut map = serializer.serialize_map(Some({% if terminal.unique_symbol %}4{% else %}5{% endif %}))?;
         map.serialize_entry("id", &self.ir_node.id())?;
         map.serialize_entry("type", "{{ terminal_type }}")?;
         map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
         map.serialize_entry("file", self.get_file_id())?;
-        {%- if not terminal.is_unique %}
+        {%- if not terminal.unique_symbol %}
         map.serialize_entry("text", self.ir_node.unparse())?;
         {%- endif %}
         map.end()

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/visitor.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/visitor.rs.jinja2
@@ -16,7 +16,7 @@ pub trait Visitor {
     fn leave_{{ parent_type | snake_case }}(&mut self, _items: &{{ parent_type }}) {}
   {% endfor -%}
   {%- for terminal_type, terminal in target.terminals %}
-    {%- if not terminal.is_unique %}
+    {%- if not terminal.unique_symbol %}
       fn visit_{{ terminal_type | snake_case }}(&mut self, _node: &{{ terminal_type }}) {}
     {% endif -%}
   {% endfor -%}
@@ -37,7 +37,7 @@ pub trait Visitor {
           if let Some(ref {{ field.label | snake_case }}) = node.{{ field.label | snake_case }}() {
             accept_{{ field.field_type.name | snake_case }}({{ field.label | snake_case }}, visitor);
           }
-        {%- elif field.field_type.is_terminal and not target.terminals[field.field_type.name].is_unique -%}
+        {%- elif field.field_type.is_terminal and not target.terminals[field.field_type.name].unique_symbol -%}
           if let Some(ref {{ field.label | snake_case }}) = node.{{ field.label | snake_case }}() {
             visitor.visit_{{ field.field_type.name | snake_case }}({{ field.label | snake_case }});
           }
@@ -45,7 +45,7 @@ pub trait Visitor {
       {%- else -%}
         {%- if not field.field_type.is_terminal and field.field_type.kind != "External" -%}
           accept_{{ field.field_type.name | snake_case }}(&node.{{ field.label | snake_case }}(), visitor);
-        {%- elif field.field_type.is_terminal and not target.terminals[field.field_type.name].is_unique -%}
+        {%- elif field.field_type.is_terminal and not target.terminals[field.field_type.name].unique_symbol -%}
           visitor.visit_{{ field.field_type.name | snake_case }}(&node.{{ field.label | snake_case }}());
         {%- endif -%}
       {%- endif -%}
@@ -99,7 +99,7 @@ pub trait Visitor {
       for item in items.iter() {
         accept_{{ collection.item_type.name | snake_case }}(&item, visitor);
       }
-    {% elif not target.terminals[collection.item_type.name].is_unique %}
+    {% elif not target.terminals[collection.item_type.name].unique_symbol %}
       for item in items.iter() {
         visitor.visit_{{ collection.item_type.name | snake_case }}(&item);
       }

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -480,6 +480,8 @@ pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_variable_declaration_value(
 pub enum slang_solidity_v2_ir::ir::AbicoderVersion
 pub slang_solidity_v2_ir::ir::AbicoderVersion::AbicoderV1Keyword(slang_solidity_v2_ir::ir::AbicoderV1Keyword)
 pub slang_solidity_v2_ir::ir::AbicoderVersion::AbicoderV2Keyword(slang_solidity_v2_ir::ir::AbicoderV2Keyword)
+impl slang_solidity_v2_ir::ir::AbicoderVersion
+pub fn slang_solidity_v2_ir::ir::AbicoderVersion::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AbicoderVersion
 pub fn slang_solidity_v2_ir::ir::AbicoderVersion::clone(&self) -> slang_solidity_v2_ir::ir::AbicoderVersion
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderVersion
@@ -487,6 +489,8 @@ pub fn slang_solidity_v2_ir::ir::AbicoderVersion::fmt(&self, f: &mut core::fmt::
 pub enum slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub slang_solidity_v2_ir::ir::AdditiveExpressionOperator::Minus(slang_solidity_v2_ir::ir::Minus)
 pub slang_solidity_v2_ir::ir::AdditiveExpressionOperator::Plus(slang_solidity_v2_ir::ir::Plus)
+impl slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
@@ -511,6 +515,8 @@ pub slang_solidity_v2_ir::ir::AssignmentExpressionOperator::MinusEqual(slang_sol
 pub slang_solidity_v2_ir::ir::AssignmentExpressionOperator::PercentEqual(slang_solidity_v2_ir::ir::PercentEqual)
 pub slang_solidity_v2_ir::ir::AssignmentExpressionOperator::PlusEqual(slang_solidity_v2_ir::ir::PlusEqual)
 pub slang_solidity_v2_ir::ir::AssignmentExpressionOperator::SlashEqual(slang_solidity_v2_ir::ir::SlashEqual)
+impl slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
@@ -545,6 +551,8 @@ pub fn slang_solidity_v2_ir::ir::ElementaryType::fmt(&self, f: &mut core::fmt::F
 pub enum slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub slang_solidity_v2_ir::ir::EqualityExpressionOperator::BangEqual(slang_solidity_v2_ir::ir::BangEqual)
 pub slang_solidity_v2_ir::ir::EqualityExpressionOperator::EqualEqual(slang_solidity_v2_ir::ir::EqualEqual)
+impl slang_solidity_v2_ir::ir::EqualityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::EqualityExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionOperator
@@ -553,6 +561,8 @@ pub enum slang_solidity_v2_ir::ir::ExperimentalFeature
 pub slang_solidity_v2_ir::ir::ExperimentalFeature::ABIEncoderV2Keyword(slang_solidity_v2_ir::ir::ABIEncoderV2Keyword)
 pub slang_solidity_v2_ir::ir::ExperimentalFeature::SMTCheckerKeyword(slang_solidity_v2_ir::ir::SMTCheckerKeyword)
 pub slang_solidity_v2_ir::ir::ExperimentalFeature::StringLiteral(slang_solidity_v2_ir::ir::StringLiteral)
+impl slang_solidity_v2_ir::ir::ExperimentalFeature
+pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ExperimentalFeature
 pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::clone(&self) -> slang_solidity_v2_ir::ir::ExperimentalFeature
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExperimentalFeature
@@ -686,6 +696,8 @@ pub slang_solidity_v2_ir::ir::InequalityExpressionOperator::GreaterThan(slang_so
 pub slang_solidity_v2_ir::ir::InequalityExpressionOperator::GreaterThanEqual(slang_solidity_v2_ir::ir::GreaterThanEqual)
 pub slang_solidity_v2_ir::ir::InequalityExpressionOperator::LessThan(slang_solidity_v2_ir::ir::LessThan)
 pub slang_solidity_v2_ir::ir::InequalityExpressionOperator::LessThanEqual(slang_solidity_v2_ir::ir::LessThanEqual)
+impl slang_solidity_v2_ir::ir::InequalityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::InequalityExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionOperator
@@ -694,6 +706,8 @@ pub enum slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::Asterisk(slang_solidity_v2_ir::ir::Asterisk)
 pub slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::Percent(slang_solidity_v2_ir::ir::Percent)
 pub slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::Slash(slang_solidity_v2_ir::ir::Slash)
+impl slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
@@ -707,6 +721,8 @@ pub slang_solidity_v2_ir::ir::NumberUnit::MinutesKeyword(slang_solidity_v2_ir::i
 pub slang_solidity_v2_ir::ir::NumberUnit::SecondsKeyword(slang_solidity_v2_ir::ir::SecondsKeyword)
 pub slang_solidity_v2_ir::ir::NumberUnit::WeeksKeyword(slang_solidity_v2_ir::ir::WeeksKeyword)
 pub slang_solidity_v2_ir::ir::NumberUnit::WeiKeyword(slang_solidity_v2_ir::ir::WeiKeyword)
+impl slang_solidity_v2_ir::ir::NumberUnit
+pub fn slang_solidity_v2_ir::ir::NumberUnit::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::clone(&self) -> slang_solidity_v2_ir::ir::NumberUnit
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NumberUnit
@@ -714,6 +730,8 @@ pub fn slang_solidity_v2_ir::ir::NumberUnit::fmt(&self, f: &mut core::fmt::Forma
 pub enum slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub slang_solidity_v2_ir::ir::PostfixExpressionOperator::MinusMinus(slang_solidity_v2_ir::ir::MinusMinus)
 pub slang_solidity_v2_ir::ir::PostfixExpressionOperator::PlusPlus(slang_solidity_v2_ir::ir::PlusPlus)
+impl slang_solidity_v2_ir::ir::PostfixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PostfixExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionOperator
@@ -733,6 +751,8 @@ pub slang_solidity_v2_ir::ir::PrefixExpressionOperator::Minus(slang_solidity_v2_
 pub slang_solidity_v2_ir::ir::PrefixExpressionOperator::MinusMinus(slang_solidity_v2_ir::ir::MinusMinus)
 pub slang_solidity_v2_ir::ir::PrefixExpressionOperator::PlusPlus(slang_solidity_v2_ir::ir::PlusPlus)
 pub slang_solidity_v2_ir::ir::PrefixExpressionOperator::Tilde(slang_solidity_v2_ir::ir::Tilde)
+impl slang_solidity_v2_ir::ir::PrefixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PrefixExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionOperator
@@ -741,6 +761,8 @@ pub enum slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub slang_solidity_v2_ir::ir::ShiftExpressionOperator::GreaterThanGreaterThan(slang_solidity_v2_ir::ir::GreaterThanGreaterThan)
 pub slang_solidity_v2_ir::ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThan)
 pub slang_solidity_v2_ir::ir::ShiftExpressionOperator::LessThanLessThan(slang_solidity_v2_ir::ir::LessThanLessThan)
+impl slang_solidity_v2_ir::ir::ShiftExpressionOperator
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::ShiftExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionOperator
@@ -821,6 +843,8 @@ pub enum slang_solidity_v2_ir::ir::StorageLocation
 pub slang_solidity_v2_ir::ir::StorageLocation::CallDataKeyword(slang_solidity_v2_ir::ir::CallDataKeyword)
 pub slang_solidity_v2_ir::ir::StorageLocation::MemoryKeyword(slang_solidity_v2_ir::ir::MemoryKeyword)
 pub slang_solidity_v2_ir::ir::StorageLocation::StorageKeyword(slang_solidity_v2_ir::ir::StorageKeyword)
+impl slang_solidity_v2_ir::ir::StorageLocation
+pub fn slang_solidity_v2_ir::ir::StorageLocation::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::clone(&self) -> slang_solidity_v2_ir::ir::StorageLocation
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StorageLocation
@@ -866,6 +890,8 @@ pub slang_solidity_v2_ir::ir::UsingOperator::Percent(slang_solidity_v2_ir::ir::P
 pub slang_solidity_v2_ir::ir::UsingOperator::Plus(slang_solidity_v2_ir::ir::Plus)
 pub slang_solidity_v2_ir::ir::UsingOperator::Slash(slang_solidity_v2_ir::ir::Slash)
 pub slang_solidity_v2_ir::ir::UsingOperator::Tilde(slang_solidity_v2_ir::ir::Tilde)
+impl slang_solidity_v2_ir::ir::UsingOperator
+pub fn slang_solidity_v2_ir::ir::UsingOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::clone(&self) -> slang_solidity_v2_ir::ir::UsingOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingOperator
@@ -906,6 +932,8 @@ pub slang_solidity_v2_ir::ir::VersionOperator::PragmaGreaterThanEqual(slang_soli
 pub slang_solidity_v2_ir::ir::VersionOperator::PragmaLessThan(slang_solidity_v2_ir::ir::PragmaLessThan)
 pub slang_solidity_v2_ir::ir::VersionOperator::PragmaLessThanEqual(slang_solidity_v2_ir::ir::PragmaLessThanEqual)
 pub slang_solidity_v2_ir::ir::VersionOperator::PragmaTilde(slang_solidity_v2_ir::ir::PragmaTilde)
+impl slang_solidity_v2_ir::ir::VersionOperator
+pub fn slang_solidity_v2_ir::ir::VersionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::clone(&self) -> slang_solidity_v2_ir::ir::VersionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionOperator
@@ -925,6 +953,8 @@ pub slang_solidity_v2_ir::ir::YulLiteral::HexLiteral(slang_solidity_v2_ir::ir::H
 pub slang_solidity_v2_ir::ir::YulLiteral::HexStringLiteral(slang_solidity_v2_ir::ir::HexStringLiteral)
 pub slang_solidity_v2_ir::ir::YulLiteral::StringLiteral(slang_solidity_v2_ir::ir::StringLiteral)
 pub slang_solidity_v2_ir::ir::YulLiteral::TrueKeyword(slang_solidity_v2_ir::ir::TrueKeyword)
+impl slang_solidity_v2_ir::ir::YulLiteral
+pub fn slang_solidity_v2_ir::ir::YulLiteral::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::clone(&self) -> slang_solidity_v2_ir::ir::YulLiteral
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLiteral
@@ -956,6 +986,7 @@ pub struct slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
@@ -975,6 +1006,7 @@ pub struct slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 pub slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
@@ -987,6 +1019,7 @@ pub struct slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
@@ -999,6 +1032,7 @@ pub struct slang_solidity_v2_ir::ir::AbstractKeywordStruct
 pub slang_solidity_v2_ir::ir::AbstractKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AbstractKeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AbstractKeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AbstractKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbstractKeywordStruct
@@ -1027,6 +1061,7 @@ pub struct slang_solidity_v2_ir::ir::AmpersandEqualStruct
 pub slang_solidity_v2_ir::ir::AmpersandEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AmpersandEqualStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AmpersandEqualStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::AmpersandEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AmpersandEqualStruct
@@ -1039,6 +1074,7 @@ pub struct slang_solidity_v2_ir::ir::AmpersandStruct
 pub slang_solidity_v2_ir::ir::AmpersandStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AmpersandStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AmpersandStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AmpersandStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandStruct::clone(&self) -> slang_solidity_v2_ir::ir::AmpersandStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AmpersandStruct
@@ -1059,6 +1095,7 @@ pub struct slang_solidity_v2_ir::ir::AnonymousKeywordStruct
 pub slang_solidity_v2_ir::ir::AnonymousKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AnonymousKeywordStruct
 pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
 pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AnonymousKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
@@ -1104,6 +1141,7 @@ pub struct slang_solidity_v2_ir::ir::AsteriskEqualStruct
 pub slang_solidity_v2_ir::ir::AsteriskEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AsteriskEqualStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AsteriskEqualStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::AsteriskEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AsteriskEqualStruct
@@ -1116,6 +1154,7 @@ pub struct slang_solidity_v2_ir::ir::AsteriskStruct
 pub slang_solidity_v2_ir::ir::AsteriskStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AsteriskStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::AsteriskStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AsteriskStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskStruct::clone(&self) -> slang_solidity_v2_ir::ir::AsteriskStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::AsteriskStruct
@@ -1128,6 +1167,7 @@ pub struct slang_solidity_v2_ir::ir::BangEqualStruct
 pub slang_solidity_v2_ir::ir::BangEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BangEqualStruct
 pub fn slang_solidity_v2_ir::ir::BangEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::BangEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::BangEqualStruct
 pub fn slang_solidity_v2_ir::ir::BangEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::BangEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::BangEqualStruct
@@ -1140,6 +1180,7 @@ pub struct slang_solidity_v2_ir::ir::BangStruct
 pub slang_solidity_v2_ir::ir::BangStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BangStruct
 pub fn slang_solidity_v2_ir::ir::BangStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::BangStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::BangStruct
 pub fn slang_solidity_v2_ir::ir::BangStruct::clone(&self) -> slang_solidity_v2_ir::ir::BangStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::BangStruct
@@ -1152,6 +1193,7 @@ pub struct slang_solidity_v2_ir::ir::BarEqualStruct
 pub slang_solidity_v2_ir::ir::BarEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BarEqualStruct
 pub fn slang_solidity_v2_ir::ir::BarEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::BarEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::BarEqualStruct
 pub fn slang_solidity_v2_ir::ir::BarEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::BarEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::BarEqualStruct
@@ -1164,6 +1206,7 @@ pub struct slang_solidity_v2_ir::ir::BarStruct
 pub slang_solidity_v2_ir::ir::BarStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BarStruct
 pub fn slang_solidity_v2_ir::ir::BarStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::BarStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::BarStruct
 pub fn slang_solidity_v2_ir::ir::BarStruct::clone(&self) -> slang_solidity_v2_ir::ir::BarStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::BarStruct
@@ -1207,6 +1250,7 @@ pub struct slang_solidity_v2_ir::ir::BoolKeywordStruct
 pub slang_solidity_v2_ir::ir::BoolKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BoolKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::BoolKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::BoolKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::BoolKeywordStruct
@@ -1242,6 +1286,7 @@ pub struct slang_solidity_v2_ir::ir::CallDataKeywordStruct
 pub slang_solidity_v2_ir::ir::CallDataKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CallDataKeywordStruct
 pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::CallDataKeywordStruct
 pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::CallDataKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::CallDataKeywordStruct
@@ -1262,6 +1307,7 @@ pub struct slang_solidity_v2_ir::ir::CaretEqualStruct
 pub slang_solidity_v2_ir::ir::CaretEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CaretEqualStruct
 pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::CaretEqualStruct
 pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::CaretEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::CaretEqualStruct
@@ -1274,6 +1320,7 @@ pub struct slang_solidity_v2_ir::ir::CaretStruct
 pub slang_solidity_v2_ir::ir::CaretStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CaretStruct
 pub fn slang_solidity_v2_ir::ir::CaretStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::CaretStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::CaretStruct
 pub fn slang_solidity_v2_ir::ir::CaretStruct::clone(&self) -> slang_solidity_v2_ir::ir::CaretStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::CaretStruct
@@ -1338,6 +1385,7 @@ pub struct slang_solidity_v2_ir::ir::DaysKeywordStruct
 pub slang_solidity_v2_ir::ir::DaysKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::DaysKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::DaysKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::DaysKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::DaysKeywordStruct
@@ -1372,6 +1420,7 @@ pub struct slang_solidity_v2_ir::ir::DeleteKeywordStruct
 pub slang_solidity_v2_ir::ir::DeleteKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::DeleteKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::DeleteKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::DeleteKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::DeleteKeywordStruct
@@ -1408,6 +1457,7 @@ pub struct slang_solidity_v2_ir::ir::EqualEqualStruct
 pub slang_solidity_v2_ir::ir::EqualEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EqualEqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualEqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::EqualEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualEqualStruct
@@ -1420,6 +1470,7 @@ pub struct slang_solidity_v2_ir::ir::EqualStruct
 pub slang_solidity_v2_ir::ir::EqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::EqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::EqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualStruct
@@ -1449,6 +1500,7 @@ pub struct slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub slang_solidity_v2_ir::ir::EtherKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::EtherKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::EtherKeywordStruct
@@ -1492,6 +1544,7 @@ pub struct slang_solidity_v2_ir::ir::FalseKeywordStruct
 pub slang_solidity_v2_ir::ir::FalseKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::FalseKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::FalseKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::FalseKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::FalseKeywordStruct
@@ -1562,6 +1615,7 @@ pub struct slang_solidity_v2_ir::ir::GlobalKeywordStruct
 pub slang_solidity_v2_ir::ir::GlobalKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GlobalKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GlobalKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::GlobalKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GlobalKeywordStruct
@@ -1574,6 +1628,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub slang_solidity_v2_ir::ir::GreaterThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
@@ -1586,6 +1641,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 pub slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
@@ -1598,6 +1654,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruc
 pub slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
@@ -1610,6 +1667,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 pub slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
@@ -1622,6 +1680,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 pub slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
@@ -1634,6 +1693,7 @@ pub struct slang_solidity_v2_ir::ir::GreaterThanStruct
 pub slang_solidity_v2_ir::ir::GreaterThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::GreaterThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GreaterThanStruct
@@ -1646,6 +1706,7 @@ pub struct slang_solidity_v2_ir::ir::GweiKeywordStruct
 pub slang_solidity_v2_ir::ir::GweiKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GweiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::GweiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::GweiKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::GweiKeywordStruct
@@ -1693,6 +1754,7 @@ pub struct slang_solidity_v2_ir::ir::HoursKeywordStruct
 pub slang_solidity_v2_ir::ir::HoursKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::HoursKeywordStruct
 pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::HoursKeywordStruct
 pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::HoursKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::HoursKeywordStruct
@@ -1753,6 +1815,7 @@ pub struct slang_solidity_v2_ir::ir::IndexedKeywordStruct
 pub slang_solidity_v2_ir::ir::IndexedKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::IndexedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::IndexedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::IndexedKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::IndexedKeywordStruct
@@ -1805,6 +1868,7 @@ pub struct slang_solidity_v2_ir::ir::LessThanEqualStruct
 pub slang_solidity_v2_ir::ir::LessThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::LessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::LessThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::LessThanEqualStruct
@@ -1817,6 +1881,7 @@ pub struct slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 pub slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
@@ -1829,6 +1894,7 @@ pub struct slang_solidity_v2_ir::ir::LessThanLessThanStruct
 pub slang_solidity_v2_ir::ir::LessThanLessThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LessThanLessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::LessThanLessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::LessThanLessThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::LessThanLessThanStruct
@@ -1841,6 +1907,7 @@ pub struct slang_solidity_v2_ir::ir::LessThanStruct
 pub slang_solidity_v2_ir::ir::LessThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::LessThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::LessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::LessThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::LessThanStruct
@@ -1877,6 +1944,7 @@ pub struct slang_solidity_v2_ir::ir::MemoryKeywordStruct
 pub slang_solidity_v2_ir::ir::MemoryKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MemoryKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MemoryKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::MemoryKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::MemoryKeywordStruct
@@ -1889,6 +1957,7 @@ pub struct slang_solidity_v2_ir::ir::MinusEqualStruct
 pub slang_solidity_v2_ir::ir::MinusEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MinusEqualStruct
 pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MinusEqualStruct
 pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::MinusEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::MinusEqualStruct
@@ -1901,6 +1970,7 @@ pub struct slang_solidity_v2_ir::ir::MinusMinusStruct
 pub slang_solidity_v2_ir::ir::MinusMinusStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MinusMinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MinusMinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::clone(&self) -> slang_solidity_v2_ir::ir::MinusMinusStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::MinusMinusStruct
@@ -1913,6 +1983,7 @@ pub struct slang_solidity_v2_ir::ir::MinusStruct
 pub slang_solidity_v2_ir::ir::MinusStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::MinusStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusStruct::clone(&self) -> slang_solidity_v2_ir::ir::MinusStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::MinusStruct
@@ -1925,6 +1996,7 @@ pub struct slang_solidity_v2_ir::ir::MinutesKeywordStruct
 pub slang_solidity_v2_ir::ir::MinutesKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MinutesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MinutesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::MinutesKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::MinutesKeywordStruct
@@ -2015,6 +2087,7 @@ pub struct slang_solidity_v2_ir::ir::PayableKeywordStruct
 pub slang_solidity_v2_ir::ir::PayableKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PayableKeywordStruct
 pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PayableKeywordStruct
 pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::PayableKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PayableKeywordStruct
@@ -2027,6 +2100,7 @@ pub struct slang_solidity_v2_ir::ir::PercentEqualStruct
 pub slang_solidity_v2_ir::ir::PercentEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PercentEqualStruct
 pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PercentEqualStruct
 pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::PercentEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PercentEqualStruct
@@ -2039,6 +2113,7 @@ pub struct slang_solidity_v2_ir::ir::PercentStruct
 pub slang_solidity_v2_ir::ir::PercentStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PercentStruct
 pub fn slang_solidity_v2_ir::ir::PercentStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PercentStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PercentStruct
 pub fn slang_solidity_v2_ir::ir::PercentStruct::clone(&self) -> slang_solidity_v2_ir::ir::PercentStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PercentStruct
@@ -2051,6 +2126,7 @@ pub struct slang_solidity_v2_ir::ir::PlusEqualStruct
 pub slang_solidity_v2_ir::ir::PlusEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PlusEqualStruct
 pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PlusEqualStruct
 pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::PlusEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PlusEqualStruct
@@ -2063,6 +2139,7 @@ pub struct slang_solidity_v2_ir::ir::PlusPlusStruct
 pub slang_solidity_v2_ir::ir::PlusPlusStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PlusPlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PlusPlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::clone(&self) -> slang_solidity_v2_ir::ir::PlusPlusStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PlusPlusStruct
@@ -2075,6 +2152,7 @@ pub struct slang_solidity_v2_ir::ir::PlusStruct
 pub slang_solidity_v2_ir::ir::PlusStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PlusStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusStruct::clone(&self) -> slang_solidity_v2_ir::ir::PlusStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PlusStruct
@@ -2095,6 +2173,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaCaretStruct
 pub slang_solidity_v2_ir::ir::PragmaCaretStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaCaretStruct
 pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaCaretStruct
 pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaCaretStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaCaretStruct
@@ -2114,6 +2193,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaEqualStruct
 pub slang_solidity_v2_ir::ir::PragmaEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaEqualStruct
@@ -2126,6 +2206,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 pub slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
@@ -2138,6 +2219,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 pub slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
@@ -2150,6 +2232,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 pub slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
@@ -2162,6 +2245,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaLessThanStruct
 pub slang_solidity_v2_ir::ir::PragmaLessThanStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaLessThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaLessThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaLessThanStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaLessThanStruct
@@ -2174,6 +2258,7 @@ pub struct slang_solidity_v2_ir::ir::PragmaTildeStruct
 pub slang_solidity_v2_ir::ir::PragmaTildeStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaTildeStruct
 pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PragmaTildeStruct
 pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::clone(&self) -> slang_solidity_v2_ir::ir::PragmaTildeStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaTildeStruct
@@ -2209,6 +2294,7 @@ pub struct slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 pub slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
@@ -2221,6 +2307,7 @@ pub struct slang_solidity_v2_ir::ir::SecondsKeywordStruct
 pub slang_solidity_v2_ir::ir::SecondsKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SecondsKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SecondsKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::SecondsKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SecondsKeywordStruct
@@ -2233,6 +2320,7 @@ pub struct slang_solidity_v2_ir::ir::SemicolonStruct
 pub slang_solidity_v2_ir::ir::SemicolonStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SemicolonStruct
 pub fn slang_solidity_v2_ir::ir::SemicolonStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SemicolonStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SemicolonStruct
 pub fn slang_solidity_v2_ir::ir::SemicolonStruct::clone(&self) -> slang_solidity_v2_ir::ir::SemicolonStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SemicolonStruct
@@ -2262,6 +2350,7 @@ pub struct slang_solidity_v2_ir::ir::SlashEqualStruct
 pub slang_solidity_v2_ir::ir::SlashEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SlashEqualStruct
 pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SlashEqualStruct
 pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::clone(&self) -> slang_solidity_v2_ir::ir::SlashEqualStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SlashEqualStruct
@@ -2274,6 +2363,7 @@ pub struct slang_solidity_v2_ir::ir::SlashStruct
 pub slang_solidity_v2_ir::ir::SlashStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SlashStruct
 pub fn slang_solidity_v2_ir::ir::SlashStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SlashStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SlashStruct
 pub fn slang_solidity_v2_ir::ir::SlashStruct::clone(&self) -> slang_solidity_v2_ir::ir::SlashStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SlashStruct
@@ -2305,6 +2395,7 @@ pub struct slang_solidity_v2_ir::ir::StorageKeywordStruct
 pub slang_solidity_v2_ir::ir::StorageKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::StorageKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StorageKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::StorageKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::StorageKeywordStruct
@@ -2317,6 +2408,7 @@ pub struct slang_solidity_v2_ir::ir::StringKeywordStruct
 pub slang_solidity_v2_ir::ir::StringKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::StringKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StringKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::StringKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::StringKeywordStruct
@@ -2359,6 +2451,7 @@ pub struct slang_solidity_v2_ir::ir::SuperKeywordStruct
 pub slang_solidity_v2_ir::ir::SuperKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SuperKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SuperKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::SuperKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::SuperKeywordStruct
@@ -2371,6 +2464,7 @@ pub struct slang_solidity_v2_ir::ir::ThisKeywordStruct
 pub slang_solidity_v2_ir::ir::ThisKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ThisKeywordStruct
 pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ThisKeywordStruct
 pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::ThisKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::ThisKeywordStruct
@@ -2383,6 +2477,7 @@ pub struct slang_solidity_v2_ir::ir::TildeStruct
 pub slang_solidity_v2_ir::ir::TildeStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::TildeStruct
 pub fn slang_solidity_v2_ir::ir::TildeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::TildeStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::TildeStruct
 pub fn slang_solidity_v2_ir::ir::TildeStruct::clone(&self) -> slang_solidity_v2_ir::ir::TildeStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::TildeStruct
@@ -2395,6 +2490,7 @@ pub struct slang_solidity_v2_ir::ir::TrueKeywordStruct
 pub slang_solidity_v2_ir::ir::TrueKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::TrueKeywordStruct
 pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::TrueKeywordStruct
 pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::TrueKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::TrueKeywordStruct
@@ -2572,6 +2668,7 @@ pub struct slang_solidity_v2_ir::ir::VirtualKeywordStruct
 pub slang_solidity_v2_ir::ir::VirtualKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::VirtualKeywordStruct
 pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VirtualKeywordStruct
 pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::VirtualKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::VirtualKeywordStruct
@@ -2584,6 +2681,7 @@ pub struct slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub slang_solidity_v2_ir::ir::WeeksKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::WeeksKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::WeeksKeywordStruct
@@ -2596,6 +2694,7 @@ pub struct slang_solidity_v2_ir::ir::WeiKeywordStruct
 pub slang_solidity_v2_ir::ir::WeiKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::WeiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::unparse(&self) -> &'static str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::WeiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::WeiKeywordStruct
 impl core::cmp::Eq for slang_solidity_v2_ir::ir::WeiKeywordStruct

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -136,7 +136,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         Arc::new(output::{{ terminal_type }}Struct {
           id: self.next_id(),
           range: source.range.clone(),
-          {%- if not terminal.is_unique %}
+          {%- if not terminal.unique_symbol %}
             text: self.unparse_range(source.range.clone()),
           {%- endif %}
         })

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -1535,10 +1535,28 @@ pub enum AbicoderVersion {
     AbicoderV2Keyword(AbicoderV2Keyword),
 }
 
+impl AbicoderVersion {
+    pub fn unparse(&self) -> &str {
+        match self {
+            AbicoderVersion::AbicoderV1Keyword(inner) => inner.unparse(),
+            AbicoderVersion::AbicoderV2Keyword(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum AdditiveExpressionOperator {
     Minus(Minus),
     Plus(Plus),
+}
+
+impl AdditiveExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            AdditiveExpressionOperator::Minus(inner) => inner.unparse(),
+            AdditiveExpressionOperator::Plus(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1561,6 +1579,27 @@ pub enum AssignmentExpressionOperator {
     PercentEqual(PercentEqual),
     PlusEqual(PlusEqual),
     SlashEqual(SlashEqual),
+}
+
+impl AssignmentExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            AssignmentExpressionOperator::AmpersandEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::AsteriskEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::BarEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::CaretEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::Equal(inner) => inner.unparse(),
+            AssignmentExpressionOperator::GreaterThanGreaterThanEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(inner) => {
+                inner.unparse()
+            }
+            AssignmentExpressionOperator::LessThanLessThanEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::MinusEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::PercentEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::PlusEqual(inner) => inner.unparse(),
+            AssignmentExpressionOperator::SlashEqual(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1594,11 +1633,30 @@ pub enum EqualityExpressionOperator {
     EqualEqual(EqualEqual),
 }
 
+impl EqualityExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            EqualityExpressionOperator::BangEqual(inner) => inner.unparse(),
+            EqualityExpressionOperator::EqualEqual(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ExperimentalFeature {
     ABIEncoderV2Keyword(ABIEncoderV2Keyword),
     SMTCheckerKeyword(SMTCheckerKeyword),
     StringLiteral(StringLiteral),
+}
+
+impl ExperimentalFeature {
+    pub fn unparse(&self) -> &str {
+        match self {
+            ExperimentalFeature::ABIEncoderV2Keyword(inner) => inner.unparse(),
+            ExperimentalFeature::SMTCheckerKeyword(inner) => inner.unparse(),
+            ExperimentalFeature::StringLiteral(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1690,11 +1748,32 @@ pub enum InequalityExpressionOperator {
     LessThanEqual(LessThanEqual),
 }
 
+impl InequalityExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            InequalityExpressionOperator::GreaterThan(inner) => inner.unparse(),
+            InequalityExpressionOperator::GreaterThanEqual(inner) => inner.unparse(),
+            InequalityExpressionOperator::LessThan(inner) => inner.unparse(),
+            InequalityExpressionOperator::LessThanEqual(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum MultiplicativeExpressionOperator {
     Asterisk(Asterisk),
     Percent(Percent),
     Slash(Slash),
+}
+
+impl MultiplicativeExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            MultiplicativeExpressionOperator::Asterisk(inner) => inner.unparse(),
+            MultiplicativeExpressionOperator::Percent(inner) => inner.unparse(),
+            MultiplicativeExpressionOperator::Slash(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1709,10 +1788,34 @@ pub enum NumberUnit {
     WeeksKeyword(WeeksKeyword),
 }
 
+impl NumberUnit {
+    pub fn unparse(&self) -> &str {
+        match self {
+            NumberUnit::WeiKeyword(inner) => inner.unparse(),
+            NumberUnit::GweiKeyword(inner) => inner.unparse(),
+            NumberUnit::EtherKeyword(inner) => inner.unparse(),
+            NumberUnit::SecondsKeyword(inner) => inner.unparse(),
+            NumberUnit::MinutesKeyword(inner) => inner.unparse(),
+            NumberUnit::HoursKeyword(inner) => inner.unparse(),
+            NumberUnit::DaysKeyword(inner) => inner.unparse(),
+            NumberUnit::WeeksKeyword(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum PostfixExpressionOperator {
     MinusMinus(MinusMinus),
     PlusPlus(PlusPlus),
+}
+
+impl PostfixExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            PostfixExpressionOperator::MinusMinus(inner) => inner.unparse(),
+            PostfixExpressionOperator::PlusPlus(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1732,11 +1835,34 @@ pub enum PrefixExpressionOperator {
     Tilde(Tilde),
 }
 
+impl PrefixExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            PrefixExpressionOperator::Bang(inner) => inner.unparse(),
+            PrefixExpressionOperator::DeleteKeyword(inner) => inner.unparse(),
+            PrefixExpressionOperator::Minus(inner) => inner.unparse(),
+            PrefixExpressionOperator::MinusMinus(inner) => inner.unparse(),
+            PrefixExpressionOperator::PlusPlus(inner) => inner.unparse(),
+            PrefixExpressionOperator::Tilde(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ShiftExpressionOperator {
     GreaterThanGreaterThan(GreaterThanGreaterThan),
     GreaterThanGreaterThanGreaterThan(GreaterThanGreaterThanGreaterThan),
     LessThanLessThan(LessThanLessThan),
+}
+
+impl ShiftExpressionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            ShiftExpressionOperator::GreaterThanGreaterThan(inner) => inner.unparse(),
+            ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(inner) => inner.unparse(),
+            ShiftExpressionOperator::LessThanLessThan(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1797,6 +1923,16 @@ pub enum StorageLocation {
     CallDataKeyword(CallDataKeyword),
 }
 
+impl StorageLocation {
+    pub fn unparse(&self) -> &str {
+        match self {
+            StorageLocation::MemoryKeyword(inner) => inner.unparse(),
+            StorageLocation::StorageKeyword(inner) => inner.unparse(),
+            StorageLocation::CallDataKeyword(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum StringExpression {
     StringLiterals(StringLiterals),
@@ -1838,6 +1974,28 @@ pub enum UsingOperator {
     Tilde(Tilde),
 }
 
+impl UsingOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            UsingOperator::Ampersand(inner) => inner.unparse(),
+            UsingOperator::Asterisk(inner) => inner.unparse(),
+            UsingOperator::BangEqual(inner) => inner.unparse(),
+            UsingOperator::Bar(inner) => inner.unparse(),
+            UsingOperator::Caret(inner) => inner.unparse(),
+            UsingOperator::EqualEqual(inner) => inner.unparse(),
+            UsingOperator::GreaterThan(inner) => inner.unparse(),
+            UsingOperator::GreaterThanEqual(inner) => inner.unparse(),
+            UsingOperator::LessThan(inner) => inner.unparse(),
+            UsingOperator::LessThanEqual(inner) => inner.unparse(),
+            UsingOperator::Minus(inner) => inner.unparse(),
+            UsingOperator::Percent(inner) => inner.unparse(),
+            UsingOperator::Plus(inner) => inner.unparse(),
+            UsingOperator::Slash(inner) => inner.unparse(),
+            UsingOperator::Tilde(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum UsingTarget {
     TypeName(TypeName),
@@ -1873,6 +2031,20 @@ pub enum VersionOperator {
     PragmaGreaterThanEqual(PragmaGreaterThanEqual),
 }
 
+impl VersionOperator {
+    pub fn unparse(&self) -> &str {
+        match self {
+            VersionOperator::PragmaCaret(inner) => inner.unparse(),
+            VersionOperator::PragmaTilde(inner) => inner.unparse(),
+            VersionOperator::PragmaEqual(inner) => inner.unparse(),
+            VersionOperator::PragmaLessThan(inner) => inner.unparse(),
+            VersionOperator::PragmaGreaterThan(inner) => inner.unparse(),
+            VersionOperator::PragmaLessThanEqual(inner) => inner.unparse(),
+            VersionOperator::PragmaGreaterThanEqual(inner) => inner.unparse(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum YulExpression {
     YulFunctionCallExpression(YulFunctionCallExpression),
@@ -1888,6 +2060,19 @@ pub enum YulLiteral {
     HexLiteral(HexLiteral),
     HexStringLiteral(HexStringLiteral),
     StringLiteral(StringLiteral),
+}
+
+impl YulLiteral {
+    pub fn unparse(&self) -> &str {
+        match self {
+            YulLiteral::TrueKeyword(inner) => inner.unparse(),
+            YulLiteral::FalseKeyword(inner) => inner.unparse(),
+            YulLiteral::DecimalLiteral(inner) => inner.unparse(),
+            YulLiteral::HexLiteral(inner) => inner.unparse(),
+            YulLiteral::HexStringLiteral(inner) => inner.unparse(),
+            YulLiteral::StringLiteral(inner) => inner.unparse(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -2001,6 +2186,9 @@ impl ABIEncoderV2KeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "ABIEncoderV2"
+    }
 }
 
 pub type AbicoderV1Keyword = Arc<AbicoderV1KeywordStruct>;
@@ -2014,6 +2202,9 @@ pub struct AbicoderV1KeywordStruct {
 impl AbicoderV1KeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "v1"
     }
 }
 
@@ -2029,6 +2220,9 @@ impl AbicoderV2KeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "v2"
+    }
 }
 
 pub type AbstractKeyword = Arc<AbstractKeywordStruct>;
@@ -2042,6 +2236,9 @@ pub struct AbstractKeywordStruct {
 impl AbstractKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "abstract"
     }
 }
 
@@ -2057,6 +2254,9 @@ impl AmpersandStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "&"
+    }
 }
 
 pub type AmpersandEqual = Arc<AmpersandEqualStruct>;
@@ -2070,6 +2270,9 @@ pub struct AmpersandEqualStruct {
 impl AmpersandEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "&="
     }
 }
 
@@ -2085,6 +2288,9 @@ impl AnonymousKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "anonymous"
+    }
 }
 
 pub type Asterisk = Arc<AsteriskStruct>;
@@ -2098,6 +2304,9 @@ pub struct AsteriskStruct {
 impl AsteriskStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "*"
     }
 }
 
@@ -2113,6 +2322,9 @@ impl AsteriskEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "*="
+    }
 }
 
 pub type Bang = Arc<BangStruct>;
@@ -2126,6 +2338,9 @@ pub struct BangStruct {
 impl BangStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "!"
     }
 }
 
@@ -2141,6 +2356,9 @@ impl BangEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "!="
+    }
 }
 
 pub type Bar = Arc<BarStruct>;
@@ -2154,6 +2372,9 @@ pub struct BarStruct {
 impl BarStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "|"
     }
 }
 
@@ -2169,6 +2390,9 @@ impl BarEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "|="
+    }
 }
 
 pub type BoolKeyword = Arc<BoolKeywordStruct>;
@@ -2182,6 +2406,9 @@ pub struct BoolKeywordStruct {
 impl BoolKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "bool"
     }
 }
 
@@ -2215,6 +2442,9 @@ impl CallDataKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "calldata"
+    }
 }
 
 pub type Caret = Arc<CaretStruct>;
@@ -2228,6 +2458,9 @@ pub struct CaretStruct {
 impl CaretStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "^"
     }
 }
 
@@ -2243,6 +2476,9 @@ impl CaretEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "^="
+    }
 }
 
 pub type DaysKeyword = Arc<DaysKeywordStruct>;
@@ -2256,6 +2492,9 @@ pub struct DaysKeywordStruct {
 impl DaysKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "days"
     }
 }
 
@@ -2289,6 +2528,9 @@ impl DeleteKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "delete"
+    }
 }
 
 pub type Equal = Arc<EqualStruct>;
@@ -2302,6 +2544,9 @@ pub struct EqualStruct {
 impl EqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "="
     }
 }
 
@@ -2317,6 +2562,9 @@ impl EqualEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "=="
+    }
 }
 
 pub type EtherKeyword = Arc<EtherKeywordStruct>;
@@ -2331,6 +2579,9 @@ impl EtherKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "ether"
+    }
 }
 
 pub type FalseKeyword = Arc<FalseKeywordStruct>;
@@ -2344,6 +2595,9 @@ pub struct FalseKeywordStruct {
 impl FalseKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "false"
     }
 }
 
@@ -2377,6 +2631,9 @@ impl GlobalKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "global"
+    }
 }
 
 pub type GreaterThan = Arc<GreaterThanStruct>;
@@ -2390,6 +2647,9 @@ pub struct GreaterThanStruct {
 impl GreaterThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        ">"
     }
 }
 
@@ -2405,6 +2665,9 @@ impl GreaterThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        ">="
+    }
 }
 
 pub type GreaterThanGreaterThan = Arc<GreaterThanGreaterThanStruct>;
@@ -2418,6 +2681,9 @@ pub struct GreaterThanGreaterThanStruct {
 impl GreaterThanGreaterThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        ">>"
     }
 }
 
@@ -2433,6 +2699,9 @@ impl GreaterThanGreaterThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        ">>="
+    }
 }
 
 pub type GreaterThanGreaterThanGreaterThan = Arc<GreaterThanGreaterThanGreaterThanStruct>;
@@ -2446,6 +2715,9 @@ pub struct GreaterThanGreaterThanGreaterThanStruct {
 impl GreaterThanGreaterThanGreaterThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        ">>>"
     }
 }
 
@@ -2461,6 +2733,9 @@ impl GreaterThanGreaterThanGreaterThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        ">>>="
+    }
 }
 
 pub type GweiKeyword = Arc<GweiKeywordStruct>;
@@ -2474,6 +2749,9 @@ pub struct GweiKeywordStruct {
 impl GweiKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "gwei"
     }
 }
 
@@ -2525,6 +2803,9 @@ impl HoursKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "hours"
+    }
 }
 
 pub type Identifier = Arc<IdentifierStruct>;
@@ -2556,6 +2837,9 @@ pub struct IndexedKeywordStruct {
 impl IndexedKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "indexed"
     }
 }
 
@@ -2589,6 +2873,9 @@ impl LessThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "<"
+    }
 }
 
 pub type LessThanEqual = Arc<LessThanEqualStruct>;
@@ -2602,6 +2889,9 @@ pub struct LessThanEqualStruct {
 impl LessThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "<="
     }
 }
 
@@ -2617,6 +2907,9 @@ impl LessThanLessThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "<<"
+    }
 }
 
 pub type LessThanLessThanEqual = Arc<LessThanLessThanEqualStruct>;
@@ -2630,6 +2923,9 @@ pub struct LessThanLessThanEqualStruct {
 impl LessThanLessThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "<<="
     }
 }
 
@@ -2645,6 +2941,9 @@ impl MemoryKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "memory"
+    }
 }
 
 pub type Minus = Arc<MinusStruct>;
@@ -2658,6 +2957,9 @@ pub struct MinusStruct {
 impl MinusStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "-"
     }
 }
 
@@ -2673,6 +2975,9 @@ impl MinusEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "-="
+    }
 }
 
 pub type MinusMinus = Arc<MinusMinusStruct>;
@@ -2686,6 +2991,9 @@ pub struct MinusMinusStruct {
 impl MinusMinusStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "--"
     }
 }
 
@@ -2701,6 +3009,9 @@ impl MinutesKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "minutes"
+    }
 }
 
 pub type PayableKeyword = Arc<PayableKeywordStruct>;
@@ -2714,6 +3025,9 @@ pub struct PayableKeywordStruct {
 impl PayableKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "payable"
     }
 }
 
@@ -2729,6 +3043,9 @@ impl PercentStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "%"
+    }
 }
 
 pub type PercentEqual = Arc<PercentEqualStruct>;
@@ -2742,6 +3059,9 @@ pub struct PercentEqualStruct {
 impl PercentEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "%="
     }
 }
 
@@ -2757,6 +3077,9 @@ impl PlusStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "+"
+    }
 }
 
 pub type PlusEqual = Arc<PlusEqualStruct>;
@@ -2770,6 +3093,9 @@ pub struct PlusEqualStruct {
 impl PlusEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "+="
     }
 }
 
@@ -2785,6 +3111,9 @@ impl PlusPlusStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "++"
+    }
 }
 
 pub type PragmaCaret = Arc<PragmaCaretStruct>;
@@ -2798,6 +3127,9 @@ pub struct PragmaCaretStruct {
 impl PragmaCaretStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "^"
     }
 }
 
@@ -2813,6 +3145,9 @@ impl PragmaEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "="
+    }
 }
 
 pub type PragmaGreaterThan = Arc<PragmaGreaterThanStruct>;
@@ -2826,6 +3161,9 @@ pub struct PragmaGreaterThanStruct {
 impl PragmaGreaterThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        ">"
     }
 }
 
@@ -2841,6 +3179,9 @@ impl PragmaGreaterThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        ">="
+    }
 }
 
 pub type PragmaLessThan = Arc<PragmaLessThanStruct>;
@@ -2854,6 +3195,9 @@ pub struct PragmaLessThanStruct {
 impl PragmaLessThanStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "<"
     }
 }
 
@@ -2869,6 +3213,9 @@ impl PragmaLessThanEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "<="
+    }
 }
 
 pub type PragmaTilde = Arc<PragmaTildeStruct>;
@@ -2882,6 +3229,9 @@ pub struct PragmaTildeStruct {
 impl PragmaTildeStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "~"
     }
 }
 
@@ -2897,6 +3247,9 @@ impl SMTCheckerKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "SMTChecker"
+    }
 }
 
 pub type SecondsKeyword = Arc<SecondsKeywordStruct>;
@@ -2910,6 +3263,9 @@ pub struct SecondsKeywordStruct {
 impl SecondsKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "seconds"
     }
 }
 
@@ -2925,6 +3281,9 @@ impl SemicolonStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        ";"
+    }
 }
 
 pub type Slash = Arc<SlashStruct>;
@@ -2938,6 +3297,9 @@ pub struct SlashStruct {
 impl SlashStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "/"
     }
 }
 
@@ -2953,6 +3315,9 @@ impl SlashEqualStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "/="
+    }
 }
 
 pub type StorageKeyword = Arc<StorageKeywordStruct>;
@@ -2967,6 +3332,9 @@ impl StorageKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "storage"
+    }
 }
 
 pub type StringKeyword = Arc<StringKeywordStruct>;
@@ -2980,6 +3348,9 @@ pub struct StringKeywordStruct {
 impl StringKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "string"
     }
 }
 
@@ -3013,6 +3384,9 @@ impl SuperKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "super"
+    }
 }
 
 pub type ThisKeyword = Arc<ThisKeywordStruct>;
@@ -3026,6 +3400,9 @@ pub struct ThisKeywordStruct {
 impl ThisKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "this"
     }
 }
 
@@ -3041,6 +3418,9 @@ impl TildeStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "~"
+    }
 }
 
 pub type TrueKeyword = Arc<TrueKeywordStruct>;
@@ -3054,6 +3434,9 @@ pub struct TrueKeywordStruct {
 impl TrueKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "true"
     }
 }
 
@@ -3141,6 +3524,9 @@ impl VirtualKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "virtual"
+    }
 }
 
 pub type WeeksKeyword = Arc<WeeksKeywordStruct>;
@@ -3155,6 +3541,9 @@ impl WeeksKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
     }
+    pub fn unparse(&self) -> &'static str {
+        "weeks"
+    }
 }
 
 pub type WeiKeyword = Arc<WeiKeywordStruct>;
@@ -3168,5 +3557,8 @@ pub struct WeiKeywordStruct {
 impl WeiKeywordStruct {
     pub fn id(&self) -> NodeId {
         self.id
+    }
+    pub fn unparse(&self) -> &'static str {
+        "wei"
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -46,13 +46,17 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
 //
 
 {% for parent_type, choice in target.choices %}
-  {% set_global all_external_terminals = true %}
+  {% set_global all_external = true %}
+  {% set_global all_terminals = true %}
   {% for variant in choice.variants %}
     {% if not variant.is_external %}
-      {% set_global all_external_terminals = false %}
+      {% set_global all_external = false %}
+    {% endif %}
+    {% if not variant.is_terminal %}
+      {% set_global all_terminals = false %}
     {% endif %}
   {% endfor %}
-  {% if all_external_terminals -%}
+  {% if all_external -%}
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
   {%- else -%}
     #[derive(Clone, Debug)]
@@ -66,6 +70,20 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
       ,
     {%- endfor -%}
   }
+  
+  {% if all_terminals -%}
+  impl {{ parent_type }} {
+    pub fn unparse(&self) -> &str {
+      match self {
+        {% for variant in choice.variants -%}
+          {{ parent_type }}::{{ variant.name }}(inner) => {
+            inner.unparse()
+          }
+        {%- endfor -%}
+      }
+    }
+   }
+   {%- endif %}
 {% endfor %}
 
 //
@@ -99,10 +117,14 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
       self.id
     }
 
-    {%- if not terminal.unique_symbol %}
-      pub fn unparse(&self) -> &str {
+    {%- if terminal.unique_symbol %}
+    pub fn unparse(&self) -> &'static str {
+        "{{ terminal.unique_symbol }}"
+    }
+    {%- else %}
+    pub fn unparse(&self) -> &str {
         &self.text
-      }
+    }
     {%- endif %}
   }
 {% endfor %}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -89,7 +89,7 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
   pub struct {{ terminal_type }}Struct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
-    {%- if not terminal.is_unique %}
+    {%- if not terminal.unique_symbol %}
       pub text: String,
     {%- endif %}
   }
@@ -99,7 +99,7 @@ pub(super) use slang_solidity_v2_common::nodes::NodeId;
       self.id
     }
 
-    {%- if not terminal.is_unique %}
+    {%- if not terminal.unique_symbol %}
       pub fn unparse(&self) -> &str {
         &self.text
       }


### PR DESCRIPTION
From https://github.com/NomicFoundation/slang/pull/1799#discussion_r3313405384 it made sense to add `unparse()` to all terminals and, as a utility, to terminal-only choices.