### PR TITLE
[security] Harden workflows against script injection

### DIFF
--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -72,13 +72,6 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "./scripts/bin/infra setup cargo pipenv"
 
-      - name: "Set bencher project"
-        if: "${{ inputs.bencherProject }}"
-        env:
-          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-        run: |
-          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
-
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke comparison"
@@ -87,6 +80,7 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} comparison"
         env:
+          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -73,10 +73,11 @@ jobs:
         run: "./scripts/bin/infra setup cargo pipenv"
 
       - name: "Set bencher project"
-
-        run: |
-          echo "SLANG_BENCHER_PROJECT=${{ inputs.bencherProject }}" >> $GITHUB_ENV
         if: "${{ inputs.bencherProject }}"
+        env:
+          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
+        run: |
+          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
 
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -72,13 +72,6 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "./scripts/bin/infra setup cargo pipenv"
 
-      - name: "Set bencher project"
-        if: "${{ inputs.bencherProject }}"
-        env:
-          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-        run: |
-          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
-
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang"
@@ -87,6 +80,7 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} slang"
         env:
+          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -73,10 +73,11 @@ jobs:
         run: "./scripts/bin/infra setup cargo pipenv"
 
       - name: "Set bencher project"
-
-        run: |
-          echo "SLANG_BENCHER_PROJECT=${{ inputs.bencherProject }}" >> $GITHUB_ENV
         if: "${{ inputs.bencherProject }}"
+        env:
+          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
+        run: |
+          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
 
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -72,10 +72,11 @@ jobs:
         run: "./scripts/bin/infra setup cargo pipenv"
 
       - name: "Set bencher project"
-
-        run: |
-          echo "SLANG_BENCHER_PROJECT=${{ inputs.bencherProject }}" >> $GITHUB_ENV
         if: "${{ inputs.bencherProject }}"
+        env:
+          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
+        run: |
+          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
 
       - name: "Benchmark > infra perf cargo slang-v2"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} slang-v2"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -71,16 +71,14 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "./scripts/bin/infra setup cargo pipenv"
 
-      - name: "Set bencher project"
-        if: "${{ inputs.bencherProject }}"
-        env:
-          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-        run: |
-          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
+      - name: "Smoke Test > infra perf cargo --smoke slang-v2"
+        if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
+        run: "./scripts/bin/infra perf cargo --smoke slang-v2"
 
       - name: "Benchmark > infra perf cargo slang-v2"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} slang-v2"
         env:
+          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -70,9 +70,11 @@ jobs:
         uses: "./.github/actions/cache/cargo-target/restore"
 
       - name: "Set bencher project"
-        run: |
-          echo "SLANG_BENCHER_PROJECT=${{ inputs.bencherProject }}" >> $GITHUB_ENV
         if: "${{ inputs.bencherProject }}"
+        env:
+          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
+        run: |
+          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
 
       - name: "infra setup cargo npm"
         run: "./scripts/bin/infra setup cargo npm"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -69,13 +69,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Set bencher project"
-        if: "${{ inputs.bencherProject }}"
-        env:
-          BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-        run: |
-          echo "SLANG_BENCHER_PROJECT=$BENCHER_PROJECT" >> "$GITHUB_ENV"
-
       - name: "infra setup cargo npm"
         run: "./scripts/bin/infra setup cargo npm"
 
@@ -90,6 +83,7 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf npm ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }}"
         env:
+          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -41,7 +41,7 @@ on:
         description: "Check name bindings on contracts reporting if there's any unresolved symbol."
         type: "string"
         required: false
-        default: null
+        default: "none"
 
 permissions: {}
 
@@ -178,17 +178,11 @@ jobs:
           CHECK_BINDER: "${{ inputs.check_binder }}"
         run: |
           chmod +x solidity_testing_sourcify
-
-          check_binder_args=()
-          if [ -n "$CHECK_BINDER" ] && [ "$CHECK_BINDER" != "none" ]; then
-            check_binder_args=("--check-binder=$CHECK_BINDER")
-          fi
-
           ./scripts/bin/with-hermit ./solidity_testing_sourcify test \
               --chain-id ${{ inputs.chain_id }} \
               --shard-count ${{ env.SHARD_COUNT }} \
               --shard-index ${{ matrix.shard_index }} \
-              "${check_binder_args[@]}" \
+              --check-binder="$CHECK_BINDER" \
               ${{ inputs.check_infer_version == true && '--check-infer-version' || '' }}
 
       - name: "Write shard results to output"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -212,7 +212,9 @@ jobs:
           name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
 
       - name: "Output shards results"
-        run: "echo '${{ toJSON(needs.singleShard.outputs) }}' > __SLANG_SOURCIFY_MATRIX_RESULTS__.json"
+        env:
+          MATRIX_RESULTS: "${{ toJSON(needs.singleShard.outputs) }}"
+        run: 'printf "%s\n" "$MATRIX_RESULTS" > __SLANG_SOURCIFY_MATRIX_RESULTS__.json'
 
       - name: "Show combined results"
         run: |

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -174,13 +174,21 @@ jobs:
           name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
 
       - name: "Run Tests"
+        env:
+          CHECK_BINDER: "${{ inputs.check_binder }}"
         run: |
           chmod +x solidity_testing_sourcify
+
+          check_binder_args=()
+          if [ -n "$CHECK_BINDER" ] && [ "$CHECK_BINDER" != "none" ]; then
+            check_binder_args=("--check-binder=$CHECK_BINDER")
+          fi
+
           ./scripts/bin/with-hermit ./solidity_testing_sourcify test \
               --chain-id ${{ inputs.chain_id }} \
               --shard-count ${{ env.SHARD_COUNT }} \
               --shard-index ${{ matrix.shard_index }} \
-              ${{ inputs.check_binder != 'none' && format('--check-binder={0}', inputs.check_binder) || '' }} \
+              "${check_binder_args[@]}" \
               ${{ inputs.check_infer_version == true && '--check-infer-version' || '' }}
 
       - name: "Write shard results to output"

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -62,7 +62,10 @@ pub(crate) fn run_bench(
         "dev"
     };
 
-    let project = std::env::var("SLANG_BENCHER_PROJECT").unwrap_or(project.to_owned());
+    let project = std::env::var("SLANG_BENCHER_PROJECT")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| project.to_owned());
 
     let mut command = Command::new("bencher")
         .arg("run")

--- a/crates/solidity/testing/sourcify/src/command.rs
+++ b/crates/solidity/testing/sourcify/src/command.rs
@@ -55,7 +55,7 @@ pub struct TestOptions {
     pub check_infer_version: bool,
 
     /// Run bindings tests
-    #[arg(long, value_enum, default_value = "none")]
+    #[arg(long, value_enum, default_value_t = CheckBinderMode::None)]
     pub check_binder: CheckBinderMode,
 }
 

--- a/crates/solidity/testing/sourcify/src/command.rs
+++ b/crates/solidity/testing/sourcify/src/command.rs
@@ -55,12 +55,13 @@ pub struct TestOptions {
     pub check_infer_version: bool,
 
     /// Run bindings tests
-    #[arg(long, value_enum)]
-    pub check_binder: Option<CheckBinderMode>,
+    #[arg(long, value_enum, default_value = "none")]
+    pub check_binder: CheckBinderMode,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum CheckBinderMode {
+    None,
     V1,
     V2,
     Compare,

--- a/crates/solidity/testing/sourcify/src/run/mod.rs
+++ b/crates/solidity/testing/sourcify/src/run/mod.rs
@@ -76,16 +76,16 @@ fn run_test(contract: &Contract, events: &Events, opts: &TestOptions) {
 
             if v1_test_outcome == SingleTestOutcome::Passed {
                 match opts.check_binder {
-                    Some(CheckBinderMode::V1) => {
+                    CheckBinderMode::None => {}
+                    CheckBinderMode::V1 => {
                         v1_test_outcome = binder_v1_check::run(contract, &unit, events);
                     }
-                    Some(CheckBinderMode::V2) => {
+                    CheckBinderMode::V2 => {
                         v1_test_outcome = binder_v2_check::run(contract, &unit, events);
                     }
-                    Some(CheckBinderMode::Compare) => {
+                    CheckBinderMode::Compare => {
                         v1_test_outcome = compare_binders::run(contract, &unit, events);
                     }
-                    _ => {}
                 }
             }
 


### PR DESCRIPTION
Small security fixes to not allow injection of `bencherProject` and `check_binder` variables. Relatively low risk, but easy fix.