### PR TITLE
fix(benchmark): cargo workspace used hashmap and created non-determinism

### DIFF
--- a/crates/infra/utils/src/cargo/manifest.rs
+++ b/crates/infra/utils/src/cargo/manifest.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -16,7 +16,7 @@ pub struct WorkspaceManifest {
 #[derive(Deserialize)]
 struct Workspace {
     package: WorkspacePackage,
-    dependencies: HashMap<String, Dependency>,
+    dependencies: BTreeMap<String, Dependency>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Our `CargoWorkspace` used hashmaps and created non-determinism on the how memory was being used, this flowed down to slang benchmarks since, before the benchmarks started, the free-list was at a different state each time.

Note: This may be better solved by adopting #1850 throughout the repo, but I think that's a bigger task worth more time and care, this is a small fix that seems to cover what we need right now.

------

### Claude summary

  Benchmarks were nondeterministic because WorkspaceManifest.dependencies (parsed from the root Cargo.toml during
  every benchmark's setup) was a randomly-seeded HashMap: dropping it freed its entries in a different order each
  process, leaving glibc's free-lists shuffled. The measured section inherits that heap, so identical code paid a
  layout-dependent amount of malloc_consolidate work — bimodal instruction-count flips of up to ~30%, and randomly
  appearing/vanishing Bencher alerts (e.g. on #1851). Found by hashing the full malloc/free sequence under
  LD_PRELOAD (totals were identical, order wasn't) and backtracing the first divergent op; infra_utils sits
  outside the v2 disallowed_types lint, so #1850 missed it. Switching to BTreeMap makes the drop order
  deterministic.

  Validated with 38 local runs + 4 CI dry runs: 24/32 benchmarks now produce bit-identical counts (worst residual
  spread 0.018%, vs 1% Bencher thresholds). The three noisiest benchmarks — create_x_compute_contracts_abi (was
  27.2% spread), one_step_leverage_f_compute_contracts_abi (22.6%), create_x_semantic (5.4%) — are all
  bit-identical across every run after the fix.
