### PR TITLE
simplify jinja templates codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,8 +845,6 @@ dependencies = [
  "codegen_generator",
  "codegen_spec",
  "infra_utils",
- "language_definition",
- "language_v2_definition",
  "rayon",
  "solidity_language",
  "solidity_v2_language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "rayon",
  "solidity_language",
  "solidity_v2_language",
+ "tera",
 ]
 
 [[package]]

--- a/crates/codegen/generator/src/ir/model.rs
+++ b/crates/codegen/generator/src/ir/model.rs
@@ -105,15 +105,6 @@ impl IrModel {
             collections: builder.collections,
         }
     }
-
-    pub fn from_model(model: &Self) -> Self {
-        Self {
-            terminals: model.terminals.clone(),
-            sequences: model.sequences.clone(),
-            choices: model.choices.clone(),
-            collections: model.collections.clone(),
-        }
-    }
 }
 
 struct IrModelBuilder {

--- a/crates/codegen/generator/src/ir/mutator.rs
+++ b/crates/codegen/generator/src/ir/mutator.rs
@@ -225,18 +225,6 @@ impl IrModelMutator {
         }
     }
 
-    pub fn add_choice_type(&mut self, name: &str) {
-        self.choices.insert(
-            name.into(),
-            MutatedChoice {
-                variants: Vec::new(),
-                added_variants: Vec::new(),
-                is_new: true,
-                has_removed_variants: false,
-            },
-        );
-    }
-
     pub fn add_choice_variant(&mut self, choice_id: &str, variant: &str) {
         let variant_type = self.find_node_type(&variant.into());
         let identifier: model::Identifier = choice_id.into();

--- a/crates/codegen/generator/src/lib.rs
+++ b/crates/codegen/generator/src/lib.rs
@@ -1,12 +1,10 @@
 mod ast;
 mod bindings;
+mod ir;
 mod kinds;
 mod parser;
 
-pub mod ir;
-
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
 
 use anyhow::Result;
 use codegen_v2_cst::structured_cst::model::StructuredCstModel;
@@ -15,7 +13,6 @@ use codegen_v2_semantic::ir::builder::build_v2_ir_model;
 use codegen_v2_semantic::ir::ModelWithBuilder;
 use indexmap::IndexSet;
 use infra_utils::cargo::CargoWorkspace;
-use infra_utils::codegen::{CodegenFileSystem, CodegenRuntime};
 use ir::builders::{build_ir_models, GenericModel};
 use language_definition::model::Language;
 use language_v2_definition::model::Language as LanguageV2;
@@ -27,31 +24,8 @@ use crate::bindings::BindingsModel;
 use crate::kinds::KindsModel;
 use crate::parser::ParserModel;
 
-pub struct RuntimeGenerator;
-
-impl RuntimeGenerator {
-    pub fn generate_templates_in_place(
-        language: &Language,
-        fs: &mut CodegenFileSystem,
-        dir: &Path,
-    ) -> Result<()> {
-        let model = RuntimeModel::from_language(language)?;
-        CodegenRuntime::render_templates_in_place(fs, dir, model)
-    }
-
-    pub fn generate_templates_in_place_v2(
-        language: &LanguageV2,
-        fs: &mut CodegenFileSystem,
-        dir: &Path,
-    ) -> Result<()> {
-        let model = RuntimeModelV2::from_language(language);
-
-        CodegenRuntime::render_templates_in_place(fs, dir, model)
-    }
-}
-
 #[derive(Serialize)]
-struct RuntimeModel {
+pub struct RuntimeModel {
     slang_version: Version,
     language_name: String,
     all_language_versions: BTreeSet<Version>,
@@ -66,7 +40,7 @@ struct RuntimeModel {
 }
 
 impl RuntimeModel {
-    fn from_language(language: &Language) -> Result<Self> {
+    pub fn from_language(language: &Language) -> Result<Self> {
         Ok(Self {
             slang_version: CargoWorkspace::local_version()?,
             language_name: language.name.to_string(),
@@ -84,39 +58,39 @@ impl RuntimeModel {
 }
 
 #[derive(Serialize)]
-struct LanguageModelV2 {
+pub struct RuntimeModelV2 {
+    language: LanguageModelV2,
+
+    parser: ParserModelV2,
+    structured_cst_model: StructuredCstModel,
+    ir_language_model: ModelWithBuilder,
+}
+
+impl RuntimeModelV2 {
+    pub fn from_language(language: &LanguageV2) -> Self {
+        Self {
+            language: LanguageModelV2::from_language(language),
+            parser: ParserModelV2::from_language(language),
+
+            structured_cst_model: StructuredCstModel::from_language(language),
+            ir_language_model: build_v2_ir_model(language),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct LanguageModelV2 {
     name: String,
     versions: IndexSet<Version>,
     built_ins: Vec<codegen_v2_semantic::built_ins::BuiltInContextModel>,
 }
 
 impl LanguageModelV2 {
-    fn from_language(language: &LanguageV2) -> Self {
+    pub fn from_language(language: &LanguageV2) -> Self {
         Self {
             name: language.name.to_string(),
             versions: language.versions.clone(),
             built_ins: codegen_v2_semantic::built_ins::build_built_ins_model(language),
-        }
-    }
-}
-
-#[derive(Serialize)]
-struct RuntimeModelV2 {
-    parser: ParserModelV2,
-
-    language: LanguageModelV2,
-
-    structured_cst_model: StructuredCstModel,
-    ir_language_model: ModelWithBuilder,
-}
-
-impl RuntimeModelV2 {
-    fn from_language(language: &LanguageV2) -> Self {
-        Self {
-            parser: ParserModelV2::from_language(language),
-            language: LanguageModelV2::from_language(language),
-            structured_cst_model: StructuredCstModel::from_language(language),
-            ir_language_model: build_v2_ir_model(language),
         }
     }
 }

--- a/crates/codegen/runner/Cargo.toml
+++ b/crates/codegen/runner/Cargo.toml
@@ -14,6 +14,7 @@ infra_utils = { workspace = true }
 rayon = { workspace = true }
 solidity_language = { workspace = true }
 solidity_v2_language = { workspace = true }
+tera = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/codegen/runner/Cargo.toml
+++ b/crates/codegen/runner/Cargo.toml
@@ -11,8 +11,6 @@ anyhow = { workspace = true }
 codegen_generator = { workspace = true }
 codegen_spec = { workspace = true }
 infra_utils = { workspace = true }
-language_definition = { workspace = true }
-language_v2_definition = { workspace = true }
 rayon = { workspace = true }
 solidity_language = { workspace = true }
 solidity_v2_language = { workspace = true }

--- a/crates/codegen/runner/src/main.rs
+++ b/crates/codegen/runner/src/main.rs
@@ -1,108 +1,27 @@
+use std::path::Path;
+
 use anyhow::Result;
 use codegen_generator::{RuntimeModel, RuntimeModelV2};
 use codegen_spec::Spec;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::{CodegenFileSystem, CodegenRuntime};
-use language_definition::model::Language;
-use language_v2_definition::model::Language as LanguageV2;
+use infra_utils::paths::PathExtensions;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use solidity_language::SolidityDefinition;
 use solidity_v2_language::SolidityDefinition as SolidityDefinitionV2;
 
 fn main() {
     [
-        || generate_solidity_v1_spec(),
-        || generate_solidity_v1_builtins(),
-        || {
-            generate_tera_templates_v1(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinition::create(),
-                "slang_solidity",
-            )
-        },
-        || {
-            generate_tera_templates_v1(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinition::create(),
-                "solidity_cargo_wasm",
-            )
-        },
-        || {
-            generate_tera_templates_v1(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinition::create(),
-                "solidity_npm_package",
-            )
-        },
-        || {
-            generate_tera_templates_v1(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinition::create(),
-                "solidity_cargo_tests",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_ast",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_cst",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_parser",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_common",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_ir",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "slang_solidity_v2_semantic",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "solidity_v2_testing_utils",
-            )
-        },
-        || {
-            generate_tera_templates_v2(
-                &mut CodegenFileSystem::default(),
-                &SolidityDefinitionV2::create(),
-                "solidity_v2_cargo_tests",
-            )
-        },
+        || generate_solidity_spec_v1(),
+        || generate_solidity_builtins_v1(),
+        || generate_tera_templates_v1(),
+        || generate_tera_templates_v2(),
     ]
     .par_iter()
     .for_each(|op| op().unwrap());
 }
 
-fn generate_solidity_v1_spec() -> Result<()> {
+fn generate_solidity_spec_v1() -> Result<()> {
     let language = SolidityDefinition::create();
 
     let output_dir = CargoWorkspace::locate_source_crate("solidity_spec")?.join("generated");
@@ -110,7 +29,7 @@ fn generate_solidity_v1_spec() -> Result<()> {
     Spec::generate(language, &output_dir)
 }
 
-fn generate_solidity_v1_builtins() -> Result<()> {
+fn generate_solidity_builtins_v1() -> Result<()> {
     let language = SolidityDefinition::create();
     let contents = solidity_language::render_built_ins(&language)?;
 
@@ -121,24 +40,40 @@ fn generate_solidity_v1_builtins() -> Result<()> {
     fs.write_file_formatted(file_path, contents)
 }
 
-fn generate_tera_templates_v1(
-    fs: &mut CodegenFileSystem,
-    language: &Language,
-    crate_name: &str,
-) -> Result<()> {
-    let crate_dir = CargoWorkspace::locate_source_crate(crate_name)?;
-    let model = RuntimeModel::from_language(language)?;
+fn generate_tera_templates_v1() -> Result<()> {
+    let language = SolidityDefinition::create();
+    let model = RuntimeModel::from_language(&language)?;
 
-    CodegenRuntime::render_templates_in_place(fs, &crate_dir, model)
+    CodegenRuntime::render_templates_in_place(model, |template_path| {
+        classify_template(template_path) == TemplateVersion::V1
+    })
 }
 
-fn generate_tera_templates_v2(
-    fs: &mut CodegenFileSystem,
-    language: &LanguageV2,
-    crate_name: &str,
-) -> Result<()> {
-    let crate_dir = CargoWorkspace::locate_source_crate(crate_name)?;
-    let model = RuntimeModelV2::from_language(language);
+fn generate_tera_templates_v2() -> Result<()> {
+    let language = SolidityDefinitionV2::create();
+    let model = RuntimeModelV2::from_language(&language);
 
-    CodegenRuntime::render_templates_in_place(fs, &crate_dir, model)
+    CodegenRuntime::render_templates_in_place(model, |template_path| {
+        classify_template(template_path) == TemplateVersion::V2
+    })
+}
+
+#[derive(PartialEq, Eq)]
+enum TemplateVersion {
+    V1,
+    V2,
+}
+
+fn classify_template(template_path: &Path) -> TemplateVersion {
+    match template_path.strip_repo_root() {
+        Ok(p) if p.starts_with("crates/language/") || p.starts_with("crates/solidity/") => {
+            TemplateVersion::V1
+        }
+        Ok(p) if p.starts_with("crates/language-v2/") || p.starts_with("crates/solidity-v2/") => {
+            TemplateVersion::V2
+        }
+        _ => {
+            panic!("Cannot categorize template (Slang v1 or v2?): {template_path:?}");
+        }
+    }
 }

--- a/crates/codegen/runner/src/main.rs
+++ b/crates/codegen/runner/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use codegen_generator::RuntimeGenerator;
+use codegen_generator::{RuntimeModel, RuntimeModelV2};
 use codegen_spec::Spec;
 use infra_utils::cargo::CargoWorkspace;
-use infra_utils::codegen::CodegenFileSystem;
+use infra_utils::codegen::{CodegenFileSystem, CodegenRuntime};
 use language_definition::model::Language;
 use language_v2_definition::model::Language as LanguageV2;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -10,95 +10,88 @@ use solidity_language::SolidityDefinition;
 use solidity_v2_language::SolidityDefinition as SolidityDefinitionV2;
 
 fn main() {
-    // TODO(#1286):
-    // Using a cargo binary rather than a build task, to avoid invalidating the build tree when only the inputs change.
-    // This is a poor man's version of a "build script" that runs all codegen steps in parallel.
-    // It is temporary step, and should be simplified/removed in subsequent PRs.
-
     [
-        || generate_solidity_spec(),
+        || generate_solidity_v1_spec(),
+        || generate_solidity_v1_builtins(),
         || {
-            let mut fs = CodegenFileSystem::default();
-            let language = SolidityDefinition::create();
-
-            generate_in_place(&mut fs, &language, "slang_solidity")?;
-
-            generate_builtins(&mut fs, &language, "slang_solidity")?;
-
-            Ok(())
+            generate_tera_templates_v1(
+                &mut CodegenFileSystem::default(),
+                &SolidityDefinition::create(),
+                "slang_solidity",
+            )
         },
         || {
-            generate_in_place(
+            generate_tera_templates_v1(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinition::create(),
                 "solidity_cargo_wasm",
             )
         },
         || {
-            generate_in_place(
+            generate_tera_templates_v1(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinition::create(),
                 "solidity_npm_package",
             )
         },
         || {
-            generate_in_place(
+            generate_tera_templates_v1(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinition::create(),
                 "solidity_cargo_tests",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_ast",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_cst",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_parser",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_common",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_ir",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "slang_solidity_v2_semantic",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "solidity_v2_testing_utils",
             )
         },
         || {
-            generate_in_place_v2(
+            generate_tera_templates_v2(
                 &mut CodegenFileSystem::default(),
                 &SolidityDefinitionV2::create(),
                 "solidity_v2_cargo_tests",
@@ -109,7 +102,7 @@ fn main() {
     .for_each(|op| op().unwrap());
 }
 
-fn generate_solidity_spec() -> Result<()> {
+fn generate_solidity_v1_spec() -> Result<()> {
     let language = SolidityDefinition::create();
 
     let output_dir = CargoWorkspace::locate_source_crate("solidity_spec")?.join("generated");
@@ -117,35 +110,35 @@ fn generate_solidity_spec() -> Result<()> {
     Spec::generate(language, &output_dir)
 }
 
-fn generate_in_place(
+fn generate_solidity_v1_builtins() -> Result<()> {
+    let language = SolidityDefinition::create();
+    let contents = solidity_language::render_built_ins(&language)?;
+
+    let file_path = CargoWorkspace::locate_source_crate("slang_solidity")?
+        .join("src/bindings/built_ins.generated.rs");
+
+    let mut fs = CodegenFileSystem::default();
+    fs.write_file_formatted(file_path, contents)
+}
+
+fn generate_tera_templates_v1(
     fs: &mut CodegenFileSystem,
     language: &Language,
     crate_name: &str,
 ) -> Result<()> {
-    let the_crate = CargoWorkspace::locate_source_crate(crate_name)?;
+    let crate_dir = CargoWorkspace::locate_source_crate(crate_name)?;
+    let model = RuntimeModel::from_language(language)?;
 
-    RuntimeGenerator::generate_templates_in_place(language, fs, &the_crate)
+    CodegenRuntime::render_templates_in_place(fs, &crate_dir, model)
 }
 
-fn generate_in_place_v2(
+fn generate_tera_templates_v2(
     fs: &mut CodegenFileSystem,
     language: &LanguageV2,
     crate_name: &str,
 ) -> Result<()> {
     let crate_dir = CargoWorkspace::locate_source_crate(crate_name)?;
+    let model = RuntimeModelV2::from_language(language);
 
-    RuntimeGenerator::generate_templates_in_place_v2(language, fs, &crate_dir)
-}
-
-fn generate_builtins(
-    fs: &mut CodegenFileSystem,
-    language: &Language,
-    output_crate: &str,
-) -> Result<()> {
-    let file_path = CargoWorkspace::locate_source_crate(output_crate)?
-        .join("src/bindings/built_ins.generated.rs");
-
-    let contents = solidity_language::render_built_ins(language)?;
-
-    fs.write_file_formatted(file_path, contents)
+    CodegenRuntime::render_templates_in_place(fs, &crate_dir, model)
 }

--- a/crates/codegen/runner/src/main.rs
+++ b/crates/codegen/runner/src/main.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use anyhow::Result;
 use codegen_generator::{RuntimeModel, RuntimeModelV2};
 use codegen_spec::Spec;
@@ -10,18 +8,17 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use solidity_language::SolidityDefinition;
 use solidity_v2_language::SolidityDefinition as SolidityDefinitionV2;
 
-fn main() {
+fn main() -> Result<()> {
     [
-        || generate_solidity_spec_v1(),
-        || generate_solidity_builtins_v1(),
-        || generate_tera_templates_v1(),
-        || generate_tera_templates_v2(),
+        || generate_solidity_v1_spec(),
+        || generate_solidity_v1_builtins(),
+        || generate_tera_templates(),
     ]
     .par_iter()
-    .for_each(|op| op().unwrap());
+    .try_for_each(|op| op())
 }
 
-fn generate_solidity_spec_v1() -> Result<()> {
+fn generate_solidity_v1_spec() -> Result<()> {
     let language = SolidityDefinition::create();
 
     let output_dir = CargoWorkspace::locate_source_crate("solidity_spec")?.join("generated");
@@ -29,7 +26,7 @@ fn generate_solidity_spec_v1() -> Result<()> {
     Spec::generate(language, &output_dir)
 }
 
-fn generate_solidity_builtins_v1() -> Result<()> {
+fn generate_solidity_v1_builtins() -> Result<()> {
     let language = SolidityDefinition::create();
     let contents = solidity_language::render_built_ins(&language)?;
 
@@ -40,40 +37,33 @@ fn generate_solidity_builtins_v1() -> Result<()> {
     fs.write_file_formatted(file_path, contents)
 }
 
-fn generate_tera_templates_v1() -> Result<()> {
-    let language = SolidityDefinition::create();
-    let model = RuntimeModel::from_language(&language)?;
+fn generate_tera_templates() -> Result<()> {
+    let v1_context = {
+        let language = SolidityDefinition::create();
+        let model = RuntimeModel::from_language(&language)?;
 
-    CodegenRuntime::render_templates_in_place(model, |template_path| {
-        classify_template(template_path) == TemplateVersion::V1
+        let mut context = tera::Context::new();
+        context.insert("model", &model);
+        context
+    };
+
+    let v2_context = {
+        let language = SolidityDefinitionV2::create();
+        let model = RuntimeModelV2::from_language(&language);
+
+        let mut context = tera::Context::new();
+        context.insert("model", &model);
+        context
+    };
+
+    CodegenRuntime::render_templates_in_place(|template_path| {
+        match template_path.strip_repo_root() {
+            Ok(p) if p.starts_with("crates/language/") => &v1_context,
+            Ok(p) if p.starts_with("crates/solidity/") => &v1_context,
+            Ok(p) if p.starts_with("crates/language-v2/") => &v2_context,
+            Ok(p) if p.starts_with("crates/solidity-v2/") => &v2_context,
+
+            _ => panic!("Cannot categorize template: {template_path:?}"),
+        }
     })
-}
-
-fn generate_tera_templates_v2() -> Result<()> {
-    let language = SolidityDefinitionV2::create();
-    let model = RuntimeModelV2::from_language(&language);
-
-    CodegenRuntime::render_templates_in_place(model, |template_path| {
-        classify_template(template_path) == TemplateVersion::V2
-    })
-}
-
-#[derive(PartialEq, Eq)]
-enum TemplateVersion {
-    V1,
-    V2,
-}
-
-fn classify_template(template_path: &Path) -> TemplateVersion {
-    match template_path.strip_repo_root() {
-        Ok(p) if p.starts_with("crates/language/") || p.starts_with("crates/solidity/") => {
-            TemplateVersion::V1
-        }
-        Ok(p) if p.starts_with("crates/language-v2/") || p.starts_with("crates/solidity-v2/") => {
-            TemplateVersion::V2
-        }
-        _ => {
-            panic!("Cannot categorize template (Slang v1 or v2?): {template_path:?}");
-        }
-    }
 }

--- a/crates/infra/utils/src/codegen/runtime.rs
+++ b/crates/infra/utils/src/codegen/runtime.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use serde::Serialize;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::codegen::tera::TeraWrapper;
 use crate::codegen::CodegenFileSystem;
@@ -11,9 +11,8 @@ use crate::paths::{PathExtensions, PrivatePathExtensions};
 pub struct CodegenRuntime;
 
 impl CodegenRuntime {
-    pub fn render_templates_in_place(
-        model: impl Serialize,
-        filter: impl Fn(&Path) -> bool,
+    pub fn render_templates_in_place<'c>(
+        context_for: impl Fn(&Path) -> &'c tera::Context + Sync,
     ) -> Result<()> {
         let repo_root = Path::repo_root();
         let tera = TeraWrapper::new(&repo_root)?;
@@ -24,27 +23,20 @@ impl CodegenRuntime {
             // Templates starting with underscore are meant to contain common macros.
             // They are not rendered directly, but imported by other templates.
             !path.unwrap_name().starts_with('_'))
-            .filter(|path| filter(path))
             .collect::<Vec<_>>();
 
         assert!(
             !all_templates.is_empty(),
-            "No templates under {repo_root:?} matched the provided filter.",
+            "No templates under {repo_root:?}",
         );
 
-        let mut fs = CodegenFileSystem::default();
+        all_templates.par_iter().try_for_each(|template_path| {
+            let generated_path = Self::get_in_place_path(template_path);
+            let rendered = tera.render(template_path, context_for(template_path))?;
 
-        let mut context = tera::Context::new();
-        context.insert("model", &model);
-
-        for template_path in all_templates {
-            let generated_path = Self::get_in_place_path(&template_path);
-            let rendered = tera.render(&template_path, &context)?;
-
-            fs.write_file_formatted(&generated_path, rendered)?;
-        }
-
-        Ok(())
+            let mut fs = CodegenFileSystem::default();
+            fs.write_file_formatted(&generated_path, rendered)
+        })
     }
 
     fn get_in_place_path(template_path: &Path) -> PathBuf {

--- a/crates/infra/utils/src/codegen/runtime.rs
+++ b/crates/infra/utils/src/codegen/runtime.rs
@@ -6,17 +6,17 @@ use serde::Serialize;
 
 use crate::codegen::tera::TeraWrapper;
 use crate::codegen::CodegenFileSystem;
-use crate::paths::PathExtensions;
+use crate::paths::{PathExtensions, PrivatePathExtensions};
 
 pub struct CodegenRuntime;
 
 impl CodegenRuntime {
     pub fn render_templates_in_place(
-        fs: &mut CodegenFileSystem,
-        dir: &Path,
         model: impl Serialize,
+        filter: impl Fn(&Path) -> bool,
     ) -> Result<()> {
-        let tera = TeraWrapper::new(dir)?;
+        let repo_root = Path::repo_root();
+        let tera = TeraWrapper::new(&repo_root)?;
 
         let all_templates = tera
             .find_all_templates()?
@@ -24,12 +24,15 @@ impl CodegenRuntime {
             // Templates starting with underscore are meant to contain common macros.
             // They are not rendered directly, but imported by other templates.
             !path.unwrap_name().starts_with('_'))
+            .filter(|path| filter(path))
             .collect::<Vec<_>>();
 
         assert!(
             !all_templates.is_empty(),
-            "No templates found in directory: {dir:?}",
+            "No templates under {repo_root:?} matched the provided filter.",
         );
+
+        let mut fs = CodegenFileSystem::default();
 
         let mut context = tera::Context::new();
         context.insert("model", &model);

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.rs.jinja2
@@ -1,4 +1,4 @@
-{%- import "src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
+{%- import "crates/solidity-v2/outputs/cargo/tests/src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
 
 {{
     common::render_snapshot_tests(

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.rs.jinja2
@@ -1,4 +1,4 @@
-{%- import "src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
+{%- import "crates/solidity-v2/outputs/cargo/tests/src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
 
 {{
     common::render_snapshot_tests(

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.rs.jinja2
@@ -1,4 +1,4 @@
-{%- import "src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
+{%- import "crates/solidity-v2/outputs/cargo/tests/src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
 
 {{
     common::render_snapshot_tests(

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/builder.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/builder.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_builder.rs.jinja2" as builder -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_builder.rs.jinja2" as builder -%}
 {{ builder::render_builder(language='ir1_structured_ast') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/nodes.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/nodes.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_nodes.rs.jinja2" as nodes -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_nodes.rs.jinja2" as nodes -%}
 {{ nodes::render_nodes(language='ir1_structured_ast') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/rewriter.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/rewriter.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_rewriter.rs.jinja2" as rewriter -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_rewriter.rs.jinja2" as rewriter -%}
 {{ rewriter::render_rewriter(language='ir1_structured_ast') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/visitor.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir1_structured_ast/visitor.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_visitor.rs.jinja2" as visitor -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_visitor.rs.jinja2" as visitor -%}
 {{ visitor::render_visitor(language='ir1_structured_ast') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/nodes.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/nodes.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_nodes.rs.jinja2" as nodes -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_nodes.rs.jinja2" as nodes -%}
 {{ nodes::render_nodes(language='ir2_flat_contracts') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/transformer.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/transformer.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_transformer.rs.jinja2" as transformer -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_transformer.rs.jinja2" as transformer -%}
 {{ transformer::render_transformer(language='ir2_flat_contracts') }}

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/visitor.rs.jinja2
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ir2_flat_contracts/visitor.rs.jinja2
@@ -1,2 +1,2 @@
-{%- import "src/backend/ir/common/_visitor.rs.jinja2" as visitor -%}
+{%- import "crates/solidity/outputs/cargo/crate/src/backend/ir/common/_visitor.rs.jinja2" as visitor -%}
 {{ visitor::render_visitor(language='ir2_flat_contracts') }}

--- a/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/snapshots.rs.jinja2
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/snapshots.rs.jinja2
@@ -1,4 +1,4 @@
-{%- import "src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
+{%- import "crates/solidity/outputs/cargo/tests/src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
 
 {{
     common::render_snapshot_tests(

--- a/crates/solidity/outputs/cargo/tests/src/cst/cst_output/snapshots.rs.jinja2
+++ b/crates/solidity/outputs/cargo/tests/src/cst/cst_output/snapshots.rs.jinja2
@@ -1,4 +1,4 @@
-{%- import "src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
+{%- import "crates/solidity/outputs/cargo/tests/src/utils/_render_snapshot_tests.rs.jinja2" as common -%}
 
 {{
     common::render_snapshot_tests(


### PR DESCRIPTION
I Needed the ability to reference templates from other crates in a later PR downstream, so I'm doing the refactoring in a separate PR (this one) to make it easy to review:

- parallelize all rendering of all templates in the codebase in one pass, instead of per-crate.
- allow importing any templates with relative path from `REPO_ROOT`

As a nice side effect, `infra check codegen` (that runs on every file save) is now down to ~2s from ~6s.