### PR TITLE
fix(ci): save ci cache on every commit

### DIFF
--- a/.github/actions/cache/cargo-cooldown/restore/action.yml
+++ b/.github/actions/cache/cargo-cooldown/restore/action.yml
@@ -7,7 +7,8 @@ runs:
       uses: "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_CARGO_COOLDOWN_PATHS__ (keep in sync)
-        key: "cargo-cooldown-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"
+        key: "cargo-cooldown-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}"
         path: "**/target/slang-cache/cargo-cooldown-check"
         restore-keys: |
+          cargo-cooldown-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}-
           cargo-cooldown-${{ runner.os }}-v1-

--- a/.github/actions/cache/cargo-cooldown/save/action.yml
+++ b/.github/actions/cache/cargo-cooldown/save/action.yml
@@ -7,5 +7,5 @@ runs:
       uses: "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_CARGO_COOLDOWN_PATHS__ (keep in sync)
-        key: "cargo-cooldown-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"
+        key: "cargo-cooldown-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}"
         path: "**/target/slang-cache/cargo-cooldown-check"

--- a/.github/actions/cache/cargo-target/restore/action.yml
+++ b/.github/actions/cache/cargo-target/restore/action.yml
@@ -7,9 +7,10 @@ runs:
       uses: "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_CARGO_TARGET_PATHS__ (keep in sync)
-        key: "cargo-target-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}"
+        key: "cargo-target-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}"
         path: |
           target/
           crates/infra/cli/target/
         restore-keys: |
+          cargo-target-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-
           cargo-target-${{ runner.os }}-v1-

--- a/.github/actions/cache/cargo-target/save/action.yml
+++ b/.github/actions/cache/cargo-target/save/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_CARGO_TARGET_PATHS__ (keep in sync)
-        key: "cargo-target-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}"
+        key: "cargo-target-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}"
         path: |
           target/
           crates/infra/cli/target/

--- a/.github/actions/cache/dependencies/restore/action.yml
+++ b/.github/actions/cache/dependencies/restore/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_DEPENDENCIES_PATHS__ (keep in sync)
-        key: "dependencies-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('Pipfile.lock') }}"
+        key: "dependencies-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('Pipfile.lock') }}-${{ github.sha }}"
         path: |
           ~/.cache/hermit/
           ~/.local/share/virtualenvs/
@@ -16,4 +16,5 @@ runs:
           ~/.cargo/git/
           ~/.local/share/pnpm/store/
         restore-keys: |
+          dependencies-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('Pipfile.lock') }}-
           dependencies-${{ runner.os }}-v1-

--- a/.github/actions/cache/dependencies/save/action.yml
+++ b/.github/actions/cache/dependencies/save/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5.0.5
       with:
         # __SLANG_CI_CACHE_DEPENDENCIES_PATHS__ (keep in sync)
-        key: "dependencies-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('Pipfile.lock') }}"
+        key: "dependencies-${{ runner.os }}-v1-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('Pipfile.lock') }}-${{ github.sha }}"
         path: |
           ~/.cache/hermit/
           ~/.local/share/virtualenvs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   # Run on merge queue validation:
   merge_group: {}
 
-  # Run on pushes to 'main' to refresh the CI cache from scratch, so that it doesn't grow indefinitely:
+  # Run on 'main' pushes to refresh the CI caches that PRs restore from
   push:
     branches:
       - "main"


### PR DESCRIPTION
As seen on [these](https://github.com/NomicFoundation/slang/actions/runs/26832981726/job/79119162543) [runs](https://github.com/NomicFoundation/slang/actions/runs/26873932682/job/79256085728) sometimes the cache on `ci` fails to be saved if neither of the lock files change, however changes to other parts of the codebase (like the actual ci pipeline itself) should also update the cache.

This PR adds the commit sha as part of the key, adding also a new restore key consisting of only the lock files hashes (the key using the commit sha will almost always be a miss)