### PR TITLE
feat(diagnostics): diagnose duplicate virtual specifiers

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -241,6 +241,7 @@ pub mod slang_solidity_v2_common::diagnostics::kinds::syntax
 pub enum slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExtraTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleMutabilitySpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers)
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleVirtualSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedEof(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnsupportedSyntax(slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedSyntax)
@@ -253,6 +254,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
@@ -309,6 +312,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::expected: alloc::collections::btree::set::BTreeSet<slang_solidity_v2_common::terminals::TerminalKind>
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
@@ -388,6 +410,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -493,6 +517,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
@@ -1,11 +1,13 @@
 mod extra_terminal;
 mod multiple_mutability_specifiers;
+mod multiple_virtual_specifiers;
 mod unexpected_eof;
 mod unexpected_terminal;
 mod unsupported_syntax;
 
 pub use extra_terminal::ExtraTerminal;
 pub use multiple_mutability_specifiers::MultipleMutabilitySpecifiers;
+pub use multiple_virtual_specifiers::MultipleVirtualSpecifiers;
 use serde::Serialize;
 pub use unexpected_eof::UnexpectedEof;
 pub use unexpected_terminal::UnexpectedTerminal;
@@ -32,5 +34,8 @@ define_diagnostic_kind! {
 
         /// More than one mutability specifier was provided on a definition.
         MultipleMutabilitySpecifiers(MultipleMutabilitySpecifiers),
+
+        /// More than one `virtual` specifier was provided on a definition.
+        MultipleVirtualSpecifiers(MultipleVirtualSpecifiers),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_virtual_specifiers.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_virtual_specifiers.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a definition carries more than one `virtual`
+/// specifier.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MultipleVirtualSpecifiers;
+
+impl DiagnosticExtensions for MultipleVirtualSpecifiers {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "syntax/multiple-virtual-specifiers"
+    }
+
+    fn message(&self) -> String {
+        "Only a single virtual specifier can be provided.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers;
+use slang_solidity_v2_common::diagnostics::kinds::syntax::{
+    MultipleMutabilitySpecifiers, MultipleVirtualSpecifiers,
+};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
@@ -215,13 +217,15 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let mutability = self
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::NonPayable);
-        let virtual_keyword = source.attributes.elements.iter().find_map(|attribute| {
-            if let input::FunctionAttribute::VirtualKeyword(virtual_keyword) = attribute {
-                Some(self.build_virtual_keyword(virtual_keyword))
-            } else {
-                None
-            }
-        });
+
+        let virtual_keyword =
+            self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
+                if let input::FunctionAttribute::VirtualKeyword(virtual_keyword) = attribute {
+                    Some(virtual_keyword)
+                } else {
+                    None
+                }
+            }));
         // TODO(validation) SDR[9]: function definitions can have only a single override specifier
         let override_specifier = self.function_override_specifier(&source.attributes);
         let modifier_invocations = self.function_modifier_invocations(&source.attributes);
@@ -604,13 +608,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let mutability = self
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::NonPayable);
-        let virtual_keyword = source.attributes.elements.iter().find_map(|attribute| {
-            if let input::FallbackFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute {
-                Some(self.build_virtual_keyword(virtual_keyword))
-            } else {
-                None
-            }
-        });
+        let virtual_keyword =
+            self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
+                if let input::FallbackFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute
+                {
+                    Some(virtual_keyword)
+                } else {
+                    None
+                }
+            }));
+
         let override_specifier = self.fallback_function_override_specifier(&source.attributes);
         let modifier_invocations = self.fallback_function_modifier_invocations(&source.attributes);
         let returns = source
@@ -680,13 +687,15 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let mutability = self
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::Payable);
-        let virtual_keyword = source.attributes.elements.iter().find_map(|attribute| {
-            if let input::ReceiveFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute {
-                Some(self.build_virtual_keyword(virtual_keyword))
-            } else {
-                None
-            }
-        });
+        let virtual_keyword =
+            self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
+                if let input::ReceiveFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute
+                {
+                    Some(virtual_keyword)
+                } else {
+                    None
+                }
+            }));
         let override_specifier = self.receive_function_override_specifier(&source.attributes);
         let modifier_invocations = self.receive_function_modifier_invocations(&source.attributes);
         let returns = None;
@@ -752,14 +761,15 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let visibility = output::FunctionVisibility::Internal;
         // mutability is irrelevant for modifiers
         let mutability = output::FunctionMutability::NonPayable;
-        // TODO(validation) SDR[1730]: check for duplicate attributes (virtual, ...)
-        let virtual_keyword = source.attributes.elements.iter().find_map(|attribute| {
-            if let input::ModifierAttribute::VirtualKeyword(virtual_keyword) = attribute {
-                Some(self.build_virtual_keyword(virtual_keyword))
-            } else {
-                None
-            }
-        });
+        // TODO(validation) SDR[1730]: modifiers can have only a single override specifier
+        let virtual_keyword =
+            self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
+                if let input::ModifierAttribute::VirtualKeyword(virtual_keyword) = attribute {
+                    Some(virtual_keyword)
+                } else {
+                    None
+                }
+            }));
         let override_specifier = self.modifier_override_specifier(&source.attributes);
         let modifier_invocations = Vec::new();
         let returns = None;
@@ -998,5 +1008,25 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         }
 
         result
+    }
+
+    /// Extracts and transforms the first virtual keyword, emitting an error
+    /// for any subsequent ones.
+    fn extract_first_virtual<'a>(
+        &mut self,
+        virtual_kws: impl IntoIterator<Item = &'a input::VirtualKeyword>,
+    ) -> Option<output::VirtualKeyword> {
+        let mut virtual_kws = virtual_kws.into_iter();
+        let first = self.build_virtual_keyword(virtual_kws.next()?);
+
+        for keyword in virtual_kws {
+            self.diagnostics.push(
+                self.file_id.to_owned(),
+                keyword.calculate_text_range().unwrap(),
+                MultipleVirtualSpecifiers,
+            );
+        }
+
+        Some(first)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -58,6 +58,30 @@ mod syntax {
         }
     }
 
+    mod multiple_virtual_specifiers {
+        use super::*;
+
+        #[test]
+        fn fallback_functions() -> Result<()> {
+            run("syntax/multiple_virtual_specifiers", "fallback_functions")
+        }
+
+        #[test]
+        fn functions() -> Result<()> {
+            run("syntax/multiple_virtual_specifiers", "functions")
+        }
+
+        #[test]
+        fn modifiers() -> Result<()> {
+            run("syntax/multiple_virtual_specifiers", "modifiers")
+        }
+
+        #[test]
+        fn receive_functions() -> Result<()> {
+            run("syntax/multiple_virtual_specifiers", "receive_functions")
+        }
+    }
+
     #[test]
     fn unexpected_eof() -> Result<()> {
         run("syntax", "unexpected_eof")

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:5:33]
+   │
+ 5 │     fallback() external virtual virtual {}
+   │                                 ───┬───  
+   │                                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 6879] Error: Virtual already specified.
+   ╭─[input.sol:5:33]
+   │
+ 5 │     fallback() external virtual virtual {}
+   │                                 ───┬───  
+   │                                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/fallback_functions/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    fallback() external virtual virtual {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:5:35]
+   │
+ 5 │     function foo() virtual public virtual {}
+   │                                   ───┬───  
+   │                                      ╰───── Error occurred here.
+───╯
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:6:35]
+   │
+ 6 │     function bar() virtual public virtual virtual {}
+   │                                   ───┬───  
+   │                                      ╰───── Error occurred here.
+───╯
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:6:43]
+   │
+ 6 │     function bar() virtual public virtual virtual {}
+   │                                           ───┬───  
+   │                                              ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[ParserError 6879] Error: Virtual already specified.
+   ╭─[input.sol:5:35]
+   │
+ 5 │     function foo() virtual public virtual {}
+   │                                   ───┬───  
+   │                                      ╰───── Error occurred here.
+───╯
+
+[ParserError 6879] Error: Virtual already specified.
+   ╭─[input.sol:6:35]
+   │
+ 6 │     function bar() virtual public virtual virtual {}
+   │                                   ───┬───  
+   │                                      ╰───── Error occurred here.
+───╯
+
+[ParserError 6879] Error: Virtual already specified.
+   ╭─[input.sol:6:43]
+   │
+ 6 │     function bar() virtual public virtual virtual {}
+   │                                           ───┬───  
+   │                                              ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/functions/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function foo() virtual public virtual {}
+    function bar() virtual public virtual virtual {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:5:29]
+   │
+ 5 │     modifier modi() virtual virtual {_;}
+   │                             ───┬───  
+   │                                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2662] Error: Virtual already specified.
+   ╭─[input.sol:5:29]
+   │
+ 5 │     modifier modi() virtual virtual {_;}
+   │                             ───┬───  
+   │                                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/modifiers/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    modifier modi() virtual virtual {_;}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single virtual specifier can be provided.
+   ╭─[input.sol:5:40]
+   │
+ 5 │     receive() external payable virtual virtual {}
+   │                                        ───┬───  
+   │                                           ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 6879] Error: Virtual already specified.
+   ╭─[input.sol:5:40]
+   │
+ 5 │     receive() external payable virtual virtual {}
+   │                                        ───┬───  
+   │                                           ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_virtual_specifiers/receive_functions/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    receive() external payable virtual virtual {}
+}


### PR DESCRIPTION
Rejects definitions carrying more than one `virtual` keyword, matching solc's behavior. Emits a new `syntax/multiple-virtual-specifiers` diagnostic ("Only a single virtual specifier can be provided.") on every `virtual` keyword after the first.

Implements solc error codes 6879 and 2662