### PR TITLE
[v2] feat(diagnostics): Check double override across definitions

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -344,6 +344,7 @@ pub enum slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticK
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExpectedArrayLengthExpression(slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExtraTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleMutabilitySpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers)
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleOverrideSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleVirtualSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedEof(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::UnexpectedTerminal(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal)
@@ -359,6 +360,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -436,6 +439,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
@@ -589,6 +611,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::E
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::ExtraTerminal) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -724,6 +748,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
@@ -1,6 +1,7 @@
 mod expected_array_length_expression;
 mod extra_terminal;
 mod multiple_mutability_specifiers;
+mod multiple_override_specifiers;
 mod multiple_virtual_specifiers;
 mod unexpected_eof;
 mod unexpected_terminal;
@@ -9,6 +10,7 @@ mod unsupported_syntax;
 pub use expected_array_length_expression::ExpectedArrayLengthExpression;
 pub use extra_terminal::ExtraTerminal;
 pub use multiple_mutability_specifiers::MultipleMutabilitySpecifiers;
+pub use multiple_override_specifiers::MultipleOverrideSpecifiers;
 pub use multiple_virtual_specifiers::MultipleVirtualSpecifiers;
 use serde::Serialize;
 pub use unexpected_eof::UnexpectedEof;
@@ -43,5 +45,8 @@ define_diagnostic_kind! {
         /// A range/slice index access was used where an array length
         /// expression is expected
         ExpectedArrayLengthExpression(ExpectedArrayLengthExpression),
+
+        /// More than one `override` specifier was provided on a definition.
+        MultipleOverrideSpecifiers(MultipleOverrideSpecifiers),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_override_specifiers.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/multiple_override_specifiers.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a definition carries more than one `override`
+/// specifier.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MultipleOverrideSpecifiers;
+
+impl DiagnosticExtensions for MultipleOverrideSpecifiers {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "syntax/multiple-override-specifiers"
+    }
+
+    fn message(&self) -> String {
+        "Only a single override specifier can be provided.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use slang_solidity_v2_common::diagnostics::kinds::syntax::{
-    MultipleMutabilitySpecifiers, MultipleVirtualSpecifiers,
+    MultipleMutabilitySpecifiers, MultipleOverrideSpecifiers, MultipleVirtualSpecifiers,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
@@ -226,7 +226,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                     None
                 }
             }));
-        // TODO(validation) SDR[9]: function definitions can have only a single override specifier
         let override_specifier = self.function_override_specifier(&source.attributes);
         let modifier_invocations = self.function_modifier_invocations(&source.attributes);
         let returns = source
@@ -470,13 +469,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::FunctionAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_single_override(attributes.elements.iter().filter_map(|attribute| {
             if let input::FunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
-        })
+        }))
     }
 
     fn function_modifier_invocations(
@@ -646,13 +645,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::FallbackFunctionAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_single_override(attributes.elements.iter().filter_map(|attribute| {
             if let input::FallbackFunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
-        })
+        }))
     }
 
     fn fallback_function_modifier_invocations(
@@ -721,13 +720,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::ReceiveFunctionAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_single_override(attributes.elements.iter().filter_map(|attribute| {
             if let input::ReceiveFunctionAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
-        })
+        }))
     }
 
     fn receive_function_modifier_invocations(
@@ -761,7 +760,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let visibility = output::FunctionVisibility::Internal;
         // mutability is irrelevant for modifiers
         let mutability = output::FunctionMutability::NonPayable;
-        // TODO(validation) SDR[1730]: modifiers can have only a single override specifier
         let virtual_keyword =
             self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
                 if let input::ModifierAttribute::VirtualKeyword(virtual_keyword) = attribute {
@@ -795,13 +793,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::ModifierAttributes,
     ) -> Option<output::OverridePaths> {
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_single_override(attributes.elements.iter().filter_map(|attribute| {
             if let input::ModifierAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
-        })
+        }))
     }
 
     //
@@ -833,14 +831,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         &mut self,
         attributes: &input::StateVariableAttributes,
     ) -> Option<output::OverridePaths> {
-        // TODO(validation) SDR[12]: only one override specifier is allowed
-        attributes.elements.iter().find_map(|attribute| {
+        self.extract_single_override(attributes.elements.iter().filter_map(|attribute| {
             if let input::StateVariableAttribute::OverrideSpecifier(specifier) = attribute {
-                Some(self.build_override_specifier_as_paths(specifier))
+                Some(specifier)
             } else {
                 None
             }
-        })
+        }))
     }
 
     fn state_variable_as_constant_definition(
@@ -1024,6 +1021,26 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                 self.file_id.to_owned(),
                 keyword.calculate_text_range().unwrap(),
                 MultipleVirtualSpecifiers,
+            );
+        }
+
+        Some(first)
+    }
+
+    /// Extracts and transforms the first `override` specifier, emitting an
+    /// error for any subsequent ones.
+    fn extract_single_override<'a>(
+        &mut self,
+        specifiers: impl IntoIterator<Item = &'a input::OverrideSpecifier>,
+    ) -> Option<output::OverridePaths> {
+        let mut specifiers = specifiers.into_iter();
+        let first = self.build_override_specifier_as_paths(specifiers.next()?);
+
+        for specifier in specifiers {
+            self.diagnostics.push(
+                self.file_id.to_owned(),
+                specifier.calculate_text_range().unwrap(),
+                MultipleOverrideSpecifiers,
             );
         }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -113,6 +113,35 @@ mod syntax {
         }
     }
 
+    mod multiple_override_specifiers {
+        use super::*;
+
+        #[test]
+        fn fallback_functions() -> Result<()> {
+            run("syntax/multiple_override_specifiers", "fallback_functions")
+        }
+
+        #[test]
+        fn functions() -> Result<()> {
+            run("syntax/multiple_override_specifiers", "functions")
+        }
+
+        #[test]
+        fn modifiers() -> Result<()> {
+            run("syntax/multiple_override_specifiers", "modifiers")
+        }
+
+        #[test]
+        fn receive_functions() -> Result<()> {
+            run("syntax/multiple_override_specifiers", "receive_functions")
+        }
+
+        #[test]
+        fn state_variables() -> Result<()> {
+            run("syntax/multiple_override_specifiers", "state_variables")
+        }
+    }
+
     mod multiple_virtual_specifiers {
         use super::*;
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single override specifier can be provided.
+   ╭─[input.sol:5:34]
+   │
+ 5 │     fallback() external override override {}
+   │                                  ────┬───  
+   │                                      ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 1827] Error: Override already specified.
+   ╭─[input.sol:5:34]
+   │
+ 5 │     fallback() external override override {}
+   │                                  ────┬───  
+   │                                      ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/fallback_functions/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    fallback() external override override {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single override specifier can be provided.
+   ╭─[input.sol:5:37]
+   │
+ 5 │     function test() public override override {}
+   │                                     ────┬───  
+   │                                         ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 1827] Error: Override already specified.
+   ╭─[input.sol:5:37]
+   │
+ 5 │     function test() public override override {}
+   │                                     ────┬───  
+   │                                         ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/functions/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract X {
+    function test() public override override {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single override specifier can be provided.
+   ╭─[input.sol:5:27]
+   │
+ 5 │     modifier f() override override {}
+   │                           ────┬───  
+   │                               ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 9102] Error: Override already specified.
+   ╭─[input.sol:5:27]
+   │
+ 5 │     modifier f() override override {}
+   │                           ────┬───  
+   │                               ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/modifiers/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    modifier f() override override {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single override specifier can be provided.
+   ╭─[input.sol:5:41]
+   │
+ 5 │     receive() external payable override override {}
+   │                                         ────┬───  
+   │                                             ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 1827] Error: Override already specified.
+   ╭─[input.sol:5:41]
+   │
+ 5 │     receive() external payable override override {}
+   │                                         ────┬───  
+   │                                             ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/receive_functions/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    receive() external payable override override {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Only a single override specifier can be provided.
+   ╭─[input.sol:5:25]
+   │
+ 5 │     int public override override testvar;
+   │                         ────┬───  
+   │                             ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 9125] Error: Override already specified.
+   ╭─[input.sol:5:25]
+   │
+ 5 │     int public override override testvar;
+   │                         ────┬───  
+   │                             ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_override_specifiers/state_variables/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract X {
+    int public override override testvar;
+}


### PR DESCRIPTION
Reject functions, fallback/receive functions, modifiers, and state variables that carry more than one `override` specifier.

Note: It doesn't check if the `override` specifier is legal, that's a typechecker responsibility. 

Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1730
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1638
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/786
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1635
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/9
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/12
