### PR TITLE
fix(ci): emit log group markers to stderr to keep infra stdout clean

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,13 +10,13 @@ _github_collapse_group() {
   shift
 
   if [[ -n "${CI:-}" ]]; then
-    echo "::group::${title}"
+    echo "::group::${title}" >&2
   fi
 
   "$@"
 
   if [[ -n "${CI:-}" ]]; then
-    echo "::endgroup::"
+    echo "::endgroup::" >&2
   fi
 }
 


### PR DESCRIPTION
  PR #1767 added `_github_collapse_group` in `scripts/_common.sh` to wrap Hermit activation and the infra_cli build
   in GitHub Actions log groups, but the `::group::` / `::endgroup::` markers were written to stdout. This broke
  `publish.yml`'s Check if publish needed step, which captures `infra publish github-release --check-only` stdout
  into `$GITHUB_OUTPUT` — the marker lines made the output multi-line and triggered Invalid format
  `::endgroup::`.

  Redirect both markers to stderr (>&2). GitHub Actions parses workflow commands from either stream, so log
  grouping still works, and stdout stays clean for callers that capture it. Matches the convention already used
   by the Rust helper in crates/infra/utils/src/github/mod.rs.
