### PR TITLE
[v2] refactor: Centralize collections and make them deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,6 +4076,7 @@ dependencies = [
 name = "slang_solidity_v2_common"
 version = "1.3.6"
 dependencies = [
+ "indexmap",
  "itertools 0.14.0",
  "semver 1.0.28",
  "serde",
@@ -4113,7 +4114,6 @@ dependencies = [
 name = "slang_solidity_v2_semantic"
 version = "1.3.6"
 dependencies = [
- "indexmap",
  "num-bigint",
  "num-integer",
  "num-rational",

--- a/crates/solidity-v2/clippy.toml
+++ b/crates/solidity-v2/clippy.toml
@@ -1,0 +1,13 @@
+# Applies to all crates under `crates/solidity-v2/`.
+#
+# All maps and sets must be picked from the `slang_solidity_v2_common::collections`
+# aliases, which document the guarantees (determinism, iteration order, indexing)
+# of each type in a single place.
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "use `slang_solidity_v2_common::collections::Map` instead" },
+  { path = "std::collections::HashSet", reason = "use `slang_solidity_v2_common::collections::Set` instead" },
+  { path = "indexmap::IndexMap", reason = "use `slang_solidity_v2_common::collections::OrderedMap` instead" },
+  { path = "indexmap::IndexSet", reason = "use `slang_solidity_v2_common::collections::OrderedSet` instead" },
+  { path = "std::collections::BTreeMap", reason = "use `slang_solidity_v2_common::collections::SortedMap` instead" },
+  { path = "std::collections::BTreeSet", reason = "use `slang_solidity_v2_common::collections::SortedSet` instead" },
+]

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -1,11 +1,11 @@
 mod node_extensions;
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
+use slang_solidity_v2_common::collections::Set;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
@@ -385,13 +385,13 @@ pub(crate) fn type_as_abi_parameter(
     semantic: &Arc<SemanticContext>,
     type_id: TypeId,
 ) -> Option<(String, Vec<ParameterComponent>)> {
-    type_as_abi_parameter_impl(semantic, type_id, &mut HashSet::new())
+    type_as_abi_parameter_impl(semantic, type_id, &mut Set::default())
 }
 
 fn type_as_abi_parameter_impl(
     semantic: &Arc<SemanticContext>,
     type_id: TypeId,
-    visited_structs: &mut HashSet<NodeId>,
+    visited_structs: &mut Set<NodeId>,
 ) -> Option<(String, Vec<ParameterComponent>)> {
     match semantic.types().get_type_by_id(type_id) {
         Type::Array(ArrayType { element_type, .. }) => {

--- a/crates/solidity-v2/outputs/cargo/common/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/common/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+indexmap = { workspace = true }
 itertools = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -172,10 +172,11 @@ pub fn slang_solidity_v2_common::built_ins::BuiltIn::hash<__H: core::hash::Hashe
 impl core::marker::Copy for slang_solidity_v2_common::built_ins::BuiltIn
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::built_ins::BuiltIn
 pub mod slang_solidity_v2_common::collections
-pub type slang_solidity_v2_common::collections::Map<K, V> = std::collections::hash::map::HashMap<K, V>
-pub type slang_solidity_v2_common::collections::OrderedMap<K, V> = indexmap::map::IndexMap<K, V>
-pub type slang_solidity_v2_common::collections::OrderedSet<T> = indexmap::set::IndexSet<T>
-pub type slang_solidity_v2_common::collections::Set<T> = std::collections::hash::set::HashSet<T>
+pub type slang_solidity_v2_common::collections::DeterministicState = core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
+pub type slang_solidity_v2_common::collections::Map<K, V> = std::collections::hash::map::HashMap<K, V, slang_solidity_v2_common::collections::DeterministicState>
+pub type slang_solidity_v2_common::collections::OrderedMap<K, V> = indexmap::map::IndexMap<K, V, slang_solidity_v2_common::collections::DeterministicState>
+pub type slang_solidity_v2_common::collections::OrderedSet<T> = indexmap::set::IndexSet<T, slang_solidity_v2_common::collections::DeterministicState>
+pub type slang_solidity_v2_common::collections::Set<T> = std::collections::hash::set::HashSet<T, slang_solidity_v2_common::collections::DeterministicState>
 pub type slang_solidity_v2_common::collections::SortedMap<K, V> = alloc::collections::btree::map::BTreeMap<K, V>
 pub type slang_solidity_v2_common::collections::SortedSet<T> = alloc::collections::btree::set::BTreeSet<T>
 pub mod slang_solidity_v2_common::diagnostics

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -171,6 +171,13 @@ impl core::hash::Hash for slang_solidity_v2_common::built_ins::BuiltIn
 pub fn slang_solidity_v2_common::built_ins::BuiltIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for slang_solidity_v2_common::built_ins::BuiltIn
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::built_ins::BuiltIn
+pub mod slang_solidity_v2_common::collections
+pub type slang_solidity_v2_common::collections::Map<K, V> = std::collections::hash::map::HashMap<K, V>
+pub type slang_solidity_v2_common::collections::OrderedMap<K, V> = indexmap::map::IndexMap<K, V>
+pub type slang_solidity_v2_common::collections::OrderedSet<T> = indexmap::set::IndexSet<T>
+pub type slang_solidity_v2_common::collections::Set<T> = std::collections::hash::set::HashSet<T>
+pub type slang_solidity_v2_common::collections::SortedMap<K, V> = alloc::collections::btree::map::BTreeMap<K, V>
+pub type slang_solidity_v2_common::collections::SortedSet<T> = alloc::collections::btree::set::BTreeSet<T>
 pub mod slang_solidity_v2_common::diagnostics
 pub mod slang_solidity_v2_common::diagnostics::kinds
 pub mod slang_solidity_v2_common::diagnostics::kinds::compilation
@@ -477,7 +484,7 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpec
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
-pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::expected: alloc::collections::btree::set::BTreeSet<slang_solidity_v2_common::terminals::TerminalKind>
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::expected: slang_solidity_v2_common::collections::SortedSet<slang_solidity_v2_common::terminals::TerminalKind>
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof
@@ -497,7 +504,7 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::code
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal
-pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::expected: alloc::collections::btree::set::BTreeSet<slang_solidity_v2_common::terminals::TerminalKind>
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::expected: slang_solidity_v2_common::collections::SortedSet<slang_solidity_v2_common::terminals::TerminalKind>
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::found: slang_solidity_v2_common::terminals::TerminalKind
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal

--- a/crates/solidity-v2/outputs/cargo/common/src/collections.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/collections.rs
@@ -9,26 +9,43 @@
 //! | [`OrderedMap`] / [`OrderedSet`] | `IndexMap` / `IndexSet` | insertion order | order is observable (API results, snapshots), or entries need stable indices (interning) |
 //! | [`SortedMap`] / [`SortedSet`]   | `BTreeMap` / `BTreeSet` | sorted by key   | output should be sorted by key, or you need range queries |
 //!
-//! [`Map`]/[`Set`] iteration order is arbitrary and shifts whenever the key
-//! set does.
+//! The hash-based aliases use the same `SipHash` algorithm as the `std`
+//! default, but with a fixed seed instead of a random per-process one, so
+//! hashing is fully deterministic from run to run (required by the
+//! instruction-counting benchmarks).
+//!
+//! The fixed seed forfeits `std`'s `HashDoS` protection; that trade-off is fine for
+//! certain compiler workloads (like `NodeId`s), but may be unsafe for external keys
+//! (like string interning). If this becomes a problem we should consider another Map/Set
+//! pair that guarantees `HashDoS` protection.
+//!
+//! Even with a deterministic hasher, [`Map`]/[`Set`] iteration order is
+//! arbitrary and shifts whenever the key set does — never let it reach
+//! user-visible output. Use [`OrderedMap`] or [`SortedMap`] there.
 //!
 //! Use of the underlying types directly is rejected by the
 //! `clippy::disallowed_types` lint, configured in `crates/solidity-v2/clippy.toml`.
 //!
-//! NOTE: prefer constructing the hash-based aliases with `::default()` rather
-//! than `::new()`, so that the backing hasher can be swapped without touching
-//! call sites.
+//! NOTE: construct the hash-based aliases with `::default()`; `::new()` is
+//! not available on collections with a non-`std` hasher.
 
 // The only place in the v2 crates allowed to name the underlying types:
 #[allow(clippy::disallowed_types)]
 mod aliases {
-    pub type Map<K, V> = std::collections::HashMap<K, V>;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::BuildHasherDefault;
 
-    pub type Set<T> = std::collections::HashSet<T>;
+    /// `std`'s default `SipHash`, seeded with a fixed key instead of
+    /// `RandomState`'s random per-process one.
+    pub type DeterministicState = BuildHasherDefault<DefaultHasher>;
 
-    pub type OrderedMap<K, V> = indexmap::IndexMap<K, V>;
+    pub type Map<K, V> = std::collections::HashMap<K, V, DeterministicState>;
 
-    pub type OrderedSet<T> = indexmap::IndexSet<T>;
+    pub type Set<T> = std::collections::HashSet<T, DeterministicState>;
+
+    pub type OrderedMap<K, V> = indexmap::IndexMap<K, V, DeterministicState>;
+
+    pub type OrderedSet<T> = indexmap::IndexSet<T, DeterministicState>;
 
     pub type SortedMap<K, V> = std::collections::BTreeMap<K, V>;
 

--- a/crates/solidity-v2/outputs/cargo/common/src/collections.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/collections.rs
@@ -1,0 +1,38 @@
+//! Canonical collection types for Slang v2.
+//!
+//! All maps and sets in the v2 crates should be picked from this module,
+//! based on the guarantees each use case needs:
+//!
+//! | Alias                           | Backed by               | Iteration order | Reach for it when…                                  |
+//! |---------------------------------|-------------------------|-----------------|-----------------------------------------------------|
+//! | [`Map`] / [`Set`]               | `HashMap` / `HashSet`   | unspecified     | order is never observed (lookups, seen-sets)        |
+//! | [`OrderedMap`] / [`OrderedSet`] | `IndexMap` / `IndexSet` | insertion order | order is observable (API results, snapshots), or entries need stable indices (interning) |
+//! | [`SortedMap`] / [`SortedSet`]   | `BTreeMap` / `BTreeSet` | sorted by key   | output should be sorted by key, or you need range queries |
+//!
+//! [`Map`]/[`Set`] iteration order is arbitrary and shifts whenever the key
+//! set does.
+//!
+//! Use of the underlying types directly is rejected by the
+//! `clippy::disallowed_types` lint, configured in `crates/solidity-v2/clippy.toml`.
+//!
+//! NOTE: prefer constructing the hash-based aliases with `::default()` rather
+//! than `::new()`, so that the backing hasher can be swapped without touching
+//! call sites.
+
+// The only place in the v2 crates allowed to name the underlying types:
+#[allow(clippy::disallowed_types)]
+mod aliases {
+    pub type Map<K, V> = std::collections::HashMap<K, V>;
+
+    pub type Set<T> = std::collections::HashSet<T>;
+
+    pub type OrderedMap<K, V> = indexmap::IndexMap<K, V>;
+
+    pub type OrderedSet<T> = indexmap::IndexSet<T>;
+
+    pub type SortedMap<K, V> = std::collections::BTreeMap<K, V>;
+
+    pub type SortedSet<T> = std::collections::BTreeSet<T>;
+}
+
+pub use aliases::*;

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/unexpected_eof.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/unexpected_eof.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeSet;
-
 use itertools::Itertools;
 use serde::Serialize;
 
+use crate::collections::SortedSet;
 use crate::diagnostics::extensions::DiagnosticExtensions;
 use crate::diagnostics::severity::DiagnosticSeverity;
 use crate::terminals::TerminalKind;
@@ -12,7 +11,7 @@ use crate::terminals::TerminalKind;
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct UnexpectedEof {
     /// The set of terminals that could have legally appeared at this position.
-    pub expected: BTreeSet<TerminalKind>,
+    pub expected: SortedSet<TerminalKind>,
 }
 
 impl DiagnosticExtensions for UnexpectedEof {

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/unexpected_terminal.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/unexpected_terminal.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeSet;
-
 use itertools::Itertools;
 use serde::Serialize;
 
+use crate::collections::SortedSet;
 use crate::diagnostics::extensions::DiagnosticExtensions;
 use crate::diagnostics::severity::DiagnosticSeverity;
 use crate::terminals::TerminalKind;
@@ -14,7 +13,7 @@ pub struct UnexpectedTerminal {
     /// The terminal kind that was encountered at the failure site.
     pub found: TerminalKind,
     /// The set of terminals that could have legally appeared at this position.
-    pub expected: BTreeSet<TerminalKind>,
+    pub expected: SortedSet<TerminalKind>,
 }
 
 impl DiagnosticExtensions for UnexpectedTerminal {

--- a/crates/solidity-v2/outputs/cargo/common/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod built_ins;
+pub mod collections;
 pub mod diagnostics;
 pub mod evm_targets;
 pub mod nodes;

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
@@ -1,6 +1,5 @@
-use std::collections::BTreeSet;
-
 use lalrpop_util::lalrpop_mod;
+use slang_solidity_v2_common::collections::SortedSet;
 use slang_solidity_v2_common::diagnostics::kinds::syntax::{UnexpectedEof, UnexpectedTerminal};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::terminals::TerminalKind;
@@ -109,7 +108,7 @@ fn convert_parse_error(
     ///
     /// TODO(v2): We may be able to improve on this if there's room for returning a discriminant instead of a string representation.
     /// [Ongoing discussion](https://github.com/lalrpop/lalrpop/issues/1089#issuecomment-4011323139)
-    fn convert_expectations(expected: &[String]) -> BTreeSet<TerminalKind> {
+    fn convert_expectations(expected: &[String]) -> SortedSet<TerminalKind> {
         expected
             .iter()
             .map(|str| str.strip_prefix("L_").unwrap())

--- a/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/semantic/Cargo.toml
@@ -19,7 +19,6 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
-indexmap = { workspace = true }
 num-bigint = { workspace = true }
 num-integer = { workspace = true }
 num-rational = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -69,14 +69,14 @@ impl core::fmt::Debug for slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Typing::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity_v2_semantic::binder::Binder
 impl slang_solidity_v2_semantic::binder::Binder
-pub fn slang_solidity_v2_semantic::binder::Binder::definitions(&self) -> &std::collections::hash::map::HashMap<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Definition>
+pub fn slang_solidity_v2_semantic::binder::Binder::definitions(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Definition>
 pub fn slang_solidity_v2_semantic::binder::Binder::find_definition_by_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Definition>
 pub fn slang_solidity_v2_semantic::binder::Binder::find_definition_by_identifier_node_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Definition>
 pub fn slang_solidity_v2_semantic::binder::Binder::find_reference_by_identifier_node_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Reference>
 pub fn slang_solidity_v2_semantic::binder::Binder::get_linearised_bases(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>>
 pub fn slang_solidity_v2_semantic::binder::Binder::get_references_by_definition_id(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::binder::Binder::node_typing(&self, node_id: slang_solidity_v2_common::nodes::NodeId) -> slang_solidity_v2_semantic::binder::Typing
-pub fn slang_solidity_v2_semantic::binder::Binder::references(&self) -> &std::collections::hash::map::HashMap<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Reference>
+pub fn slang_solidity_v2_semantic::binder::Binder::references(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Reference>
 impl core::default::Default for slang_solidity_v2_semantic::binder::Binder
 pub fn slang_solidity_v2_semantic::binder::Binder::default() -> slang_solidity_v2_semantic::binder::Binder
 pub struct slang_solidity_v2_semantic::binder::Reference

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
+use slang_solidity_v2_common::collections::{Map, Set};
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::built_ins::InternalBuiltIn;
@@ -89,25 +90,25 @@ pub struct Binder {
     /// Index of `Scope` objects. The `ScopeId` is an opaque index into this vector
     scopes: Vec<Scope>,
     /// Scopes (set of definitions contained and relationship to other scopes), indexed by `NodeId`
-    scopes_by_node_id: HashMap<NodeId, ScopeId>,
+    scopes_by_node_id: Map<NodeId, ScopeId>,
     /// Index of root `FileScope`s for all files in the `CompilationUnit`
-    scopes_by_file_id: HashMap<String, ScopeId>,
+    scopes_by_file_id: Map<String, ScopeId>,
     /// `UsingDirective` objects registered globally (contract level directives
     /// are stored in the corresponding `ContractScope`)
     global_using_directives: Vec<UsingDirective>,
     /// `Definition` objects (identifier + definiens node), indexed by definiens `NodeId`
-    definitions: HashMap<NodeId, Definition>,
+    definitions: Map<NodeId, Definition>,
     /// Definitions indexed by the `NodeId` of the identifier that names them
-    definitions_by_identifier: HashMap<NodeId, NodeId>,
+    definitions_by_identifier: Map<NodeId, NodeId>,
     /// `Reference` objects (identifier + `Resolution`), indexed by identifier `NodeId`
-    references: HashMap<NodeId, Reference>,
+    references: Map<NodeId, Reference>,
     /// `Typing` information for each relevant `NodeId` of the AST
-    node_typing: HashMap<NodeId, Typing>,
+    node_typing: Map<NodeId, Typing>,
     /// Linearisations, as a vector of definitions, indexed by the
     /// contract/interface definition's `NodeId`
-    linearisations: HashMap<NodeId, Vec<NodeId>>,
+    linearisations: Map<NodeId, Vec<NodeId>>,
     /// Reverse mapping from definition `NodeId` to the set of references that bind to it
-    definitions_to_references: HashMap<NodeId, Vec<NodeId>>,
+    definitions_to_references: Map<NodeId, Vec<NodeId>>,
 }
 
 /// This controls visibility filtering and how to use the linearisation when
@@ -222,11 +223,11 @@ impl Binder {
     }
 
     #[cfg(test)]
-    pub(crate) fn linearisations(&self) -> &HashMap<NodeId, Vec<NodeId>> {
+    pub(crate) fn linearisations(&self) -> &Map<NodeId, Vec<NodeId>> {
         &self.linearisations
     }
 
-    pub fn definitions(&self) -> &HashMap<NodeId, Definition> {
+    pub fn definitions(&self) -> &Map<NodeId, Definition> {
         &self.definitions
     }
 
@@ -244,13 +245,13 @@ impl Binder {
         self.references.get(&node_id)
     }
 
-    pub fn references(&self) -> &HashMap<NodeId, Reference> {
+    pub fn references(&self) -> &Map<NodeId, Reference> {
         &self.references
     }
 
     pub(crate) fn update_definitions_to_references_index(&mut self) {
         // Build reverse mapping from definitions to references
-        let mut definitions: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+        let mut definitions: Map<NodeId, Vec<NodeId>> = Map::default();
         for (reference_id, reference) in &self.references {
             match &reference.resolution {
                 Resolution::Definition(node_id) => {
@@ -347,7 +348,7 @@ impl Binder {
     // the file.
     fn resolve_in_file_scope(&self, file_id: &str, symbol: &str) -> Resolution {
         let mut found_definitions = Vec::new();
-        let mut visited_files = HashSet::new();
+        let mut visited_files = Set::default();
         let mut files_to_search = VecDeque::new();
         files_to_search.push_back(file_id.to_owned());
 
@@ -525,7 +526,7 @@ impl Binder {
         // it to try and avoid them by returning iterators from the delegated
         // resolution functions
         let mut found_ids = Vec::new();
-        let mut seen_ids = HashSet::new();
+        let mut seen_ids = Set::default();
         let mut working_set = resolution.get_definition_ids();
 
         while let Some(definition_id) = working_set.pop() {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -1,5 +1,4 @@
-use std::collections::{HashMap, HashSet};
-
+use slang_solidity_v2_common::collections::{Map, Set};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -26,26 +25,26 @@ pub(crate) enum Scope {
 pub(crate) struct BlockScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 pub(crate) struct ContractScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, Vec<NodeId>>,
+    pub(crate) definitions: Map<String, Vec<NodeId>>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
 pub(crate) struct EnumScope {
     pub(crate) node_id: NodeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 pub(crate) struct FileScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_id: String,
-    pub(crate) definitions: HashMap<String, Vec<NodeId>>,
-    pub(crate) imported_files: HashSet<String>,
+    pub(crate) definitions: Map<String, Vec<NodeId>>,
+    pub(crate) imported_files: Set<String>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
@@ -53,7 +52,7 @@ pub(crate) struct FunctionScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
     pub(crate) parameters_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 // TODO: this is similar to a function scope, but it doesn't have a separate
@@ -65,7 +64,7 @@ pub(crate) struct FunctionScope {
 pub(crate) struct ModifierScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 /// This is stored in a vector in the `ParametersScope` below preserving order
@@ -86,24 +85,24 @@ pub(crate) struct ParametersScope {
 
 pub(crate) struct StructScope {
     pub(crate) node_id: NodeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 pub(crate) struct UsingScope {
     pub(crate) node_id: NodeId,
-    pub(crate) symbols: HashMap<String, Vec<NodeId>>,
+    pub(crate) symbols: Map<String, Vec<NodeId>>,
 }
 
 pub(crate) struct YulBlockScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 pub(crate) struct YulFunctionScope {
     pub(crate) node_id: NodeId,
     pub(crate) parent_scope_id: ScopeId,
-    pub(crate) definitions: HashMap<String, NodeId>,
+    pub(crate) definitions: Map<String, NodeId>,
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -190,7 +189,7 @@ impl Scope {
         Self::Struct(StructScope::new(node_id))
     }
 
-    pub(crate) fn new_using(node_id: NodeId, symbols: HashMap<String, Vec<NodeId>>) -> Self {
+    pub(crate) fn new_using(node_id: NodeId, symbols: Map<String, Vec<NodeId>>) -> Self {
         Self::Using(UsingScope::new(node_id, symbols))
     }
 
@@ -208,7 +207,7 @@ impl BlockScope {
         Self {
             node_id,
             parent_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -222,7 +221,7 @@ impl ContractScope {
         Self {
             node_id,
             file_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
             using_directives: Vec::new(),
         }
     }
@@ -240,7 +239,7 @@ impl EnumScope {
     fn new(node_id: NodeId) -> Self {
         Self {
             node_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -254,8 +253,8 @@ impl FileScope {
         Self {
             node_id,
             file_id: file_id.to_string(),
-            definitions: HashMap::new(),
-            imported_files: HashSet::new(),
+            definitions: Map::default(),
+            imported_files: Set::default(),
             using_directives: Vec::new(),
         }
     }
@@ -286,7 +285,7 @@ impl FunctionScope {
             node_id,
             parent_scope_id,
             parameters_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -300,7 +299,7 @@ impl ModifierScope {
         Self {
             node_id,
             parent_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -345,7 +344,7 @@ impl StructScope {
     fn new(node_id: NodeId) -> Self {
         Self {
             node_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -355,7 +354,7 @@ impl StructScope {
 }
 
 impl UsingScope {
-    fn new(node_id: NodeId, symbols: HashMap<String, Vec<NodeId>>) -> Self {
+    fn new(node_id: NodeId, symbols: Map<String, Vec<NodeId>>) -> Self {
         Self { node_id, symbols }
     }
 }
@@ -365,7 +364,7 @@ impl YulBlockScope {
         Self {
             node_id,
             parent_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -379,7 +378,7 @@ impl YulFunctionScope {
         Self {
             node_id,
             parent_scope_id,
-            definitions: HashMap::new(),
+            definitions: Map::default(),
         }
     }
 
@@ -402,7 +401,7 @@ pub(crate) enum UsingDirective {
     },
     SingleTypeOperator {
         scope_id: ScopeId,
-        operator_mapping: HashMap<UsingOperator, String>,
+        operator_mapping: Map<UsingOperator, String>,
         type_id: TypeId,
     },
 }
@@ -461,7 +460,7 @@ impl UsingDirective {
     pub(crate) fn new_single_type_with_operators(
         scope_id: ScopeId,
         type_id: TypeId,
-        operator_mapping: HashMap<UsingOperator, String>,
+        operator_mapping: Map<UsingOperator, String>,
     ) -> Self {
         Self::SingleTypeOperator {
             scope_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/contract_data.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/contract_data.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -19,13 +18,13 @@ pub(crate) struct ContractData {
     /// order (deterministic iteration for `all_contracts`).
     contracts: Vec<ir::ContractDefinition>,
     /// Per-contract linearised members, keyed by contract `NodeId`.
-    linearisations: HashMap<NodeId, ContractLinearisations>,
+    linearisations: Map<NodeId, ContractLinearisations>,
 }
 
 impl ContractData {
     pub(crate) fn new(
         contracts: Vec<ir::ContractDefinition>,
-        data: HashMap<NodeId, ContractLinearisations>,
+        data: Map<NodeId, ContractLinearisations>,
     ) -> Self {
         Self {
             contracts,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
-
 pub(crate) use contract_data::{ContractData, ContractLinearisations};
 use file_node_mapper::FileNodeMapper;
+use slang_solidity_v2_common::collections::Set;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::utils::strip_string_literal_quotes;
@@ -255,13 +254,13 @@ impl SemanticContext {
     }
 
     pub fn type_canonical_name(&self, type_id: TypeId) -> Option<String> {
-        self.type_canonical_name_impl(type_id, &mut HashSet::new())
+        self.type_canonical_name_impl(type_id, &mut Set::default())
     }
 
     fn type_canonical_name_impl(
         &self,
         type_id: TypeId,
-        visited_structs: &mut HashSet<NodeId>,
+        visited_structs: &mut Set<NodeId>,
     ) -> Option<String> {
         match self.types.get_type_by_id(type_id) {
             Type::Address(_)
@@ -337,13 +336,13 @@ impl SemanticContext {
     pub(crate) const SELECTOR_SIZE: usize = 4;
 
     pub fn storage_size_of_type_id(&self, type_id: TypeId) -> Option<usize> {
-        self.storage_size_of_type_id_impl(type_id, &mut HashSet::new())
+        self.storage_size_of_type_id_impl(type_id, &mut Set::default())
     }
 
     fn storage_size_of_type_id_impl(
         &self,
         type_id: TypeId,
-        visited_structs: &mut HashSet<NodeId>,
+        visited_structs: &mut Set<NodeId>,
     ) -> Option<usize> {
         match self.types.get_type_by_id(type_id) {
             Type::Address(_) | Type::Contract(_) | Type::Interface(_) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/c3.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/c3.rs
@@ -1,6 +1,8 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::hash::Hash;
+
+use slang_solidity_v2_common::collections::Map;
 
 /// Produces a linearisation of a hierarchy of items using the C3 linearisation
 /// algorithm. Given an item `A` with parents `(B1, B2)` in that order, the
@@ -15,9 +17,9 @@ use std::hash::Hash;
 /// linearisation algorithm, ie. Python style.
 pub(crate) fn linearise<Item: Clone + Debug + Eq + Hash + PartialEq>(
     target: &Item,
-    parents: &HashMap<Item, Vec<Item>>,
+    parents: &Map<Item, Vec<Item>>,
 ) -> Option<Vec<Item>> {
-    let mut linearisations: HashMap<Item, Vec<Item>> = HashMap::new();
+    let mut linearisations: Map<Item, Vec<Item>> = Map::default();
 
     // Keeps a running queue of pending linearisations.
     let mut queue: VecDeque<Item> = VecDeque::new();
@@ -194,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_linearise() {
-        let mut parents = HashMap::new();
+        let mut parents = Map::default();
         parents.insert('A', vec![]);
         parents.insert('B', vec!['A']);
         parents.insert('C', vec!['A']);
@@ -207,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_linearise_not_linearisable() {
-        let mut parents = HashMap::new();
+        let mut parents = Map::default();
         parents.insert('X', vec![]);
         parents.insert('A', vec!['X']);
         parents.insert('C', vec!['X', 'A']);
@@ -217,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_linearise_with_shallow_cycles() {
-        let mut parents = HashMap::new();
+        let mut parents = Map::default();
         parents.insert('B', vec!['A']);
         parents.insert('A', vec!['B']);
 
@@ -227,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_linearise_with_deep_cycles() {
-        let mut parents = HashMap::new();
+        let mut parents = Map::default();
         parents.insert('X', vec!['Y']);
         parents.insert('Y', vec!['Z']);
         parents.insert('Z', vec!['X']);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound;
 use slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
@@ -160,8 +159,8 @@ impl<'a> Pass<'a> {
         }
     }
 
-    fn find_contract_bases_recursively(&self, node_id: NodeId) -> HashMap<NodeId, Vec<NodeId>> {
-        let mut result = HashMap::new();
+    fn find_contract_bases_recursively(&self, node_id: NodeId) -> Map<NodeId, Vec<NodeId>> {
+        let mut result = Map::default();
         let mut queue = vec![node_id];
         while let Some(node_id) = queue.pop() {
             if result.contains_key(&node_id) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/evaluator.rs
@@ -343,11 +343,10 @@ fn compute_erc7201(value: &[u8]) -> BigInt {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use num_bigint::{BigInt, ToBigInt};
     use num_rational::BigRational;
     use num_traits::Num;
+    use slang_solidity_v2_common::collections::Map;
     use slang_solidity_v2_common::versions::LanguageVersion;
     use slang_solidity_v2_parser::{ParseOutput, Parser};
 
@@ -356,7 +355,7 @@ mod tests {
     struct MapResolver {
         // qualified identifier => (target expression, target scope)
         // qualified identifier is the concatenation of the scope and identifier
-        context: HashMap<String, (ir::Expression, String)>,
+        context: Map<String, (ir::Expression, String)>,
         // Tests that exercise the erc7201 evaluation path opt in by toggling
         // this flag, mirroring what the production resolver does when the
         // language version enables the built-in and it isn't shadowed.
@@ -385,9 +384,7 @@ mod tests {
     }
 
     impl MapResolver {
-        fn build_context(
-            context: &[(&str, &str, &str)],
-        ) -> HashMap<String, (ir::Expression, String)> {
+        fn build_context(context: &[(&str, &str, &str)]) -> Map<String, (ir::Expression, String)> {
             context
                 .iter()
                 .map(|(name, input, target_scope)| {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use ruint::aliases::U256;
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
@@ -355,8 +355,8 @@ impl Visitor for Pass<'_> {
                         UsingDirective::new_single_type(scope_id, type_id)
                     }
                     ir::UsingClause::UsingDeconstruction(using_deconstruction) => {
-                        let mut symbols = HashMap::new();
-                        let mut operators = HashMap::new();
+                        let mut symbols = Map::default();
+                        let mut operators = Map::default();
 
                         for symbol in &using_deconstruction.symbols {
                             let symbol_name = symbol.name.last().unwrap();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_compute_linearisations/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_compute_linearisations/mod.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -20,7 +20,7 @@ use crate::types::TypeRegistry;
 /// resolution and typing, but it's fully independent for now.
 pub fn run(binder: &Binder, types: &TypeRegistry) -> ContractData {
     let mut contracts = Vec::new();
-    let mut data = HashMap::new();
+    let mut data = Map::default();
 
     for (contract_id, definition) in binder.definitions() {
         let Definition::Contract(contract) = definition else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
+use slang_solidity_v2_common::collections::Set;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -278,7 +278,7 @@ impl Pass<'_> {
         definition_ids: &mut Vec<NodeId>,
     ) {
         let active_directives = self.active_using_directives_for_type(receiver_type_id);
-        let mut seen_ids = HashSet::new();
+        let mut seen_ids = Set::default();
         for directive in active_directives {
             let scope_id = directive.get_scope_id();
             let ids = self

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind;
 use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
@@ -44,8 +43,8 @@ contract Test is Base layout at 0 {}
     assert_eq!(2, binder.linearisations().len());
 }
 
-fn get_contract_to_bases_map(binder: &Binder) -> HashMap<String, Vec<String>> {
-    let mut contract_to_bases = HashMap::new();
+fn get_contract_to_bases_map(binder: &Binder) -> Map<String, Vec<String>> {
+    let mut contract_to_bases = Map::default();
     for (key, values) in binder.linearisations() {
         let contract_name = binder
             .find_definition_by_id(*key)
@@ -103,7 +102,7 @@ interface A is C {}
 
     let contract_to_bases = get_contract_to_bases_map(&binder);
 
-    let mut expected = HashMap::new();
+    let mut expected = Map::default();
     expected.insert(
         "D".to_string(),
         vec![
@@ -166,7 +165,7 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
 
     let contract_to_bases = get_contract_to_bases_map(&binder);
 
-    let mut expected = HashMap::new();
+    let mut expected = Map::default();
     expected.insert("Base".to_string(), vec!["Base".to_string()]);
     expected.insert(
         "Test".to_string(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
-use indexmap::IndexSet;
 use num_bigint::BigInt;
 use num_traits::Zero;
+use slang_solidity_v2_common::collections::{Map, OrderedSet};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 
@@ -20,11 +18,11 @@ use crate::types::ImplicitlyConvertible;
 /// some common elementary types required to type most built-ins functions and
 /// some kinds of expressions (eg. the boolean type).
 pub struct TypeRegistry {
-    types: IndexSet<Type>,
+    types: OrderedSet<Type>,
     // This is used to register the _is-subclass_ and _implements_ relationships
     // between contract/interface types. The `NodeId`s correspond to the
     // `definition_id` in the respective `Type` variants.
-    super_types: HashMap<NodeId, Vec<NodeId>>,
+    super_types: Map<NodeId, Vec<NodeId>>,
     // Some implicit conversion rules are version dependant. The version is
     // threaded in here so we can gate those rules on it.
     language_version: LanguageVersion,
@@ -49,7 +47,7 @@ pub struct TypeRegistry {
 impl TypeRegistry {
     #[allow(clippy::similar_names)]
     pub(crate) fn new(language_version: LanguageVersion) -> Self {
-        let mut types = IndexSet::new();
+        let mut types = OrderedSet::default();
         let (address_type, _) = types.insert_full(Type::Address(AddressType { payable: false }));
         let (address_payable_type, _) =
             types.insert_full(Type::Address(AddressType { payable: true }));
@@ -83,7 +81,7 @@ impl TypeRegistry {
 
         Self {
             types,
-            super_types: HashMap::new(),
+            super_types: Map::default(),
             language_version,
 
             address_type_id: TypeId(address_type),

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -1,5 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-
+use slang_solidity_v2_common::collections::{Set, SortedMap, SortedSet};
 use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::utils::strip_string_literal_quotes;
@@ -42,7 +41,7 @@ pub trait CompilationBuilderConfig {
 struct BuilderFile {
     source_unit: cst::SourceUnit,
     contents: String,
-    resolved_imports: BTreeMap<String, String>,
+    resolved_imports: SortedMap<String, String>,
 }
 
 /// A builder for creating compilation units.
@@ -54,8 +53,8 @@ pub struct CompilationBuilder<C: CompilationBuilderConfig> {
     language_version: LanguageVersion,
     diagnostics: DiagnosticCollection,
 
-    files: BTreeMap<String, BuilderFile>,
-    seen_files: HashSet<String>,
+    files: SortedMap<String, BuilderFile>,
+    seen_files: Set<String>,
 }
 
 impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
@@ -67,8 +66,8 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
             language_version,
             diagnostics: DiagnosticCollection::default(),
 
-            files: BTreeMap::new(),
-            seen_files: HashSet::new(),
+            files: SortedMap::new(),
+            seen_files: Set::default(),
         }
     }
 
@@ -109,7 +108,7 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
 
         let import_paths = extract_import_paths_from_cst(&source_unit, &source);
 
-        let mut resolved_imports = BTreeMap::new();
+        let mut resolved_imports = SortedMap::new();
         for import_path in import_paths {
             match self.config.resolve_import(&file_id, &import_path) {
                 Ok(resolved_id) => {
@@ -178,8 +177,8 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
 fn extract_import_paths_from_cst(
     source_unit: &cst::SourceUnit,
     contents: &str,
-) -> BTreeSet<String> {
-    let mut import_paths = BTreeSet::new();
+) -> SortedSet<String> {
+    let mut import_paths = SortedSet::new();
 
     for member in &source_unit.members.elements {
         let cst::SourceUnitMember::ImportDirective(import_directive) = member else {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
@@ -11,7 +11,7 @@ pub(crate) struct InternalFile {
     // TODO(v2): abstract this into a `FileId` type
     id: String,
     ir_root: ir::SourceUnit,
-    resolved_imports: HashMap<NodeId, String>,
+    resolved_imports: Map<NodeId, String>,
 }
 
 impl InternalFile {
@@ -19,7 +19,7 @@ impl InternalFile {
         Self {
             id,
             ir_root,
-            resolved_imports: HashMap::new(),
+            resolved_imports: Map::default(),
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use slang_solidity_v2_ast::{abi, ast};
+use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
@@ -11,7 +11,7 @@ use super::{File, FileStruct};
 
 pub struct CompilationUnit {
     language_version: LanguageVersion,
-    files: BTreeMap<String, Arc<InternalFile>>,
+    files: SortedMap<String, Arc<InternalFile>>,
     semantic: Arc<SemanticContext>,
     diagnostics: DiagnosticCollection,
 }
@@ -23,7 +23,7 @@ impl CompilationUnit {
         semantic: SemanticContext,
         diagnostics: DiagnosticCollection,
     ) -> Self {
-        let files: BTreeMap<String, Arc<InternalFile>> = files
+        let files: SortedMap<String, Arc<InternalFile>> = files
             .into_iter()
             .map(|file| (file.id().to_string(), Arc::new(file)))
             .collect();

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
@@ -1,10 +1,10 @@
-use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::ops::Range;
 
 use anyhow::Result;
 use ariadne::{Color, Config, Label, Report, ReportBuilder, ReportKind, Source};
 use slang_solidity_v2::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::collections::SortedMap;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use super::report_data::{
@@ -106,7 +106,7 @@ fn report_unbound_identifiers(
 fn report_diagnostics(
     report: &mut String,
     diagnostics: &DiagnosticCollection,
-    file_contents: &BTreeMap<String, String>,
+    file_contents: &SortedMap<String, String>,
 ) -> Result<()> {
     writeln!(report, "Parse errors:")?;
     for diagnostic in diagnostics {

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -1,4 +1,3 @@
-use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::ops::Range;
 use std::sync::Arc;
@@ -6,10 +5,11 @@ use std::sync::Arc;
 use slang_solidity_v2::ast::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2::ast::{DataLocation, Definition, Identifier, LiteralKind, NodeId, Type};
 use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2_common::collections::{Map, SortedMap};
 
 // Types
 
-type FileSourceMap = BTreeMap<String, String>;
+type FileSourceMap = SortedMap<String, String>;
 
 pub(crate) struct ReportData<'a> {
     pub(crate) compilation: &'a CompilationUnit,
@@ -66,7 +66,7 @@ impl<'a> ReportData<'a> {
         let all_definitions = DefinitionCollector::collect_from(compilation, files);
         // This is used to map the reference resolutions to the internal
         // `DefinitionId` of the report.
-        let definitions_by_node_id: HashMap<NodeId, DefinitionId> = all_definitions
+        let definitions_by_node_id: Map<NodeId, DefinitionId> = all_definitions
             .iter()
             .map(|definition| (definition.definition.node_id(), definition.definition_id))
             .collect();
@@ -138,7 +138,7 @@ struct DefinitionCollector<'a> {
 impl<'a> DefinitionCollector<'a> {
     fn collect_from(
         compilation: &CompilationUnit,
-        files: &'a BTreeMap<String, String>,
+        files: &'a SortedMap<String, String>,
     ) -> Vec<CollectedDefinition> {
         let mut collector = Self {
             files,
@@ -175,8 +175,8 @@ impl IdentifierCollector for DefinitionCollector<'_> {
 // Identifiers collection and classification
 
 struct ReferenceCollector<'a> {
-    files: &'a BTreeMap<String, String>,
-    definitions_by_node_id: &'a HashMap<NodeId, DefinitionId>,
+    files: &'a SortedMap<String, String>,
+    definitions_by_node_id: &'a Map<NodeId, DefinitionId>,
     all_references: Vec<CollectedReference>,
     unbound_identifiers: Vec<CollectedIdentifier>,
 }
@@ -185,7 +185,7 @@ impl<'a> ReferenceCollector<'a> {
     fn collect_from(
         compilation: &CompilationUnit,
         files: &'a FileSourceMap,
-        definitions_by_node_id: &'a HashMap<NodeId, DefinitionId>,
+        definitions_by_node_id: &'a Map<NodeId, DefinitionId>,
     ) -> (Vec<CollectedReference>, Vec<CollectedIdentifier>) {
         let mut collector = Self {
             files,

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
@@ -1,10 +1,9 @@
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
+use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::versions::LanguageVersion;
 
 use super::report::binder_report;
@@ -13,7 +12,7 @@ use crate::utils::multi_part_file::split_multi_file;
 use crate::utils::path_resolver;
 
 struct TestConfig {
-    files: BTreeMap<String, String>,
+    files: SortedMap<String, String>,
 }
 
 impl CompilationBuilderConfig for TestConfig {
@@ -46,7 +45,7 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
 
     let multi_part = split_multi_file(&contents);
 
-    let files: BTreeMap<String, String> = multi_part
+    let files: SortedMap<String, String> = multi_part
         .parts
         .iter()
         .map(|part| (part.name.to_string(), part.contents.to_string()))

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
@@ -1,4 +1,3 @@
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::Path;
 
@@ -7,6 +6,7 @@ use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use semver::Version;
+use slang_solidity_v2_common::collections::{SortedMap, SortedSet};
 use slang_solidity_v2_common::versions::LanguageVersion;
 
 use crate::diagnostics_output::targets::{SlangTarget, SolcTarget, TestTarget};
@@ -31,7 +31,7 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
     let multi_part = split_multi_file(&contents);
 
     // Use a sorted map so file iteration order is deterministic across runs.
-    let files: BTreeMap<String, String> = multi_part
+    let files: SortedMap<String, String> = multi_part
         .parts
         .iter()
         .map(|part| (part.name.to_string(), part.contents.to_string()))
@@ -40,7 +40,7 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
     let versions = LanguageVersion::ALL
         .iter()
         .map(|v| (*v).into())
-        .collect::<BTreeSet<Version>>();
+        .collect::<SortedSet<Version>>();
 
     let slang_target = SlangTarget;
     let solc_target = SolcTarget::new(versions.clone())?;
@@ -61,8 +61,8 @@ fn run_target(
     target: &dyn TestTarget,
     test_dir: &Path,
     fs: &mut CodegenFileSystem,
-    files: &BTreeMap<String, String>,
-    versions: &BTreeSet<Version>,
+    files: &SortedMap<String, String>,
+    versions: &SortedSet<Version>,
 ) -> Result<Vec<CompilationStatus>> {
     let mut last_report = None;
     let mut statuses = Vec::with_capacity(versions.len());
@@ -104,7 +104,7 @@ fn run_target(
 fn compare_statuses(
     group_name: &str,
     test_name: &str,
-    versions: &BTreeSet<Version>,
+    versions: &SortedSet<Version>,
     slang_statuses: &[CompilationStatus],
     solc_statuses: &[CompilationStatus],
 ) -> Result<()> {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/mod.rs
@@ -1,11 +1,10 @@
 mod slang;
 mod solc;
 
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use semver::Version;
 pub(crate) use slang::SlangTarget;
+use slang_solidity_v2_common::collections::SortedMap;
 pub(crate) use solc::SolcTarget;
 
 pub(crate) trait TestTarget {
@@ -13,7 +12,7 @@ pub(crate) trait TestTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &BTreeMap<String, String>,
+        files: &SortedMap<String, String>,
         version: &Version,
     ) -> Result<Vec<String>>;
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use semver::Version;
 use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
+use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
@@ -18,7 +17,7 @@ impl TestTarget for SlangTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &BTreeMap<String, String>,
+        files: &SortedMap<String, String>,
         version: &Version,
     ) -> Result<Vec<String>> {
         let language_version = LanguageVersion::try_from(version.clone())
@@ -48,7 +47,7 @@ impl TestTarget for SlangTarget {
 }
 
 struct TestConfig {
-    files: BTreeMap<String, String>,
+    files: SortedMap<String, String>,
 }
 
 impl CompilationBuilderConfig for TestConfig {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
@@ -1,13 +1,12 @@
-use std::collections::BTreeMap;
-
 use anyhow::{anyhow, Result};
 use infra_utils::solc::{render_solc_error, Binary, CliInput, InputSource, LanguageSelector};
 use semver::Version;
+use slang_solidity_v2_common::collections::SortedMap;
 
 use crate::diagnostics_output::targets::TestTarget;
 
 pub(crate) struct SolcTarget {
-    binaries: BTreeMap<Version, Binary>,
+    binaries: SortedMap<Version, Binary>,
 }
 
 impl SolcTarget {
@@ -25,7 +24,7 @@ impl TestTarget for SolcTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &BTreeMap<String, String>,
+        files: &SortedMap<String, String>,
         version: &Version,
     ) -> Result<Vec<String>> {
         let binary = self

--- a/crates/solidity-v2/testing/utils/src/migration.rs
+++ b/crates/solidity-v2/testing/utils/src/migration.rs
@@ -1,9 +1,9 @@
-use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
 use infra_utils::paths::{FileWalker, PathExtensions};
+use slang_solidity_v2_common::collections::Set;
 
 /// Migrates v1 test inputs to v2 format by wrapping them in valid `SourceUnit` boilerplate.
 ///
@@ -11,7 +11,7 @@ use infra_utils::paths::{FileWalker, PathExtensions};
 /// The v2 parser only supports parsing `SourceUnit`, so we wrap each snippet in appropriate
 /// Solidity context.
 pub fn migrate_v1_tests_to_v2(v1_snapshots_dir: &Path, v2_output_dir: &Path) -> Result<()> {
-    let mut written_files = HashSet::<PathBuf>::new();
+    let mut written_files = Set::<PathBuf>::default();
 
     for file in FileWalker::from_directory(v1_snapshots_dir).find_all()? {
         if file.is_generated() {

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
@@ -14,7 +13,7 @@ use crate::dataset::SolidityProject;
 pub struct File {
     id: String,
     ir_root: ir::SourceUnit,
-    resolved_imports: HashMap<NodeId, String>,
+    resolved_imports: Map<NodeId, String>,
 }
 
 impl File {


### PR DESCRIPTION
This PR aims at improving the determinism of slang, in particular dropping the use of non-deterministic hashmaps/sets. The change is split in two steps (commits):

1. Centralize all the relevant collections (maps and sets) into a single module, this allows us to make this kind of change very easy in the future. The type alias names intend to show their characteristics, rather than the implementation.
2. Actually get rid of non deterministic hashers, using a deterministic hasher. There's the option to use a `BTreeMap/Set` throughout, but that was a hit on performance.

Note: I experimented briefly with using [`FxBuildHasher`](https://docs.rs/rustc-hash/latest/rustc_hash/struct.FxBuildHasher.html) and saw  the semantics benchmarks taking ~50% of the time, I'll leave the analysis as a separate PR, but there's a huge improvement to be made here, with this change it should be ver easy to try alternatives.