### PR TITLE
[v2] Cache contracts' storage layouts (permanent and transient)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,7 +4062,6 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "paste",
- "ruint",
  "serde",
  "sha3 0.12.0",
  "slang_solidity_v2_common",

--- a/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
@@ -22,7 +22,6 @@ categories = ["compilers", "utilities"]
 num-bigint = { workspace = true }
 num-rational = { workspace = true }
 paste = { workspace = true }
-ruint = { workspace = true }
 serde = { workspace = true }
 sha3 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -2,6 +2,8 @@
 
 pub mod slang_solidity_v2_ast
 pub mod slang_solidity_v2_ast::abi
+pub use slang_solidity_v2_ast::abi::StorageItem
+pub use slang_solidity_v2_ast::abi::StorageLayouts
 pub enum slang_solidity_v2_ast::abi::AbiEntry
 pub slang_solidity_v2_ast::abi::AbiEntry::Constructor(slang_solidity_v2_ast::abi::AbiConstructor)
 pub slang_solidity_v2_ast::abi::AbiEntry::Error(slang_solidity_v2_ast::abi::AbiError)
@@ -98,8 +100,8 @@ pub fn slang_solidity_v2_ast::abi::ContractAbi::entries(&self) -> &[slang_solidi
 pub fn slang_solidity_v2_ast::abi::ContractAbi::file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::ContractAbi::name(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::ContractAbi::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::abi::ContractAbi::storage_layout(&self) -> &[slang_solidity_v2_ast::abi::StorageItem]
-pub fn slang_solidity_v2_ast::abi::ContractAbi::transient_storage_layout(&self) -> &[slang_solidity_v2_ast::abi::StorageItem]
+pub fn slang_solidity_v2_ast::abi::ContractAbi::storage_layout(&self) -> &[slang_solidity_v2_semantic::context::contract_data_cache::StorageItem]
+pub fn slang_solidity_v2_ast::abi::ContractAbi::transient_storage_layout(&self) -> &[slang_solidity_v2_semantic::context::contract_data_cache::StorageItem]
 pub struct slang_solidity_v2_ast::abi::ParameterComponent
 impl slang_solidity_v2_ast::abi::ParameterComponent
 pub fn slang_solidity_v2_ast::abi::ParameterComponent::components(&self) -> &[slang_solidity_v2_ast::abi::ParameterComponent]
@@ -113,21 +115,6 @@ pub fn slang_solidity_v2_ast::abi::ParameterComponent::eq(&self, other: &slang_s
 impl core::fmt::Debug for slang_solidity_v2_ast::abi::ParameterComponent
 pub fn slang_solidity_v2_ast::abi::ParameterComponent::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ast::abi::ParameterComponent
-pub struct slang_solidity_v2_ast::abi::StorageItem
-impl slang_solidity_v2_ast::abi::StorageItem
-pub fn slang_solidity_v2_ast::abi::StorageItem::label(&self) -> &str
-pub fn slang_solidity_v2_ast::abi::StorageItem::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::abi::StorageItem::offset(&self) -> usize
-pub fn slang_solidity_v2_ast::abi::StorageItem::slot(&self) -> ruint::aliases::U256
-pub fn slang_solidity_v2_ast::abi::StorageItem::type_name(&self) -> &str
-impl core::clone::Clone for slang_solidity_v2_ast::abi::StorageItem
-pub fn slang_solidity_v2_ast::abi::StorageItem::clone(&self) -> slang_solidity_v2_ast::abi::StorageItem
-impl core::cmp::Eq for slang_solidity_v2_ast::abi::StorageItem
-impl core::cmp::PartialEq for slang_solidity_v2_ast::abi::StorageItem
-pub fn slang_solidity_v2_ast::abi::StorageItem::eq(&self, other: &slang_solidity_v2_ast::abi::StorageItem) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ast::abi::StorageItem
-pub fn slang_solidity_v2_ast::abi::StorageItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ast::abi::StorageItem
 pub fn slang_solidity_v2_ast::abi::selector_from_signature(signature: &str) -> u32
 pub type slang_solidity_v2_ast::abi::AbiMutability = slang_solidity_v2_semantic::types::FunctionTypeMutability
 pub mod slang_solidity_v2_ast::ast

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -4,11 +4,11 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
+pub use slang_solidity_v2_semantic::context::{StorageItem, StorageLayouts};
 use slang_solidity_v2_semantic::types::{FunctionTypeMutability, Type, TypeId};
 
 pub struct ContractAbi {
@@ -307,37 +307,6 @@ impl AbiParameter {
 
     pub fn indexed(&self) -> bool {
         self.indexed
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StorageItem {
-    node_id: NodeId,
-    label: String,
-    slot: U256,
-    offset: usize,
-    type_name: String,
-}
-
-impl StorageItem {
-    pub fn node_id(&self) -> NodeId {
-        self.node_id
-    }
-
-    pub fn label(&self) -> &str {
-        &self.label
-    }
-
-    pub fn slot(&self) -> U256 {
-        self.slot
-    }
-
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-
-    pub fn type_name(&self) -> &str {
-        &self.type_name
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
@@ -1,23 +1,19 @@
-use ruint::aliases::U256;
-use slang_solidity_v2_semantic::binder;
-use slang_solidity_v2_semantic::context::SLOT_SIZE;
-
-use crate::abi::{AbiEntry, ContractAbi, StorageItem};
-use crate::ast::{ContractDefinitionStruct, StateVariableDefinition, StateVariableMutability};
+use crate::abi::{AbiEntry, ContractAbi};
+use crate::ast::ContractDefinitionStruct;
 
 impl ContractDefinitionStruct {
     pub fn compute_abi(&self) -> Option<ContractAbi> {
         let name = self.ir_node.name.unparse().to_string();
         let file_id = self.get_file_id().to_string();
         let entries = self.compute_abi_entries()?;
-        let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
+        let layouts = self.semantic.storage_layouts(self.ir_node.id())?.clone();
         Some(ContractAbi {
             node_id: self.ir_node.id(),
             name,
             file_id,
             entries,
-            storage_layout,
-            transient_storage_layout,
+            storage_layout: layouts.permanent,
+            transient_storage_layout: layouts.transient,
         })
     }
 
@@ -45,88 +41,5 @@ impl ContractDefinitionStruct {
 
         entries.sort();
         Some(entries)
-    }
-
-    /// Retrieves the custom base slot for this contract, if specified. This is
-    /// used for computing the base of the storage layout for non-transient
-    /// state variables.
-    fn base_slot(&self) -> Option<U256> {
-        let binder::Definition::Contract(definition) = self
-            .semantic
-            .binder()
-            .find_definition_by_id(self.ir_node.id())?
-        else {
-            unreachable!("definition is not a contract");
-        };
-        definition.base_slot
-    }
-
-    /// Computes the layouts of both permanent and transient state variables
-    fn compute_storage_layout(&self) -> Option<(Vec<StorageItem>, Vec<StorageItem>)> {
-        let all_state_variables = self.linearised_state_variables();
-
-        // TODO(validation) SDR[2]: it is an error if any contract in the hierarchy
-        // other than the leaf has a custom offset layout
-        let storage_layout = self.lay_out_state_variables(
-            self.base_slot().unwrap_or(U256::ZERO),
-            all_state_variables.iter().filter(|state_variable| {
-                matches!(
-                    state_variable.mutability(),
-                    StateVariableMutability::Mutable
-                )
-            }),
-        )?;
-        let transient_storage_layout = self.lay_out_state_variables(
-            U256::ZERO,
-            all_state_variables.iter().filter(|state_variable| {
-                matches!(
-                    state_variable.mutability(),
-                    StateVariableMutability::Transient
-                )
-            }),
-        )?;
-        Some((storage_layout, transient_storage_layout))
-    }
-
-    fn lay_out_state_variables<'a>(
-        &self,
-        base_slot: U256,
-        variables: impl Iterator<Item = &'a StateVariableDefinition>,
-    ) -> Option<Vec<StorageItem>> {
-        let mut storage_layout = Vec::new();
-        let mut current_slot: U256 = base_slot;
-        let mut byte_offset_in_slot: usize = 0;
-        for state_variable in variables {
-            let node_id = state_variable.ir_node.id();
-            let variable_type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;
-            let variable_size = self.semantic.storage_size_of_type_id(variable_type_id)?;
-
-            // Check if we can pack the variable in the current slot, otherwise
-            // we start at the beginning of the next slot.
-            let remaining_bytes = SLOT_SIZE - byte_offset_in_slot;
-            if byte_offset_in_slot > 0 && variable_size > remaining_bytes {
-                current_slot += U256::from(1u64);
-                byte_offset_in_slot = 0;
-            }
-
-            let label = state_variable.ir_node.name.unparse().to_string();
-            let type_name = self
-                .semantic
-                .type_internal_name(variable_type_id)
-                .to_owned();
-            storage_layout.push(StorageItem {
-                node_id,
-                label,
-                slot: current_slot,
-                offset: byte_offset_in_slot,
-                type_name,
-            });
-
-            // Ready slot and offset for the next variable
-            byte_offset_in_slot += variable_size;
-            current_slot += U256::from(byte_offset_in_slot / SLOT_SIZE);
-            byte_offset_in_slot %= SLOT_SIZE;
-        }
-        Some(storage_layout)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -276,9 +276,36 @@ pub fn slang_solidity_v2_semantic::context::SemanticContext::linearised_function
 pub fn slang_solidity_v2_semantic::context::SemanticContext::linearised_state_variables(&self, contract_id: slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_ir::ir::nodes::StateVariableDefinition]
 pub fn slang_solidity_v2_semantic::context::SemanticContext::resolve_reference_identifier_to_definition_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::resolve_reference_identifier_to_immediate_definition_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+pub fn slang_solidity_v2_semantic::context::SemanticContext::storage_layouts(&self, contract_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::context::StorageLayouts>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::storage_size_of_type_id(&self, type_id: slang_solidity_v2_semantic::types::TypeId) -> core::option::Option<usize>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::type_canonical_name(&self, type_id: slang_solidity_v2_semantic::types::TypeId) -> core::option::Option<&str>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::type_internal_name(&self, type_id: slang_solidity_v2_semantic::types::TypeId) -> &str
+pub struct slang_solidity_v2_semantic::context::StorageItem
+impl slang_solidity_v2_semantic::context::StorageItem
+pub fn slang_solidity_v2_semantic::context::StorageItem::label(&self) -> &str
+pub fn slang_solidity_v2_semantic::context::StorageItem::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_semantic::context::StorageItem::offset(&self) -> usize
+pub fn slang_solidity_v2_semantic::context::StorageItem::slot(&self) -> ruint::aliases::U256
+pub fn slang_solidity_v2_semantic::context::StorageItem::type_name(&self) -> &str
+impl core::clone::Clone for slang_solidity_v2_semantic::context::StorageItem
+pub fn slang_solidity_v2_semantic::context::StorageItem::clone(&self) -> slang_solidity_v2_semantic::context::StorageItem
+impl core::cmp::Eq for slang_solidity_v2_semantic::context::StorageItem
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::context::StorageItem
+pub fn slang_solidity_v2_semantic::context::StorageItem::eq(&self, other: &slang_solidity_v2_semantic::context::StorageItem) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::context::StorageItem
+pub fn slang_solidity_v2_semantic::context::StorageItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::context::StorageItem
+pub struct slang_solidity_v2_semantic::context::StorageLayouts
+pub slang_solidity_v2_semantic::context::StorageLayouts::permanent: alloc::vec::Vec<slang_solidity_v2_semantic::context::StorageItem>
+pub slang_solidity_v2_semantic::context::StorageLayouts::transient: alloc::vec::Vec<slang_solidity_v2_semantic::context::StorageItem>
+impl core::clone::Clone for slang_solidity_v2_semantic::context::StorageLayouts
+pub fn slang_solidity_v2_semantic::context::StorageLayouts::clone(&self) -> slang_solidity_v2_semantic::context::StorageLayouts
+impl core::cmp::Eq for slang_solidity_v2_semantic::context::StorageLayouts
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::context::StorageLayouts
+pub fn slang_solidity_v2_semantic::context::StorageLayouts::eq(&self, other: &slang_solidity_v2_semantic::context::StorageLayouts) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::context::StorageLayouts
+pub fn slang_solidity_v2_semantic::context::StorageLayouts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::context::StorageLayouts
 pub const slang_solidity_v2_semantic::context::SLOT_SIZE: usize
 pub trait slang_solidity_v2_semantic::context::SemanticFile
 pub fn slang_solidity_v2_semantic::context::SemanticFile::id(&self) -> &str

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/contract_data_cache.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/contract_data_cache.rs
@@ -2,11 +2,56 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ruint::aliases::U256;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
+use super::type_data_cache::TypeDataCache;
 use crate::binder::{Binder, Definition};
+use crate::context::SLOT_SIZE;
 use crate::types::TypeRegistry;
+
+/// One state-variable slot in a contract's storage layout. Holds the byte
+/// offset and slot index assigned to the variable, plus the resolved internal
+/// type name for downstream consumers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageItem {
+    node_id: NodeId,
+    label: String,
+    slot: U256,
+    offset: usize,
+    type_name: String,
+}
+
+impl StorageItem {
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub fn slot(&self) -> U256 {
+        self.slot
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+}
+
+/// Storage layouts computed for a contract, split into permanent (the
+/// regular contract storage) and transient slots.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageLayouts {
+    pub permanent: Vec<StorageItem>,
+    pub transient: Vec<StorageItem>,
+}
 
 /// Pre-computed derived data for a single contract.
 #[allow(clippy::struct_field_names)]
@@ -15,6 +60,9 @@ struct ContractData {
     linearised_state_variables: Vec<ir::StateVariableDefinition>,
     linearised_errors: Vec<ir::ErrorDefinition>,
     linearised_events: Vec<ir::EventDefinition>,
+    /// Storage layouts. `None` means the layout couldn't be computed (e.g.
+    /// an unresolved state variable type).
+    storage_layouts: Option<StorageLayouts>,
 }
 
 /// Cache of derived data about contracts, computed once at the end of the
@@ -32,7 +80,11 @@ pub(super) struct ContractDataCache {
 }
 
 impl ContractDataCache {
-    pub(super) fn build_from(binder: &Binder, types: &TypeRegistry) -> Self {
+    pub(super) fn build_from(
+        binder: &Binder,
+        types: &TypeRegistry,
+        type_data: &TypeDataCache,
+    ) -> Self {
         let mut contracts = Vec::new();
         let mut contract_by_name = HashMap::new();
         let mut data = HashMap::new();
@@ -50,6 +102,11 @@ impl ContractDataCache {
                 collect_linearised_state_variables(binder, contract_id);
             let linearised_errors = collect_linearised_errors(binder, contract_id);
             let linearised_events = collect_linearised_events(binder, contract_id);
+            // TODO(validation) SDR[2]: it is an error if any contract in the hierarchy
+            // other than the leaf has a custom offset layout
+            let base_slot = contract.base_slot.unwrap_or(U256::ZERO);
+            let storage_layouts =
+                lay_out_storage(binder, type_data, &linearised_state_variables, base_slot);
 
             data.insert(
                 contract_id,
@@ -58,6 +115,7 @@ impl ContractDataCache {
                     linearised_state_variables,
                     linearised_errors,
                     linearised_events,
+                    storage_layouts,
                 },
             );
 
@@ -103,6 +161,12 @@ impl ContractDataCache {
 
     pub(super) fn linearised_events(&self, contract_id: NodeId) -> &[ir::EventDefinition] {
         &self.get(contract_id).linearised_events
+    }
+
+    /// Returns the storage layouts for a contract, or `None` if they couldn't
+    /// be computed (e.g. an unresolved state variable type).
+    pub(super) fn storage_layouts(&self, contract_id: NodeId) -> Option<&StorageLayouts> {
+        self.get(contract_id).storage_layouts.as_ref()
     }
 }
 
@@ -242,4 +306,74 @@ fn collect_linearised_events(binder: &Binder, contract_id: NodeId) -> Vec<ir::Ev
         }
     }
     events
+}
+
+/// Computes the storage layouts for a contract. Returns `None` if any
+/// state-variable type isn't resolved or has no storage size.
+fn lay_out_storage(
+    binder: &Binder,
+    type_data: &TypeDataCache,
+    state_variables: &[ir::StateVariableDefinition],
+    base_slot: U256,
+) -> Option<StorageLayouts> {
+    let permanent = lay_out_variables(
+        binder,
+        type_data,
+        state_variables
+            .iter()
+            .filter(|var| var.mutability == ir::StateVariableMutability::Mutable),
+        base_slot,
+    )?;
+    let transient = lay_out_variables(
+        binder,
+        type_data,
+        state_variables
+            .iter()
+            .filter(|var| var.mutability == ir::StateVariableMutability::Transient),
+        U256::ZERO,
+    )?;
+    Some(StorageLayouts {
+        permanent,
+        transient,
+    })
+}
+
+fn lay_out_variables<'a>(
+    binder: &Binder,
+    type_data: &TypeDataCache,
+    state_variables: impl Iterator<Item = &'a ir::StateVariableDefinition>,
+    base_slot: U256,
+) -> Option<Vec<StorageItem>> {
+    let mut storage_layout = Vec::new();
+    let mut current_slot: U256 = base_slot;
+    let mut byte_offset_in_slot: usize = 0;
+    for state_variable in state_variables {
+        let node_id = state_variable.id();
+        let variable_type_id = binder.node_typing(node_id).as_type_id()?;
+        let variable_size = type_data.size_in_storage(variable_type_id)?;
+
+        // Check if we can pack the variable in the current slot, otherwise we
+        // start at the beginning of the next slot.
+        let remaining_bytes = SLOT_SIZE - byte_offset_in_slot;
+        if byte_offset_in_slot > 0 && variable_size > remaining_bytes {
+            current_slot += U256::from(1u64);
+            byte_offset_in_slot = 0;
+        }
+
+        let label = state_variable.name.unparse().to_string();
+        let type_name = type_data.internal_name(variable_type_id).to_owned();
+        storage_layout.push(StorageItem {
+            node_id,
+            label,
+            slot: current_slot,
+            offset: byte_offset_in_slot,
+            type_name,
+        });
+
+        // Ready slot and offset for the next variable
+        byte_offset_in_slot += variable_size;
+        current_slot += U256::from(byte_offset_in_slot / SLOT_SIZE);
+        byte_offset_in_slot %= SLOT_SIZE;
+    }
+    Some(storage_layout)
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,4 +1,5 @@
 use contract_data_cache::ContractDataCache;
+pub use contract_data_cache::{StorageItem, StorageLayouts};
 use file_node_mapper::FileNodeMapper;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::utils::strip_string_literal_quotes;
@@ -76,7 +77,7 @@ impl SemanticContext {
 
         let file_node_mapper = FileNodeMapper::build_from(files);
         let type_data = TypeDataCache::build_from(&binder, &types);
-        let contract_data = ContractDataCache::build_from(&binder, &types);
+        let contract_data = ContractDataCache::build_from(&binder, &types, &type_data);
 
         Self {
             binder,
@@ -153,6 +154,14 @@ impl SemanticContext {
     /// definition.
     pub fn linearised_events(&self, contract_id: NodeId) -> &[ir::EventDefinition] {
         self.contract_data.linearised_events(contract_id)
+    }
+
+    /// Returns the storage layouts pre-computed for the given contract, or
+    /// `None` if they couldn't be computed (e.g. because of an unresolved
+    /// state-variable type). `contract_id` must be a registered contract
+    /// definition.
+    pub fn storage_layouts(&self, contract_id: NodeId) -> Option<&StorageLayouts> {
+        self.contract_data.storage_layouts(contract_id)
     }
 
     pub fn resolve_reference_identifier_to_definition_id(&self, node_id: NodeId) -> Option<NodeId> {


### PR DESCRIPTION
Built on top of #1816 

Adds caching for storage layouts, which needs the size in storage type information from the `TypeDataCache`. The layouts are stored in `ContractDataCache`.
