### PR TITLE
[v2] Error on unresolvable or invalid inheritance bases

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -237,6 +237,46 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub mod slang_solidity_v2_common::diagnostics::kinds::resolution
+pub enum slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IdentifierNotFound(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound)
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::structure
 pub enum slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::FunctionNameMatchesContainer(slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer)
@@ -454,10 +494,52 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub mod slang_solidity_v2_common::diagnostics::kinds::type_system
+pub enum slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::InvalidBase(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase)
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub enum slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Compilation(slang_solidity_v2_common::diagnostics::kinds::compilation::CompilationDiagnosticKind)
+pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Resolution(slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind)
 pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Structure(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind)
 pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Syntax(slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind)
+pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::TypeSystem(slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -469,6 +551,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::compilati
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::compilation::MissingFile) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -489,6 +575,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::U
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -578,6 +668,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::UnresolvedImport::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer::message(&self) -> alloc::string::String
@@ -618,6 +716,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::nodes
 #[repr(transparent)] pub struct slang_solidity_v2_common::nodes::NodeId(_)
 impl core::clone::Clone for slang_solidity_v2_common::nodes::NodeId

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/mod.rs
@@ -1,13 +1,17 @@
 mod utils;
 
 pub mod compilation;
+pub mod resolution;
 pub mod structure;
 pub mod syntax;
+pub mod type_system;
 
 use compilation::CompilationDiagnosticKind;
+use resolution::ResolutionDiagnosticKind;
 use serde::Serialize;
 use structure::StructureDiagnosticKind;
 use syntax::SyntaxDiagnosticKind;
+use type_system::TypeSystemDiagnosticKind;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
 
@@ -23,5 +27,11 @@ define_diagnostic_kind! {
         Syntax(SyntaxDiagnosticKind),
         /// A diagnostic about structural shape.
         Structure(StructureDiagnosticKind),
+        /// A diagnostic produced for undeclared identifiers, duplicate
+        /// definitions, import failures, shadowing, ambiguous references
+        /// and scope errors.
+        Resolution(ResolutionDiagnosticKind),
+        /// A diagnostic about the type system.
+        TypeSystem(TypeSystemDiagnosticKind),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_found.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_found.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an identifier could not be found.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IdentifierNotFound;
+
+impl DiagnosticExtensions for IdentifierNotFound {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "resolution/identifier-not-found"
+    }
+
+    fn message(&self) -> String {
+        "Identifier not found.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/mod.rs
@@ -1,0 +1,20 @@
+mod identifier_not_found;
+
+pub use identifier_not_found::IdentifierNotFound;
+use serde::Serialize;
+
+use crate::diagnostics::kinds::utils::define_diagnostic_kind;
+use crate::diagnostics::kinds::DiagnosticKind;
+
+define_diagnostic_kind! {
+    parent_kind = DiagnosticKind::Resolution;
+
+    /// Group of diagnostics for undeclared identifiers, duplicate
+    /// definitions, import failures, shadowing, ambiguous references
+    /// and scope errors.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+    pub enum ResolutionDiagnosticKind {
+        /// An identifier could not be resolved.
+        IdentifierNotFound(IdentifierNotFound),
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/invalid_base.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/invalid_base.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a base in an inheritance list resolves to something
+/// that is not a contract or interface (for example a library, struct, or free
+/// function), and therefore cannot be used as a base.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InvalidBase;
+
+impl DiagnosticExtensions for InvalidBase {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/invalid-base"
+    }
+
+    fn message(&self) -> String {
+        "Only a contract or interface can be used as a base.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
@@ -1,0 +1,20 @@
+mod invalid_base;
+
+pub use invalid_base::InvalidBase;
+use serde::Serialize;
+
+use crate::diagnostics::kinds::utils::define_diagnostic_kind;
+use crate::diagnostics::kinds::DiagnosticKind;
+
+define_diagnostic_kind! {
+    parent_kind = DiagnosticKind::TypeSystem;
+
+    /// Group of diagnostics about the type system — type mismatches, invalid
+    /// conversions, operator type errors, function-call type mismatches, and ABI
+    /// encoding constraints that are properties of a type.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+    pub enum TypeSystemDiagnosticKind {
+        /// A base in an inheritance list is not a contract or interface.
+        InvalidBase(InvalidBase),
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -72,7 +72,7 @@ impl SemanticContext {
         let mut types = TypeRegistry::default();
 
         p1_collect_definitions::run(files, &mut binder, diagnostics);
-        p2_linearise_contracts::run(files, &mut binder);
+        p2_linearise_contracts::run(files, &mut binder, diagnostics);
         p3_type_definitions::run(files, &mut binder, &mut types, language_version);
         p4_resolve_references::run(files, &mut binder, &mut types, language_version);
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase;
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -11,27 +14,49 @@ mod c3;
 
 /// In this pass we collect all bases of contracts and interfaces and then
 /// compute the linearisation for each of them.
-pub fn run(files: &[impl SemanticFile], binder: &mut Binder) {
+pub fn run(
+    files: &[impl SemanticFile],
+    binder: &mut Binder,
+    diagnostics: &mut DiagnosticCollection,
+) {
     for file in files {
-        Pass::visit_file_collect_bases(file, binder);
+        Pass::visit_file_collect_bases(file, binder, diagnostics);
     }
     for file in files {
-        Pass::visit_file_linearise_contracts(file, binder);
+        Pass::visit_file_linearise_contracts(file, binder, diagnostics);
     }
 }
 
 struct Pass<'a> {
     binder: &'a mut Binder,
+    diagnostics: &'a mut DiagnosticCollection,
+    file_id: String,
 }
 
 impl<'a> Pass<'a> {
-    fn visit_file_collect_bases(file: &impl SemanticFile, binder: &'a mut Binder) {
-        let mut pass = Self { binder };
+    fn visit_file_collect_bases(
+        file: &impl SemanticFile,
+        binder: &'a mut Binder,
+        diagnostics: &'a mut DiagnosticCollection,
+    ) {
+        let mut pass = Self {
+            binder,
+            diagnostics,
+            file_id: file.id().to_owned(),
+        };
         pass.collect_bases_from(file.ir_root());
     }
 
-    fn visit_file_linearise_contracts(file: &impl SemanticFile, binder: &'a mut Binder) {
-        let mut pass = Self { binder };
+    fn visit_file_linearise_contracts(
+        file: &impl SemanticFile,
+        binder: &'a mut Binder,
+        diagnostics: &'a mut DiagnosticCollection,
+    ) {
+        let mut pass = Self {
+            binder,
+            diagnostics,
+            file_id: file.id().to_owned(),
+        };
         pass.linearise_contracts_from(file.ir_root());
     }
 
@@ -80,22 +105,38 @@ impl<'a> Pass<'a> {
         types: &ir::InheritanceTypes,
         scope_id: ScopeId,
     ) -> Vec<NodeId> {
-        // TODO(validation) SDR[23]: check that we are able to resolve all bases as
-        // otherwise we end up with a short list saved in the definition
-        types
-            .iter()
-            .filter_map(|inheritance_type| {
-                resolve_identifier_path_in_scope(self.binder, &inheritance_type.type_name, scope_id)
-                    .as_definition_id()
-                    .filter(|definition_id| {
-                        // bases are either contracts or interfaces, discard anything else
-                        matches!(
-                            self.binder.find_definition_by_id(*definition_id).unwrap(),
-                            Definition::Contract(_) | Definition::Interface(_)
-                        )
-                    })
-            })
-            .collect()
+        let mut resolved_bases = Vec::new();
+        for inheritance_type in types {
+            let resolution = resolve_identifier_path_in_scope(
+                self.binder,
+                &inheritance_type.type_name,
+                scope_id,
+            );
+            match resolution.as_definition_id() {
+                None => {
+                    self.diagnostics.push(
+                        self.file_id.clone(),
+                        inheritance_type.range.clone(),
+                        IdentifierNotFound,
+                    );
+                }
+                Some(definition_id) => {
+                    match self.binder.find_definition_by_id(definition_id).unwrap() {
+                        Definition::Contract(_) | Definition::Interface(_) => {
+                            resolved_bases.push(definition_id);
+                        }
+                        _ => {
+                            self.diagnostics.push(
+                                self.file_id.clone(),
+                                inheritance_type.range.clone(),
+                                InvalidBase,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        resolved_bases
     }
 
     fn linearise_contracts_from(&mut self, source_unit: &ir::SourceUnit) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind;
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::NodeIdGenerator;
@@ -30,11 +32,11 @@ contract Test is Base layout at 0 {}
     let mut binder = Binder::default();
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
 
     // Verify definitions were collected
     assert_eq!(2, binder.definitions().len());
@@ -93,11 +95,11 @@ interface A is C {}
     let mut binder = Binder::default();
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
 
     let contract_to_bases = get_contract_to_bases_map(&binder);
 
@@ -147,7 +149,20 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
+
+    // `Foo` is a library which can't be used as a base, so check if the
+    // expected diagnostic was emitted.
+    let emitted: Vec<_> = diagnostics.iter().collect();
+    assert_eq!(
+        emitted.len(),
+        1,
+        "expected one diagnostic, got: {emitted:?}"
+    );
+    assert!(matches!(
+        emitted[0].kind(),
+        DiagnosticKind::TypeSystem(TypeSystemDiagnosticKind::InvalidBase(_))
+    ));
 
     let contract_to_bases = get_contract_to_bases_map(&binder);
 
@@ -198,11 +213,11 @@ contract Test is Base {
 
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
 
     let types_before = types.iter_types().count();
     p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
@@ -257,11 +272,11 @@ contract Test is Base {
 
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
     p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -32,11 +32,11 @@ fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
     let mut types = TypeRegistry::default();
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
     );
-    p2_linearise_contracts::run(&files, &mut binder);
     p3_type_definitions::run(&files, &mut binder, &mut types, language_version);
     p4_resolve_references::run(&files, &mut binder, &mut types, language_version);
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -18,6 +18,19 @@ mod compilation {
     }
 }
 
+mod resolution {
+    use super::*;
+
+    mod identifier_not_found {
+        use super::*;
+
+        #[test]
+        fn unresolved_base() -> Result<()> {
+            run("resolution/identifier_not_found", "unresolved_base")
+        }
+    }
+}
+
 mod structure {
     use super::*;
 
@@ -123,5 +136,23 @@ mod syntax {
     #[test]
     fn unsupported_syntax() -> Result<()> {
         run("syntax", "unsupported_syntax")
+    }
+}
+
+mod type_system {
+    use super::*;
+
+    mod invalid_base {
+        use super::*;
+
+        #[test]
+        fn function() -> Result<()> {
+            run("type_system/invalid_base", "function")
+        }
+
+        #[test]
+        fn library() -> Result<()> {
+            run("type_system/invalid_base", "library")
+        }
     }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Identifier not found.
+   ╭─[input.sol:4:15]
+   │
+ 4 │ contract C is Missing {}
+   │               ───┬───  
+   │                  ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 7920] Error: Identifier not found or not unique.
+   ╭─[input.sol:4:15]
+   │
+ 4 │ contract C is Missing {}
+   │               ───┬───  
+   │                  ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_not_found/unresolved_base/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C is Missing {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a contract or interface can be used as a base.
+   ╭─[input.sol:6:15]
+   │
+ 6 │ contract C is someFreeFunction {}
+   │               ────────┬───────  
+   │                       ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8758] Error: Contract expected.
+   ╭─[input.sol:6:15]
+   │
+ 6 │ contract C is someFreeFunction {}
+   │               ────────┬───────  
+   │                       ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/function/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function someFreeFunction() {}
+
+contract C is someFreeFunction {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a contract or interface can be used as a base.
+   ╭─[input.sol:6:15]
+   │
+ 6 │ contract C is L {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2571] Error: Libraries cannot be inherited from.
+   ╭─[input.sol:6:15]
+   │
+ 6 │ contract C is L {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/invalid_base/library/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+library L {}
+
+contract C is L {}


### PR DESCRIPTION
Add a diagnostic when encountering unresolvable or invalid inheritance bases.
Adds two diagnostic groups: Resolution (IdentifierNotFound) for bases that don't resolve, and Type System (InvalidBase) for bases that resolve to a non-contract/interface (e.g. a library, struct, or free function).