### PR TITLE
feat(ci): cache perf dependencies and target

### DIFF
--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -74,8 +74,8 @@ jobs:
           echo "SLANG_BENCHER_PROJECT=${{ inputs.bencherProject }}" >> $GITHUB_ENV
         if: "${{ inputs.bencherProject }}"
 
-      - name: "infra setup"
-        run: "./scripts/bin/infra setup"
+      - name: "infra setup cargo npm"
+        run: "./scripts/bin/infra setup cargo npm"
 
       - name: "infra check npm"
         run: "./scripts/bin/infra check npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,17 @@ jobs:
       - name: "infra lint"
         run: "./scripts/bin/infra lint"
 
+      # On main pushes, warm the dependency and cargo-target caches with the perf
+      # toolchain (bencher_cli, iai-callgrind-runner, and the bench binaries) so
+      # subsequent PR perf runs don't compile them from scratch.
+      - name: "infra perf cargo --smoke slang-v2"
+        if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+        run: "./scripts/bin/infra perf cargo --smoke --no-apt-deps slang-v2"
+
+      - name: "infra perf npm --smoke"
+        if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+        run: "./scripts/bin/infra perf npm --smoke"
+
       - name: "Save Cargo Target Cache"
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
         uses: "./.github/actions/cache/cargo-target/save"

--- a/crates/infra/cli/src/commands/perf/archive.rs
+++ b/crates/infra/cli/src/commands/perf/archive.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Result};
 use clap::Parser;
-use infra_utils::cargo::CargoWorkspace;
 use infra_utils::commands::Command;
 
+use crate::commands::perf::binaries;
 use crate::toolchains::bencher;
 
 const BENCHER_PROJECTS: &[&str] = &[
@@ -49,7 +49,7 @@ fn resolve_branch(branch: Option<&str>) -> Result<String> {
 impl ArchiveController {
     pub fn execute(&self) -> Result<()> {
         let branch = resolve_branch(self.branch.as_deref())?;
-        CargoWorkspace::install_binary("bencher_cli")?;
+        binaries::install_bencher_cli()?;
 
         for project in BENCHER_PROJECTS {
             bencher::archive_branch(project, &branch);
@@ -62,7 +62,7 @@ impl ArchiveController {
 impl UnarchiveController {
     pub fn execute(&self) -> Result<()> {
         let branch = resolve_branch(self.branch.as_deref())?;
-        CargoWorkspace::install_binary("bencher_cli")?;
+        binaries::install_bencher_cli()?;
 
         for project in BENCHER_PROJECTS {
             bencher::unarchive_branch(project, &branch);

--- a/crates/infra/cli/src/commands/perf/binaries.rs
+++ b/crates/infra/cli/src/commands/perf/binaries.rs
@@ -1,0 +1,63 @@
+use anyhow::{bail, Result};
+use infra_utils::cargo::CargoWorkspace;
+use infra_utils::commands::Command;
+use infra_utils::github::GitHub;
+
+pub fn install_bencher_cli() -> Result<()> {
+    CargoWorkspace::install_binary("bencher_cli")
+}
+
+pub fn install_iai_callgrind_runner() -> Result<()> {
+    CargoWorkspace::install_binary("iai-callgrind-runner")
+}
+
+pub fn install_valgrind() -> Result<()> {
+    install_from_apt("valgrind", "1:3.22.0-0ubuntu3");
+
+    match Command::new("valgrind").flag("--version").evaluate() {
+        Ok(output) if output.starts_with("valgrind-") => Ok(()),
+        other => bail!(
+            "valgrind needs to be installed on this machine to run perf tests.
+            Supported Platforms: https://valgrind.org/downloads/current.html
+            {other:?}"
+        ),
+    }
+}
+
+pub fn install_graphviz() -> Result<()> {
+    install_from_apt("graphviz", "2.42.2-9ubuntu0.1");
+
+    // dot prints its version to stderr, using the help page instead
+    match Command::new("dot").flag("-?").evaluate() {
+        Ok(output) if output.starts_with("Usage: dot") => Ok(()),
+        other => bail!(
+            "graphviz needs to be installed on this machine to generate callgraphs.
+            Supported Platforms: https://graphviz.org/download/
+            {other:?}"
+        ),
+    }
+}
+
+fn install_from_apt(package_name: &str, version: &str) {
+    if GitHub::is_running_in_ci() {
+        Command::new("sudo").args(["apt", "update"]).run();
+
+        Command::new("sudo")
+            .args(["apt", "install"])
+            .arg(format!("{package_name}={version}"))
+            .flag("--yes")
+            .run();
+
+        return;
+    }
+
+    if GitHub::is_running_in_devcontainer() {
+        Command::new("sudo").args(["apt-get", "update"]).run();
+
+        Command::new("sudo")
+            .args(["apt-get", "install"])
+            .arg(format!("{package_name}={version}"))
+            .flag("--yes")
+            .run();
+    }
+}

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -2,11 +2,10 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use infra_utils::cargo::CargoWorkspace;
 use infra_utils::commands::Command;
-use infra_utils::github::GitHub;
 use infra_utils::paths::{FileWalker, PathExtensions};
 
+use crate::commands::perf::binaries;
 use crate::toolchains::bencher::{run_bench, BencherThreshold};
 use crate::toolchains::pipenv::PipEnv;
 use crate::utils::DryRun;
@@ -15,6 +14,7 @@ const DEFAULT_BENCHER_PROJECT_CMP: &str = "slang-dashboard-cargo-cmp";
 const DEFAULT_BENCHER_PROJECT_SLANG: &str = "slang-dashboard-cargo-slang";
 const DEFAULT_BENCHER_PROJECT_SLANG_V2: &str = "slang-dashboard-cargo-slang-v2";
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Parser)]
 pub struct CargoController {
     #[command(subcommand)]
@@ -26,6 +26,9 @@ pub struct CargoController {
     pr_benchmark: bool,
     #[arg(long)]
     no_deps: bool,
+    /// Skip installing apt-managed deps (valgrind, graphviz).
+    #[arg(long)]
+    no_apt_deps: bool,
     /// Install deps and build bench binaries, but skip running benchmarks.
     #[arg(long, conflicts_with = "pr_benchmark")]
     smoke: bool,
@@ -44,11 +47,12 @@ enum Benches {
 impl CargoController {
     pub fn execute(&self) -> Result<()> {
         if !self.no_deps {
-            Self::install_valgrind();
-            CargoWorkspace::install_binary("iai-callgrind-runner")?;
-            CargoWorkspace::install_binary("bencher_cli")?;
-
-            Self::install_graphviz();
+            if !self.no_apt_deps {
+                binaries::install_valgrind()?;
+                binaries::install_graphviz()?;
+            }
+            binaries::install_iai_callgrind_runner()?;
+            binaries::install_bencher_cli()?;
         }
 
         if self.smoke {
@@ -85,65 +89,6 @@ impl CargoController {
             ),
         }
         Ok(())
-    }
-
-    fn install_valgrind() {
-        Self::install_from_apt("valgrind", "1:3.22.0-0ubuntu3");
-
-        match Command::new("valgrind").flag("--version").evaluate() {
-            Ok(output) if output.starts_with("valgrind-") => {
-                // Valgrind is available
-            }
-            other => {
-                panic!(
-                    "valgrind needs to be installed on this machine to run perf tests.
-                    Supported Platforms: https://valgrind.org/downloads/current.html
-                    {other:?}"
-                );
-            }
-        }
-    }
-
-    fn install_graphviz() {
-        Self::install_from_apt("graphviz", "2.42.2-9ubuntu0.1");
-
-        // dot prints its version to stderr, using the help page instead
-        match Command::new("dot").flag("-?").evaluate() {
-            Ok(output) if output.starts_with("Usage: dot") => {
-                // graphviz is available
-            }
-            other => {
-                panic!(
-                    "graphviz needs to be installed on this machine to generate callgraphs.
-                    Supported Platforms: https://graphviz.org/download/
-                    {other:?}"
-                );
-            }
-        }
-    }
-
-    fn install_from_apt(package_name: &str, version: &str) {
-        if GitHub::is_running_in_ci() {
-            Command::new("sudo").args(["apt", "update"]).run();
-
-            Command::new("sudo")
-                .args(["apt", "install"])
-                .arg(format!("{package_name}={version}"))
-                .flag("--yes")
-                .run();
-
-            return;
-        }
-
-        if GitHub::is_running_in_devcontainer() {
-            Command::new("sudo").args(["apt-get", "update"]).run();
-
-            Command::new("sudo")
-                .args(["apt-get", "install"])
-                .arg(format!("{package_name}={version}"))
-                .flag("--yes")
-                .run();
-        }
     }
 
     fn run_iai_bench(&self, package_name: &str, bench_name: &str, bencher_project: &str) {

--- a/crates/infra/cli/src/commands/perf/mod.rs
+++ b/crates/infra/cli/src/commands/perf/mod.rs
@@ -1,4 +1,5 @@
 mod archive;
+mod binaries;
 mod cargo;
 mod npm;
 

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
-use infra_utils::cargo::CargoWorkspace;
 use infra_utils::commands::Command;
 
+use crate::commands::perf::binaries;
 use crate::toolchains::bencher::{run_bench, BencherThreshold};
 use crate::utils::DryRun;
 
@@ -34,11 +34,6 @@ pub struct NpmController {
 }
 
 impl NpmController {
-    fn install_deps() -> Result<()> {
-        CargoWorkspace::install_binary("bencher_cli")?;
-        Ok(())
-    }
-
     fn execute_npm_benchmarks(&self) {
         let test_runner = format!(
             "cargo run --package {package} -- --pattern=\"{pattern}\" --cold={cold} --hot={hot}",
@@ -62,7 +57,7 @@ impl NpmController {
 
     #[allow(clippy::unnecessary_wraps)]
     pub fn execute(&self) -> Result<()> {
-        Self::install_deps()?;
+        binaries::install_bencher_cli()?;
 
         if self.smoke {
             Command::new("cargo")


### PR DESCRIPTION
Overhauls #1753 

#1753 attempted to improve caching for perf runs on the CI, as shown by [different](https://github.com/NomicFoundation/slang/pull/1753#pullrequestreview-4255571552) [reasons](https://github.com/NomicFoundation/slang/pull/1753#discussion_r3315319586) discussed on the PR, the solution was not ideal.

This PR attempts to get the gain, without the downsides or the big refactors on the pipeline, by caching the perf dependencies on the `ci` runs on main (the same that populates the other caches).

Since we care mainly about dependencies (`bencher-cli` and `iai-callgrind-runner`), and targets (the benchmark binaries) we run the `--smoke` test on `slang-v2` (it represents all cargo benchmarks) and `npm`.

Other things this PR does:
- Narrows the setup stage on npm benchmark runs
- Refactors installation of dependencies for benchmarks, mainly to unify certain apt concerns.
- Addes a `--no-apt-deps` flag to `infra perf cargo`, to avoid installing certain dependencies that we don't cache

-----

A note on caching `valgrind` and `graphviz`, even though it'd be ideal to cache them, we don't have the functionality in place to properly cache APT packages and it needs some investigation, so avoiding in this PR and may come back to it in the future.