### PR TITLE
Patch ip-address, idna, and pymdown-extensions security advisories

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -239,11 +239,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3",
-                "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69"
+                "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c",
+                "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.14"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.17"
         },
         "jinja2": {
             "hashes": [
@@ -489,11 +489,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638",
-                "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc"
+                "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354",
+                "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==10.21.2"
+            "version": "==10.21.3"
         },
         "pyparsing": {
             "hashes": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ overrides:
   brace-expansion: ^5.0.6
   diff@>=4.0.0 <4.0.4: ^4.0.4
   follow-redirects@<1.16.0: ^1.16.0
+  ip-address@<=10.1.0: ^10.1.1
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   smol-toml@<1.6.1: ^1.6.1
@@ -2437,8 +2438,8 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-absolute-url@4.0.1:
@@ -6099,7 +6100,7 @@ snapshots:
 
   ini@6.0.0: {}
 
-  ip-address@10.0.1: {}
+  ip-address@10.2.0: {}
 
   is-absolute-url@4.0.1: {}
 
@@ -7358,7 +7359,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.0.1
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   solc@0.8.35:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,7 @@ overrides:
   "brace-expansion": "^5.0.6" # GHSA-f886-m6hf-6m8v, GHSA-jxxr-4gwj-5jf2
   "diff@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-73rr-hh4g-fpgx
   "follow-redirects@<1.16.0": "^1.16.0" # GHSA-r4q5-vmmm-2653
+  "ip-address@<=10.1.0": "^10.1.1" # GHSA-v2v4-37r5-5v8g
   "picomatch@<2.3.2": "^2.3.2" # GHSA-c2c7-rcm5-vvqj
   "picomatch@>=4.0.0 <4.0.4": "^4.0.4" # GHSA-c2c7-rcm5-vvqj
   "smol-toml@<1.6.1": "^1.6.1" # GHSA-v3rj-xjv7-4jmq


### PR DESCRIPTION
Patch ip-address, idna, and pymdown-extensions security advisories. Transitive deps, so not picked up by Renovate.
