### PR TITLE
add missing syntax tests

### DIFF
--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -8,6 +8,11 @@ mod assembly_statement {
     use super::*;
 
     #[test]
+    fn empty_flags() -> Result<()> {
+        run("AssemblyStatement", "empty_flags")
+    }
+
+    #[test]
     fn simple() -> Result<()> {
         run("AssemblyStatement", "simple")
     }
@@ -76,6 +81,11 @@ mod constant_definition {
     #[test]
     fn int() -> Result<()> {
         run("ConstantDefinition", "int")
+    }
+
+    #[test]
+    fn invalid_visibility() -> Result<()> {
+        run("ConstantDefinition", "invalid_visibility")
     }
 }
 
@@ -210,6 +220,11 @@ mod contract_definition {
     #[test]
     fn member_using_directive() -> Result<()> {
         run("ContractDefinition", "member_using_directive")
+    }
+
+    #[test]
+    fn member_var_keyword() -> Result<()> {
+        run("ContractDefinition", "member_var_keyword")
     }
 
     #[test]
@@ -478,6 +493,11 @@ mod enum_definition {
 
 mod error_definition {
     use super::*;
+
+    #[test]
+    fn parameter_with_location() -> Result<()> {
+        run("ErrorDefinition", "parameter_with_location")
+    }
 
     #[test]
     fn top_level() -> Result<()> {
@@ -939,6 +959,20 @@ mod fallback_function_definition {
     }
 }
 
+mod for_statement {
+    use super::*;
+
+    #[test]
+    fn unchecked_in_initializer() -> Result<()> {
+        run("ForStatement", "unchecked_in_initializer")
+    }
+
+    #[test]
+    fn unchecked_in_iterator() -> Result<()> {
+        run("ForStatement", "unchecked_in_iterator")
+    }
+}
+
 mod function_call_expression {
     use super::*;
 
@@ -1377,6 +1411,11 @@ mod source_unit {
     #[test]
     fn layout_at() -> Result<()> {
         run("SourceUnit", "layout_at")
+    }
+
+    #[test]
+    fn layout_at_missing_expression() -> Result<()> {
+        run("SourceUnit", "layout_at_missing_expression")
     }
 
     #[test]
@@ -1949,6 +1988,11 @@ mod user_defined_value_type_definition {
     fn bool() -> Result<()> {
         run("UserDefinedValueTypeDefinition", "bool")
     }
+
+    #[test]
+    fn missing_identifier() -> Result<()> {
+        run("UserDefinedValueTypeDefinition", "missing_identifier")
+    }
 }
 
 mod using_deconstruction_symbol {
@@ -1991,6 +2035,11 @@ mod using_directive {
     #[test]
     fn destructure_single() -> Result<()> {
         run("UsingDirective", "destructure_single")
+    }
+
+    #[test]
+    fn operator_missing_name() -> Result<()> {
+        run("UsingDirective", "operator_missing_name")
     }
 
     #[test]

--- a/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/empty_flags/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/empty_flags/generated/0.8.0-failure.yml
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     function f() public {                                                        │ 13..38
+  3  │         assembly () {}                                                           │ 39..61
+  4  │     }                                                                            │ 62..67
+  5  │ }                                                                                │ 68..69
+
+Errors: # 1 total
+  - >
+    Error: Unexpected YulCloseParen. One of YulStringLiteral was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/empty_flags/input.sol:3:19]
+       │
+     3 │         assembly () {}
+       │                   ┬  
+       │                   ╰── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/empty_flags/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/empty_flags/input.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() public {
+        assembly () {}
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/ConstantDefinition/invalid_visibility/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ConstantDefinition/invalid_visibility/generated/0.8.0-failure.yml
@@ -1,0 +1,17 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ uint public constant x = 7;                                                      │ 0..27
+
+Errors: # 1 total
+  - >
+    Error: Unexpected PublicKeyword. One of ConstantKeyword, OpenBracket was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ConstantDefinition/invalid_visibility/input.sol:1:6]
+       │
+     1 │ uint public constant x = 7;
+       │      ───┬──  
+       │         ╰──── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ConstantDefinition/invalid_visibility/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ConstantDefinition/invalid_visibility/input.sol
@@ -1,0 +1,1 @@
+uint public constant x = 7;

--- a/crates/solidity-v2/testing/snapshots/cst_output/ContractDefinition/member_var_keyword/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ContractDefinition/member_var_keyword/generated/0.8.0-failure.yml
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     var a;                                                                       │ 13..23
+  3  │ }                                                                                │ 24..25
+
+Errors: # 1 total
+  - >
+    Error: Unexpected VarKeyword. One of AddressKeyword, AtKeyword, BoolKeyword, BytesKeyword, CloseBrace, ConstructorKeyword, EnumKeyword, ErrorKeyword, EventKeyword, FallbackKeyword, FixedKeyword, FromKeyword, FunctionKeyword, GlobalKeyword, Identifier, IntKeyword, LayoutKeyword, MappingKeyword, ModifierKeyword, ReceiveKeyword, RevertKeyword, StringKeyword, StructKeyword, TransientKeyword, TypeKeyword, UfixedKeyword, UintKeyword, UsingKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ContractDefinition/member_var_keyword/input.sol:2:5]
+       │
+     2 │     var a;
+       │     ─┬─  
+       │      ╰─── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ContractDefinition/member_var_keyword/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ContractDefinition/member_var_keyword/input.sol
@@ -1,0 +1,3 @@
+contract C {
+    var a;
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/ErrorDefinition/parameter_with_location/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ErrorDefinition/parameter_with_location/generated/0.8.0-failure.yml
@@ -1,0 +1,17 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ error E(uint[] memory);                                                          │ 0..23
+
+Errors: # 1 total
+  - >
+    Error: Unexpected MemoryKeyword. One of AtKeyword, CloseParen, Comma, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, RevertKeyword, TransientKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ErrorDefinition/parameter_with_location/input.sol:1:16]
+       │
+     1 │ error E(uint[] memory);
+       │                ───┬──  
+       │                   ╰──── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ErrorDefinition/parameter_with_location/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ErrorDefinition/parameter_with_location/input.sol
@@ -1,0 +1,1 @@
+error E(uint[] memory);

--- a/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_initializer/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_initializer/generated/0.8.0-failure.yml
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     function f() public {                                                        │ 13..38
+  3  │         for (unchecked { uint x = 2; }; x < 2; x++) {}                           │ 39..93
+  4  │     }                                                                            │ 94..99
+  5  │ }                                                                                │ 100..101
+
+Errors: # 1 total
+  - >
+    Error: Unexpected UncheckedKeyword. One of AddressKeyword, AtKeyword, Bang, BoolKeyword, BytesKeyword, DecimalLiteral, DeleteKeyword, ErrorKeyword, FalseKeyword, FixedKeyword, FromKeyword, FunctionKeyword, GlobalKeyword, HexLiteral, HexStringLiteral, Identifier, IntKeyword, LayoutKeyword, MappingKeyword, Minus, MinusMinus, NewKeyword, OpenBracket, OpenParen, PayableKeyword, PlusPlus, RevertKeyword, Semicolon, StringKeyword, StringLiteral, SuperKeyword, ThisKeyword, Tilde, TransientKeyword, TrueKeyword, TypeKeyword, UfixedKeyword, UintKeyword, UnicodeStringLiteral was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_initializer/input.sol:3:14]
+       │
+     3 │         for (unchecked { uint x = 2; }; x < 2; x++) {}
+       │              ────┬────  
+       │                  ╰────── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_initializer/input.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() public {
+        for (unchecked { uint x = 2; }; x < 2; x++) {}
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_iterator/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_iterator/generated/0.8.0-failure.yml
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     function f() public {                                                        │ 13..38
+  3  │         for (uint x = 2; x < 2; unchecked { x++; }) {}                           │ 39..93
+  4  │     }                                                                            │ 94..99
+  5  │ }                                                                                │ 100..101
+
+Errors: # 1 total
+  - >
+    Error: Unexpected UncheckedKeyword. One of AddressKeyword, AtKeyword, Bang, BoolKeyword, BytesKeyword, CloseParen, DecimalLiteral, DeleteKeyword, ErrorKeyword, FalseKeyword, FixedKeyword, FromKeyword, GlobalKeyword, HexLiteral, HexStringLiteral, Identifier, IntKeyword, LayoutKeyword, Minus, MinusMinus, NewKeyword, OpenBracket, OpenParen, PayableKeyword, PlusPlus, RevertKeyword, StringKeyword, StringLiteral, SuperKeyword, ThisKeyword, Tilde, TransientKeyword, TrueKeyword, TypeKeyword, UfixedKeyword, UintKeyword, UnicodeStringLiteral was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_iterator/input.sol:3:33]
+       │
+     3 │         for (uint x = 2; x < 2; unchecked { x++; }) {}
+       │                                 ────┬────  
+       │                                     ╰────── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_iterator/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ForStatement/unchecked_in_iterator/input.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() public {
+        for (uint x = 2; x < 2; unchecked { x++; }) {}
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/SourceUnit/layout_at_missing_expression/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/SourceUnit/layout_at_missing_expression/generated/0.8.0-failure.yml
@@ -1,0 +1,17 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C layout at {}                                                          │ 0..23
+
+Errors: # 1 total
+  - >
+    Error: Unexpected OpenBrace. One of AddressKeyword, AtKeyword, Bang, BoolKeyword, BytesKeyword, DecimalLiteral, DeleteKeyword, ErrorKeyword, FalseKeyword, FixedKeyword, FromKeyword, GlobalKeyword, HexLiteral, HexStringLiteral, Identifier, IntKeyword, LayoutKeyword, Minus, MinusMinus, NewKeyword, OpenBracket, OpenParen, PayableKeyword, PlusPlus, RevertKeyword, StringKeyword, StringLiteral, SuperKeyword, ThisKeyword, Tilde, TransientKeyword, TrueKeyword, TypeKeyword, UfixedKeyword, UintKeyword, UnicodeStringLiteral was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/SourceUnit/layout_at_missing_expression/input.sol:1:22]
+       │
+     1 │ contract C layout at {}
+       │                      ┬  
+       │                      ╰── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/SourceUnit/layout_at_missing_expression/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/SourceUnit/layout_at_missing_expression/input.sol
@@ -1,0 +1,1 @@
+contract C layout at {}

--- a/crates/solidity-v2/testing/snapshots/cst_output/UserDefinedValueTypeDefinition/missing_identifier/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/UserDefinedValueTypeDefinition/missing_identifier/generated/0.8.0-failure.yml
@@ -1,0 +1,17 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ type(MyInt) is uint256;                                                          │ 0..23
+
+Errors: # 1 total
+  - >
+    Error: Unexpected OpenParen. One of AtKeyword, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, RevertKeyword, TransientKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/UserDefinedValueTypeDefinition/missing_identifier/input.sol:1:5]
+       │
+     1 │ type(MyInt) is uint256;
+       │     ┬  
+       │     ╰── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/UserDefinedValueTypeDefinition/missing_identifier/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/UserDefinedValueTypeDefinition/missing_identifier/input.sol
@@ -1,0 +1,1 @@
+type(MyInt) is uint256;

--- a/crates/solidity-v2/testing/snapshots/cst_output/UsingDirective/operator_missing_name/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/UsingDirective/operator_missing_name/generated/0.8.0-failure.yml
@@ -1,0 +1,17 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ using {as -} for uint global;                                                    │ 0..29
+
+Errors: # 1 total
+  - >
+    Error: Unexpected AsKeyword. One of AtKeyword, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, RevertKeyword, TransientKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/UsingDirective/operator_missing_name/input.sol:1:8]
+       │
+     1 │ using {as -} for uint global;
+       │        ─┬  
+       │         ╰── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/UsingDirective/operator_missing_name/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/UsingDirective/operator_missing_name/input.sol
@@ -1,0 +1,1 @@
+using {as -} for uint global;


### PR DESCRIPTION
Add missing syntax tests for a few solc syntax errors that are already covered by our LALRPOP grammar, so we don't need a specific diagnostic for it:

- ParserError 9182:
  - `var` at contract-member position
- ParserError 6933:
  - unchecked primary expressions in for-loop initializer and iterator slots
  - missing primary expressions in storage layout specifiers
- ParserError 2314:
  - file-level constant with a visibility modifier
  - user-defined value type with a missing identifier
  - error definition with a parameter data location
  - empty inline-assembly flag list
  -  user-defined operator with a missing function name