### PR TITLE
fix `infra` build in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,7 +404,7 @@ jobs:
 
       # Compile infra_cli with no registry token in scope.
       - name: "Build infra_cli (before any token)"
-        run: "./scripts/bin/infra --version"
+        run: "./scripts/bin/infra --help"
 
       - name: "infra publish npm"
         # No tarball means prepare packed nothing (version already on npm) — nothing to publish.


### PR DESCRIPTION
[Previous publish failed](https://github.com/NomicFoundation/slang/actions/runs/27218266661/job/80368895921) because `infra` doesn't support `--version` (added in #1785).
Switching to `--help` to unblock the pipeline.
cc @nebasuke 