### PR TITLE
[v2] Carry integer value in address literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,8 @@ dependencies = [
 name = "slang_solidity_v2"
 version = "1.3.5"
 dependencies = [
+ "num-bigint",
+ "num-rational",
  "ruint",
  "serde_json",
  "slang_solidity_v2_ast",

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -343,6 +343,7 @@ impl core::marker::Copy for slang_solidity_v2_semantic::types::FunctionTypeVisib
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionTypeVisibility
 pub enum slang_solidity_v2_semantic::types::LiteralKind
 pub slang_solidity_v2_semantic::types::LiteralKind::Address
+pub slang_solidity_v2_semantic::types::LiteralKind::Address::value: ruint::aliases::U160
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::bytes: u32
 pub slang_solidity_v2_semantic::types::LiteralKind::HexInteger::value: num_bigint::bigint::BigInt

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -362,7 +362,9 @@ impl<'a> BuiltInsResolver<'a> {
                 }
             }
             Type::Integer { .. } => None,
-            Type::Literal(LiteralKind::Address) => Self::lookup_member_of_address(symbol, false),
+            Type::Literal(LiteralKind::Address { .. }) => {
+                Self::lookup_member_of_address(symbol, false)
+            }
             Type::Literal(_) => None,
             Type::Mapping { .. } => None,
             Type::String { .. } => match symbol {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -1,3 +1,4 @@
+use ruint::aliases::U160;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -610,7 +611,11 @@ impl Pass<'_> {
         if digits == 40 {
             // TODO(validation) SDR[38]: verify the address is valid (ie. has a valid checksum)
             // We need at least an implementation of SHA3 to compute the checksum
-            return Some(LiteralKind::Address);
+
+            // Skip `0x` prefix and parse the hexadecimal number.
+            // `U160::from_str_radix` ignores `_` separators.
+            let value = U160::from_str_radix(&hex_number[2..], 16).ok()?;
+            return Some(LiteralKind::Address { value });
         }
         let value = Number::from_hex_number_expression(hex_number_expression)?
             .into_integer()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -70,10 +70,9 @@ impl Number {
             LiteralKind::Integer { value } | LiteralKind::HexInteger { value, .. } => {
                 Some(Self::Integer(value.clone()))
             }
+            LiteralKind::Address { value } => Some(Self::Integer(value.into())),
             LiteralKind::Rational { value } => Some(Self::Rational(value.clone())),
-            LiteralKind::HexString { .. } | LiteralKind::String { .. } | LiteralKind::Address => {
-                None
-            }
+            LiteralKind::HexString { .. } | LiteralKind::String { .. } => None,
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -1,6 +1,7 @@
 use literals::numbers;
 use num_bigint::BigInt;
 use num_rational::BigRational;
+use ruint::aliases::U160;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -100,7 +101,9 @@ pub enum LiteralKind {
     String {
         bytes: usize,
     },
-    Address,
+    Address {
+        value: U160,
+    },
 }
 
 impl LiteralKind {
@@ -117,7 +120,7 @@ impl LiteralKind {
             LiteralKind::HexString { .. } | LiteralKind::String { .. } => Some(Type::String {
                 location: DataLocation::Memory,
             }),
-            LiteralKind::Address => Some(Type::Address { payable: false }),
+            LiteralKind::Address { .. } => Some(Type::Address { payable: false }),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -30,6 +30,8 @@ slang_solidity_v2_parser = { workspace = true }
 slang_solidity_v2_semantic = { workspace = true }
 
 [dev-dependencies]
+num-bigint = { workspace = true }
+num-rational = { workspace = true }
 ruint = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast.rs
@@ -1,5 +1,8 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
+
 use super::fixtures;
-use crate::ast::{self, BuiltIn, ContractBase, ContractMember, Definition, FunctionKind};
+use crate::ast::{self, BuiltIn, ContractBase, ContractMember, Definition, FunctionKind, Number};
 
 #[derive(Default)]
 struct IdentifierCounter {
@@ -469,4 +472,131 @@ fn test_get_file_id_and_text_range() {
         .find_contract_by_name("Counter")
         .expect("contract is found");
     assert_eq!(counter.get_file_id(), "main.sol");
+}
+
+#[derive(Default)]
+struct NumberLiteralCollector {
+    hex: Vec<(String, Option<BigInt>, Option<Number>)>,
+    decimal: Vec<(String, Option<BigInt>, Option<Number>)>,
+}
+
+impl ast::visitor::Visitor for NumberLiteralCollector {
+    fn enter_hex_number_expression(&mut self, node: &ast::HexNumberExpression) -> bool {
+        let text = node.literal().unparse().to_owned();
+        self.hex
+            .push((text, node.integer_value(), node.number_value()));
+        true
+    }
+
+    fn enter_decimal_number_expression(&mut self, node: &ast::DecimalNumberExpression) -> bool {
+        let text = node.literal().unparse().to_owned();
+        self.decimal
+            .push((text, node.integer_value(), node.number_value()));
+        true
+    }
+}
+
+fn integer(value: u128) -> Number {
+    Number::Integer(BigInt::from(value))
+}
+
+fn rational(numerator: i64, denominator: u64) -> Number {
+    Number::Rational(BigRational::new(
+        BigInt::from(numerator),
+        BigInt::from(denominator),
+    ))
+}
+
+#[test]
+fn test_hex_number_expression_value() {
+    let unit = fixtures::NumberLiterals::build_compilation_unit();
+    let ast = unit.file("main.sol").unwrap().ast();
+
+    let mut collector = NumberLiteralCollector::default();
+    ast::visitor::accept_source_unit(&ast, &mut collector);
+
+    // Each entry: (literal source text, expected integer value). A 40-digit hex literal is
+    // typed as an address, but its integer/number value is still surfaced as an integer.
+    let expected: &[(&str, u128)] = &[
+        ("0xff", 255),
+        ("0xDeAdBeEf", 3_735_928_559),
+        ("0x1234_5678", 305_419_896),
+        ("0x0", 0),
+        ("0x000000000000000000000000000000000000beef", 0xbeef),
+    ];
+
+    assert_eq!(
+        collector.hex.len(),
+        expected.len(),
+        "unexpected number of hex literals visited: {:?}",
+        collector.hex,
+    );
+
+    for ((text, integer_value, number_value), (expected_text, expected_value)) in
+        collector.hex.iter().zip(expected.iter())
+    {
+        assert_eq!(text, expected_text);
+        assert_eq!(integer_value, &Some(BigInt::from(*expected_value)));
+        assert_eq!(number_value, &Some(integer(*expected_value)));
+    }
+}
+
+#[test]
+fn test_decimal_number_expression_value() {
+    let unit = fixtures::NumberLiterals::build_compilation_unit();
+    let ast = unit.file("main.sol").unwrap().ast();
+
+    let mut collector = NumberLiteralCollector::default();
+    ast::visitor::accept_source_unit(&ast, &mut collector);
+
+    // Each entry: (literal source text, expected integer value if any, expected number value).
+    // The expected integer value is None for rational literals that do not reduce to an integer
+    // (with their unit applied).
+    let expected: &[(&str, Option<u128>, Number)] = &[
+        ("0", Some(0), integer(0)),
+        ("42", Some(42), integer(42)),
+        ("1_000_000", Some(1_000_000), integer(1_000_000)),
+        ("1e3", Some(1_000), integer(1_000)),
+        ("1500e-2", Some(15), integer(15)),
+        ("1", Some(1), integer(1)),
+        ("1", Some(1_000_000_000), integer(1_000_000_000)),
+        (
+            "1",
+            Some(1_000_000_000_000_000_000),
+            integer(1_000_000_000_000_000_000),
+        ),
+        (
+            "0.5",
+            Some(500_000_000_000_000_000),
+            integer(500_000_000_000_000_000),
+        ),
+        ("1", Some(3_600), integer(3_600)),
+        ("0.5", None, rational(1, 2)),
+        ("4", Some(4), integer(4)),
+        ("1.5", None, rational(3, 2)),
+        ("2", Some(2), integer(2)),
+    ];
+
+    assert_eq!(
+        collector.decimal.len(),
+        expected.len(),
+        "unexpected number of decimal literals visited: {:?}",
+        collector.decimal,
+    );
+
+    for ((text, integer_value, number_value), (expected_text, expected_integer, expected_number)) in
+        collector.decimal.iter().zip(expected.iter())
+    {
+        assert_eq!(text, expected_text);
+        assert_eq!(
+            integer_value,
+            &expected_integer.map(BigInt::from),
+            "integer_value mismatch for literal {text:?}",
+        );
+        assert_eq!(
+            number_value,
+            &Some(expected_number.clone()),
+            "number_value mismatch for literal {text:?}",
+        );
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -7,6 +7,7 @@ mod abi_with_tuples;
 mod chained_imports;
 mod counter;
 mod full_abi;
+mod number_literals;
 mod overrides;
 mod storage_layout;
 
@@ -14,6 +15,7 @@ pub(super) use abi_with_tuples::AbiWithTuples;
 pub(super) use chained_imports::ChainedImports;
 pub(super) use counter::Counter;
 pub(super) use full_abi::FullAbi;
+pub(super) use number_literals::NumberLiterals;
 pub(super) use overrides::Overrides;
 pub(super) use storage_layout::StorageLayout;
 
@@ -117,6 +119,12 @@ fn test_build_counter_fixture() {
 #[test]
 fn test_build_full_abi_fixture() {
     let unit = FullAbi::build_compilation_unit();
+    assert_eq!(1, unit.file_ids().len());
+}
+
+#[test]
+fn test_build_number_literals_fixture() {
+    let unit = NumberLiterals::build_compilation_unit();
     assert_eq!(1, unit.file_ids().len());
 }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/number_literals.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/number_literals.rs
@@ -1,0 +1,40 @@
+use crate::define_fixture;
+
+define_fixture!(
+    NumberLiterals,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.29;
+
+contract NumberLiterals {
+    // Hex literals
+    uint constant HEX_SMALL = 0xff;
+    uint constant HEX_MIXED_CASE = 0xDeAdBeEf;
+    uint constant HEX_WITH_SEP = 0x1234_5678;
+    uint constant HEX_ZERO = 0x0;
+
+    // Address literal: a hex literal of exactly 40 digits is typed as an address.
+    address constant ADDRESS_BEEF = 0x000000000000000000000000000000000000beef;
+
+    // Decimal integer literals
+    uint constant DEC_ZERO = 0;
+    uint constant DEC_INT = 42;
+    uint constant DEC_WITH_SEP = 1_000_000;
+
+    // Decimal with scientific notation
+    uint constant DEC_EXP_POS = 1e3;
+    uint constant DEC_EXP_NEG_INT = 1500e-2;
+
+    // Decimal with units
+    uint constant ONE_WEI = 1 wei;
+    uint constant ONE_GWEI = 1 gwei;
+    uint constant ONE_ETHER = 1 ether;
+    uint constant HALF_ETHER = 0.5 ether;
+    uint constant ONE_HOUR = 1 hours;
+
+    // Rational decimal literals folded to integers through multiplication
+    uint constant FROM_HALF = 0.5 * 4;
+    uint constant FROM_ONE_AND_HALF = 1.5 * 2;
+}
+"#,
+);

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -386,7 +386,7 @@ impl CollectedDefinitionDisplay<'_> {
                 LiteralKind::Rational { value } => format!("lit-rational({value})"),
                 LiteralKind::HexString { bytes } => format!("lit-hexstring({bytes})"),
                 LiteralKind::String { bytes } => format!("lit-string({bytes})"),
-                LiteralKind::Address => "lit-address".to_string(),
+                LiteralKind::Address { value } => format!("lit-address({value})"),
             },
             Type::String { location } => {
                 format!(


### PR DESCRIPTION
Supersedes #1801

Save the parsed integer value for literal addresses, so users can transparently get the numeric value from `HexNumberExpression` AST nodes.

Also adds AST unit tests to exercise decimal and hex number expressions nodes to get their values.
