### PR TITLE
cache solc outputs on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
+ "sha3 0.12.0",
  "similar-asserts 2.0.0",
  "strum 0.28.0",
  "tera",

--- a/crates/infra/utils/Cargo.toml
+++ b/crates/infra/utils/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha3 = { workspace = true }
 similar-asserts = { workspace = true }
 strum = { workspace = true }
 tera = { workspace = true }

--- a/crates/infra/utils/src/solc/binaries.rs
+++ b/crates/infra/utils/src/solc/binaries.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write;
 use std::fs::{File, OpenOptions};
 use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -8,6 +9,7 @@ use anyhow::{Context, Result};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use semver::Version;
 use serde::Deserialize;
+use sha3::{Digest, Sha3_256};
 use url::Url;
 
 use crate::commands::Command;
@@ -28,114 +30,83 @@ impl Binary {
         versions: impl IntoIterator<Item = Version>,
     ) -> Result<BTreeMap<Version, Self>> {
         let versions: Vec<Version> = versions.into_iter().collect();
-        let binaries_dir = get_binaries_dir();
 
-        with_lock(&binaries_dir.join("fetch.lock"), || {
-            let mirror_url = get_mirror_url()?;
-            let releases = fetch_releases(&mirror_url, &binaries_dir)?;
+        let mirror_url = get_mirror_url()?;
+        let releases = fetch_binaries_list(&mirror_url)?;
 
-            versions
-                .iter()
-                .par_bridge()
-                .map(|version| {
-                    let local_path = binaries_dir.join(version.to_string());
-                    if !local_path.exists() {
-                        let release = releases.get(version).unwrap_or_else(|| {
-                            panic!("Expected release '{version}' to exist at: {mirror_url}")
-                        });
+        versions
+            .into_iter()
+            .par_bridge()
+            .map(|version| {
+                let release = releases.get(&version).with_context(|| {
+                    format!("Expected release '{version}' to exist at: {mirror_url}")
+                })?;
 
-                        let remote_url = mirror_url.join(release)?;
-                        download_file(remote_url, &local_path)?;
-                        make_file_executable(&local_path)?;
-                        println!("Downloaded: {local_path:?}");
-                    }
+                let remote_url = mirror_url.join(release)?;
+                let binary = fetch_binary(version.clone(), remote_url)?;
 
-                    Ok((
-                        version.to_owned(),
-                        Self {
-                            version: version.to_owned(),
-                            local_path,
-                        },
-                    ))
-                })
-                .collect()
-        })
+                Ok((version, binary))
+            })
+            .collect()
     }
 
     pub fn run(&self, input: &CliInput) -> Result<CliOutput> {
         let input = serde_json::to_string(input)?;
+        let entry_path = cache_entry_path(&self.version, &input);
 
-        let output = Command::new(self.local_path.unwrap_str())
-            .flag("--standard-json")
-            .evaluate_with_input(input)?;
+        ensure_file_exists(&entry_path, None, || {
+            let output = Command::new(self.local_path.unwrap_str())
+                .flag("--standard-json")
+                .evaluate_with_input(&input)?;
+
+            std::fs::write(&entry_path, &output)
+                .with_context(|| format!("Failed to write cache entry: {entry_path:?}"))
+        })?;
+
+        let output = entry_path
+            .read_to_string()
+            .with_context(|| format!("Failed to read cache entry: {entry_path:?}"))?;
 
         serde_json::from_str(&output)
             .with_context(|| format!("Failed to parse solc JSON output:\n{output}"))
     }
 }
 
-/// Runs `body` while holding an exclusive `flock(2)` on the given path. The
-/// lock is associated with the open file description, so it serializes
-/// concurrent callers across both threads and processes.
-fn with_lock<T>(lock_path: &Path, body: impl FnOnce() -> Result<T>) -> Result<T> {
-    let lock_file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(lock_path)
-        .with_context(|| format!("Failed to open lock file: {lock_path:?}"))?;
-
-    File::lock(&lock_file).with_context(|| format!("Failed to acquire lock: {lock_path:?}"))?;
-
-    let result = body();
-
-    // Released implicitly on drop, but make it explicit for clarity.
-    let _ = File::unlock(&lock_file);
-    result
-}
-
-fn fetch_releases(mirror_url: &Url, binaries_dir: &Path) -> Result<HashMap<Version, String>> {
+fn fetch_binaries_list(mirror_url: &Url) -> Result<HashMap<Version, String>> {
     #[derive(Deserialize)]
     struct MirrorList {
         releases: HashMap<Version, String>,
     }
 
-    let list_path = binaries_dir.join("list.json");
+    const LIST_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24);
 
-    let should_download_list = match list_path.metadata() {
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
-        Err(err) => return Err(err)?,
-        Ok(metadata) => metadata.created()?.elapsed()? > Duration::from_secs(60 * 60 * 24),
-    };
+    let list_path = solc_dir().join("list.json");
 
-    if should_download_list {
+    ensure_file_exists(&list_path, Some(LIST_MAX_AGE), || {
         let list_url = mirror_url.join("list.json")?;
-        download_file(list_url, &list_path)?;
-    }
+        download_file(list_url, &list_path)
+    })?;
 
-    let list_file = std::fs::read_to_string(list_path)?;
+    let list_file = list_path.read_to_string()?;
     let list: MirrorList = serde_json::from_str(&list_file)?;
     Ok(list.releases)
 }
 
-fn download_file(url: Url, path: &Path) -> Result<()> {
-    let bytes = reqwest::blocking::get(url)?.bytes()?;
-    std::fs::create_dir_all(path.unwrap_parent())?;
-    std::fs::write(path, bytes)?;
-    Ok(())
-}
+fn fetch_binary(version: Version, remote_url: Url) -> Result<Binary> {
+    let local_path = solc_dir().join("binaries").join(version.to_string());
 
-fn make_file_executable(local_path: &PathBuf) -> Result<()> {
-    let mut permissions = local_path.metadata()?.permissions();
-    permissions.set_mode(0o744);
-    std::fs::set_permissions(local_path, permissions)?;
-    Ok(())
-}
+    ensure_file_exists(&local_path, None, || {
+        download_file(remote_url, &local_path)?;
+        make_file_executable(&local_path)?;
+        println!("Downloaded: {local_path:?}");
 
-fn get_binaries_dir() -> PathBuf {
-    let dir = Path::repo_path("target/solc-binaries");
-    std::fs::create_dir_all(&dir).expect("Failed to create solc binaries dir");
-    dir
+        Ok(())
+    })?;
+
+    Ok(Binary {
+        version,
+        local_path,
+    })
 }
 
 fn get_mirror_url() -> Result<Url> {
@@ -155,4 +126,82 @@ fn get_mirror_url() -> Result<Url> {
 
     // See the list at <https://github.com/ethereum/solc-bin>.
     Ok(format!("https://binaries.soliditylang.org/{platform_dir}/").parse()?)
+}
+
+fn cache_entry_path(version: &Version, input: &str) -> PathBuf {
+    let mut hasher = Sha3_256::new();
+    hasher.update(version.to_string().as_bytes());
+    hasher.update([0u8]); // Domain separator; versions never contain NUL bytes.
+    hasher.update(input.as_bytes());
+
+    let mut name = String::new();
+    for byte in hasher.finalize() {
+        write!(&mut name, "{byte:02x}").unwrap();
+    }
+
+    solc_dir().join("cache").join(name)
+}
+
+fn download_file(url: Url, file_path: &Path) -> Result<()> {
+    let bytes = reqwest::blocking::get(url)?.bytes()?;
+    std::fs::write(file_path, bytes)?;
+    Ok(())
+}
+
+fn make_file_executable(file_path: &PathBuf) -> Result<()> {
+    let mut permissions = file_path.metadata()?.permissions();
+    permissions.set_mode(0o744);
+
+    std::fs::set_permissions(file_path, permissions)
+        .with_context(|| format!("Failed to make file executable: {file_path:?}"))
+}
+
+fn ensure_file_exists(
+    file_path: &Path,
+    max_age: Option<Duration>,
+    create_file: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    let parent_dir = file_path.unwrap_parent();
+    std::fs::create_dir_all(parent_dir)
+        .with_context(|| format!("Failed to create directory: {parent_dir:?}"))?;
+
+    let file = match File::open(file_path) {
+        Ok(file) => file,
+
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(file_path)
+            .with_context(|| format!("Failed to create file: {file_path:?}"))?,
+
+        Err(error) => {
+            return Err(error).with_context(|| format!("Failed to open file: {file_path:?}"));
+        }
+    };
+
+    File::lock(&file).with_context(|| format!("Failed to acquire lock: {file_path:?}"))?;
+
+    let up_to_date = match file.metadata() {
+        Ok(metadata) if metadata.len() > 0 => match max_age {
+            None => true,
+            Some(max_age) => metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.elapsed().ok())
+                .is_some_and(|age| age <= max_age),
+        },
+        // Missing, empty, or unreadable metadata: (re)create.
+        _ => false,
+    };
+
+    let result = if up_to_date { Ok(()) } else { create_file() };
+
+    File::unlock(&file).with_context(|| format!("Failed to release lock: {file_path:?}"))?;
+
+    result
+}
+
+fn solc_dir() -> PathBuf {
+    Path::repo_path("target/solc")
 }

--- a/crates/infra/utils/src/solc/json_cli.rs
+++ b/crates/infra/utils/src/solc/json_cli.rs
@@ -1,7 +1,7 @@
 //! This module contains the serde types for the of 'solc' JSON CLI:
 //! <https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description>
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use strum::Display;
 #[derive(Debug, Serialize)]
 pub struct CliInput {
     pub language: LanguageSelector,
-    pub sources: HashMap<String, InputSource>,
+    pub sources: BTreeMap<String, InputSource>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
adds a small cache to behind `solc` invocations, saved at `target/`. Since we invoke it repeatedly from `diagnostic_output` tests for each version, it cuts down execution of each test from ~3s to 0.1s.

cc @teofr 