### PR TITLE
fix `sourcify_all_chains` permissions

### DIFF
--- a/.github/workflows/sourcify_all_chains.yml
+++ b/.github/workflows/sourcify_all_chains.yml
@@ -23,11 +23,15 @@ permissions: {}
 
 jobs:
   run_tests:
+    permissions:
+      contents: "read"
+
     uses: "./.github/workflows/sourcify_single_chain.yml"
     with:
       chain_id: "${{ matrix.chain_id }}"
       check_infer_version: "${{ inputs.check_infer_version }}"
       check_binder: "${{ inputs.check_binder }}"
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Child workflow succeeds on its own, but requires permissions to be passed explicitly when invoked from parent workflow.

- [Failed run on main](https://github.com/NomicFoundation/slang/actions/runs/27197438935)

> The nested job 'singleShard' is requesting 'contents: read', but is only allowed 'contents: none'.

- [Successful run with the fix](https://github.com/NomicFoundation/slang/actions/runs/27197885960)