### PR TITLE
Run CI dependency installs behind Socket Firewall (SFW)

### DIFF
--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -38,18 +38,21 @@ runs:
       shell: "bash"
       run: |
         command -v sfw &>/dev/null || { echo "::warning::sfw not found — skipping CA trust"; exit 0; }
-        # Generation is lazy; a wrapped command triggers it. The cert's directory
-        # isn't documented, so locate it by its documented filename. The trailing
-        # `|| true` keeps find's nonzero exit (it descends unreadable dirs) from
-        # tripping this step's pipefail+errexit before we can check the result.
-        sfw npm ping >/dev/null 2>&1 || true
-        ca="$(find / -name "socketFirewallCa.crt" 2>/dev/null | head -n1 || true)"
-        if [ -z "$ca" ]; then
-          echo "::error::SFW CA (socketFirewallCa.crt) not found after install"
+        # sfw (free) doesn't drop the CA at a fixed path; it advertises the cert
+        # to processes it wraps via NODE_EXTRA_CA_CERTS. Read that path from a
+        # wrapped shell, then install the file system-wide (the documented Linux
+        # method) so curl/git/cargo trust it — node/pnpm already get the env var.
+        ca="$(sfw bash -c 'printf "%s" "${NODE_EXTRA_CA_CERTS:-}"' 2>/dev/null || true)"
+        if [ -z "$ca" ] || [ ! -f "$ca" ]; then
+          echo "::error::could not resolve SFW CA from NODE_EXTRA_CA_CERTS (got: '${ca:-<empty>}')"
+          echo "== env sfw injects into wrapped processes =="
+          sfw bash -c 'env' 2>/dev/null | grep -iE "ca|cert|ssl|proxy" | sort || true
+          echo "== candidate cert files on disk =="
+          find / \( -iname "*.crt" -o -iname "*.pem" \) 2>/dev/null | grep -iE "socket|sfw|firewall" || true
           exit 1
         fi
         echo "SFW CA: $ca"
-        sudo cp "$ca" /usr/local/share/ca-certificates/socketFirewallCa.crt
+        sudo cp "$ca" /usr/local/share/ca-certificates/socket-firewall.crt
         sudo update-ca-certificates
 
     - name: "Export SFW prefix"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -2,11 +2,13 @@ name: "Setup Socket Firewall (SFW)"
 description: >
   Installs Socket Firewall (SFW) Free via socketdev/action and exports
   SFW_PREFIX (`sfw`) so callers can wrap their dependency-fetching commands with
-  it. SFW is documented as zero-config — it wraps the package manager
-  (npm/pnpm/pip/cargo) and sets up its own proxy + TLS trust for the wrapped
-  process tree — so this action does NO manual CA handling. Linux-only (the MITM
-  is incompatible with macOS/Windows TLS stacks); on other runners SFW_PREFIX is
-  left unset and callers run unwrapped.
+  it. SFW auto-trusts only the package managers it wraps (npm/pnpm/pip/cargo);
+  a raw `curl` — like the hermit bootstrap that runs first in `infra setup` —
+  reads the system trust store and rejects the MITM cert. So this action also
+  installs SFW's CA system-wide the way Socket documents for Linux (drop it in
+  /usr/local/share/ca-certificates and run update-ca-certificates), which covers
+  curl/git/cargo. Linux-only (the MITM is incompatible with macOS/Windows TLS
+  stacks); on other runners SFW_PREFIX is left unset and callers run unwrapped.
 
 inputs:
   mode:
@@ -25,6 +27,30 @@ runs:
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
         mode: "${{ inputs.mode }}"
+
+    # socketdev/action injects its CA only into the package managers sfw wraps,
+    # not into the system trust store. `infra setup` first bootstraps hermit via
+    # a raw curl, which then fails TLS verification against the MITM cert. Trust
+    # the CA system-wide using Socket's documented Linux method so curl (and git
+    # + cargo/rustls) accept it.
+    - name: "Trust SFW CA system-wide"
+      if: "${{ runner.os == 'Linux' }}"
+      shell: "bash"
+      run: |
+        command -v sfw &>/dev/null || { echo "::warning::sfw not found — skipping CA trust"; exit 0; }
+        # Generation is lazy; a wrapped command triggers it. The cert's directory
+        # isn't documented, so locate it by its documented filename. The trailing
+        # `|| true` keeps find's nonzero exit (it descends unreadable dirs) from
+        # tripping this step's pipefail+errexit before we can check the result.
+        sfw npm ping >/dev/null 2>&1 || true
+        ca="$(find / -name "socketFirewallCa.crt" 2>/dev/null | head -n1 || true)"
+        if [ -z "$ca" ]; then
+          echo "::error::SFW CA (socketFirewallCa.crt) not found after install"
+          exit 1
+        fi
+        echo "SFW CA: $ca"
+        sudo cp "$ca" /usr/local/share/ca-certificates/socketFirewallCa.crt
+        sudo update-ca-certificates
 
     - name: "Export SFW prefix"
       if: "${{ runner.os == 'Linux' }}"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -3,18 +3,25 @@ description: >
   Installs Socket Firewall Free and exports SFW_PREFIX, a wrapper that callers
   prefix onto dependency commands to run installs behind the firewall (it also
   fixes sfw's CA handling — see the wrapper step).
-  Soft-fails: if SFW can't be installed, SFW_PREFIX is left unset and callers
-  run unprotected (so a socket.dev outage doesn't redden every PR). Jobs that
-  must never install unprotected deps (publish) add an explicit Require SFW
-  guard that fails when SFW_PREFIX is empty.
+  Fails the job if SFW can't be installed, so dependency installs never silently
+  run unprotected. Jobs where SFW is best-effort (a socket.dev outage must not
+  fail them) opt out with optional, which warns and leaves SFW_PREFIX unset
+  instead — callers then run unwrapped.
+
+inputs:
+  optional:
+    description: >
+      When "true", a failed SFW install warns and leaves SFW_PREFIX unset
+      (callers run unprotected) instead of failing the job.
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
   steps:
     - name: "Install SFW"
-      # Soft-fail: a socket.dev outage must not block PR/benchmark CI. The
-      # wrapper step below leaves SFW_PREFIX unset when sfw is absent; publish
-      # jobs re-assert it via a Require SFW guard.
+      # Failures are decided by the wrapper step below, which knows the
+      # optional input — keep this step itself from failing the job.
       continue-on-error: true
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
@@ -27,10 +34,16 @@ runs:
     # bundle, re-points the CA vars at the union, and exec's the real command.
     - name: "Create SFW CA-merge wrapper"
       shell: "bash"
+      env:
+        SFW_OPTIONAL: "${{ inputs.optional }}"
       run: |
         if ! command -v sfw &>/dev/null; then
-          echo "::warning::sfw not found after install — dependency installs will run UNPROTECTED. Jobs requiring SFW (publish) fail at their Require SFW guard."
-          exit 0
+          if [ "${SFW_OPTIONAL}" = "true" ]; then
+            echo "::warning::sfw not found after install — dependency installs will run UNPROTECTED."
+            exit 0
+          fi
+          echo "::error::sfw not found after install — refusing to run dependency installs unprotected. Pass optional: \"true\" if this job may run without SFW."
+          exit 1
         fi
         wrapper="${RUNNER_TEMP}/sfw-wrap"
         cat > "${wrapper}" <<'EOF'
@@ -54,5 +67,5 @@ runs:
         chmod +x "${wrapper}"
         # Consumed UNQUOTED by callers (`${SFW_PREFIX:-} <cmd>`) so the shell splits
         # it into two argv entries — `sfw` and the wrapper path. Quoting it breaks that;
-        # when unset (soft-fail) it expands to nothing and <cmd> runs unwrapped.
+        # when unset (optional + failed install) it expands to nothing and <cmd> runs unwrapped.
         echo "SFW_PREFIX=sfw ${wrapper}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,9 +1,8 @@
 name: "Setup Socket Firewall (SFW)"
 description: >
-  Installs Socket Firewall Free (Linux-only) and exports SFW_PREFIX, a wrapper
-  that callers prefix onto dependency commands to run installs behind the
-  firewall (it also fixes sfw's CA handling — see the wrapper step). Left unset
-  on non-Linux runners, so callers run unwrapped.
+  Installs Socket Firewall Free and exports SFW_PREFIX, a wrapper that callers
+  prefix onto dependency commands to run installs behind the firewall (it also
+  fixes sfw's CA handling — see the wrapper step).
 
 inputs:
   mode:
@@ -18,7 +17,6 @@ runs:
   using: "composite"
   steps:
     - name: "Install SFW"
-      if: "${{ runner.os == 'Linux' }}"
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
         mode: "${{ inputs.mode }}"
@@ -29,7 +27,6 @@ runs:
     # its temp-CA env into the wrapper, which merges that root with the system
     # bundle, re-points the CA vars at the union, and exec's the real command.
     - name: "Create SFW CA-merge wrapper"
-      if: "${{ runner.os == 'Linux' }}"
       shell: "bash"
       run: |
         if ! command -v sfw &>/dev/null; then

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -14,7 +14,10 @@ description: >
 
 inputs:
   mode:
-    description: 'SFW mode: "firewall" blocks risky packages, "audit" only warns.'
+    description: >
+      socketdev/action operation mode: "firewall" (the MITM proxy), "patch", or
+      "cli". Socket Firewall Free has no warn-only mode — "firewall" blocks
+      confirmed-malicious packages and only warns on AI-flagged-unconfirmed ones.
     required: false
     default: "firewall"
 

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -35,12 +35,15 @@ runs:
         if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
           merged="$(mktemp)"
           cat /etc/ssl/certs/ca-certificates.crt "${SSL_CERT_FILE}" > "${merged}"
+          # REQUESTS_CA_BUNDLE: pip/requests can ignore CURL_CA_BUNDLE inside a venv (pipenv) — psf/requests#6660.
           export SSL_CERT_FILE="${merged}" CURL_CA_BUNDLE="${merged}" \
                  CARGO_HTTP_CAINFO="${merged}" GIT_SSL_CAINFO="${merged}" \
-                 NODE_EXTRA_CA_CERTS="${merged}"
+                 NODE_EXTRA_CA_CERTS="${merged}" REQUESTS_CA_BUNDLE="${merged}"
           unset SSL_CERT_DIR
         fi
         exec "$@"
         EOF
         chmod +x "${wrapper}"
+        # Consumed UNQUOTED by callers (`${SFW_PREFIX:-} <cmd>`) so the shell splits
+        # it into two argv entries — `sfw` and the wrapper path. Quoting it breaks that.
         echo "SFW_PREFIX=sfw ${wrapper}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -7,8 +7,6 @@ description: >
 runs:
   using: "composite"
   steps:
-    # "firewall" is the only useful Free mode (no warn-only): it blocks
-    # confirmed-malicious packages and warns on AI-flagged-unconfirmed ones.
     - name: "Install SFW"
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,16 +1,9 @@
 name: "Setup Socket Firewall (SFW)"
 description: >
-  Installs Socket Firewall (SFW) Free via socketdev/action and exports
-  SFW_PREFIX so callers can wrap their dependency-fetching commands with it.
-  Inside a wrap, sfw points the CA vars (SSL_CERT_FILE, CARGO_HTTP_CAINFO, …) at
-  a temp bundle holding ONLY its MITM root and hijacks SSL_CERT_DIR — so raw TLS
-  to hosts sfw passes through (github.com for the hermit bootstrap,
-  static.rust-lang.org for rustup) fails with "unable to get local issuer
-  certificate" for lack of the public roots. SFW_PREFIX therefore points at a
-  wrapper that, inside the wrap, merges sfw's root with the system bundle and
-  re-points the CA vars at the union before exec'ing the command. Linux-only
-  (the MITM is incompatible with macOS/Windows TLS stacks); on other runners
-  SFW_PREFIX is left unset and callers run unwrapped.
+  Installs Socket Firewall Free (Linux-only) and exports SFW_PREFIX, a wrapper
+  that callers prefix onto dependency commands to run installs behind the
+  firewall (it also fixes sfw's CA handling — see the wrapper step). Left unset
+  on non-Linux runners, so callers run unwrapped.
 
 inputs:
   mode:

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -4,22 +4,15 @@ description: >
   prefix onto dependency commands to run installs behind the firewall (it also
   fixes sfw's CA handling — see the wrapper step).
 
-inputs:
-  mode:
-    description: >
-      socketdev/action operation mode: "firewall" (the proxy), "patch", or
-      "cli". Socket Firewall Free has no warn-only mode — "firewall" blocks
-      confirmed-malicious packages and only warns on AI-flagged-unconfirmed ones.
-    required: false
-    default: "firewall"
-
 runs:
   using: "composite"
   steps:
+    # "firewall" is the only useful Free mode (no warn-only): it blocks
+    # confirmed-malicious packages and warns on AI-flagged-unconfirmed ones.
     - name: "Install SFW"
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
-        mode: "${{ inputs.mode }}"
+        mode: "firewall"
 
     # sfw has no persistent CA file and overrides the CA env vars inside every
     # wrap, so the union bundle must be built *inside* the wrap. Write a wrapper

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -3,11 +3,19 @@ description: >
   Installs Socket Firewall Free and exports SFW_PREFIX, a wrapper that callers
   prefix onto dependency commands to run installs behind the firewall (it also
   fixes sfw's CA handling — see the wrapper step).
+  Soft-fails: if SFW can't be installed, SFW_PREFIX is left unset and callers
+  run unprotected (so a socket.dev outage doesn't redden every PR). Jobs that
+  must never install unprotected deps (publish) add an explicit Require SFW
+  guard that fails when SFW_PREFIX is empty.
 
 runs:
   using: "composite"
   steps:
     - name: "Install SFW"
+      # Soft-fail: a socket.dev outage must not block PR/benchmark CI. The
+      # wrapper step below leaves SFW_PREFIX unset when sfw is absent; publish
+      # jobs re-assert it via a Require SFW guard.
+      continue-on-error: true
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
         mode: "firewall"
@@ -21,7 +29,7 @@ runs:
       shell: "bash"
       run: |
         if ! command -v sfw &>/dev/null; then
-          echo "::warning::sfw not found after install — callers will run unwrapped"
+          echo "::warning::sfw not found after install — dependency installs will run UNPROTECTED. Jobs requiring SFW (publish) fail at their Require SFW guard."
           exit 0
         fi
         wrapper="${RUNNER_TEMP}/sfw-wrap"
@@ -45,5 +53,6 @@ runs:
         EOF
         chmod +x "${wrapper}"
         # Consumed UNQUOTED by callers (`${SFW_PREFIX:-} <cmd>`) so the shell splits
-        # it into two argv entries — `sfw` and the wrapper path. Quoting it breaks that.
+        # it into two argv entries — `sfw` and the wrapper path. Quoting it breaks that;
+        # when unset (soft-fail) it expands to nothing and <cmd> runs unwrapped.
         echo "SFW_PREFIX=sfw ${wrapper}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,14 +1,16 @@
 name: "Setup Socket Firewall (SFW)"
 description: >
   Installs Socket Firewall (SFW) Free via socketdev/action and exports
-  SFW_PREFIX (`sfw`) so callers can wrap their dependency-fetching commands with
-  it. SFW auto-trusts only the package managers it wraps (npm/pnpm/pip/cargo);
-  a raw `curl` — like the hermit bootstrap that runs first in `infra setup` —
-  reads the system trust store and rejects the MITM cert. So this action also
-  installs SFW's CA system-wide the way Socket documents for Linux (drop it in
-  /usr/local/share/ca-certificates and run update-ca-certificates), which covers
-  curl/git/cargo. Linux-only (the MITM is incompatible with macOS/Windows TLS
-  stacks); on other runners SFW_PREFIX is left unset and callers run unwrapped.
+  SFW_PREFIX so callers can wrap their dependency-fetching commands with it.
+  Inside a wrap, sfw points the CA vars (SSL_CERT_FILE, CARGO_HTTP_CAINFO, …) at
+  a temp bundle holding ONLY its MITM root and hijacks SSL_CERT_DIR — so raw TLS
+  to hosts sfw passes through (github.com for the hermit bootstrap,
+  static.rust-lang.org for rustup) fails with "unable to get local issuer
+  certificate" for lack of the public roots. SFW_PREFIX therefore points at a
+  wrapper that, inside the wrap, merges sfw's root with the system bundle and
+  re-points the CA vars at the union before exec'ing the command. Linux-only
+  (the MITM is incompatible with macOS/Windows TLS stacks); on other runners
+  SFW_PREFIX is left unset and callers run unwrapped.
 
 inputs:
   mode:
@@ -28,39 +30,36 @@ runs:
       with:
         mode: "${{ inputs.mode }}"
 
-    # socketdev/action injects its CA only into the package managers sfw wraps,
-    # not into the system trust store. `infra setup` first bootstraps hermit via
-    # a raw curl, which then fails TLS verification against the MITM cert. Trust
-    # the CA system-wide using Socket's documented Linux method so curl (and git
-    # + cargo/rustls) accept it.
-    - name: "Trust SFW CA system-wide"
+    # sfw has no persistent CA file and overrides the CA env vars inside every
+    # wrap, so the union bundle must be built *inside* the wrap. Write a wrapper
+    # that does exactly that, then run it as `sfw <wrapper> <command>`: sfw injects
+    # its temp-CA env into the wrapper, which merges that root with the system
+    # bundle, re-points the CA vars at the union, and exec's the real command.
+    - name: "Create SFW CA-merge wrapper"
       if: "${{ runner.os == 'Linux' }}"
       shell: "bash"
       run: |
-        command -v sfw &>/dev/null || { echo "::warning::sfw not found — skipping CA trust"; exit 0; }
-        # sfw (free) doesn't drop the CA at a fixed path; it advertises the cert
-        # to processes it wraps via NODE_EXTRA_CA_CERTS. Read that path from a
-        # wrapped shell, then install the file system-wide (the documented Linux
-        # method) so curl/git/cargo trust it — node/pnpm already get the env var.
-        ca="$(sfw bash -c 'printf "%s" "${NODE_EXTRA_CA_CERTS:-}"' 2>/dev/null || true)"
-        if [ -z "$ca" ] || [ ! -f "$ca" ]; then
-          echo "::error::could not resolve SFW CA from NODE_EXTRA_CA_CERTS (got: '${ca:-<empty>}')"
-          echo "== env sfw injects into wrapped processes =="
-          sfw bash -c 'env' 2>/dev/null | grep -iE "ca|cert|ssl|proxy" | sort || true
-          echo "== candidate cert files on disk =="
-          find / \( -iname "*.crt" -o -iname "*.pem" \) 2>/dev/null | grep -iE "socket|sfw|firewall" || true
-          exit 1
-        fi
-        echo "SFW CA: $ca"
-        sudo cp "$ca" /usr/local/share/ca-certificates/socket-firewall.crt
-        sudo update-ca-certificates
-
-    - name: "Export SFW prefix"
-      if: "${{ runner.os == 'Linux' }}"
-      shell: "bash"
-      run: |
-        if command -v sfw &>/dev/null; then
-          echo "SFW_PREFIX=sfw" >> "$GITHUB_ENV"
-        else
+        if ! command -v sfw &>/dev/null; then
           echo "::warning::sfw not found after install — callers will run unwrapped"
+          exit 0
         fi
+        wrapper="${RUNNER_TEMP}/sfw-wrap"
+        cat > "${wrapper}" <<'EOF'
+        #!/usr/bin/env bash
+        # Invoked as: sfw sfw-wrap <command...>. sfw has injected SSL_CERT_FILE
+        # (and friends) pointing at a temp bundle that holds only its MITM root.
+        # Merge that root with the system roots so TLS works for both the hosts
+        # sfw MITMs (registries) and the ones it passes through (github.com etc.).
+        set -euo pipefail
+        if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
+          merged="$(mktemp)"
+          cat /etc/ssl/certs/ca-certificates.crt "${SSL_CERT_FILE}" > "${merged}"
+          export SSL_CERT_FILE="${merged}" CURL_CA_BUNDLE="${merged}" \
+                 CARGO_HTTP_CAINFO="${merged}" GIT_SSL_CAINFO="${merged}" \
+                 NODE_EXTRA_CA_CERTS="${merged}"
+          unset SSL_CERT_DIR
+        fi
+        exec "$@"
+        EOF
+        chmod +x "${wrapper}"
+        echo "SFW_PREFIX=sfw ${wrapper}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,0 +1,126 @@
+name: "Setup Socket Firewall (SFW)"
+description: >
+  Installs and configures Socket Firewall (SFW) to police package fetches at
+  install time. Installs the sfw-free MITM proxy via socketdev/action, discovers
+  SFW's generated CA, and exports a merged CA bundle via CARGO_HTTP_CAINFO /
+  GIT_SSL_CAINFO / SSL_CERT_FILE so cargo, git, and rustls trust the MITM cert.
+  Exports SFW_PREFIX (the `sfw` wrapper) for callers to prefix their fetch/build
+  commands with. On any failure (unsupported platform, missing CA) it leaves
+  SFW_PREFIX unset and reports available=false, so callers degrade to running
+  unwrapped rather than breaking the build.
+
+  Linux-only: macOS (LibreSSL) and Windows (Schannel) reject the MITM cert at the
+  crypto level. slang CI is all Linux, so this is just a defensive guard.
+
+inputs:
+  mode:
+    description: 'SFW mode: "firewall" blocks risky packages, "audit" only warns.'
+    required: false
+    default: "firewall"
+
+outputs:
+  available:
+    description: "Whether SFW is available for use (true/false)."
+    value: "${{ steps.set-prefix.outputs.available }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Detect platform support"
+      id: "detect"
+      shell: "bash"
+      run: |
+        if [[ "$RUNNER_OS" != "Linux" ]]; then
+          echo "::notice::SFW skipped: MITM proxy not compatible with $RUNNER_OS TLS stack"
+          echo "supported=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "supported=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: "Install SFW"
+      if: "${{ steps.detect.outputs.supported == 'true' }}"
+      uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
+      with:
+        mode: "${{ inputs.mode }}"
+
+    # The sfw-free proxy exposes its generated CA via NODE_EXTRA_CA_CERTS when it
+    # wraps a child process. cargo (libgit2/rustls) needs that CA on an explicit
+    # path, otherwise git-dep clones and crates.io fetches fail with "unable to
+    # get local issuer certificate" once the proxy intercepts the TLS.
+    - name: "Configure cargo/git TLS trust for SFW"
+      id: "ca-cert"
+      if: "${{ steps.detect.outputs.supported == 'true' }}"
+      shell: "bash"
+      run: |
+        # Trigger SFW cert generation (may be lazy).
+        sfw npm ping > /dev/null 2>&1 || true
+
+        # Read NODE_EXTRA_CA_CERTS from inside an sfw-wrapped process, via a temp
+        # file to avoid sfw's banner lines polluting stdout.
+        cat > "${RUNNER_TEMP}/sfw-get-cert.js" << 'SCRIPT'
+        const fs = require("fs");
+        const p = process.env.NODE_EXTRA_CA_CERTS || "";
+        fs.writeFileSync(process.env.RUNNER_TEMP + "/sfw-cert-path.txt", p);
+        SCRIPT
+        sfw node "${RUNNER_TEMP}/sfw-get-cert.js" > /dev/null 2>&1 || true
+        SFW_CA=""
+        [ -f "${RUNNER_TEMP}/sfw-cert-path.txt" ] && SFW_CA=$(cat "${RUNNER_TEMP}/sfw-cert-path.txt")
+        rm -f "${RUNNER_TEMP}/sfw-get-cert.js" "${RUNNER_TEMP}/sfw-cert-path.txt"
+
+        if [ -z "$SFW_CA" ] || [ ! -f "$SFW_CA" ]; then
+          echo "::warning::SFW CA cert not found — disabling SFW to avoid opaque SSL errors"
+          echo "ca-failed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "SFW CA cert: $SFW_CA"
+        BUNDLE="${RUNNER_TEMP}/sfw-ca-bundle.pem"
+
+        # Merge the SFW CA into the system bundle (Linux paths only).
+        FOUND_SYSTEM=false
+        for f in \
+          /etc/ssl/certs/ca-certificates.crt \
+          /etc/ssl/certs/ca-bundle.crt \
+          /etc/pki/tls/certs/ca-bundle.crt; do
+          if [ -f "$f" ]; then
+            cp "$f" "$BUNDLE"
+            echo "System CA bundle: $f"
+            FOUND_SYSTEM=true
+            break
+          fi
+        done
+
+        if [ "$FOUND_SYSTEM" = false ]; then
+          echo "::warning::Could not find system CA bundle — using SFW cert only"
+          cp "$SFW_CA" "$BUNDLE"
+        else
+          echo "" >> "$BUNDLE"
+          cat "$SFW_CA" >> "$BUNDLE"
+        fi
+
+        # cargo, git, and rustls-native-certs (SSL_CERT_FILE) all read these.
+        echo "CARGO_HTTP_CAINFO=$BUNDLE" >> "$GITHUB_ENV"
+        echo "GIT_SSL_CAINFO=$BUNDLE" >> "$GITHUB_ENV"
+        echo "SSL_CERT_FILE=$BUNDLE" >> "$GITHUB_ENV"
+        echo "CA bundle created at $BUNDLE ($(wc -l < "$BUNDLE") lines)"
+
+    - name: "Set SFW prefix"
+      id: "set-prefix"
+      shell: "bash"
+      run: |
+        if [[ "${{ steps.detect.outputs.supported }}" != "true" ]]; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [[ "${{ steps.ca-cert.outputs.ca-failed }}" == "true" ]]; then
+          echo "::notice::SFW available but CA cert missing — disabling to prevent SSL errors"
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if command -v sfw &>/dev/null; then
+          echo "SFW_PREFIX=sfw" >> "$GITHUB_ENV"
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::SFW command not found after install"
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,129 +1,37 @@
 name: "Setup Socket Firewall (SFW)"
 description: >
-  Installs and configures Socket Firewall (SFW) to police package fetches at
-  install time. Installs the sfw-free MITM proxy via socketdev/action, discovers
-  SFW's generated CA, and exports a merged CA bundle via CARGO_HTTP_CAINFO /
-  GIT_SSL_CAINFO / SSL_CERT_FILE so cargo, git, and rustls trust the MITM cert.
-  Exports SFW_PREFIX (the `sfw` wrapper) for callers to prefix their fetch/build
-  commands with. On any failure (unsupported platform, missing CA) it leaves
-  SFW_PREFIX unset and reports available=false, so callers degrade to running
-  unwrapped rather than breaking the build.
-
-  Linux-only: macOS (LibreSSL) and Windows (Schannel) reject the MITM cert at the
-  crypto level. slang CI is all Linux, so this is just a defensive guard.
+  Installs Socket Firewall (SFW) Free via socketdev/action and exports
+  SFW_PREFIX (`sfw`) so callers can wrap their dependency-fetching commands with
+  it. SFW is documented as zero-config — it wraps the package manager
+  (npm/pnpm/pip/cargo) and sets up its own proxy + TLS trust for the wrapped
+  process tree — so this action does NO manual CA handling. Linux-only (the MITM
+  is incompatible with macOS/Windows TLS stacks); on other runners SFW_PREFIX is
+  left unset and callers run unwrapped.
 
 inputs:
   mode:
     description: >
-      socketdev/action operation mode: "firewall" (the MITM proxy), "patch", or
+      socketdev/action operation mode: "firewall" (the proxy), "patch", or
       "cli". Socket Firewall Free has no warn-only mode — "firewall" blocks
       confirmed-malicious packages and only warns on AI-flagged-unconfirmed ones.
     required: false
     default: "firewall"
 
-outputs:
-  available:
-    description: "Whether SFW is available for use (true/false)."
-    value: "${{ steps.set-prefix.outputs.available }}"
-
 runs:
   using: "composite"
   steps:
-    - name: "Detect platform support"
-      id: "detect"
-      shell: "bash"
-      run: |
-        if [[ "$RUNNER_OS" != "Linux" ]]; then
-          echo "::notice::SFW skipped: MITM proxy not compatible with $RUNNER_OS TLS stack"
-          echo "supported=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "supported=true" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: "Install SFW"
-      if: "${{ steps.detect.outputs.supported == 'true' }}"
+      if: "${{ runner.os == 'Linux' }}"
       uses: "socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143" # v1
       with:
         mode: "${{ inputs.mode }}"
 
-    # The sfw-free proxy exposes its generated CA via NODE_EXTRA_CA_CERTS when it
-    # wraps a child process. cargo (libgit2/rustls) needs that CA on an explicit
-    # path, otherwise git-dep clones and crates.io fetches fail with "unable to
-    # get local issuer certificate" once the proxy intercepts the TLS.
-    - name: "Configure cargo/git TLS trust for SFW"
-      id: "ca-cert"
-      if: "${{ steps.detect.outputs.supported == 'true' }}"
+    - name: "Export SFW prefix"
+      if: "${{ runner.os == 'Linux' }}"
       shell: "bash"
       run: |
-        # Trigger SFW cert generation (may be lazy).
-        sfw npm ping > /dev/null 2>&1 || true
-
-        # Read NODE_EXTRA_CA_CERTS from inside an sfw-wrapped process, via a temp
-        # file to avoid sfw's banner lines polluting stdout.
-        cat > "${RUNNER_TEMP}/sfw-get-cert.js" << 'SCRIPT'
-        const fs = require("fs");
-        const p = process.env.NODE_EXTRA_CA_CERTS || "";
-        fs.writeFileSync(process.env.RUNNER_TEMP + "/sfw-cert-path.txt", p);
-        SCRIPT
-        sfw node "${RUNNER_TEMP}/sfw-get-cert.js" > /dev/null 2>&1 || true
-        SFW_CA=""
-        [ -f "${RUNNER_TEMP}/sfw-cert-path.txt" ] && SFW_CA=$(cat "${RUNNER_TEMP}/sfw-cert-path.txt")
-        rm -f "${RUNNER_TEMP}/sfw-get-cert.js" "${RUNNER_TEMP}/sfw-cert-path.txt"
-
-        if [ -z "$SFW_CA" ] || [ ! -f "$SFW_CA" ]; then
-          echo "::warning::SFW CA cert not found — disabling SFW to avoid opaque SSL errors"
-          echo "ca-failed=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        echo "SFW CA cert: $SFW_CA"
-        BUNDLE="${RUNNER_TEMP}/sfw-ca-bundle.pem"
-
-        # Merge the SFW CA into the system bundle (Linux paths only).
-        FOUND_SYSTEM=false
-        for f in \
-          /etc/ssl/certs/ca-certificates.crt \
-          /etc/ssl/certs/ca-bundle.crt \
-          /etc/pki/tls/certs/ca-bundle.crt; do
-          if [ -f "$f" ]; then
-            cp "$f" "$BUNDLE"
-            echo "System CA bundle: $f"
-            FOUND_SYSTEM=true
-            break
-          fi
-        done
-
-        if [ "$FOUND_SYSTEM" = false ]; then
-          echo "::warning::Could not find system CA bundle — using SFW cert only"
-          cp "$SFW_CA" "$BUNDLE"
-        else
-          echo "" >> "$BUNDLE"
-          cat "$SFW_CA" >> "$BUNDLE"
-        fi
-
-        # cargo, git, and rustls-native-certs (SSL_CERT_FILE) all read these.
-        echo "CARGO_HTTP_CAINFO=$BUNDLE" >> "$GITHUB_ENV"
-        echo "GIT_SSL_CAINFO=$BUNDLE" >> "$GITHUB_ENV"
-        echo "SSL_CERT_FILE=$BUNDLE" >> "$GITHUB_ENV"
-        echo "CA bundle created at $BUNDLE ($(wc -l < "$BUNDLE") lines)"
-
-    - name: "Set SFW prefix"
-      id: "set-prefix"
-      shell: "bash"
-      run: |
-        if [[ "${{ steps.detect.outputs.supported }}" != "true" ]]; then
-          echo "available=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        if [[ "${{ steps.ca-cert.outputs.ca-failed }}" == "true" ]]; then
-          echo "::notice::SFW available but CA cert missing — disabling to prevent SSL errors"
-          echo "available=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
         if command -v sfw &>/dev/null; then
           echo "SFW_PREFIX=sfw" >> "$GITHUB_ENV"
-          echo "available=true" >> "$GITHUB_OUTPUT"
         else
-          echo "::warning::SFW command not found after install"
-          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::sfw not found after install — callers will run unwrapped"
         fi

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -36,8 +36,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the dependency-fetching setup step through SFW (the perf step below
-      # only archives results, so it's left unwrapped).
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -46,6 +44,7 @@ jobs:
       - name: "infra setup cargo"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo"
 
+      # Not SFW-wrapped: archives benchmark results, not a dependency install.
       - name: "infra perf archive"
         continue-on-error: true
         env:

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "infra setup cargo"

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -42,7 +42,6 @@ jobs:
       - name: "infra setup cargo"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo"
 
-      # Not SFW-wrapped: archives benchmark results, not a dependency install.
       - name: "infra perf archive"
         continue-on-error: true
         env:

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -36,8 +36,15 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the dependency-fetching setup step through SFW (the perf step below
+      # only archives results, so it's left unwrapped).
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "infra setup cargo"
-        run: "./scripts/bin/infra setup cargo"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo"
 
       - name: "infra perf archive"
         continue-on-error: true

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -36,8 +36,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup cargo"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo"

--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "infra setup cargo"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -69,8 +69,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -75,7 +75,6 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
-      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke comparison"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -69,8 +69,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the dependency-fetching setup step through SFW (the perf steps below
-      # build/run benchmarks and upload to bencher, so they're left unwrapped).
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -79,6 +77,7 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
+      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke comparison"

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -69,8 +69,15 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the dependency-fetching setup step through SFW (the perf steps below
+      # build/run benchmarks and upload to bencher, so they're left unwrapped).
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "infra setup cargo pipenv"
-        run: "./scripts/bin/infra setup cargo pipenv"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
       - name: "Smoke Test > infra perf cargo --smoke comparison"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -75,7 +75,6 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
-      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -69,8 +69,15 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the dependency-fetching setup step through SFW (the perf steps below
+      # build/run benchmarks and upload to bencher, so they're left unwrapped).
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "infra setup cargo pipenv"
-        run: "./scripts/bin/infra setup cargo pipenv"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -69,8 +69,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -69,8 +69,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the dependency-fetching setup step through SFW (the perf steps below
-      # build/run benchmarks and upload to bencher, so they're left unwrapped).
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -79,6 +77,7 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
+      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke slang"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -68,7 +68,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -74,7 +74,6 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
-      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke slang-v2"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang-v2"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -68,8 +68,15 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the dependency-fetching setup step through SFW (the perf steps below
+      # build/run benchmarks and upload to bencher, so they're left unwrapped).
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "infra setup cargo pipenv"
-        run: "./scripts/bin/infra setup cargo pipenv"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
       - name: "Smoke Test > infra perf cargo --smoke slang-v2"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -68,8 +68,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the dependency-fetching setup step through SFW (the perf steps below
-      # build/run benchmarks and upload to bencher, so they're left unwrapped).
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -78,6 +76,7 @@ jobs:
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"
 
+      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf cargo --smoke slang-v2"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang-v2"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -68,8 +68,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -70,8 +70,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "infra setup cargo pipenv"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo pipenv"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "infra setup cargo npm"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo npm"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -69,8 +69,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup cargo npm"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo npm"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -69,11 +69,18 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the dependency-fetching steps through SFW (the perf steps below
+      # build/run benchmarks and upload to bencher, so they're left unwrapped).
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "infra setup cargo npm"
-        run: "./scripts/bin/infra setup cargo npm"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup cargo npm"
 
       - name: "infra check npm"
-        run: "./scripts/bin/infra check npm"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra check npm"
 
       - name: "Smoke Test > infra perf npm --smoke"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -69,8 +69,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the dependency-fetching steps through SFW (the perf steps below
-      # build/run benchmarks and upload to bencher, so they're left unwrapped).
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -82,6 +80,7 @@ jobs:
       - name: "infra check npm"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra check npm"
 
+      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf npm --smoke"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf npm --smoke"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "infra setup cargo npm"

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -78,7 +78,6 @@ jobs:
       - name: "infra check npm"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra check npm"
 
-      # Not SFW-wrapped: builds/runs benchmarks and uploads to bencher, not a dependency install.
       - name: "Smoke Test > infra perf npm --smoke"
         if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf npm --smoke"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,21 +80,22 @@ jobs:
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)
       #
 
-      # `${SFW_PREFIX:-}` wraps the command with `sfw` when SFW is available, and
-      # expands to nothing otherwise (so a non-Linux runner or SFW failure just
-      # runs setup unwrapped). PoC wraps only `setup` — that's where the cargo
-      # crates + pnpm package fetches happen.
+      # `${SFW_PREFIX:-}` wraps the command with the sfw CA-merge wrapper when SFW
+      # is available, and expands to nothing otherwise (so a non-Linux runner or
+      # SFW failure just runs unwrapped). Every infra step is wrapped: setup pulls
+      # crates/pnpm/toolchains, and check/test/lint can still hit the network via
+      # build.rs or npx, so the whole pipeline runs behind the firewall.
       - name: "infra setup"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 
       - name: "infra check"
-        run: "./scripts/bin/infra check"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra check"
 
       - name: "infra test"
-        run: "./scripts/bin/infra test"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra test"
 
       - name: "infra lint"
-        run: "./scripts/bin/infra lint"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra lint"
 
       # On main pushes, warm the dependency and cargo-target caches with the perf
       # toolchain (bencher_cli, iai-callgrind-runner, and the bench binaries) so
@@ -137,8 +138,14 @@ jobs:
         if: "${{ github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/restore"
 
+      # Route the cargo cooldown check (which fetches crate metadata) through SFW.
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "Cargo cooldown check"
-        run: "./scripts/bin/with-hermit cargo cooldown-check"
+        run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo cooldown-check"
 
       - name: "Save Cargo Cooldown Cache"
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
@@ -156,8 +163,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # `npx --yes renovate` pulls renovate (and its deps) from npm — wrap it.
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "Renovate schema check"
-        run: "./bin/npx --yes --package renovate -- renovate-config-validator renovate.json"
+        run: "${SFW_PREFIX:-} ./bin/npx --yes --package renovate -- renovate-config-validator renovate.json"
 
       - name: "Renovate extraction dry-run"
         env:
@@ -165,7 +178,7 @@ jobs:
           # anonymous 60 req/hr rate limit shared across the runner IP.
           GITHUB_COM_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           LOG_LEVEL: "debug"
-        run: "./bin/npx --yes renovate --platform=local --dry-run=full"
+        run: "${SFW_PREFIX:-} ./bin/npx --yes renovate --platform=local --dry-run=full"
 
   # The full CI runs on the bare runner so it can reuse the cargo-target cache;
   # reproducing that cache-mount setup inside a devcontainer would slow CI down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Route the dependency installs in the steps below through Socket Firewall.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,10 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)
@@ -118,8 +120,10 @@ jobs:
         if: "${{ github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "Cargo cooldown check"
         run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo cooldown-check"
@@ -140,8 +144,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "Renovate schema check"
         run: "${SFW_PREFIX:-} ./bin/npx --yes --package renovate -- renovate-config-validator renovate.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,16 @@ jobs:
 
       # Cache is updated in this workflow, and reused in subsequent workflows.
       # Always start with a fresh cache when running on the main branch.
+      #
+      # TEMP (SFW PoC — revert before merge): force `if: false` so the
+      # dependencies cache is NOT restored. That cache holds ~/.cache/hermit/,
+      # the pnpm store, and ~/.cargo/registry/; its restore-keys prefix
+      # (dependencies-${{ runner.os }}-v1-) means a key bump still hits, so the
+      # only way to force a cold fetch through the firewall is to skip the
+      # restore entirely. With it skipped, hermit/rustup/pnpm/cargo all download
+      # cold through SFW, which is what this PoC actually needs to validate.
       - name: "Restore Dependencies Cache"
-        if: "${{ github.ref_name != 'main' }}"
+        if: "${{ false && github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/dependencies/restore"
 
       # Restore compiled Rust artifacts from a previous build on main for non-main runs,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,7 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # PoC: Socket Firewall (Free) via socketdev/action. Free has no warn-only
-      # mode — it blocks confirmed-malicious packages and only warns (without
-      # blocking) on AI-flagged-unconfirmed ones. slang's tree is known-clean,
-      # so this shouldn't block anything; the run validates MITM compatibility,
-      # notably whether hermit/rustup downloads survive it (see PR). Exports
-      # SFW_PREFIX (`sfw`) for the wrapped step below.
+      # Route the dependency installs in the steps below through Socket Firewall.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -138,7 +133,6 @@ jobs:
         if: "${{ github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/restore"
 
-      # Route the cargo cooldown check (which fetches crate metadata) through SFW.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -163,7 +157,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # `npx --yes renovate` pulls renovate (and its deps) from npm — wrap it.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,26 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # PoC: Socket Firewall in AUDIT mode — warns on risky packages, never
+      # blocks. Exports SFW_PREFIX (`sfw`), which the wrapped step below uses to
+      # route its dependency fetches through SFW's malware-scanning MITM proxy.
+      # Audit-first so it can't break CI while we validate compatibility — in
+      # particular whether hermit/rustup downloads survive the MITM (see PR).
+      - name: "Setup SFW (audit)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "audit"
+
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)
       #
 
+      # `${SFW_PREFIX:-}` wraps the command with `sfw` when SFW is available, and
+      # expands to nothing otherwise (so a non-Linux runner or SFW failure just
+      # runs setup unwrapped). PoC wraps only `setup` — that's where the cargo
+      # crates + pnpm package fetches happen.
       - name: "infra setup"
-        run: "./scripts/bin/infra setup"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 
       - name: "infra check"
         run: "./scripts/bin/infra check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,16 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # PoC: Socket Firewall in AUDIT mode — warns on risky packages, never
-      # blocks. Exports SFW_PREFIX (`sfw`), which the wrapped step below uses to
-      # route its dependency fetches through SFW's malware-scanning MITM proxy.
-      # Audit-first so it can't break CI while we validate compatibility — in
-      # particular whether hermit/rustup downloads survive the MITM (see PR).
-      - name: "Setup SFW (audit)"
+      # PoC: Socket Firewall (Free) via socketdev/action. Free has no warn-only
+      # mode — it blocks confirmed-malicious packages and only warns (without
+      # blocking) on AI-flagged-unconfirmed ones. slang's tree is known-clean,
+      # so this shouldn't block anything; the run validates MITM compatibility,
+      # notably whether hermit/rustup downloads survive it (see PR). Exports
+      # SFW_PREFIX (`sfw`) for the wrapped step below.
+      - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
-          mode: "audit"
+          mode: "firewall"
 
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,6 @@ jobs:
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)
       #
 
-      # `${SFW_PREFIX:-}` wraps the command with the sfw CA-merge wrapper when SFW
-      # is available, and expands to nothing otherwise (so a non-Linux runner or
-      # SFW failure just runs unwrapped). Every infra step is wrapped: setup pulls
-      # crates/pnpm/toolchains, and check/test/lint can still hit the network via
-      # build.rs or npx, so the whole pipeline runs behind the firewall.
       - name: "infra setup"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,8 @@ jobs:
 
       # Cache is updated in this workflow, and reused in subsequent workflows.
       # Always start with a fresh cache when running on the main branch.
-      #
-      # TEMP (SFW PoC — revert before merge): force `if: false` so the
-      # dependencies cache is NOT restored. That cache holds ~/.cache/hermit/,
-      # the pnpm store, and ~/.cargo/registry/; its restore-keys prefix
-      # (dependencies-${{ runner.os }}-v1-) means a key bump still hits, so the
-      # only way to force a cold fetch through the firewall is to skip the
-      # restore entirely. With it skipped, hermit/rustup/pnpm/cargo all download
-      # cold through SFW, which is what this PoC actually needs to validate.
       - name: "Restore Dependencies Cache"
-        if: "${{ false && github.ref_name != 'main' }}"
+        if: "${{ github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/dependencies/restore"
 
       # Restore compiled Rust artifacts from a previous build on main for non-main runs,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,6 @@ jobs:
       # Route the dependency installs in the steps below through Socket Firewall.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)
@@ -135,8 +133,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "Cargo cooldown check"
         run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo cooldown-check"
@@ -159,8 +155,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "Renovate schema check"
         run: "${SFW_PREFIX:-} ./bin/npx --yes --package renovate -- renovate-config-validator renovate.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         if: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       #
@@ -117,7 +117,7 @@ jobs:
         if: "${{ github.ref_name != 'main' }}"
         uses: "./.github/actions/cache/cargo-cooldown/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "Cargo cooldown check"
@@ -139,7 +139,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "Renovate schema check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,21 +71,22 @@ jobs:
         run: "${SFW_PREFIX:-} ./scripts/bin/infra check"
 
       - name: "infra test"
-        run: "${SFW_PREFIX:-} ./scripts/bin/infra test"
+        run: "./scripts/bin/infra test"
 
       - name: "infra lint"
-        run: "${SFW_PREFIX:-} ./scripts/bin/infra lint"
+        run: "./scripts/bin/infra lint"
 
       # On main pushes, warm the dependency and cargo-target caches with the perf
       # toolchain (bencher_cli, iai-callgrind-runner, and the bench binaries) so
-      # subsequent PR perf runs don't compile them from scratch.
+      # subsequent PR perf runs don't compile them from scratch. Wrapped: these
+      # cargo-install from crates.io (no bencher upload, so no MITM concern).
       - name: "infra perf cargo --smoke slang-v2"
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
-        run: "./scripts/bin/infra perf cargo --smoke --no-apt-deps slang-v2"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra perf cargo --smoke --no-apt-deps slang-v2"
 
       - name: "infra perf npm --smoke"
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
-        run: "./scripts/bin/infra perf npm --smoke"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra perf npm --smoke"
 
       - name: "Save Cargo Target Cache"
         if: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,13 +99,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Release path: SFW is required (the action's default) — fail rather than
+      # install deps unprotected.
       - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
-
-      # Release path: refuse to install deps unprotected if SFW is unavailable.
-      # Each release job needs its own guard (they set up SFW on separate runners).
-      - name: "Require SFW"
-        run: '[ -n "${SFW_PREFIX:-}" ] || { echo "::error::SFW unavailable — refusing to install deps unprotected on the release path"; exit 1; }'
 
       - name: "infra setup"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
@@ -192,16 +189,13 @@ jobs:
         if: "${{ needs.changesets.outputs.publishNeeded != 'true' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # On a real release this job builds the published npm tarball, so SFW is
+      # required and a failed install stops the job. On PRs/pending pushes the
+      # build is best-effort (same condition the cache-restore steps above gate on).
       - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
-
-      # On a real release this job builds the published npm tarball, so if SFW
-      # couldn't be installed, stop here rather than build the release without it.
-      # On PRs/pending pushes the build still runs without SFW (same condition the
-      # cache-restore steps above gate on).
-      - name: "Require SFW"
-        if: "${{ needs.changesets.outputs.publishNeeded == 'true' }}"
-        run: '[ -n "${SFW_PREFIX:-}" ] || { echo "::error::SFW unavailable — refusing to build release artifacts unprotected"; exit 1; }'
+        with:
+          optional: "${{ needs.changesets.outputs.publishNeeded != 'true' }}"
 
       - name: "infra setup"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
@@ -261,8 +255,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "infra setup"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
@@ -424,13 +420,15 @@ jobs:
           name: "${{ needs.prepare.outputs.artifact-name }}"
           path: "target/publish-artifacts/"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          # Best-effort: this job only uploads the artifact built in `prepare`;
+          # the published bytes were already fetched behind SFW there.
+          optional: "true"
 
-      # Compile infra_cli with no registry token in scope. Routed through SFW when
-      # available, but no Require SFW guard here: if SFW didn't install, this still
-      # builds without it (the published bytes were already checked behind SFW in
-      # prepare). The infra publish steps below upload with auth, left unwrapped.
+      # Compile infra_cli with no registry token in scope. The infra publish
+      # steps below upload with auth, left unwrapped.
       - name: "Build infra_cli (before any token)"
         run: "${SFW_PREFIX:-} ./scripts/bin/infra --help"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,8 +99,16 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      - name: "Setup SFW"
+        uses: "./.github/actions/setup-sfw"
+
+      # Release path: refuse to install deps unprotected if SFW is unavailable.
+      # Each release job needs its own guard (they set up SFW on separate runners).
+      - name: "Require SFW"
+        run: '[ -n "${SFW_PREFIX:-}" ] || { echo "::error::SFW unavailable — refusing to install deps unprotected on the release path"; exit 1; }'
+
       - name: "infra setup"
-        run: "./scripts/bin/infra setup"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 
       # Consume the changesets, and create a git stash, to be popped by the next step:
       - name: "infra publish changesets"
@@ -184,8 +192,19 @@ jobs:
         if: "${{ needs.changesets.outputs.publishNeeded != 'true' }}"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      - name: "Setup SFW"
+        uses: "./.github/actions/setup-sfw"
+
+      # On a real release this job builds the published npm tarball, so if SFW
+      # couldn't be installed, stop here rather than build the release without it.
+      # On PRs/pending pushes the build still runs without SFW (same condition the
+      # cache-restore steps above gate on).
+      - name: "Require SFW"
+        if: "${{ needs.changesets.outputs.publishNeeded == 'true' }}"
+        run: '[ -n "${SFW_PREFIX:-}" ] || { echo "::error::SFW unavailable — refusing to build release artifacts unprotected"; exit 1; }'
+
       - name: "infra setup"
-        run: "./scripts/bin/infra setup"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 
       - name: "Prepare publish artifacts"
         id: "prepare"
@@ -242,8 +261,11 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      - name: "Setup SFW"
+        uses: "./.github/actions/setup-sfw"
+
       - name: "infra setup"
-        run: "./scripts/bin/infra setup"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra setup"
 
       - name: "Download publish artifacts"
         uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
@@ -402,9 +424,15 @@ jobs:
           name: "${{ needs.prepare.outputs.artifact-name }}"
           path: "target/publish-artifacts/"
 
-      # Compile infra_cli with no registry token in scope.
+      - name: "Setup SFW"
+        uses: "./.github/actions/setup-sfw"
+
+      # Compile infra_cli with no registry token in scope. Routed through SFW when
+      # available, but no Require SFW guard here: if SFW didn't install, this still
+      # builds without it (the published bytes were already checked behind SFW in
+      # prepare). The infra publish steps below upload with auth, left unwrapped.
       - name: "Build infra_cli (before any token)"
-        run: "./scripts/bin/infra --help"
+        run: "${SFW_PREFIX:-} ./scripts/bin/infra --help"
 
       - name: "infra publish npm"
         # No tarball means prepare packed nothing (version already on npm) — nothing to publish.

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -71,8 +71,10 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW"
+      - name: "Setup SFW (optional)"
         uses: "./.github/actions/setup-sfw"
+        with:
+          optional: "true"
 
       - name: "Build Test Binary"
         run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo build --locked --bin solidity_testing_sourcify --release"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -71,7 +71,7 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      - name: "Setup SFW (firewall)"
+      - name: "Setup SFW"
         uses: "./.github/actions/setup-sfw"
 
       - name: "Build Test Binary"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -176,7 +176,6 @@ jobs:
         with:
           name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
 
-      # Not SFW-wrapped: hits chain RPCs / the Sourcify API, not package registries.
       - name: "Run Tests"
         env:
           CHECK_BINDER: "${{ inputs.check_binder }}"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -71,8 +71,16 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
+      # Wrap the build (which fetches crates) through SFW. The test run in the
+      # other job hits chain RPCs / the Sourcify API, not package registries, so
+      # it is intentionally left unwrapped.
+      - name: "Setup SFW (firewall)"
+        uses: "./.github/actions/setup-sfw"
+        with:
+          mode: "firewall"
+
       - name: "Build Test Binary"
-        run: "./scripts/bin/with-hermit cargo build --locked --bin solidity_testing_sourcify --release"
+        run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo build --locked --bin solidity_testing_sourcify --release"
 
       - name: "Save Test Binary"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -71,9 +71,6 @@ jobs:
       - name: "Restore Cargo Target Cache"
         uses: "./.github/actions/cache/cargo-target/restore"
 
-      # Wrap the build (which fetches crates) through SFW. The test run in the
-      # other job hits chain RPCs / the Sourcify API, not package registries, so
-      # it is intentionally left unwrapped.
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
         with:
@@ -181,6 +178,7 @@ jobs:
         with:
           name: "solidity_testing_sourcify_${{ inputs.chain_id }}"
 
+      # Not SFW-wrapped: hits chain RPCs / the Sourcify API, not package registries.
       - name: "Run Tests"
         env:
           CHECK_BINDER: "${{ inputs.check_binder }}"

--- a/.github/workflows/sourcify_single_chain.yml
+++ b/.github/workflows/sourcify_single_chain.yml
@@ -73,8 +73,6 @@ jobs:
 
       - name: "Setup SFW (firewall)"
         uses: "./.github/actions/setup-sfw"
-        with:
-          mode: "firewall"
 
       - name: "Build Test Binary"
         run: "${SFW_PREFIX:-} ./scripts/bin/with-hermit cargo build --locked --bin solidity_testing_sourcify --release"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,21 +83,21 @@ it and exports `SFW_PREFIX`, which prefixes the dependency-fetching steps (`infr
 setup`, `infra check`, and the cooldown and renovate checks). It runs **only in CI** —
 local `infra` commands are unaffected.
 
-**Soft-fail by default.** If Socket Firewall can't be installed (e.g. a socket.dev
-outage), the affected step logs a `::warning::` and runs _unprotected_ rather than
-failing, so a Socket outage doesn't fail every PR. The exception is the **release
-path** (`changesets` and `publish` jobs in `publish.yml`): those carry a `Require SFW`
-guard and fail hard if SFW is unavailable, so we never publish dependencies that were
-installed unprotected.
+**Required by default.** If Socket Firewall can't be installed (e.g. a socket.dev
+outage), the `Setup SFW` step fails the job rather than let dependency installs run
+_unprotected_, so we never publish dependencies that were installed unprotected. Jobs
+where the firewall is best-effort — PR/benchmark CI, and release jobs that only
+consume artifacts already built behind SFW — opt out with `optional: "true"`, which
+logs a `::warning::` and continues unprotected instead.
 
 ### When a build fails because of Socket
 
 The two failure modes look different:
 
-- **SFW unavailable (not a block).** A wrapped step logs
-  `::warning::sfw not found after install …` and continues unprotected. This is a
-  Socket/network availability problem, not a flagged package. On the release path the
-  `Require SFW` step fails instead — re-run once Socket is reachable.
+- **SFW unavailable (not a block).** The `Setup SFW` step fails with
+  `::error::sfw not found after install …` (or, on `optional: "true"` jobs, logs a
+  `::warning::` and continues unprotected). This is a Socket/network availability
+  problem, not a flagged package — re-run once Socket is reachable.
 - **A package was blocked.** A wrapped step (usually `infra setup`) fails and the `sfw`
   output names the offending package, version, and why Socket flagged it. This is the
   firewall doing its job. Note that firewall mode blocks _transitively_ — a flagged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,33 @@ The following still need to be updated manually:
 
 1. Rust toolchains: `$RUST_STABLE_VERSION` and `$RUST_NIGHTLY_VERSION` defined in `hermit.hcl` and updated via `rustup install`.
 2. Node.js major versions (only even LTS releases): bump the hermit package, then `@types/node` follows automatically.
+
+## Supply-Chain Firewall (Socket)
+
+CI installs dependencies behind [Socket Firewall](https://docs.socket.dev/) (`sfw`)
+in _firewall_ mode, which intercepts package-manager traffic (cargo, npm, pip) and
+blocks packages Socket flags as malicious. The `setup-sfw` composite action installs
+it and exports `SFW_PREFIX`, which prefixes the dependency-fetching steps (`infra
+setup`, `infra check`, and the cooldown and renovate checks). It runs **only in CI** —
+local `infra` commands are unaffected.
+
+**Soft-fail by default.** If Socket Firewall can't be installed (e.g. a socket.dev
+outage), the affected step logs a `::warning::` and runs _unprotected_ rather than
+failing, so a Socket outage doesn't fail every PR. The exception is the **release
+path** (`changesets` and `publish` jobs in `publish.yml`): those carry a `Require SFW`
+guard and fail hard if SFW is unavailable, so we never publish dependencies that were
+installed unprotected.
+
+### When a build fails because of Socket
+
+The two failure modes look different:
+
+- **SFW unavailable (not a block).** A wrapped step logs
+  `::warning::sfw not found after install …` and continues unprotected. This is a
+  Socket/network availability problem, not a flagged package. On the release path the
+  `Require SFW` step fails instead — re-run once Socket is reachable.
+- **A package was blocked.** A wrapped step (usually `infra setup`) fails and the `sfw`
+  output names the offending package, version, and why Socket flagged it. This is the
+  firewall doing its job. Note that firewall mode blocks _transitively_ — a flagged
+  package deep in the dependency tree fails the whole install, even if you didn't add
+  it directly.


### PR DESCRIPTION
Implement a wrapper for Socket Firewall using https://github.com/SocketDev/sfw-free, preventing malicious downloads in CI.

I've made the wrapper optional on sfw installation failure as it's another layer of defense on top of the already implemented cargo-cooldown-check, cooldowns, and locked installs, and I've seen the occasional flake for sfw installs in solx/edr repos. It is strictly required for the publish flow (not dry-run), to avoid installing any malicious packages.

Tested by temporarily disabling the deps cache.


# Claude Summary
Runs CI dependency installs behind Socket Firewall (SFW) Free as a supply-chain
guard. The `setup-sfw` action installs sfw and exports `SFW_PREFIX`; steps that
install dependencies are prefixed with `${SFW_PREFIX:-}` to run behind it.

SFW is best-effort by default: if sfw can't be installed the action warns and
leaves `SFW_PREFIX` unset, so the step runs unprotected rather than failing the
job (it's a layer on top of cargo-cooldown-check, cooldowns, and locked
installs, and sfw installs occasionally flake). The release path is the
exception — the `changesets` and `publish` jobs carry a `Require SFW` guard that
fails when `SFW_PREFIX` is empty, so a release never installs dependencies with
the firewall off.

`SFW_PREFIX` is a wrapper, not bare `sfw`: inside a wrap sfw narrows the CA vars
(`SSL_CERT_FILE`, `CARGO_HTTP_CAINFO`, …) to its own MITM root and hijacks
`SSL_CERT_DIR`, breaking TLS to hosts it passes through (github.com for the
hermit bootstrap, static.rust-lang.org for rustup). The wrapper merges sfw's
root with the system CA bundle and re-points the CA vars at the union before
running the command.

## Wrapping

Only dependency-installing steps are wrapped; steps that build/run, upload, or
execute tests are left unwrapped on purpose.

- **ci**: `infra setup`/`check`, cargo cooldown check, both renovate `npx` steps
  (`infra test`/`lint` don't fetch dependencies, so they're left unwrapped).
- **benchmark_***: `infra setup*` (the `perf` build/run + bencher upload steps
  left unwrapped).
- **publish**: `infra setup` only — `infra publish` steps upload with auth and
  must not go through the MITM. The `changesets` and `publish` jobs add a
  `Require SFW` guard (the `build-and-validate` dry-run stays best-effort).
- **sourcify**: the cargo build (the test run hits chain RPCs / Sourcify API,
  not registries).
- **excluded**: `validate-devcontainer` (in-container; the bare-metal
  `socketdev/action` proxy doesn't apply).
