### PR TITLE
[v2] Extend `compute_internal_signature` to support fallback/receive and constructors

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/function_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/function_definition.rs
@@ -74,7 +74,17 @@ impl FunctionDefinitionStruct {
     /// well-defined for any function, including internal ones with parameter
     /// types that cannot be ABI-encoded.
     pub fn compute_internal_signature(&self) -> Option<String> {
-        let name = self.ir_node.name.as_ref()?.unparse();
+        let name = match self.ir_node.kind {
+            ir::FunctionKind::Regular | ir::FunctionKind::Modifier => self
+                .ir_node
+                .name
+                .as_ref()
+                .expect("regular functions and modifiers must have a name")
+                .unparse(),
+            ir::FunctionKind::Constructor => "@constructor",
+            ir::FunctionKind::Fallback => "fallback",
+            ir::FunctionKind::Receive => "receive",
+        };
         let parameters = self.parameters().compute_internal_signature()?;
         Some(format!("{name}({parameters})"))
     }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi.rs
@@ -292,6 +292,74 @@ fn test_abi_entries_with_tuples() {
 }
 
 #[test]
+fn test_compute_internal_signature() {
+    let unit = fixtures::FullAbi::build_compilation_unit();
+
+    let test_contract = unit
+        .find_contract_by_name("Test")
+        .expect("Test contract can be found");
+
+    // Functions are linearised in alphabetical order, with the unnamed
+    // `receive`/`fallback` functions sorted first.
+    let functions = test_contract.compute_linearised_functions();
+    assert_eq!(functions.len(), 3);
+
+    assert_eq!(
+        functions[0].compute_internal_signature(),
+        Some("receive()".to_string())
+    );
+    assert_eq!(
+        functions[1].compute_internal_signature(),
+        Some("fallback()".to_string())
+    );
+    assert_eq!(
+        functions[2].compute_internal_signature(),
+        Some("foo(uint256)".to_string())
+    );
+
+    // The constructor is not part of the linearised functions list.
+    let constructor = test_contract
+        .constructor()
+        .expect("Test contract has a constructor");
+    assert_eq!(
+        constructor.compute_internal_signature(),
+        Some("@constructor()".to_string())
+    );
+
+    // State variables are linearised in storage layout order (bases first).
+    // Only the public `b` defines a getter with an internal signature.
+    let state_variables = test_contract.compute_linearised_state_variables();
+    assert_eq!(state_variables.len(), 1);
+    assert_eq!(
+        state_variables[0].compute_internal_signature(),
+        Some("b()".to_string())
+    );
+
+    // Errors and events are linearised with base contracts first.
+    let errors = test_contract.compute_linearised_errors();
+    assert_eq!(errors.len(), 2);
+    assert_eq!(
+        errors[0].compute_internal_signature(),
+        Some("SomethingWrong(string)".to_string())
+    );
+    assert_eq!(
+        errors[1].compute_internal_signature(),
+        Some("InsufficientBalance(uint256,uint256)".to_string())
+    );
+
+    let events = test_contract.compute_linearised_events();
+    assert_eq!(events.len(), 2);
+    assert_eq!(
+        events[0].compute_internal_signature(),
+        Some("BaseEvent(uint256,string)".to_string())
+    );
+    assert_eq!(
+        events[1].compute_internal_signature(),
+        Some("Event(uint256,bytes32)".to_string())
+    );
+}
+
+#[test]
 fn test_selectors_for_functions_with_tuple_parameters() {
     let unit = fixtures::AbiWithTuples::build_compilation_unit();
 


### PR DESCRIPTION
`compute_internal_signature()` now also works for unnamed functions:
  - receive -> `receive`
  - fallback -> `fallback`
  - constructors -> `@constructor` (chosen to avoid clashes with valid function identifiers)

@hedgar2017 could you review and confirm if this covers your needs?