### PR TITLE
fix(ci): Don't reinstall `iai-callgrind-runner` unnecessarily

### DIFF
--- a/crates/infra/cli/src/commands/perf/binaries.rs
+++ b/crates/infra/cli/src/commands/perf/binaries.rs
@@ -8,7 +8,16 @@ pub fn install_bencher_cli() -> Result<()> {
 }
 
 pub fn install_iai_callgrind_runner() -> Result<()> {
-    CargoWorkspace::install_binary("iai-callgrind-runner")
+    // Specify the bin `iai-callgrind-runner` to avoid reinstalling every time due to a
+    // [cargo bug](https://github.com/rust-lang/cargo/issues/8703).
+    //
+    // `iai-callgrind-runner` defines two binaries, one of them behind a feature flag.
+    // When `cargo install` checks if binaries are up to date, it checks all of them,
+    // not only those enabled by the current feature flags, it then proceeds to install
+    // only the enabled ones.
+    // This causes a reinstall every time. By installing the single binary we need,
+    // we force cargo to only check if that one is up to date.
+    CargoWorkspace::install_binary_bin("iai-callgrind-runner", "iai-callgrind-runner")
 }
 
 pub fn install_valgrind() -> Result<()> {

--- a/crates/infra/utils/src/cargo/workspace.rs
+++ b/crates/infra/utils/src/cargo/workspace.rs
@@ -13,13 +13,26 @@ pub struct CargoWorkspace;
 
 impl CargoWorkspace {
     pub fn install_binary(crate_name: impl AsRef<str>) -> Result<()> {
-        let crate_name = crate_name.as_ref();
+        Self::install_binary_impl(crate_name.as_ref(), None)
+    }
 
+    /// Like [`Self::install_binary`], but restricts the install to a single binary via `--bin`.
+    ///
+    /// Useful to skip rebuilding unnecessarily due to a [cargo bug](https://github.com/rust-lang/cargo/issues/8703).
+    pub fn install_binary_bin(crate_name: impl AsRef<str>, bin: impl AsRef<str>) -> Result<()> {
+        Self::install_binary_impl(crate_name.as_ref(), Some(bin.as_ref()))
+    }
+
+    fn install_binary_impl(crate_name: &str, bin: Option<&str>) -> Result<()> {
         let manifest = WorkspaceManifest::load()?;
 
         let mut command = Command::new("cargo")
             .args(["install", crate_name])
             .flag("--locked");
+
+        if let Some(bin) = bin {
+            command = command.property("--bin", bin);
+        }
 
         let dependency = manifest.dependency(crate_name)?;
 


### PR DESCRIPTION
Due to https://github.com/rust-lang/cargo/issues/8703 `iai-callgrind-runner` is installed every time, even if the previous command just installed it.

This should make `infra perf` around 1min faster on CI.