### PR TITLE
feat(diagnostics): Sort `DiagnosticCollection` by file + location

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -586,8 +586,12 @@ pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::TypeSystem(sla
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+impl core::cmp::Ord for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::eq(&self, other: &slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind) -> bool
+impl core::cmp::PartialOrd for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::compilation::CompilationDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(d: slang_solidity_v2_common::diagnostics::kinds::compilation::CompilationDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::compilation::MissingFile> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -640,8 +644,12 @@ pub slang_solidity_v2_common::diagnostics::DiagnosticSeverity::Error
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticSeverity::clone(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl core::cmp::Ord for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub fn slang_solidity_v2_common::diagnostics::DiagnosticSeverity::cmp(&self, other: &slang_solidity_v2_common::diagnostics::DiagnosticSeverity) -> core::cmp::Ordering
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticSeverity::eq(&self, other: &slang_solidity_v2_common::diagnostics::DiagnosticSeverity) -> bool
+impl core::cmp::PartialOrd for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub fn slang_solidity_v2_common::diagnostics::DiagnosticSeverity::partial_cmp(&self, other: &slang_solidity_v2_common::diagnostics::DiagnosticSeverity) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticSeverity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
@@ -653,8 +661,12 @@ pub fn slang_solidity_v2_common::diagnostics::Diagnostic::text_range(&self) -> &
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::Diagnostic
 pub fn slang_solidity_v2_common::diagnostics::Diagnostic::clone(&self) -> slang_solidity_v2_common::diagnostics::Diagnostic
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::Diagnostic
+impl core::cmp::Ord for slang_solidity_v2_common::diagnostics::Diagnostic
+pub fn slang_solidity_v2_common::diagnostics::Diagnostic::cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::Diagnostic
 pub fn slang_solidity_v2_common::diagnostics::Diagnostic::eq(&self, other: &slang_solidity_v2_common::diagnostics::Diagnostic) -> bool
+impl core::cmp::PartialOrd for slang_solidity_v2_common::diagnostics::Diagnostic
+pub fn slang_solidity_v2_common::diagnostics::Diagnostic::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::Diagnostic
 pub fn slang_solidity_v2_common::diagnostics::Diagnostic::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::iter::traits::collect::Extend<slang_solidity_v2_common::diagnostics::Diagnostic> for slang_solidity_v2_common::diagnostics::DiagnosticCollection
@@ -671,7 +683,6 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::is_empty(&self) -> bool
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = &slang_solidity_v2_common::diagnostics::Diagnostic>
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::push(&mut self, file_id: alloc::string::String, text_range: core::ops::range::Range<usize>, kind: impl core::convert::Into<slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind>)
-pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::sort(&mut self)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::clone(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticCollection
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::DiagnosticCollection
@@ -689,7 +700,7 @@ pub type slang_solidity_v2_common::diagnostics::DiagnosticCollection::Item = sla
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::into_iter(self) -> Self::IntoIter
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::DiagnosticCollection
 impl<'a> core::iter::traits::collect::IntoIterator for &'a slang_solidity_v2_common::diagnostics::DiagnosticCollection
-pub type &'a slang_solidity_v2_common::diagnostics::DiagnosticCollection::IntoIter = core::slice::iter::Iter<'a, slang_solidity_v2_common::diagnostics::Diagnostic>
+pub type &'a slang_solidity_v2_common::diagnostics::DiagnosticCollection::IntoIter = alloc::vec::into_iter::IntoIter<&'a slang_solidity_v2_common::diagnostics::Diagnostic>
 pub type &'a slang_solidity_v2_common::diagnostics::DiagnosticCollection::Item = &'a slang_solidity_v2_common::diagnostics::Diagnostic
 pub fn &'a slang_solidity_v2_common::diagnostics::DiagnosticCollection::into_iter(self) -> Self::IntoIter
 pub trait slang_solidity_v2_common::diagnostics::DiagnosticExtensions
@@ -1209,8 +1220,12 @@ pub const fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::till(
 impl core::clone::Clone for slang_solidity_v2_common::versions::LanguageVersionSpecifier
 pub fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::clone(&self) -> slang_solidity_v2_common::versions::LanguageVersionSpecifier
 impl core::cmp::Eq for slang_solidity_v2_common::versions::LanguageVersionSpecifier
+impl core::cmp::Ord for slang_solidity_v2_common::versions::LanguageVersionSpecifier
+pub fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::cmp(&self, other: &slang_solidity_v2_common::versions::LanguageVersionSpecifier) -> core::cmp::Ordering
 impl core::cmp::PartialEq for slang_solidity_v2_common::versions::LanguageVersionSpecifier
 pub fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::eq(&self, other: &slang_solidity_v2_common::versions::LanguageVersionSpecifier) -> bool
+impl core::cmp::PartialOrd for slang_solidity_v2_common::versions::LanguageVersionSpecifier
+pub fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::partial_cmp(&self, other: &slang_solidity_v2_common::versions::LanguageVersionSpecifier) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for slang_solidity_v2_common::versions::LanguageVersionSpecifier
 pub fn slang_solidity_v2_common::versions::LanguageVersionSpecifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::versions::LanguageVersionSpecifier

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -671,6 +671,7 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::is_empty(&self) -> bool
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = &slang_solidity_v2_common::diagnostics::Diagnostic>
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::push(&mut self, file_id: alloc::string::String, text_range: core::ops::range::Range<usize>, kind: impl core::convert::Into<slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind>)
+pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::sort(&mut self)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::clone(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticCollection
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::DiagnosticCollection

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
@@ -49,7 +49,7 @@ impl IntoIterator for DiagnosticCollection {
     type IntoIter = std::vec::IntoIter<Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        itertools::sorted(self.contents)
+        self.contents.into_iter().sorted()
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
@@ -31,6 +31,16 @@ impl DiagnosticCollection {
     pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
         self.contents.iter()
     }
+
+    /// Sorts the diagnostics by file ID and start of their text range,
+    /// preserving the insertion order of diagnostics at the same position.
+    pub fn sort(&mut self) {
+        self.contents.sort_by(|a, b| {
+            a.file_id()
+                .cmp(b.file_id())
+                .then(a.text_range().start.cmp(&b.text_range().start))
+        });
+    }
 }
 
 impl<'a> IntoIterator for &'a DiagnosticCollection {

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use itertools::Itertools;
+
 use crate::diagnostics::diagnostic::Diagnostic;
 use crate::diagnostics::kinds::DiagnosticKind;
 
@@ -27,28 +29,18 @@ impl DiagnosticCollection {
         self.contents.is_empty()
     }
 
-    /// Returns an iterator over the diagnostics in the collection.
+    /// Returns an iterator over the sorted diagnostics in the collection.
     pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
-        self.contents.iter()
-    }
-
-    /// Sorts the diagnostics by file ID and start of their text range,
-    /// preserving the insertion order of diagnostics at the same position.
-    pub fn sort(&mut self) {
-        self.contents.sort_by(|a, b| {
-            a.file_id()
-                .cmp(b.file_id())
-                .then(a.text_range().start.cmp(&b.text_range().start))
-        });
+        self.contents.iter().sorted()
     }
 }
 
 impl<'a> IntoIterator for &'a DiagnosticCollection {
     type Item = &'a Diagnostic;
-    type IntoIter = std::slice::Iter<'a, Diagnostic>;
+    type IntoIter = std::vec::IntoIter<&'a Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.contents.iter()
+        self.contents.iter().sorted()
     }
 }
 
@@ -57,7 +49,7 @@ impl IntoIterator for DiagnosticCollection {
     type IntoIter = std::vec::IntoIter<Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.contents.into_iter()
+        itertools::sorted(self.contents)
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
@@ -76,6 +76,7 @@ impl Ord for Diagnostic {
         self.file_id()
             .cmp(other.file_id())
             .then(self.text_range().start.cmp(&other.text_range().start))
+            .then(self.text_range().end.cmp(&other.text_range().end))
             .then(self.kind().cmp(other.kind()))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use serde::Serialize;
@@ -67,5 +68,20 @@ impl DiagnosticExtensions for Diagnostic {
 
     fn message(&self) -> String {
         self.kind.message()
+    }
+}
+
+impl Ord for Diagnostic {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.file_id()
+            .cmp(other.file_id())
+            .then(self.text_range().start.cmp(&other.text_range().start))
+            .then(self.kind().cmp(other.kind()))
+    }
+}
+
+impl PartialOrd for Diagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/mod.rs
@@ -6,6 +6,8 @@ pub mod structure;
 pub mod syntax;
 pub mod type_system;
 
+use std::cmp::Ordering;
+
 use compilation::CompilationDiagnosticKind;
 use resolution::ResolutionDiagnosticKind;
 use serde::Serialize;
@@ -13,6 +15,7 @@ use structure::StructureDiagnosticKind;
 use syntax::SyntaxDiagnosticKind;
 use type_system::TypeSystemDiagnosticKind;
 
+use super::extensions::DiagnosticExtensions;
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
 
 define_diagnostic_kind! {
@@ -33,5 +36,19 @@ define_diagnostic_kind! {
         Resolution(ResolutionDiagnosticKind),
         /// A diagnostic about the type system.
         TypeSystem(TypeSystemDiagnosticKind),
+    }
+}
+
+impl Ord for DiagnosticKind {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.severity()
+            .cmp(&other.severity())
+            .then(self.code().cmp(other.code()))
+    }
+}
+
+impl PartialOrd for DiagnosticKind {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/severity.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/severity.rs
@@ -1,5 +1,5 @@
 /// Severity classification for a [`crate::diagnostics::Diagnostic`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DiagnosticSeverity {
     /// A correctness problem — input cannot be considered valid.
     Error,

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/specifier.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/specifier.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::versions::LanguageVersion;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub enum LanguageVersionSpecifier {
     From {
         from: LanguageVersion,

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -171,6 +171,8 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
 
         let semantic = SemanticContext::build_from(language_version, &files, &mut diagnostics);
 
+        diagnostics.sort();
+
         CompilationUnit::create(language_version, files, semantic, diagnostics)
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -171,8 +171,6 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
 
         let semantic = SemanticContext::build_from(language_version, &files, &mut diagnostics);
 
-        diagnostics.sort();
-
         CompilationUnit::create(language_version, files, semantic, diagnostics)
     }
 }


### PR DESCRIPTION
To ensure deterministic output of diagnostic outputs without regards of how they are reported during validation. This allows more liberal iteration of internal data structures without fear of breaking existing snapshot tests.

I ran into this issue while working on #1851: to ensure snapshot stability we would need to sort conflicts found or the collections we use to perform certain checks. Besides that, diagnostics will be emitted from different parts of the pipeline, possibly out of order if we do parallelization, so IMHO it makes sense to provide some default ordering.