### PR TITLE
[v2]: Add library type

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -919,6 +919,7 @@ pub slang_solidity_v2_ast::ast::Type::FixedSizeArray(slang_solidity_v2_ast::ast:
 pub slang_solidity_v2_ast::ast::Type::Function(slang_solidity_v2_ast::ast::FunctionType)
 pub slang_solidity_v2_ast::ast::Type::Integer(slang_solidity_v2_ast::ast::IntegerType)
 pub slang_solidity_v2_ast::ast::Type::Interface(slang_solidity_v2_ast::ast::InterfaceType)
+pub slang_solidity_v2_ast::ast::Type::Library(slang_solidity_v2_ast::ast::types::LibraryType)
 pub slang_solidity_v2_ast::ast::Type::Literal(slang_solidity_v2_ast::ast::LiteralType)
 pub slang_solidity_v2_ast::ast::Type::Mapping(slang_solidity_v2_ast::ast::MappingType)
 pub slang_solidity_v2_ast::ast::Type::String(slang_solidity_v2_ast::ast::StringType)

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -26,6 +26,7 @@ pub enum Type {
     Function(FunctionType),
     Integer(IntegerType),
     Interface(InterfaceType),
+    Library(LibraryType),
     Literal(LiteralType),
     Mapping(MappingType),
     String(StringType),
@@ -66,6 +67,7 @@ define_type_variant!(FixedPointNumber);
 define_type_variant!(Function);
 define_type_variant!(Integer);
 define_type_variant!(Interface);
+define_type_variant!(Library);
 define_type_variant!(Literal);
 define_type_variant!(Mapping);
 define_type_variant!(String);
@@ -103,6 +105,7 @@ impl Type {
             types::Type::Function(_) => Self::Function(FunctionType { type_id, semantic }),
             types::Type::Integer { .. } => Self::Integer(IntegerType { type_id, semantic }),
             types::Type::Interface { .. } => Self::Interface(InterfaceType { type_id, semantic }),
+            types::Type::Library { .. } => Self::Library(LibraryType { type_id, semantic }),
             types::Type::Literal(_) => Self::Literal(LiteralType { type_id, semantic }),
             types::Type::Mapping { .. } => Self::Mapping(MappingType { type_id, semantic }),
             types::Type::String { .. } => Self::String(StringType { type_id, semantic }),
@@ -129,6 +132,7 @@ impl Type {
             Type::Function(details) => details.type_id,
             Type::Integer(details) => details.type_id,
             Type::Interface(details) => details.type_id,
+            Type::Library(details) => details.type_id,
             Type::Literal(details) => details.type_id,
             Type::Mapping(details) => details.type_id,
             Type::String(details) => details.type_id,
@@ -358,6 +362,15 @@ impl InterfaceType {
         };
         Definition::try_create(*definition_id, &self.semantic)
             .expect("invalid interface definition")
+    }
+}
+
+impl LibraryType {
+    pub fn definition(&self) -> Definition {
+        let types::Type::Library { definition_id } = self.internal_type() else {
+            unreachable!("invalid library type");
+        };
+        Definition::try_create(*definition_id, &self.semantic).expect("invalid library definition")
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -408,6 +408,8 @@ pub slang_solidity_v2_semantic::types::Type::Integer::bits: u32
 pub slang_solidity_v2_semantic::types::Type::Integer::signed: bool
 pub slang_solidity_v2_semantic::types::Type::Interface
 pub slang_solidity_v2_semantic::types::Type::Interface::definition_id: slang_solidity_v2_common::nodes::NodeId
+pub slang_solidity_v2_semantic::types::Type::Library
+pub slang_solidity_v2_semantic::types::Type::Library::definition_id: slang_solidity_v2_common::nodes::NodeId
 pub slang_solidity_v2_semantic::types::Type::Literal(slang_solidity_v2_semantic::types::LiteralKind)
 pub slang_solidity_v2_semantic::types::Type::Mapping
 pub slang_solidity_v2_semantic::types::Type::Mapping::key_type_id: slang_solidity_v2_semantic::types::TypeId

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -425,7 +425,7 @@ pub slang_solidity_v2_semantic::types::Type::UserDefinedValue
 pub slang_solidity_v2_semantic::types::Type::UserDefinedValue::definition_id: slang_solidity_v2_common::nodes::NodeId
 pub slang_solidity_v2_semantic::types::Type::Void
 impl slang_solidity_v2_semantic::types::Type
-pub fn slang_solidity_v2_semantic::types::Type::can_return_from_getter(&self) -> bool
+pub fn slang_solidity_v2_semantic::types::Type::can_return_from_getter_directly(&self) -> bool
 pub fn slang_solidity_v2_semantic::types::Type::data_location(&self) -> core::option::Option<slang_solidity_v2_semantic::types::DataLocation>
 pub fn slang_solidity_v2_semantic::types::Type::is_contract_or_interface(&self) -> bool
 pub fn slang_solidity_v2_semantic::types::Type::is_inherited_location(&self) -> bool

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -207,11 +207,10 @@ impl<'a> BuiltInsResolver<'a> {
                 _ => None,
             },
             BuiltIn::Type(type_id) => match self.types.get_type_by_id(*type_id) {
-                Type::Contract { .. } => match symbol {
+                Type::Contract { .. } | Type::Library { .. } => match symbol {
                     "name" => Some(BuiltIn::TypeName),
                     "creationCode" => Some(BuiltIn::TypeCreationCode),
                     "runtimeCode" => Some(BuiltIn::TypeRuntimeCode),
-                    "interfaceId" => Some(BuiltIn::TypeInterfaceId),
                     _ => None,
                 },
                 Type::Interface { .. } => match symbol {
@@ -338,7 +337,7 @@ impl<'a> BuiltInsResolver<'a> {
                 }
                 _ => None,
             },
-            Type::Contract { .. } | Type::Interface { .. } => None,
+            Type::Contract { .. } | Type::Interface { .. } | Type::Library { .. } => None,
             Type::Enum { .. } => None,
             Type::FixedPointNumber { .. } => None,
             Type::FixedSizeArray { .. } => match symbol {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -196,9 +196,8 @@ impl SemanticContext {
             | Type::Enum { definition_id }
             | Type::Interface { definition_id }
             | Type::Struct { definition_id, .. }
-            | Type::UserDefinedValue { definition_id } => {
-                self.definition_canonical_name(*definition_id)
-            }
+            | Type::UserDefinedValue { definition_id }
+            | Type::Library { definition_id } => self.definition_canonical_name(*definition_id),
             Type::Void => "void".to_string(),
         }
     }
@@ -273,7 +272,11 @@ impl SemanticContext {
                     .and_then(|type_id| self.type_canonical_name_impl(type_id, visited_structs))
             }
 
-            Type::Literal(_) | Type::Mapping { .. } | Type::Tuple { .. } | Type::Void => None,
+            Type::Literal(_)
+            | Type::Mapping { .. }
+            | Type::Tuple { .. }
+            | Type::Void
+            | Type::Library { .. } => None,
         }
     }
 
@@ -370,9 +373,7 @@ impl SemanticContext {
                 )
             }
 
-            Type::Literal(_) => None,
-            Type::Tuple { .. } => None,
-            Type::Void => None,
+            Type::Literal(_) | Type::Tuple { .. } | Type::Void | Type::Library { .. } => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -212,7 +212,7 @@ impl Pass<'_> {
                             return None;
                         };
                         let member_type = self.types.get_type_by_id(member_type_id);
-                        if !member_type.can_return_from_getter() {
+                        if !member_type.can_return_from_getter_directly() {
                             continue;
                         }
                         let member_type_id = if member_type

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -37,9 +37,11 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         if let Some(definition) = self.binder.find_definition_by_id(definition_id) {
             match definition {
-                Definition::Contract(_) | Definition::Library(_) => {
-                    // TODO: do we need a separate type for libraries?
+                Definition::Contract(_) => {
                     Some(self.types.register_type(Type::Contract { definition_id }))
+                }
+                Definition::Library(_) => {
+                    Some(self.types.register_type(Type::Library { definition_id }))
                 }
                 Definition::Enum(_) => Some(self.types.register_type(Type::Enum { definition_id })),
                 Definition::Interface(_) => {
@@ -249,7 +251,7 @@ impl Pass<'_> {
                 }
 
                 // invalid types
-                Type::Literal(_) | Type::Tuple { .. } | Type::Void => {
+                Type::Literal(_) | Type::Library { .. } | Type::Tuple { .. } | Type::Void => {
                     unreachable!("cannot compute the getter type for {type_id:?}")
                 }
             }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -2,7 +2,7 @@ use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
 use super::Pass;
-use crate::binder::{Definition, Scope};
+use crate::binder::Definition;
 use crate::types::{
     DataLocation, FunctionType, FunctionTypeMutability, FunctionTypeVisibility, Type, TypeId,
 };
@@ -191,19 +191,22 @@ impl Pass<'_> {
 
                 Type::Struct { definition_id, .. } => {
                     // For structs the getter will return a tuple with all value
-                    // type and string/bytes fields. It won't return nested
-                    // structs or arrays.
-                    // To retrieve the fields we need to go through the
-                    // scope associated to the struct...
-                    let scope_id = self
-                        .binder
-                        .scope_id_for_node_id(*definition_id)
-                        .expect("definition in struct type has no associated scope");
-                    let Scope::Struct(struct_scope) = self.binder.get_scope_by_id(scope_id) else {
-                        unreachable!("definition in struct type has no valid scope");
+                    // type and string/bytes fields, in declaration order. It
+                    // won't return nested mappings or arrays.
+                    // We iterate the struct's IR members directly: the struct
+                    // scope is a name->id map with no stable ordering, but the
+                    // getter's tuple must preserve the source field order.
+                    let Some(Definition::Struct(struct_definition)) =
+                        self.binder.find_definition_by_id(*definition_id)
+                    else {
+                        unreachable!("struct type does not refer to a struct definition");
                     };
-                    let member_ids: Vec<NodeId> =
-                        struct_scope.definitions.values().copied().collect();
+                    let member_ids: Vec<NodeId> = struct_definition
+                        .ir_node
+                        .members
+                        .iter()
+                        .map(|member| member.id())
+                        .collect();
                     let mut types = Vec::new();
                     for member_id in member_ids {
                         let Some(member_type_id) = self.binder.node_typing(member_id).as_type_id()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -96,6 +96,11 @@ impl Visitor for Pass<'_> {
 
     fn enter_library_definition(&mut self, node: &ir::LibraryDefinition) -> bool {
         self.enter_scope_for_node_id(node.id());
+
+        self.types.register_type(Type::Library {
+            definition_id: node.id(),
+        });
+
         true
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -241,7 +241,7 @@ impl Pass<'_> {
         let mut definition_ids = match type_ {
             Type::Contract { definition_id, .. } | Type::Interface { definition_id, .. } => {
                 // A `Type::Library` doesn't belong here, since values of type `library` (ie `this`)
-                // can't be used to acces to library members.
+                // can't be used to access to library members.
                 let scope_id = self.binder.scope_id_for_node_id(*definition_id).unwrap();
                 self.binder
                     .resolve_in_contract_scope(scope_id, symbol, ResolveOptions::External)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/resolution.rs
@@ -161,6 +161,7 @@ impl Pass<'_> {
 
                     if matches!(typing, Typing::This) {
                         // Consider active `using` directives for `this`
+                        // TODO(this-typing): Once `This` carries a type, use that and check it's a contract
                         if let Some(receiver_type_id) = self.types.find_type(&Type::Contract {
                             definition_id: node_id,
                         }) {
@@ -239,6 +240,8 @@ impl Pass<'_> {
         // Resolve direct members of the type first
         let mut definition_ids = match type_ {
             Type::Contract { definition_id, .. } | Type::Interface { definition_id, .. } => {
+                // A `Type::Library` doesn't belong here, since values of type `library` (ie `this`)
+                // can't be used to acces to library members.
                 let scope_id = self.binder.scope_id_for_node_id(*definition_id).unwrap();
                 self.binder
                     .resolve_in_contract_scope(scope_id, symbol, ResolveOptions::External)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -70,6 +70,7 @@ impl Pass<'_> {
             Definition::Contract(_) => Some(Type::Contract { definition_id }),
             Definition::Enum(_) => Some(Type::Enum { definition_id }),
             Definition::Interface(_) => Some(Type::Interface { definition_id }),
+            Definition::Library(_) => Some(Type::Library { definition_id }),
             Definition::Struct(_) => Some(Type::Struct {
                 definition_id,
                 location: DataLocation::Memory,
@@ -236,6 +237,7 @@ impl Pass<'_> {
 
     pub(super) fn typing_is_contract_reference(&self, typing: &Typing) -> bool {
         match typing {
+            // TODO(this-typing): Once `This` carries a type, check that it's either a contract or an interface type
             Typing::This => true,
             Typing::Resolved(type_id) => matches!(
                 self.types.get_type_by_id(*type_id),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_resolve_references/typing.rs
@@ -415,6 +415,13 @@ impl Pass<'_> {
                         });
                         Typing::Resolved(type_id)
                     }
+                    Some(Definition::Library(_)) => {
+                        // TODO(validation) SDR[39]: the type of the first argument should be an address
+                        let type_id = self.types.register_type(Type::Library {
+                            definition_id: node_id,
+                        });
+                        Typing::Resolved(type_id)
+                    }
                     Some(Definition::Struct(_)) => {
                         // struct construction
                         let type_id = self.types.register_type(Type::Struct {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -3,7 +3,7 @@ use num_rational::BigRational;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 
-use super::build_file;
+use super::{build_file, TestFile};
 use crate::binder::Binder;
 use crate::context::SemanticFile;
 use crate::passes::common::node_id_for_expression_typing;
@@ -11,6 +11,81 @@ use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p4_resolve_references,
 };
 use crate::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
+
+/// Builds and runs every semantic pass over an arbitrary Solidity `source`,
+fn analyze(language_version: LanguageVersion, source: &str) -> (TestFile, Binder, TypeRegistry) {
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file("test.sol", source, &mut id_generator, language_version);
+    let files = vec![file];
+
+    let mut binder = Binder::default();
+    let mut types = TypeRegistry::default();
+    p1_collect_definitions::run(&files, &mut binder);
+    p2_linearise_contracts::run(&files, &mut binder);
+    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
+    p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
+
+    (files.into_iter().next().unwrap(), binder, types)
+}
+
+/// Recovers the typing recorded for an expression `node`, resolved to a
+/// concrete [`Type`].
+fn recover_expression_type(
+    node: &ir::Expression,
+    binder: &Binder,
+    types: &TypeRegistry,
+) -> Option<Type> {
+    let node_id = node_id_for_expression_typing(node)?;
+    binder
+        .node_typing(node_id)
+        .as_type_id()
+        .map(|type_id| types.get_type_by_id(type_id).clone())
+}
+
+/// Finds the function named `name` among a contract's or library's `members`.
+fn find_function<'a>(
+    members: &'a [ir::ContractMember],
+    name: &str,
+) -> Option<&'a ir::FunctionDefinition> {
+    members.iter().find_map(|member| match member {
+        ir::ContractMember::FunctionDefinition(function)
+            if function.name.as_ref().is_some_and(|n| n.unparse() == name) =>
+        {
+            Some(function)
+        }
+        _ => None,
+    })
+}
+
+/// Finds the top-level contract named `name`.
+fn find_contract<'a>(file: &'a TestFile, name: &str) -> &'a ir::ContractDefinition {
+    file.ir_root()
+        .members
+        .iter()
+        .find_map(|member| match member {
+            ir::SourceUnitMember::ContractDefinition(c) if c.name.unparse() == name => Some(c),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("contract `{name}` not found"))
+}
+
+/// Collects the recovered type of each expression statement in `body`, in
+/// source order.
+fn expression_statement_types(
+    body: &ir::Block,
+    binder: &Binder,
+    types: &TypeRegistry,
+) -> Vec<Option<Type>> {
+    body.statements
+        .iter()
+        .filter_map(|stmt| match stmt {
+            ir::Statement::ExpressionStatement(s) => {
+                Some(recover_expression_type(&s.expression, binder, types))
+            }
+            _ => None,
+        })
+        .collect()
+}
 
 /// Wraps each expression in a no-op expression statement inside the body of an
 /// `__test()` function of a synthesized `Test` contract, runs every semantic
@@ -41,53 +116,13 @@ fn type_of_expressions(
         }}\n"
     );
 
-    let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", &source, &mut id_generator, language_version);
-    let files = [file];
+    let (file, binder, types) = analyze(language_version, &source);
 
-    let mut binder = Binder::default();
-    let mut types = TypeRegistry::default();
-    p1_collect_definitions::run(&files, &mut binder);
-    p2_linearise_contracts::run(&files, &mut binder);
-    p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
-    p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
-
-    let contract = match files[0].ir_root().members.last().unwrap() {
-        ir::SourceUnitMember::ContractDefinition(c) => c,
-        other => panic!("expected ContractDefinition, got {other:?}"),
-    };
-    let function = contract
-        .members
-        .iter()
-        .find_map(|member| match member {
-            ir::ContractMember::FunctionDefinition(f)
-                if f.name.as_ref().is_some_and(|n| n.unparse() == "__test") =>
-            {
-                Some(f)
-            }
-            _ => None,
-        })
-        .expect("__test function not found");
+    let contract = find_contract(&file, "Test");
+    let function = find_function(&contract.members, "__test").expect("__test function not found");
     let block = function.body.as_ref().expect("__test has a body");
 
-    let typings = block
-        .statements
-        .iter()
-        .filter_map(|stmt| match stmt {
-            ir::Statement::ExpressionStatement(s) => {
-                let node_id = node_id_for_expression_typing(&s.expression)
-                    .expect("expression registers its typing in the binder");
-                Some(
-                    binder
-                        .node_typing(node_id)
-                        .as_type_id()
-                        .map(|type_id| types.get_type_by_id(type_id))
-                        .cloned(),
-                )
-            }
-            _ => None,
-        })
-        .collect();
+    let typings = expression_statement_types(block, &binder, &types);
 
     (typings, types)
 }
@@ -905,4 +940,41 @@ fn test_data_locations_of_state_variable_and_getter_accesses() {
         }),
     ];
     assert_eq!(typings, expected);
+}
+
+#[test]
+fn test_cast_address_to_library_is_library_typed() {
+    // Casting an address to a library (`MyLib(x)`) is valid Solidity and
+    // yields a value of the library type, which can then be compared against
+    // another library value.
+    let source = "\
+        library MyLib {\n\
+            function f() public pure returns (uint) { return 1; }\n\
+        }\n\
+        contract Test {\n\
+            function probe(address x, address y) internal pure {\n\
+                MyLib(x);\n\
+                MyLib(x) == MyLib(y);\n\
+            }\n\
+        }\n";
+    let (file, binder, types) = analyze(LanguageVersion::LATEST, source);
+
+    let contract = find_contract(&file, "Test");
+    let probe = find_function(&contract.members, "probe").expect("probe function");
+    let body = probe.body.as_ref().expect("probe has a body");
+
+    let typings = expression_statement_types(body, &binder, &types);
+    let [cast, comparison] = typings.as_slice() else {
+        panic!("expected two expression statements, got {typings:?}");
+    };
+
+    assert!(
+        matches!(cast, Some(Type::Library { .. })),
+        "expected `MyLib(x)` to be typed as the library, got {cast:?}",
+    );
+    assert_eq!(
+        comparison,
+        &Some(Type::Boolean),
+        "expected `MyLib(x) == MyLib(y)` to be a boolean",
+    );
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1009,7 +1009,7 @@ fn test_getter_of_struct_with_function_member() {
                 Type::Function(_),
             ]
         ),
-        "expected getter tuple `(function() external)`, got {element_types:?}",
+        "expected getter tuple `(uint256, function() external)`, got {element_types:?}",
     );
 }
 
@@ -1044,6 +1044,6 @@ fn test_getter_of_struct_with_struct_member() {
                 },
             ]
         ),
-        "expected getter tuple `(Struct)`, got {element_types:?}",
+        "expected getter tuple `(Struct, uint256)`, got {element_types:?}",
     );
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -12,8 +12,14 @@ use crate::passes::{
 };
 use crate::types::{DataLocation, LiteralKind, Type, TypeId, TypeRegistry};
 
+struct TypeAnalysis {
+    file: TestFile,
+    binder: Binder,
+    types: TypeRegistry,
+}
+
 /// Builds and runs every semantic pass over an arbitrary Solidity `source`,
-fn analyze(language_version: LanguageVersion, source: &str) -> (TestFile, Binder, TypeRegistry) {
+fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file("test.sol", source, &mut id_generator, language_version);
     let files = vec![file];
@@ -25,7 +31,11 @@ fn analyze(language_version: LanguageVersion, source: &str) -> (TestFile, Binder
     p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 
-    (files.into_iter().next().unwrap(), binder, types)
+    TypeAnalysis {
+        file: files.into_iter().next().unwrap(),
+        binder,
+        types,
+    }
 }
 
 /// Recovers the typing recorded for an expression `node`, resolved to a
@@ -108,15 +118,21 @@ fn type_of_expressions(
         .collect::<Vec<_>>()
         .join("\n");
     let source = format!(
-        "contract Test {{\n\
-            {context_block}\n\
-            function __test() internal {{\n\
-                {expression_statements}\n\
-            }}\n\
-        }}\n"
+        r#"
+        contract Test {{
+            {context_block}
+            function __test() internal {{
+                {expression_statements}
+            }}
+        }}
+        "#
     );
 
-    let (file, binder, types) = analyze(language_version, &source);
+    let TypeAnalysis {
+        file,
+        binder,
+        types,
+    } = analyze(language_version, &source);
 
     let contract = find_contract(&file, "Test");
     let function = find_function(&contract.members, "__test").expect("__test function not found");
@@ -918,10 +934,12 @@ fn test_data_locations_of_state_variable_and_getter_accesses() {
     let (typings, _) = type_of_expressions(
         LanguageVersion::LATEST,
         Some(
-            "struct Foo { bytes xs; }\n\
-             bytes public bs;\n\
-             Foo public foo;\n\
-             Test t;",
+            r#"
+            struct Foo { bytes xs; }
+            bytes public bs;
+            Foo public foo;
+            Test t;
+            "#,
         ),
         &["bs", "foo.xs", "t.bs()", "t.foo()"],
     );
@@ -947,17 +965,22 @@ fn test_cast_address_to_library_is_library_typed() {
     // Casting an address to a library (`MyLib(x)`) is valid Solidity and
     // yields a value of the library type, which can then be compared against
     // another library value.
-    let source = "\
-        library MyLib {\n\
-            function f() public pure returns (uint) { return 1; }\n\
-        }\n\
-        contract Test {\n\
-            function probe(address x, address y) internal pure {\n\
-                MyLib(x);\n\
-                MyLib(x) == MyLib(y);\n\
-            }\n\
-        }\n";
-    let (file, binder, types) = analyze(LanguageVersion::LATEST, source);
+    let source = r#"
+        library MyLib {
+            function f() public pure returns (uint) { return 1; }
+        }
+        contract Test {
+            function probe(address x, address y) internal pure {
+                MyLib(x);
+                MyLib(x) == MyLib(y);
+            }
+        }
+    "#;
+    let TypeAnalysis {
+        file,
+        binder,
+        types,
+    } = analyze(LanguageVersion::LATEST, source);
 
     let contract = find_contract(&file, "Test");
     let probe = find_function(&contract.members, "probe").expect("probe function");
@@ -984,9 +1007,11 @@ fn test_getter_of_struct_with_function_member() {
     // The auto-generated getter of a public struct state variable returns a
     // tuple of its value-type fields.
     let (getter_type, types) = type_of_expression_in_context(
-        "struct S { uint a; function() external fn; }\n\
-         S public s;\n\
-         Test other;",
+        r#"
+        struct S { uint a; function() external fn; }
+        S public s;
+        Test other;
+        "#,
         "other.s()",
     );
 
@@ -1018,10 +1043,12 @@ fn test_getter_of_struct_with_struct_member() {
     // The auto-generated getter of a public struct state variable returns a
     // tuple of its value-type fields.
     let (getter_type, types) = type_of_expression_in_context(
-        "struct P { bool a; }\n\
-         struct S { P p; uint a; }\n\
-         S public s;\n\
-         Test other;",
+        r#"
+        struct P { bool a; }
+        struct S { P p; uint a; }
+        S public s;
+        Test other;
+        "#,
         "other.s()",
     );
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -978,3 +978,72 @@ fn test_cast_address_to_library_is_library_typed() {
         "expected `MyLib(x) == MyLib(y)` to be a boolean",
     );
 }
+
+#[test]
+fn test_getter_of_struct_with_function_member() {
+    // The auto-generated getter of a public struct state variable returns a
+    // tuple of its value-type fields.
+    let (getter_type, types) = type_of_expression_in_context(
+        "struct S { uint a; function() external fn; }\n\
+         S public s;\n\
+         Test other;",
+        "other.s()",
+    );
+
+    let Type::Tuple { types: elements } = getter_type else {
+        panic!("expected the getter to return a tuple, got {getter_type:?}");
+    };
+    let element_types: Vec<&Type> = elements
+        .iter()
+        .map(|type_id| types.get_type_by_id(*type_id))
+        .collect();
+
+    assert!(
+        matches!(
+            element_types.as_slice(),
+            [
+                Type::Integer {
+                    signed: false,
+                    bits: 256
+                },
+                Type::Function(_),
+            ]
+        ),
+        "expected getter tuple `(function() external)`, got {element_types:?}",
+    );
+}
+
+#[test]
+fn test_getter_of_struct_with_struct_member() {
+    // The auto-generated getter of a public struct state variable returns a
+    // tuple of its value-type fields.
+    let (getter_type, types) = type_of_expression_in_context(
+        "struct P { bool a; }\n\
+         struct S { P p; uint a; }\n\
+         S public s;\n\
+         Test other;",
+        "other.s()",
+    );
+
+    let Type::Tuple { types: elements } = getter_type else {
+        panic!("expected the getter to return a tuple, got {getter_type:?}");
+    };
+    let element_types: Vec<&Type> = elements
+        .iter()
+        .map(|type_id| types.get_type_by_id(*type_id))
+        .collect();
+
+    assert!(
+        matches!(
+            element_types.as_slice(),
+            [
+                Type::Struct { .. },
+                Type::Integer {
+                    signed: false,
+                    bits: 256
+                },
+            ]
+        ),
+        "expected getter tuple `(Struct)`, got {element_types:?}",
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -57,6 +57,9 @@ pub enum Type {
     Interface {
         definition_id: NodeId,
     },
+    Library {
+        definition_id: NodeId,
+    },
     Literal(LiteralKind),
     Mapping {
         key_type_id: TypeId,
@@ -319,6 +322,7 @@ impl Type {
             | Type::Literal(_)
             | Type::Struct { .. }
             | Type::Tuple { .. }
+            | Type::Library { .. }
             | Type::Void => false,
         }
     }
@@ -352,7 +356,8 @@ impl Type {
             | Type::Enum { definition_id }
             | Type::Interface { definition_id }
             | Type::Struct { definition_id, .. }
-            | Type::UserDefinedValue { definition_id } => Some(*definition_id),
+            | Type::UserDefinedValue { definition_id }
+            | Type::Library { definition_id } => Some(*definition_id),
             _ => None,
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -317,15 +317,20 @@ impl Type {
             | Type::Integer { .. }
             | Type::Interface { .. }
             | Type::String { .. }
-            | Type::Function(_)
             | Type::Struct { .. }
             | Type::UserDefinedValue { .. } => true,
+            Type::Function(FunctionType { visibility, .. }) => {
+                // Function types can only be returned if they're external
+                visibility == &FunctionTypeVisibility::External
+            }
 
             // Can be returned, just not inside a struct
             Type::Array { .. }
             | Type::FixedSizeArray { .. }
             | Type::Mapping { .. }
             // Actually can't return from a getter
+            // TODO(validation) SDR[1394]: Not sure if this is the best place for this check,
+            // but it's related.
             | Type::Literal(_)
             | Type::Library { .. }
             | Type::Tuple { .. }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -301,7 +301,11 @@ impl Type {
             .is_some_and(|location| location == DataLocation::Inherited)
     }
 
-    pub fn can_return_from_getter(&self) -> bool {
+    /// This function determines whether a type can be returned directly from
+    /// a getter function without any extra parameter.
+    ///
+    /// Arrays and mapping can't
+    pub fn can_return_from_getter_directly(&self) -> bool {
         match self {
             Type::Address { .. }
             | Type::Boolean
@@ -313,16 +317,18 @@ impl Type {
             | Type::Integer { .. }
             | Type::Interface { .. }
             | Type::String { .. }
+            | Type::Function(_)
+            | Type::Struct { .. }
             | Type::UserDefinedValue { .. } => true,
 
+            // Can be returned, just not inside a struct
             Type::Array { .. }
             | Type::FixedSizeArray { .. }
-            | Type::Function(_)
             | Type::Mapping { .. }
+            // Actually can't return from a getter
             | Type::Literal(_)
-            | Type::Struct { .. }
-            | Type::Tuple { .. }
             | Type::Library { .. }
+            | Type::Tuple { .. }
             | Type::Void => false,
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -473,6 +473,7 @@ impl TypeRegistry {
             | Type::FixedPointNumber { .. }
             | Type::Integer { .. }
             | Type::Interface { .. }
+            | Type::Library { .. }
             | Type::Literal(_)
             | Type::Mapping { .. }
             | Type::Tuple { .. }
@@ -532,6 +533,7 @@ impl TypeRegistry {
             | Type::Function(_)
             | Type::Integer { .. }
             | Type::Interface { .. }
+            | Type::Library { .. }
             | Type::Literal(_)
             | Type::Mapping { .. }
             | Type::UserDefinedValue { .. }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -328,8 +328,11 @@ impl CollectedDefinitionDisplay<'_> {
                     location = data_location_display(*location)
                 )
             }
-            Type::Contract { definition_id } => self.definition_name(*definition_id),
-            Type::Enum { definition_id } => self.definition_name(*definition_id),
+            Type::Contract { definition_id }
+            | Type::Enum { definition_id }
+            | Type::Interface { definition_id }
+            | Type::Library { definition_id } => self.definition_name(*definition_id),
+
             Type::FixedPointNumber {
                 signed,
                 bits,
@@ -367,7 +370,6 @@ impl CollectedDefinitionDisplay<'_> {
             Type::Integer { signed, bits } => {
                 format!("{signed}int{bits}", signed = if *signed { "" } else { "u" })
             }
-            Type::Interface { definition_id } => self.definition_name(*definition_id),
             Type::Mapping {
                 key_type_id,
                 value_type_id,


### PR DESCRIPTION
This PR adds a library type to the IR and AST type constructs, although not very useful, Solidity can have values with type `library MyLib`, in particular `this` inside a library function, and an explicit cast `MyLib(x)`.

An option would've been to reuse the `Contract` type, since they behave extremely similar. However, given that we differentiate between `Contract` and `Interface`, this approach made more sense.

On top of that:
- Small refactor on how typing is tested
- Removed `interfaceId` from `type(MyContract)`, it's not valid Solidity (I think it was befor 0.5.0)
- Added a bunch of `TODO(this-typing)` for when the `This` type can carry its type (next PR)
- Fixed and tested some bugs on getter generation.