### PR TITLE
[v2] Error when contract linearisation is impossible

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -312,6 +312,8 @@ pub enum slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnos
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicConstantDefinition(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition)
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicConstantDependency(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency)
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicDependencyValidatorExhausted(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted)
+pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicInheritance(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance)
+pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::LinearisationImpossible(slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
@@ -323,6 +325,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic:
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
@@ -393,6 +399,44 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::structure
 pub enum slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::FunctionNameMatchesContainer(slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer)
@@ -749,6 +793,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic:
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -902,6 +950,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicInheritance::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpossible::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/cyclic_inheritance.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/cyclic_inheritance.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a contract's or interface's inheritance hierarchy
+/// contains a cycle.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CyclicInheritance;
+
+impl DiagnosticExtensions for CyclicInheritance {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "semantic/cyclic-inheritance"
+    }
+
+    fn message(&self) -> String {
+        "Circular inheritance is not allowed.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/linearisation_impossible.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/linearisation_impossible.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when the C3 linearisation of a contract's or interface's
+/// inheritance hierarchy cannot be computed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LinearisationImpossible;
+
+impl DiagnosticExtensions for LinearisationImpossible {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "semantic/linearisation-impossible"
+    }
+
+    fn message(&self) -> String {
+        "Linearization of inheritance graph is impossible.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/mod.rs
@@ -1,10 +1,14 @@
 mod cyclic_constant_definition;
 mod cyclic_constant_dependency;
 mod cyclic_dependency_validator_exhausted;
+mod cyclic_inheritance;
+mod linearisation_impossible;
 
 pub use cyclic_constant_definition::CyclicConstantDefinition;
 pub use cyclic_constant_dependency::CyclicConstantDependency;
 pub use cyclic_dependency_validator_exhausted::CyclicDependencyValidatorExhausted;
+pub use cyclic_inheritance::CyclicInheritance;
+pub use linearisation_impossible::LinearisationImpossible;
 use serde::Serialize;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
@@ -23,5 +27,10 @@ define_diagnostic_kind! {
         CyclicConstantDependency(CyclicConstantDependency),
         /// Constant dependency graph traversal exceeded the depth limit.
         CyclicDependencyValidatorExhausted(CyclicDependencyValidatorExhausted),
+        /// A contract's or interface's inheritance hierarchy contains a cycle.
+        CyclicInheritance(CyclicInheritance),
+        /// The inheritance hierarchy cannot be linearised into a consistent
+        /// method resolution order.
+        LinearisationImpossible(LinearisationImpossible),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/c3.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/c3.rs
@@ -3,6 +3,14 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use slang_solidity_v2_common::collections::Map;
+/// The reason why linearisation failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LinearisationFailure {
+    /// The inheritance graph contains a cycle.
+    Cycle,
+    /// The base orderings are inconsistent.
+    Inconsistent,
+}
 
 /// Produces a linearisation of a hierarchy of items using the C3 linearisation
 /// algorithm. Given an item `A` with parents `(B1, B2)` in that order, the
@@ -18,7 +26,7 @@ use slang_solidity_v2_common::collections::Map;
 pub(crate) fn linearise<Item: Clone + Debug + Eq + Hash + PartialEq>(
     target: &Item,
     parents: &Map<Item, Vec<Item>>,
-) -> Option<Vec<Item>> {
+) -> Result<Vec<Item>, LinearisationFailure> {
     let mut linearisations: Map<Item, Vec<Item>> = Map::default();
 
     // Keeps a running queue of pending linearisations.
@@ -52,7 +60,7 @@ pub(crate) fn linearise<Item: Clone + Debug + Eq + Hash + PartialEq>(
         }
         if merge_set.len() == item_parents.len() {
             merge_set.push(item_parents.clone());
-            let merge_result = merge(merge_set)?;
+            let merge_result = merge(merge_set).ok_or(LinearisationFailure::Inconsistent)?;
 
             let mut result = Vec::new();
             result.push(item.clone());
@@ -73,7 +81,7 @@ pub(crate) fn linearise<Item: Clone + Debug + Eq + Hash + PartialEq>(
                     if *check_item == item {
                         if items_linearised == linearisations.len() {
                             // no progress since last checkpoint; this indicates a cycle
-                            return None;
+                            return Err(LinearisationFailure::Cycle);
                         }
                         // Update progress and re-try
                         checkpoint = Some((item.clone(), linearisations.len()));
@@ -88,7 +96,9 @@ pub(crate) fn linearise<Item: Clone + Debug + Eq + Hash + PartialEq>(
         }
     }
 
-    linearisations.remove(target)
+    linearisations
+        .remove(target)
+        .ok_or(LinearisationFailure::Inconsistent)
 }
 
 /// Merges the items in the set in C3 linearisation order. Returns None if
@@ -203,8 +213,8 @@ mod tests {
         parents.insert('D', vec!['B', 'C']);
         parents.insert('E', vec!['C', 'B']);
 
-        assert_eq!(Some(vec!['D', 'B', 'C', 'A']), linearise(&'D', &parents));
-        assert_eq!(Some(vec!['E', 'C', 'B', 'A']), linearise(&'E', &parents));
+        assert_eq!(Ok(vec!['D', 'B', 'C', 'A']), linearise(&'D', &parents));
+        assert_eq!(Ok(vec!['E', 'C', 'B', 'A']), linearise(&'E', &parents));
     }
 
     #[test]
@@ -214,7 +224,10 @@ mod tests {
         parents.insert('A', vec!['X']);
         parents.insert('C', vec!['X', 'A']);
 
-        assert_eq!(None, linearise(&'C', &parents));
+        assert_eq!(
+            Err(LinearisationFailure::Inconsistent),
+            linearise(&'C', &parents)
+        );
     }
 
     #[test]
@@ -223,8 +236,8 @@ mod tests {
         parents.insert('B', vec!['A']);
         parents.insert('A', vec!['B']);
 
-        assert_eq!(None, linearise(&'A', &parents));
-        assert_eq!(None, linearise(&'B', &parents));
+        assert_eq!(Err(LinearisationFailure::Cycle), linearise(&'A', &parents));
+        assert_eq!(Err(LinearisationFailure::Cycle), linearise(&'B', &parents));
     }
 
     #[test]
@@ -234,8 +247,8 @@ mod tests {
         parents.insert('Y', vec!['Z']);
         parents.insert('Z', vec!['X']);
 
-        assert_eq!(None, linearise(&'X', &parents));
-        assert_eq!(None, linearise(&'Y', &parents));
-        assert_eq!(None, linearise(&'Z', &parents));
+        assert_eq!(Err(LinearisationFailure::Cycle), linearise(&'X', &parents));
+        assert_eq!(Err(LinearisationFailure::Cycle), linearise(&'Y', &parents));
+        assert_eq!(Err(LinearisationFailure::Cycle), linearise(&'Z', &parents));
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
@@ -1,5 +1,8 @@
 use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound;
+use slang_solidity_v2_common::diagnostics::kinds::semantic::{
+    CyclicInheritance, LinearisationImpossible,
+};
 use slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
@@ -140,21 +143,31 @@ impl<'a> Pass<'a> {
 
     fn linearise_contracts_from(&mut self, source_unit: &ir::SourceUnit) {
         for member in &source_unit.members {
-            let node_id = match member {
+            let (node_id, range) = match member {
                 ir::SourceUnitMember::ContractDefinition(contract_definition) => {
-                    contract_definition.id()
+                    (contract_definition.id(), contract_definition.range.clone())
                 }
-                ir::SourceUnitMember::InterfaceDefinition(interface_definition) => {
-                    interface_definition.id()
-                }
+                ir::SourceUnitMember::InterfaceDefinition(interface_definition) => (
+                    interface_definition.id(),
+                    interface_definition.range.clone(),
+                ),
                 _ => continue,
             };
             let parents = self.find_contract_bases_recursively(node_id);
-            if let Some(linearisation) = c3::linearise(&node_id, &parents) {
-                self.binder.insert_linearised_bases(node_id, linearisation);
-            } else {
-                // TODO(validation) SDR[24]: linearisation failed, so emit an error
-                self.binder.insert_linearised_bases(node_id, Vec::new());
+            match c3::linearise(&node_id, &parents) {
+                Ok(linearisation) => {
+                    self.binder.insert_linearised_bases(node_id, linearisation);
+                }
+                Err(c3::LinearisationFailure::Cycle) => {
+                    self.diagnostics
+                        .push(self.file_id.clone(), range, CyclicInheritance);
+                    self.binder.insert_linearised_bases(node_id, Vec::new());
+                }
+                Err(c3::LinearisationFailure::Inconsistent) => {
+                    self.diagnostics
+                        .push(self.file_id.clone(), range, LinearisationImpossible);
+                    self.binder.insert_linearised_bases(node_id, Vec::new());
+                }
             }
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -120,6 +120,45 @@ interface A is C {}
 }
 
 #[test]
+fn test_linearise_with_forward_reference() {
+    // A base is referenced before it is defined. solc emits an error here
+    // (`TypeError 2449: Definition of base has to precede definition of derived
+    // contract`), but slang does not, as its linearisation pass is
+    // order-independent, so it accepts the forward reference and computes the
+    // linearisation `[D, B]`.
+    const CONTENTS: &str = r#"
+contract D is B {}
+contract B {}
+"#;
+
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file(
+        "test.sol",
+        CONTENTS,
+        &mut id_generator,
+        LanguageVersion::LATEST,
+    );
+
+    let files = [file];
+    let mut binder = Binder::default();
+    let mut diagnostics = DiagnosticCollection::default();
+    p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
+    assert!(
+        diagnostics.is_empty(),
+        "Semantic diagnostics: {diagnostics:?}"
+    );
+
+    let contract_to_bases = get_contract_to_bases_map(&binder);
+
+    let mut expected = Map::default();
+    expected.insert("D".to_string(), vec!["D".to_string(), "B".to_string()]);
+    expected.insert("B".to_string(), vec!["B".to_string()]);
+
+    assert_eq!(contract_to_bases, expected);
+}
+
+#[test]
 fn test_linearise_with_invalid_input() {
     const CONTENTS: &str = r#"
 contract Base {}

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -503,6 +503,44 @@ mod semantic {
             }
         }
     }
+
+    mod cyclic_inheritance {
+        use super::*;
+
+        #[test]
+        fn cross_file() -> Result<()> {
+            run("semantic/cyclic_inheritance", "cross_file")
+        }
+
+        #[test]
+        fn deep() -> Result<()> {
+            run("semantic/cyclic_inheritance", "deep")
+        }
+
+        #[test]
+        fn mutual() -> Result<()> {
+            run("semantic/cyclic_inheritance", "mutual")
+        }
+
+        #[test]
+        fn self_inheritance() -> Result<()> {
+            run("semantic/cyclic_inheritance", "self_inheritance")
+        }
+    }
+
+    mod linearisation_impossible {
+        use super::*;
+
+        #[test]
+        fn contract() -> Result<()> {
+            run("semantic/linearisation_impossible", "contract")
+        }
+
+        #[test]
+        fn interface() -> Result<()> {
+            run("semantic/linearisation_impossible", "interface")
+        }
+    }
 }
 
 mod structure {

--- a/crates/solidity-v2/testing/snapshots/binder_output/contracts/cyclic_inheritance/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/contracts/cyclic_inheritance/generated/0.8.0-failure.txt
@@ -1,5 +1,30 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+Parse errors:
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract A is A {} // this should bind even though it makes no sense
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:3:1]
+   │
+ 3 │ contract B is C {} // this should bind even though it makes no sense
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ contract C is B {} // this should bind even though it makes no sense
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+------------------------------------------------------------------------
+
 Definitions (3):
 - Def: #1 ["A" @ input.sol:1:10] (contract)
 - Def: #2 ["B" @ input.sol:3:10] (contract)

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+Error: Circular inheritance is not allowed.
+   ╭─[a.sol:6:1]
+   │
+ 6 │ contract A is B {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+Error: Circular inheritance is not allowed.
+   ╭─[b.sol:6:1]
+   │
+ 6 │ contract B is C {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+Error: Circular inheritance is not allowed.
+   ╭─[c.sol:6:1]
+   │
+ 6 │ contract C is A {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2449] Error: Definition of base has to precede definition of derived contract
+   ╭─[c.sol:6:15]
+   │
+ 6 │ contract C is A {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/cross_file/input.sol
@@ -1,0 +1,23 @@
+// ---- path: a.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import {B} from "./b.sol";
+
+contract A is B {}
+
+// ---- path: b.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import {C} from "./c.sol";
+
+contract B is C {}
+
+// ---- path: c.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import {A} from "./a.sol";
+
+contract C is A {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ contract X is Y {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:5:1]
+   │
+ 5 │ contract Y is Z {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ contract Z is X {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2449] Error: Definition of base has to precede definition of derived contract
+   ╭─[input.sol:4:15]
+   │
+ 4 │ contract X is Y {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/deep/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract X is Y {}
+contract Y is Z {}
+contract Z is X {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ contract A is B {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:5:1]
+   │
+ 5 │ contract B is A {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2449] Error: Definition of base has to precede definition of derived contract
+   ╭─[input.sol:4:15]
+   │
+ 4 │ contract A is B {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/mutual/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A is B {}
+contract B is A {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Circular inheritance is not allowed.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ contract A is A {}
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2449] Error: Definition of base has to precede definition of derived contract
+   ╭─[input.sol:4:15]
+   │
+ 4 │ contract A is A {}
+   │               ┬  
+   │               ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/cyclic_inheritance/self_inheritance/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A is A {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Linearization of inheritance graph is impossible.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ contract ListsBoth is Sub, ParentA, ParentB {}
+   │ ───────────────────────┬──────────────────────  
+   │                        ╰──────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5005] Error: Linearization of inheritance graph impossible
+   ╭─[input.sol:8:1]
+   │
+ 8 │ contract ListsBoth is Sub, ParentA, ParentB {}
+   │ ───────────────────────┬──────────────────────  
+   │                        ╰──────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/contract/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+interface ParentA {}
+interface ParentB {}
+interface Sub is ParentA, ParentB {}
+
+contract ListsBoth is Sub, ParentA, ParentB {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Linearization of inheritance graph is impossible.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ interface ListsA is Sub, ParentA {}
+   │ ─────────────────┬─────────────────  
+   │                  ╰─────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5005] Error: Linearization of inheritance graph impossible
+   ╭─[input.sol:8:1]
+   │
+ 8 │ interface ListsA is Sub, ParentA {}
+   │ ─────────────────┬─────────────────  
+   │                  ╰─────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/linearisation_impossible/interface/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+interface ParentA {}
+interface ParentB {}
+interface Sub is ParentA, ParentB {}
+
+interface ListsA is Sub, ParentA {}


### PR DESCRIPTION
Add two diagnostics from the linearisation pass:
1) cyclic-inheritance for inheritance cycles.
2) linearisation-impossible for inconsistent C3 orderings.
Add a binder test for the forward-reference case, where solc errors but slang intentionally accepts it.