### PR TITLE
[v2] impl Display for NodeId

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -524,6 +524,8 @@ impl core::convert::From<usize> for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::from(value: usize) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_common::nodes::NodeId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for slang_solidity_v2_common::nodes::NodeId

--- a/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -8,5 +10,11 @@ pub struct NodeId(usize);
 impl From<usize> for NodeId {
     fn from(value: usize) -> Self {
         Self(value)
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
Mirrors `metaslang_cst::NodeId`, which already implements `Display` (via the `From<NodeId> for usize` impl plus a `Display` derive in older revisions). The v2 `NodeId` only exposed `From<usize>` and `Debug`, so downstream consumers that need to format a node id (for example, embedding it in an MLIR symbol name) had to fall back to `Debug` (`NodeId(N)`) or serialize via `serde_json`. This adds a direct `Display` impl that formats just the inner `usize`, and updates the `public_api.txt` snapshot.