### PR TITLE
simplify boolean fields in the IR/AST

### DIFF
--- a/crates/codegen-v2/semantic/src/ir/builder.rs
+++ b/crates/codegen-v2/semantic/src/ir/builder.rs
@@ -30,6 +30,9 @@ pub fn build_v2_ir_model(language: &Language) -> ModelWithBuilder {
     simplify_mapping_type_parameters(&mut mutator);
     rename_operator_fields(&mut mutator);
     rename_operator_choice_types(&mut mutator);
+    simplify_booleans(&mut mutator);
+
+    // Final clean-up:
     remove_unused_types(&mut mutator);
     remove_unreferenced_terminals(&mut mutator);
 
@@ -332,7 +335,7 @@ fn simplify_imports(mutator: &mut IrModelMutator) {
 fn simplify_parameters(mutator: &mut IrModelMutator) {
     // Replace `EventParameter` and `ErrorParameter` with `Parameter`. This
     // requires adding an `indexed` attribute (required for event parameters).
-    mutator.add_sequence_field("Parameter", "indexed", "IndexedKeyword", true);
+    mutator.add_sequence_field("Parameter", "indexed_keyword", "IndexedKeyword", true);
 
     mutator.remove_type("EventParametersDeclaration");
     mutator.remove_type("EventParameters");
@@ -343,6 +346,15 @@ fn simplify_parameters(mutator: &mut IrModelMutator) {
     mutator.remove_type("ErrorParameters");
     mutator.remove_type("ErrorParameter");
     mutator.add_sequence_field("ErrorDefinition", "parameters", "Parameters", false);
+}
+
+fn simplify_booleans(mutator: &mut IrModelMutator) {
+    mutator.convert_optional_to_boolean("AddressType", "payable_keyword", "is_payable");
+    mutator.convert_optional_to_boolean("ContractDefinition", "abstract_keyword", "is_abstract");
+    mutator.convert_optional_to_boolean("EventDefinition", "anonymous_keyword", "is_anonymous");
+    mutator.convert_optional_to_boolean("FunctionDefinition", "virtual_keyword", "is_virtual");
+    mutator.convert_optional_to_boolean("Parameter", "indexed_keyword", "is_indexed");
+    mutator.convert_optional_to_boolean("UsingDirective", "global_keyword", "is_global");
 }
 
 fn simplify_mapping_type_parameters(mutator: &mut IrModelMutator) {

--- a/crates/codegen-v2/semantic/src/ir/mutator.rs
+++ b/crates/codegen-v2/semantic/src/ir/mutator.rs
@@ -690,4 +690,46 @@ impl IrModelMutator {
             .unwrap_or_else(|| panic!("Field {old_label} not found in sequence {sequence_id}"));
         field.label = new_label_id;
     }
+
+    // Converts an optional, unique-terminal sequence field into a boolean
+    // field, rendered via a shared synthetic `External` "Boolean" type. The
+    // original terminal type is preserved in `field_type` and `source_label`.
+    pub fn convert_optional_to_boolean(
+        &mut self,
+        sequence_id: &str,
+        field_label: &str,
+        new_label: &str,
+    ) {
+        let sequence_id: model::Identifier = sequence_id.into();
+        let field_label: model::Identifier = field_label.into();
+        let new_label: model::Identifier = new_label.into();
+
+        {
+            let Some(sequence) = self.sequences.get_mut(&sequence_id) else {
+                panic!("Sequence {sequence_id} not found in IR model");
+            };
+            let field = sequence
+                .fields
+                .iter_mut()
+                .find(|field| field.label == field_label)
+                .unwrap_or_else(|| {
+                    panic!("Field {field_label} not found in sequence {sequence_id}")
+                });
+
+            assert!(
+                field.is_optional,
+                "Cannot convert non-optional field {field_label} in {sequence_id} to a boolean"
+            );
+            assert!(
+                matches!(field.target_type, NodeType::UniqueTerminal(_)),
+                "Cannot convert field {field_label} in {sequence_id} to a boolean: \
+                 expected an optional unique terminal"
+            );
+
+            field.target_type = NodeType::External("Boolean".into());
+            field.label = new_label;
+        }
+
+        self.external_types.insert("Boolean".into());
+    }
 }

--- a/crates/codegen-v2/semantic/src/ir/mutator.rs
+++ b/crates/codegen-v2/semantic/src/ir/mutator.rs
@@ -704,31 +704,27 @@ impl IrModelMutator {
         let field_label: model::Identifier = field_label.into();
         let new_label: model::Identifier = new_label.into();
 
-        {
-            let Some(sequence) = self.sequences.get_mut(&sequence_id) else {
-                panic!("Sequence {sequence_id} not found in IR model");
-            };
-            let field = sequence
-                .fields
-                .iter_mut()
-                .find(|field| field.label == field_label)
-                .unwrap_or_else(|| {
-                    panic!("Field {field_label} not found in sequence {sequence_id}")
-                });
+        let Some(sequence) = self.sequences.get_mut(&sequence_id) else {
+            panic!("Sequence {sequence_id} not found in IR model");
+        };
+        let field = sequence
+            .fields
+            .iter_mut()
+            .find(|field| field.label == field_label)
+            .unwrap_or_else(|| panic!("Field {field_label} not found in sequence {sequence_id}"));
 
-            assert!(
-                field.is_optional,
-                "Cannot convert non-optional field {field_label} in {sequence_id} to a boolean"
-            );
-            assert!(
-                matches!(field.target_type, NodeType::UniqueTerminal(_)),
-                "Cannot convert field {field_label} in {sequence_id} to a boolean: \
+        assert!(
+            field.is_optional,
+            "Cannot convert non-optional field {field_label} in {sequence_id} to a boolean"
+        );
+        assert!(
+            matches!(field.target_type, NodeType::UniqueTerminal(_)),
+            "Cannot convert field {field_label} in {sequence_id} to a boolean: \
                  expected an optional unique terminal"
-            );
+        );
 
-            field.target_type = NodeType::External("Boolean".into());
-            field.label = new_label;
-        }
+        field.target_type = NodeType::External("Boolean".into());
+        field.label = new_label;
 
         self.external_types.insert("Boolean".into());
     }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -42,8 +42,8 @@ impl core::fmt::Debug for slang_solidity_v2_ast::abi::AbiError
 pub fn slang_solidity_v2_ast::abi::AbiError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity_v2_ast::abi::AbiEvent
 impl slang_solidity_v2_ast::abi::AbiEvent
+pub fn slang_solidity_v2_ast::abi::AbiEvent::anonymous(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiEvent::inputs(&self) -> &[slang_solidity_v2_ast::abi::AbiParameter]
-pub fn slang_solidity_v2_ast::abi::AbiEvent::is_anonymous(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiEvent::name(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::AbiEvent::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::clone::Clone for slang_solidity_v2_ast::abi::AbiEvent
@@ -72,7 +72,7 @@ pub fn slang_solidity_v2_ast::abi::AbiFunction::fmt(&self, f: &mut core::fmt::Fo
 pub struct slang_solidity_v2_ast::abi::AbiParameter
 impl slang_solidity_v2_ast::abi::AbiParameter
 pub fn slang_solidity_v2_ast::abi::AbiParameter::components(&self) -> &[slang_solidity_v2_ast::abi::ParameterComponent]
-pub fn slang_solidity_v2_ast::abi::AbiParameter::is_indexed(&self) -> bool
+pub fn slang_solidity_v2_ast::abi::AbiParameter::indexed(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiParameter::name(&self) -> core::option::Option<&str>
 pub fn slang_solidity_v2_ast::abi::AbiParameter::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_ast::abi::AbiParameter::type_name(&self) -> &str

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -42,8 +42,8 @@ impl core::fmt::Debug for slang_solidity_v2_ast::abi::AbiError
 pub fn slang_solidity_v2_ast::abi::AbiError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct slang_solidity_v2_ast::abi::AbiEvent
 impl slang_solidity_v2_ast::abi::AbiEvent
-pub fn slang_solidity_v2_ast::abi::AbiEvent::anonymous(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiEvent::inputs(&self) -> &[slang_solidity_v2_ast::abi::AbiParameter]
+pub fn slang_solidity_v2_ast::abi::AbiEvent::is_anonymous(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiEvent::name(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::AbiEvent::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::clone::Clone for slang_solidity_v2_ast::abi::AbiEvent
@@ -72,7 +72,7 @@ pub fn slang_solidity_v2_ast::abi::AbiFunction::fmt(&self, f: &mut core::fmt::Fo
 pub struct slang_solidity_v2_ast::abi::AbiParameter
 impl slang_solidity_v2_ast::abi::AbiParameter
 pub fn slang_solidity_v2_ast::abi::AbiParameter::components(&self) -> &[slang_solidity_v2_ast::abi::ParameterComponent]
-pub fn slang_solidity_v2_ast::abi::AbiParameter::indexed(&self) -> bool
+pub fn slang_solidity_v2_ast::abi::AbiParameter::is_indexed(&self) -> bool
 pub fn slang_solidity_v2_ast::abi::AbiParameter::name(&self) -> core::option::Option<&str>
 pub fn slang_solidity_v2_ast::abi::AbiParameter::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_ast::abi::AbiParameter::type_name(&self) -> &str
@@ -1064,15 +1064,6 @@ pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::node_id(&self) -> sl
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::AbstractKeywordStruct
-impl slang_solidity_v2_ast::ast::AbstractKeywordStruct
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::unparse(&self) -> &str
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbstractKeywordStruct
-pub fn slang_solidity_v2_ast::ast::AbstractKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 impl slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::get_file_id(&self) -> &str
@@ -1086,7 +1077,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AdditiveExpressi
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AddressType
 impl slang_solidity_v2_ast::ast::AddressType
-pub fn slang_solidity_v2_ast::ast::AddressType::payable(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::AddressType::is_payable(&self) -> bool
 impl core::clone::Clone for slang_solidity_v2_ast::ast::AddressType
 pub fn slang_solidity_v2_ast::ast::AddressType::clone(&self) -> slang_solidity_v2_ast::ast::AddressType
 pub struct slang_solidity_v2_ast::ast::AddressTypeStruct
@@ -1094,8 +1085,8 @@ impl slang_solidity_v2_ast::ast::AddressTypeStruct
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::is_payable(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::payable_keyword(&self) -> core::option::Option<slang_solidity_v2_ast::ast::PayableKeyword>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AddressTypeStruct
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AmpersandEqualStruct
@@ -1126,15 +1117,6 @@ pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::node_id(&self) -> slang_
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::right_operand(&self) -> slang_solidity_v2_ast::ast::Expression
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AndExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::AnonymousKeywordStruct
-impl slang_solidity_v2_ast::ast::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::unparse(&self) -> &str
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ast::ast::AnonymousKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ArrayExpressionStruct
 impl slang_solidity_v2_ast::ast::ArrayExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_file_id(&self) -> &str
@@ -1428,16 +1410,6 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ContinueStatemen
 pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ContractDefinitionStruct
 impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::abstract_keyword(&self) -> core::option::Option<slang_solidity_v2_ast::ast::AbstractKeyword>
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::inheritance_types(&self) -> slang_solidity_v2_ast::ast::InheritanceTypes
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::members(&self) -> slang_solidity_v2_ast::ast::ContractMembers
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::storage_layout(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
-impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
@@ -1455,6 +1427,16 @@ pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::linearised_function
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::linearised_state_variables(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::StateVariableDefinition>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::modifiers(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::state_variables(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::StateVariableDefinition>
+impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::inheritance_types(&self) -> slang_solidity_v2_ast::ast::InheritanceTypes
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::is_abstract(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::members(&self) -> slang_solidity_v2_ast::ast::ContractMembers
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::storage_layout(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ContractDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ContractMembersStruct
@@ -1613,14 +1595,6 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EtherKeywordStru
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EventDefinitionStruct
 impl slang_solidity_v2_ast::ast::EventDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::anonymous_keyword(&self) -> core::option::Option<slang_solidity_v2_ast::ast::AnonymousKeyword>
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::parameters(&self) -> slang_solidity_v2_ast::ast::Parameters
-impl slang_solidity_v2_ast::ast::EventDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::EventDefinitionStruct
@@ -1628,6 +1602,14 @@ pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::compute_abi_entry(&sel
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::compute_canonical_signature(&self) -> core::option::Option<alloc::string::String>
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::compute_internal_signature(&self) -> core::option::Option<alloc::string::String>
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::compute_selector(&self) -> core::option::Option<u32>
+impl slang_solidity_v2_ast::ast::EventDefinitionStruct
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::is_anonymous(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::parameters(&self) -> slang_solidity_v2_ast::ast::Parameters
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EventDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ExperimentalPragmaStruct
@@ -1680,7 +1662,7 @@ pub struct slang_solidity_v2_ast::ast::FixedPointNumberType
 impl slang_solidity_v2_ast::ast::FixedPointNumberType
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::bits(&self) -> u32
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::decimal_places(&self) -> u32
-pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::signed(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::is_signed(&self) -> bool
 impl core::clone::Clone for slang_solidity_v2_ast::ast::FixedPointNumberType
 pub fn slang_solidity_v2_ast::ast::FixedPointNumberType::clone(&self) -> slang_solidity_v2_ast::ast::FixedPointNumberType
 pub struct slang_solidity_v2_ast::ast::FixedSizeArrayType
@@ -1723,6 +1705,7 @@ pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::body(&self) -> core
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::is_virtual(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::kind(&self) -> slang_solidity_v2_ast::ast::FunctionKind
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::modifier_invocations(&self) -> slang_solidity_v2_ast::ast::ModifierInvocations
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::mutability(&self) -> slang_solidity_v2_ast::ast::FunctionMutability
@@ -1731,7 +1714,6 @@ pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::node_id(&self) -> s
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::override_specifier(&self) -> core::option::Option<slang_solidity_v2_ast::ast::OverridePaths>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::parameters(&self) -> slang_solidity_v2_ast::ast::Parameters
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::returns(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Parameters>
-pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::virtual_keyword(&self) -> core::option::Option<slang_solidity_v2_ast::ast::VirtualKeyword>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::visibility(&self) -> slang_solidity_v2_ast::ast::FunctionVisibility
 impl slang_solidity_v2_ast::ast::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_abi_entry(&self) -> core::option::Option<slang_solidity_v2_ast::abi::AbiEntry>
@@ -1764,15 +1746,6 @@ pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::returns(&self) -> core::o
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::visibility(&self) -> slang_solidity_v2_ast::ast::FunctionVisibility
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FunctionTypeStruct
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::GlobalKeywordStruct
-impl slang_solidity_v2_ast::ast::GlobalKeywordStruct
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::unparse(&self) -> &str
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GlobalKeywordStruct
-pub fn slang_solidity_v2_ast::ast::GlobalKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 impl slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_file_id(&self) -> &str
@@ -1967,15 +1940,6 @@ pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::operand(&self) -
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::start(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::IndexedKeywordStruct
-impl slang_solidity_v2_ast::ast::IndexedKeywordStruct
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::unparse(&self) -> &str
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IndexedKeywordStruct
-pub fn slang_solidity_v2_ast::ast::IndexedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::InequalityExpressionStruct
 impl slang_solidity_v2_ast::ast::InequalityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::get_file_id(&self) -> &str
@@ -2016,7 +1980,7 @@ pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::serialize<S: serde_core::se
 pub struct slang_solidity_v2_ast::ast::IntegerType
 impl slang_solidity_v2_ast::ast::IntegerType
 pub fn slang_solidity_v2_ast::ast::IntegerType::bits(&self) -> u32
-pub fn slang_solidity_v2_ast::ast::IntegerType::signed(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::IntegerType::is_signed(&self) -> bool
 impl core::clone::Clone for slang_solidity_v2_ast::ast::IntegerType
 pub fn slang_solidity_v2_ast::ast::IntegerType::clone(&self) -> slang_solidity_v2_ast::ast::IntegerType
 pub struct slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
@@ -2283,7 +2247,7 @@ impl slang_solidity_v2_ast::ast::ParameterStruct
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::ParameterStruct::indexed(&self) -> core::option::Option<slang_solidity_v2_ast::ast::IndexedKeyword>
+pub fn slang_solidity_v2_ast::ast::ParameterStruct::is_indexed(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::name(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Identifier>
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::storage_location(&self) -> core::option::Option<slang_solidity_v2_ast::ast::StorageLocation>
@@ -2876,7 +2840,7 @@ pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::clause(&self) -> slang_
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::global_keyword(&self) -> core::option::Option<slang_solidity_v2_ast::ast::GlobalKeyword>
+pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::is_global(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::target(&self) -> slang_solidity_v2_ast::ast::UsingTarget
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UsingDirectiveStruct
@@ -2956,15 +2920,6 @@ pub fn slang_solidity_v2_ast::ast::VersionTermStruct::node_id(&self) -> slang_so
 pub fn slang_solidity_v2_ast::ast::VersionTermStruct::operator(&self) -> core::option::Option<slang_solidity_v2_ast::ast::VersionOperator>
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VersionTermStruct
 pub fn slang_solidity_v2_ast::ast::VersionTermStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::VirtualKeywordStruct
-impl slang_solidity_v2_ast::ast::VirtualKeywordStruct
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_file_id(&self) -> &str
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::unparse(&self) -> &str
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VirtualKeywordStruct
-pub fn slang_solidity_v2_ast::ast::VirtualKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VoidType
 impl core::clone::Clone for slang_solidity_v2_ast::ast::VoidType
 pub fn slang_solidity_v2_ast::ast::VoidType::clone(&self) -> slang_solidity_v2_ast::ast::VoidType
@@ -3288,12 +3243,10 @@ pub type slang_solidity_v2_ast::ast::ABIEncoderV2Keyword = alloc::sync::Arc<slan
 pub type slang_solidity_v2_ast::ast::AbicoderPragma = alloc::sync::Arc<slang_solidity_v2_ast::ast::AbicoderPragmaStruct>
 pub type slang_solidity_v2_ast::ast::AbicoderV1Keyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct>
 pub type slang_solidity_v2_ast::ast::AbicoderV2Keyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct>
-pub type slang_solidity_v2_ast::ast::AbstractKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::AbstractKeywordStruct>
 pub type slang_solidity_v2_ast::ast::AdditiveExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::AdditiveExpressionStruct>
 pub type slang_solidity_v2_ast::ast::Ampersand = alloc::sync::Arc<slang_solidity_v2_ast::ast::AmpersandStruct>
 pub type slang_solidity_v2_ast::ast::AmpersandEqual = alloc::sync::Arc<slang_solidity_v2_ast::ast::AmpersandEqualStruct>
 pub type slang_solidity_v2_ast::ast::AndExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::AndExpressionStruct>
-pub type slang_solidity_v2_ast::ast::AnonymousKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::AnonymousKeywordStruct>
 pub type slang_solidity_v2_ast::ast::ArrayExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::ArrayExpressionStruct>
 pub type slang_solidity_v2_ast::ast::ArrayTypeName = alloc::sync::Arc<slang_solidity_v2_ast::ast::ArrayTypeNameStruct>
 pub type slang_solidity_v2_ast::ast::ArrayValues = alloc::sync::Arc<slang_solidity_v2_ast::ast::ArrayValuesStruct>
@@ -3347,7 +3300,6 @@ pub type slang_solidity_v2_ast::ast::FixedKeyword = alloc::sync::Arc<slang_solid
 pub type slang_solidity_v2_ast::ast::ForStatement = alloc::sync::Arc<slang_solidity_v2_ast::ast::ForStatementStruct>
 pub type slang_solidity_v2_ast::ast::FunctionCallExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::FunctionCallExpressionStruct>
 pub type slang_solidity_v2_ast::ast::FunctionDefinition = alloc::sync::Arc<slang_solidity_v2_ast::ast::FunctionDefinitionStruct>
-pub type slang_solidity_v2_ast::ast::GlobalKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::GlobalKeywordStruct>
 pub type slang_solidity_v2_ast::ast::GreaterThan = alloc::sync::Arc<slang_solidity_v2_ast::ast::GreaterThanStruct>
 pub type slang_solidity_v2_ast::ast::GreaterThanEqual = alloc::sync::Arc<slang_solidity_v2_ast::ast::GreaterThanEqualStruct>
 pub type slang_solidity_v2_ast::ast::GreaterThanGreaterThan = alloc::sync::Arc<slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct>
@@ -3367,7 +3319,6 @@ pub type slang_solidity_v2_ast::ast::ImportDeconstruction = alloc::sync::Arc<sla
 pub type slang_solidity_v2_ast::ast::ImportDeconstructionSymbol = alloc::sync::Arc<slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct>
 pub type slang_solidity_v2_ast::ast::ImportDeconstructionSymbols = alloc::sync::Arc<slang_solidity_v2_ast::ast::ImportDeconstructionSymbolsStruct>
 pub type slang_solidity_v2_ast::ast::IndexAccessExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::IndexAccessExpressionStruct>
-pub type slang_solidity_v2_ast::ast::IndexedKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::IndexedKeywordStruct>
 pub type slang_solidity_v2_ast::ast::InequalityExpression = alloc::sync::Arc<slang_solidity_v2_ast::ast::InequalityExpressionStruct>
 pub type slang_solidity_v2_ast::ast::InheritanceType = alloc::sync::Arc<slang_solidity_v2_ast::ast::InheritanceTypeStruct>
 pub type slang_solidity_v2_ast::ast::InheritanceTypes = alloc::sync::Arc<slang_solidity_v2_ast::ast::InheritanceTypesStruct>
@@ -3465,7 +3416,6 @@ pub type slang_solidity_v2_ast::ast::VersionPragma = alloc::sync::Arc<slang_soli
 pub type slang_solidity_v2_ast::ast::VersionRange = alloc::sync::Arc<slang_solidity_v2_ast::ast::VersionRangeStruct>
 pub type slang_solidity_v2_ast::ast::VersionSpecifier = alloc::sync::Arc<slang_solidity_v2_ast::ast::VersionSpecifierStruct>
 pub type slang_solidity_v2_ast::ast::VersionTerm = alloc::sync::Arc<slang_solidity_v2_ast::ast::VersionTermStruct>
-pub type slang_solidity_v2_ast::ast::VirtualKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::VirtualKeywordStruct>
 pub type slang_solidity_v2_ast::ast::WeeksKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::WeeksKeywordStruct>
 pub type slang_solidity_v2_ast::ast::WeiKeyword = alloc::sync::Arc<slang_solidity_v2_ast::ast::WeiKeywordStruct>
 pub type slang_solidity_v2_ast::ast::WhileStatement = alloc::sync::Arc<slang_solidity_v2_ast::ast::WhileStatementStruct>

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -97,7 +97,7 @@ pub struct AbiEvent {
     node_id: NodeId,
     name: String,
     inputs: Vec<AbiParameter>,
-    is_anonymous: bool,
+    anonymous: bool,
 }
 
 impl AbiEvent {
@@ -113,8 +113,8 @@ impl AbiEvent {
         &self.inputs
     }
 
-    pub fn is_anonymous(&self) -> bool {
-        self.is_anonymous
+    pub fn anonymous(&self) -> bool {
+        self.anonymous
     }
 }
 
@@ -287,7 +287,7 @@ pub struct AbiParameter {
     name: Option<String>,
     type_name: String,
     components: Vec<ParameterComponent>,
-    is_indexed: bool,
+    indexed: bool,
 }
 
 impl AbiParameter {
@@ -307,8 +307,8 @@ impl AbiParameter {
         &self.components
     }
 
-    pub fn is_indexed(&self) -> bool {
-        self.is_indexed
+    pub fn indexed(&self) -> bool {
+        self.indexed
     }
 }
 
@@ -367,7 +367,7 @@ pub(crate) fn extract_function_type_parameters_abi(
             name: None,
             type_name,
             components,
-            is_indexed: false,
+            indexed: false,
         });
     }
     let (type_name, components) = type_as_abi_parameter(semantic, function_type.return_type)?;
@@ -376,7 +376,7 @@ pub(crate) fn extract_function_type_parameters_abi(
         name: None,
         type_name,
         components,
-        is_indexed: false,
+        indexed: false,
     }];
     Some((inputs, outputs))
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -97,7 +97,7 @@ pub struct AbiEvent {
     node_id: NodeId,
     name: String,
     inputs: Vec<AbiParameter>,
-    anonymous: bool,
+    is_anonymous: bool,
 }
 
 impl AbiEvent {
@@ -113,8 +113,8 @@ impl AbiEvent {
         &self.inputs
     }
 
-    pub fn anonymous(&self) -> bool {
-        self.anonymous
+    pub fn is_anonymous(&self) -> bool {
+        self.is_anonymous
     }
 }
 
@@ -287,7 +287,7 @@ pub struct AbiParameter {
     name: Option<String>,
     type_name: String,
     components: Vec<ParameterComponent>,
-    indexed: bool,
+    is_indexed: bool,
 }
 
 impl AbiParameter {
@@ -307,8 +307,8 @@ impl AbiParameter {
         &self.components
     }
 
-    pub fn indexed(&self) -> bool {
-        self.indexed
+    pub fn is_indexed(&self) -> bool {
+        self.is_indexed
     }
 }
 
@@ -367,7 +367,7 @@ pub(crate) fn extract_function_type_parameters_abi(
             name: None,
             type_name,
             components,
-            indexed: false,
+            is_indexed: false,
         });
     }
     let (type_name, components) = type_as_abi_parameter(semantic, function_type.return_type)?;
@@ -376,7 +376,7 @@ pub(crate) fn extract_function_type_parameters_abi(
         name: None,
         type_name,
         components,
-        indexed: false,
+        is_indexed: false,
     }];
     Some((inputs, outputs))
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/event_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/event_definition.rs
@@ -21,7 +21,7 @@ impl EventDefinitionStruct {
             node_id: self.ir_node.id(),
             name: self.ir_node.name.unparse().to_string(),
             inputs,
-            is_anonymous: self.ir_node.is_anonymous,
+            anonymous: self.ir_node.is_anonymous,
         }))
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/event_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/event_definition.rs
@@ -21,7 +21,7 @@ impl EventDefinitionStruct {
             node_id: self.ir_node.id(),
             name: self.ir_node.name.unparse().to_string(),
             inputs,
-            anonymous: self.ir_node.anonymous_keyword.is_some(),
+            is_anonymous: self.ir_node.is_anonymous,
         }))
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
@@ -12,7 +12,7 @@ impl ParametersStruct {
                 .name
                 .as_ref()
                 .map(|name| name.unparse().to_string());
-            let indexed = parameter.indexed.is_some();
+            let is_indexed = parameter.is_indexed;
             // Bail out with `None` if any of the parameters fails typing
             let type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;
             let (type_name, components) = type_as_abi_parameter(&self.semantic, type_id)?;
@@ -21,7 +21,7 @@ impl ParametersStruct {
                 name,
                 type_name,
                 components,
-                indexed,
+                is_indexed,
             });
         }
         Some(result)

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
@@ -12,7 +12,7 @@ impl ParametersStruct {
                 .name
                 .as_ref()
                 .map(|name| name.unparse().to_string());
-            let is_indexed = parameter.is_indexed;
+            let indexed = parameter.is_indexed;
             // Bail out with `None` if any of the parameters fails typing
             let type_id = self.semantic.binder().node_typing(node_id).as_type_id()?;
             let (type_name, components) = type_as_abi_parameter(&self.semantic, type_id)?;
@@ -21,7 +21,7 @@ impl ParametersStruct {
                 name,
                 type_name,
                 components,
-                is_indexed,
+                indexed,
             });
         }
         Some(result)

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/source_unit.rs
@@ -6,7 +6,7 @@ impl SourceUnitStruct {
         self.contracts()
             .iter()
             .filter_map(|contract| {
-                if contract.abstract_keyword().is_some() {
+                if contract.is_abstract() {
                     None
                 } else {
                     contract.compute_abi()

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -122,11 +122,8 @@ impl AddressTypeStruct {
         self.ir_node.id()
     }
 
-    pub fn payable_keyword(&self) -> Option<PayableKeyword> {
-        self.ir_node
-            .payable_keyword
-            .as_ref()
-            .map(|ir_node| create_payable_keyword(ir_node, &self.semantic))
+    pub fn is_payable(&self) -> bool {
+        self.ir_node.is_payable
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -866,11 +863,8 @@ impl ContractDefinitionStruct {
         self.ir_node.id()
     }
 
-    pub fn abstract_keyword(&self) -> Option<AbstractKeyword> {
-        self.ir_node
-            .abstract_keyword
-            .as_ref()
-            .map(|ir_node| create_abstract_keyword(ir_node, &self.semantic))
+    pub fn is_abstract(&self) -> bool {
+        self.ir_node.is_abstract
     }
 
     pub fn name(&self) -> Identifier {
@@ -1196,11 +1190,8 @@ impl EventDefinitionStruct {
         create_identifier(&self.ir_node.name, &self.semantic)
     }
 
-    pub fn anonymous_keyword(&self) -> Option<AnonymousKeyword> {
-        self.ir_node
-            .anonymous_keyword
-            .as_ref()
-            .map(|ir_node| create_anonymous_keyword(ir_node, &self.semantic))
+    pub fn is_anonymous(&self) -> bool {
+        self.ir_node.is_anonymous
     }
 
     pub fn parameters(&self) -> Parameters {
@@ -1483,11 +1474,8 @@ impl FunctionDefinitionStruct {
         create_function_mutability(&self.ir_node.mutability, &self.semantic)
     }
 
-    pub fn virtual_keyword(&self) -> Option<VirtualKeyword> {
-        self.ir_node
-            .virtual_keyword
-            .as_ref()
-            .map(|ir_node| create_virtual_keyword(ir_node, &self.semantic))
+    pub fn is_virtual(&self) -> bool {
+        self.ir_node.is_virtual
     }
 
     pub fn override_specifier(&self) -> Option<OverridePaths> {
@@ -2425,11 +2413,8 @@ impl ParameterStruct {
             .map(|ir_node| create_identifier(ir_node, &self.semantic))
     }
 
-    pub fn indexed(&self) -> Option<IndexedKeyword> {
-        self.ir_node
-            .indexed
-            .as_ref()
-            .map(|ir_node| create_indexed_keyword(ir_node, &self.semantic))
+    pub fn is_indexed(&self) -> bool {
+        self.ir_node.is_indexed
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -3346,11 +3331,8 @@ impl UsingDirectiveStruct {
         create_using_target(&self.ir_node.target, &self.semantic)
     }
 
-    pub fn global_keyword(&self) -> Option<GlobalKeyword> {
-        self.ir_node
-            .global_keyword
-            .as_ref()
-            .map(|ir_node| create_global_keyword(ir_node, &self.semantic))
+    pub fn is_global(&self) -> bool {
+        self.ir_node.is_global
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -6849,45 +6831,6 @@ impl AbicoderV2KeywordStruct {
     }
 }
 
-pub type AbstractKeyword = Arc<AbstractKeywordStruct>;
-
-pub struct AbstractKeywordStruct {
-    pub(crate) ir_node: ir::AbstractKeyword,
-    pub(crate) semantic: Arc<SemanticContext>,
-}
-
-pub(crate) fn create_abstract_keyword(
-    ir_node: &ir::AbstractKeyword,
-    semantic: &Arc<SemanticContext>,
-) -> AbstractKeyword {
-    Arc::new(AbstractKeywordStruct {
-        ir_node: Arc::clone(ir_node),
-        semantic: Arc::clone(semantic),
-    })
-}
-
-impl AbstractKeywordStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
-    pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
-    }
-
-    pub fn get_type(&self) -> Option<Type> {
-        Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
-    }
-
-    pub fn get_file_id(&self) -> &str {
-        self.semantic.file_id_from_node_id(self.ir_node.id())
-    }
-
-    pub fn get_text_range(&self) -> &Range<usize> {
-        &self.ir_node.range
-    }
-}
-
 pub type Ampersand = Arc<AmpersandStruct>;
 
 pub struct AmpersandStruct {
@@ -6945,45 +6888,6 @@ pub(crate) fn create_ampersand_equal(
 }
 
 impl AmpersandEqualStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
-    pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
-    }
-
-    pub fn get_type(&self) -> Option<Type> {
-        Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
-    }
-
-    pub fn get_file_id(&self) -> &str {
-        self.semantic.file_id_from_node_id(self.ir_node.id())
-    }
-
-    pub fn get_text_range(&self) -> &Range<usize> {
-        &self.ir_node.range
-    }
-}
-
-pub type AnonymousKeyword = Arc<AnonymousKeywordStruct>;
-
-pub struct AnonymousKeywordStruct {
-    pub(crate) ir_node: ir::AnonymousKeyword,
-    pub(crate) semantic: Arc<SemanticContext>,
-}
-
-pub(crate) fn create_anonymous_keyword(
-    ir_node: &ir::AnonymousKeyword,
-    semantic: &Arc<SemanticContext>,
-) -> AnonymousKeyword {
-    Arc::new(AnonymousKeywordStruct {
-        ir_node: Arc::clone(ir_node),
-        semantic: Arc::clone(semantic),
-    })
-}
-
-impl AnonymousKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
@@ -7731,45 +7635,6 @@ impl FixedKeywordStruct {
     }
 }
 
-pub type GlobalKeyword = Arc<GlobalKeywordStruct>;
-
-pub struct GlobalKeywordStruct {
-    pub(crate) ir_node: ir::GlobalKeyword,
-    pub(crate) semantic: Arc<SemanticContext>,
-}
-
-pub(crate) fn create_global_keyword(
-    ir_node: &ir::GlobalKeyword,
-    semantic: &Arc<SemanticContext>,
-) -> GlobalKeyword {
-    Arc::new(GlobalKeywordStruct {
-        ir_node: Arc::clone(ir_node),
-        semantic: Arc::clone(semantic),
-    })
-}
-
-impl GlobalKeywordStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
-    pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
-    }
-
-    pub fn get_type(&self) -> Option<Type> {
-        Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
-    }
-
-    pub fn get_file_id(&self) -> &str {
-        self.semantic.file_id_from_node_id(self.ir_node.id())
-    }
-
-    pub fn get_text_range(&self) -> &Range<usize> {
-        &self.ir_node.range
-    }
-}
-
 pub type GreaterThan = Arc<GreaterThanStruct>;
 
 pub struct GreaterThanStruct {
@@ -8178,45 +8043,6 @@ pub(crate) fn create_identifier(
 }
 
 impl IdentifierStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
-    pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
-    }
-
-    pub fn get_type(&self) -> Option<Type> {
-        Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
-    }
-
-    pub fn get_file_id(&self) -> &str {
-        self.semantic.file_id_from_node_id(self.ir_node.id())
-    }
-
-    pub fn get_text_range(&self) -> &Range<usize> {
-        &self.ir_node.range
-    }
-}
-
-pub type IndexedKeyword = Arc<IndexedKeywordStruct>;
-
-pub struct IndexedKeywordStruct {
-    pub(crate) ir_node: ir::IndexedKeyword,
-    pub(crate) semantic: Arc<SemanticContext>,
-}
-
-pub(crate) fn create_indexed_keyword(
-    ir_node: &ir::IndexedKeyword,
-    semantic: &Arc<SemanticContext>,
-) -> IndexedKeyword {
-    Arc::new(IndexedKeywordStruct {
-        ir_node: Arc::clone(ir_node),
-        semantic: Arc::clone(semantic),
-    })
-}
-
-impl IndexedKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }
@@ -9723,45 +9549,6 @@ pub(crate) fn create_version_specifier(
 }
 
 impl VersionSpecifierStruct {
-    pub fn node_id(&self) -> NodeId {
-        self.ir_node.id()
-    }
-
-    pub fn unparse(&self) -> &str {
-        self.ir_node.unparse()
-    }
-
-    pub fn get_type(&self) -> Option<Type> {
-        Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
-    }
-
-    pub fn get_file_id(&self) -> &str {
-        self.semantic.file_id_from_node_id(self.ir_node.id())
-    }
-
-    pub fn get_text_range(&self) -> &Range<usize> {
-        &self.ir_node.range
-    }
-}
-
-pub type VirtualKeyword = Arc<VirtualKeywordStruct>;
-
-pub struct VirtualKeywordStruct {
-    pub(crate) ir_node: ir::VirtualKeyword,
-    pub(crate) semantic: Arc<SemanticContext>,
-}
-
-pub(crate) fn create_virtual_keyword(
-    ir_node: &ir::VirtualKeyword,
-    semantic: &Arc<SemanticContext>,
-) -> VirtualKeyword {
-    Arc::new(VirtualKeywordStruct {
-        ir_node: Arc::clone(ir_node),
-        semantic: Arc::clone(semantic),
-    })
-}
-
-impl VirtualKeywordStruct {
     pub fn node_id(&self) -> NodeId {
         self.ir_node.id()
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
@@ -56,7 +56,7 @@ impl Serialize for AddressTypeStruct {
         map.serialize_entry("type", "AddressType")?;
         map.serialize_entry("range", &SerializeRange(self.get_text_range()))?;
         map.serialize_entry("file", self.get_file_id())?;
-        map.serialize_entry("payable_keyword", &self.payable_keyword())?;
+        map.serialize_entry("is_payable", &self.is_payable())?;
         map.end()
     }
 }
@@ -275,7 +275,7 @@ impl Serialize for ContractDefinitionStruct {
         map.serialize_entry("type", "ContractDefinition")?;
         map.serialize_entry("range", &SerializeRange(self.get_text_range()))?;
         map.serialize_entry("file", self.get_file_id())?;
-        map.serialize_entry("abstract_keyword", &self.abstract_keyword())?;
+        map.serialize_entry("is_abstract", &self.is_abstract())?;
         map.serialize_entry("name", &self.name())?;
         map.serialize_entry("inheritance_types", &self.inheritance_types())?;
         map.serialize_entry("storage_layout", &self.storage_layout())?;
@@ -371,7 +371,7 @@ impl Serialize for EventDefinitionStruct {
         map.serialize_entry("range", &SerializeRange(self.get_text_range()))?;
         map.serialize_entry("file", self.get_file_id())?;
         map.serialize_entry("name", &self.name())?;
-        map.serialize_entry("anonymous_keyword", &self.anonymous_keyword())?;
+        map.serialize_entry("is_anonymous", &self.is_anonymous())?;
         map.serialize_entry("parameters", &self.parameters())?;
         map.end()
     }
@@ -454,7 +454,7 @@ impl Serialize for FunctionDefinitionStruct {
         map.serialize_entry("parameters", &self.parameters())?;
         map.serialize_entry("visibility", &self.visibility())?;
         map.serialize_entry("mutability", &self.mutability())?;
-        map.serialize_entry("virtual_keyword", &self.virtual_keyword())?;
+        map.serialize_entry("is_virtual", &self.is_virtual())?;
         map.serialize_entry("override_specifier", &self.override_specifier())?;
         map.serialize_entry("modifier_invocations", &self.modifier_invocations())?;
         map.serialize_entry("returns", &self.returns())?;
@@ -724,7 +724,7 @@ impl Serialize for ParameterStruct {
         map.serialize_entry("type_name", &self.type_name())?;
         map.serialize_entry("storage_location", &self.storage_location())?;
         map.serialize_entry("name", &self.name())?;
-        map.serialize_entry("indexed", &self.indexed())?;
+        map.serialize_entry("is_indexed", &self.is_indexed())?;
         map.end()
     }
 }
@@ -997,7 +997,7 @@ impl Serialize for UsingDirectiveStruct {
         map.serialize_entry("file", self.get_file_id())?;
         map.serialize_entry("clause", &self.clause())?;
         map.serialize_entry("target", &self.target())?;
-        map.serialize_entry("global_keyword", &self.global_keyword())?;
+        map.serialize_entry("is_global", &self.is_global())?;
         map.end()
     }
 }
@@ -2243,17 +2243,6 @@ impl Serialize for AbicoderV2KeywordStruct {
     }
 }
 
-impl Serialize for AbstractKeywordStruct {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(4))?;
-        map.serialize_entry("id", &self.ir_node.id())?;
-        map.serialize_entry("type", "AbstractKeyword")?;
-        map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
-        map.serialize_entry("file", self.get_file_id())?;
-        map.end()
-    }
-}
-
 impl Serialize for AmpersandStruct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(Some(4))?;
@@ -2270,17 +2259,6 @@ impl Serialize for AmpersandEqualStruct {
         let mut map = serializer.serialize_map(Some(4))?;
         map.serialize_entry("id", &self.ir_node.id())?;
         map.serialize_entry("type", "AmpersandEqual")?;
-        map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
-        map.serialize_entry("file", self.get_file_id())?;
-        map.end()
-    }
-}
-
-impl Serialize for AnonymousKeywordStruct {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(4))?;
-        map.serialize_entry("id", &self.ir_node.id())?;
-        map.serialize_entry("type", "AnonymousKeyword")?;
         map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
         map.serialize_entry("file", self.get_file_id())?;
         map.end()
@@ -2499,17 +2477,6 @@ impl Serialize for FixedKeywordStruct {
     }
 }
 
-impl Serialize for GlobalKeywordStruct {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(4))?;
-        map.serialize_entry("id", &self.ir_node.id())?;
-        map.serialize_entry("type", "GlobalKeyword")?;
-        map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
-        map.serialize_entry("file", self.get_file_id())?;
-        map.end()
-    }
-}
-
 impl Serialize for GreaterThanStruct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(Some(4))?;
@@ -2630,17 +2597,6 @@ impl Serialize for IdentifierStruct {
         map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
         map.serialize_entry("file", self.get_file_id())?;
         map.serialize_entry("text", self.ir_node.unparse())?;
-        map.end()
-    }
-}
-
-impl Serialize for IndexedKeywordStruct {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(4))?;
-        map.serialize_entry("id", &self.ir_node.id())?;
-        map.serialize_entry("type", "IndexedKeyword")?;
-        map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
-        map.serialize_entry("file", self.get_file_id())?;
         map.end()
     }
 }
@@ -3076,17 +3032,6 @@ impl Serialize for VersionSpecifierStruct {
         map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
         map.serialize_entry("file", self.get_file_id())?;
         map.serialize_entry("text", self.ir_node.unparse())?;
-        map.end()
-    }
-}
-
-impl Serialize for VirtualKeywordStruct {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(4))?;
-        map.serialize_entry("id", &self.ir_node.id())?;
-        map.serialize_entry("type", "VirtualKeyword")?;
-        map.serialize_entry("range", &SerializeRange(&self.ir_node.range))?;
-        map.serialize_entry("file", self.get_file_id())?;
         map.end()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -168,8 +168,8 @@ impl Type {
 }
 
 impl AddressType {
-    pub fn payable(&self) -> bool {
-        self.inner.payable
+    pub fn is_payable(&self) -> bool {
+        self.inner.is_payable
     }
 }
 
@@ -223,8 +223,8 @@ impl FixedSizeArrayType {
 }
 
 impl FixedPointNumberType {
-    pub fn signed(&self) -> bool {
-        self.inner.signed
+    pub fn is_signed(&self) -> bool {
+        self.inner.is_signed
     }
     pub fn bits(&self) -> u32 {
         self.inner.bits
@@ -274,8 +274,8 @@ impl FunctionType {
 }
 
 impl IntegerType {
-    pub fn signed(&self) -> bool {
-        self.inner.signed
+    pub fn is_signed(&self) -> bool {
+        self.inner.is_signed
     }
     pub fn bits(&self) -> u32 {
         self.inner.bits

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -345,10 +345,8 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_variable_names(&mut
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_abi_encoder_v2_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::ABIEncoderV2Keyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_abicoder_v1_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::AbicoderV1Keyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_abicoder_v2_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::AbicoderV2Keyword)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_abstract_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::AbstractKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_ampersand(&mut self, _node: &slang_solidity_v2_ir::ir::Ampersand)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_ampersand_equal(&mut self, _node: &slang_solidity_v2_ir::ir::AmpersandEqual)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_anonymous_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::AnonymousKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_asterisk(&mut self, _node: &slang_solidity_v2_ir::ir::Asterisk)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_asterisk_equal(&mut self, _node: &slang_solidity_v2_ir::ir::AsteriskEqual)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_bang(&mut self, _node: &slang_solidity_v2_ir::ir::Bang)
@@ -368,7 +366,6 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_equal_equal(&mut self, 
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_ether_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::EtherKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_false_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::FalseKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_fixed_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::FixedKeyword)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_global_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::GlobalKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_greater_than(&mut self, _node: &slang_solidity_v2_ir::ir::GreaterThan)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_greater_than_equal(&mut self, _node: &slang_solidity_v2_ir::ir::GreaterThanEqual)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_greater_than_greater_than(&mut self, _node: &slang_solidity_v2_ir::ir::GreaterThanGreaterThan)
@@ -380,7 +377,6 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_hex_literal(&mut self, 
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_hex_string_literal(&mut self, _node: &slang_solidity_v2_ir::ir::HexStringLiteral)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_hours_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::HoursKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_identifier(&mut self, _node: &slang_solidity_v2_ir::ir::Identifier)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_indexed_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::IndexedKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_int_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::IntKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_less_than(&mut self, _node: &slang_solidity_v2_ir::ir::LessThan)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_less_than_equal(&mut self, _node: &slang_solidity_v2_ir::ir::LessThanEqual)
@@ -420,7 +416,6 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_ufixed_keyword(&mut sel
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_uint_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::UintKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_unicode_string_literal(&mut self, _node: &slang_solidity_v2_ir::ir::UnicodeStringLiteral)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_version_specifier(&mut self, _node: &slang_solidity_v2_ir::ir::VersionSpecifier)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_virtual_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::VirtualKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_weeks_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::WeeksKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::visit_wei_keyword(&mut self, _node: &slang_solidity_v2_ir::ir::WeiKeyword)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_abicoder_pragma(node: &slang_solidity_v2_ir::ir::AbicoderPragma, visitor: &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
@@ -1196,21 +1191,6 @@ pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::fmt(&self, f: &mut cor
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub struct slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub slang_solidity_v2_ir::ir::AbstractKeywordStruct::range: core::ops::range::Range<usize>
-impl slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::unparse(&self) -> &'static str
-impl core::clone::Clone for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AbstractKeywordStruct
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::eq(&self, other: &slang_solidity_v2_ir::ir::AbstractKeywordStruct) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::left_operand: slang_solidity_v2_ir::ir::Expression
 pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::operator: slang_solidity_v2_ir::ir::AdditiveExpressionOperator
@@ -1223,7 +1203,7 @@ pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::fmt(&self, f: &mut co
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AddressTypeStruct
-pub slang_solidity_v2_ir::ir::AddressTypeStruct::payable_keyword: core::option::Option<slang_solidity_v2_ir::ir::PayableKeyword>
+pub slang_solidity_v2_ir::ir::AddressTypeStruct::is_payable: bool
 pub slang_solidity_v2_ir::ir::AddressTypeStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1271,21 +1251,6 @@ impl core::fmt::Debug for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub struct slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub slang_solidity_v2_ir::ir::AnonymousKeywordStruct::range: core::ops::range::Range<usize>
-impl slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::unparse(&self) -> &'static str
-impl core::clone::Clone for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::eq(&self, other: &slang_solidity_v2_ir::ir::AnonymousKeywordStruct) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::items: slang_solidity_v2_ir::ir::ArrayValues
 pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::range: core::ops::range::Range<usize>
@@ -1605,8 +1570,8 @@ pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::fmt(&self, f: &mut cor
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ContractDefinitionStruct
-pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::abstract_keyword: core::option::Option<slang_solidity_v2_ir::ir::AbstractKeyword>
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::inheritance_types: slang_solidity_v2_ir::ir::InheritanceTypes
+pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::is_abstract: bool
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::members: slang_solidity_v2_ir::ir::ContractMembers
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::name: slang_solidity_v2_ir::ir::Identifier
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::range: core::ops::range::Range<usize>
@@ -1770,7 +1735,7 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EtherKeywor
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EventDefinitionStruct
-pub slang_solidity_v2_ir::ir::EventDefinitionStruct::anonymous_keyword: core::option::Option<slang_solidity_v2_ir::ir::AnonymousKeyword>
+pub slang_solidity_v2_ir::ir::EventDefinitionStruct::is_anonymous: bool
 pub slang_solidity_v2_ir::ir::EventDefinitionStruct::name: slang_solidity_v2_ir::ir::Identifier
 pub slang_solidity_v2_ir::ir::EventDefinitionStruct::parameters: slang_solidity_v2_ir::ir::Parameters
 pub slang_solidity_v2_ir::ir::EventDefinitionStruct::range: core::ops::range::Range<usize>
@@ -1863,6 +1828,7 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionC
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::body: core::option::Option<slang_solidity_v2_ir::ir::Block>
+pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::is_virtual: bool
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::kind: slang_solidity_v2_ir::ir::FunctionKind
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::modifier_invocations: slang_solidity_v2_ir::ir::ModifierInvocations
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::mutability: slang_solidity_v2_ir::ir::FunctionMutability
@@ -1871,7 +1837,6 @@ pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::override_specifier: core
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::parameters: slang_solidity_v2_ir::ir::Parameters
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::Parameters>
-pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::virtual_keyword: core::option::Option<slang_solidity_v2_ir::ir::VirtualKeyword>
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1891,21 +1856,6 @@ impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub struct slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub slang_solidity_v2_ir::ir::GlobalKeywordStruct::range: core::ops::range::Range<usize>
-impl slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::unparse(&self) -> &'static str
-impl core::clone::Clone for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::GlobalKeywordStruct
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::eq(&self, other: &slang_solidity_v2_ir::ir::GlobalKeywordStruct) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub slang_solidity_v2_ir::ir::GreaterThanEqualStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::GreaterThanEqualStruct
@@ -2125,21 +2075,6 @@ impl core::fmt::Debug for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub struct slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub slang_solidity_v2_ir::ir::IndexedKeywordStruct::range: core::ops::range::Range<usize>
-impl slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::unparse(&self) -> &'static str
-impl core::clone::Clone for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::IndexedKeywordStruct
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::eq(&self, other: &slang_solidity_v2_ir::ir::IndexedKeywordStruct) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::left_operand: slang_solidity_v2_ir::ir::Expression
 pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::operator: slang_solidity_v2_ir::ir::InequalityExpressionOperator
@@ -2428,7 +2363,7 @@ pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::fmt(&self, f: &mut core::fm
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ParameterStruct
-pub slang_solidity_v2_ir::ir::ParameterStruct::indexed: core::option::Option<slang_solidity_v2_ir::ir::IndexedKeyword>
+pub slang_solidity_v2_ir::ir::ParameterStruct::is_indexed: bool
 pub slang_solidity_v2_ir::ir::ParameterStruct::name: core::option::Option<slang_solidity_v2_ir::ir::Identifier>
 pub slang_solidity_v2_ir::ir::ParameterStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::ParameterStruct::storage_location: core::option::Option<slang_solidity_v2_ir::ir::StorageLocation>
@@ -3064,7 +2999,7 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeco
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::clause: slang_solidity_v2_ir::ir::UsingClause
-pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::global_keyword: core::option::Option<slang_solidity_v2_ir::ir::GlobalKeyword>
+pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::is_global: bool
 pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::target: slang_solidity_v2_ir::ir::UsingTarget
 impl slang_solidity_v2_ir::ir::UsingDirectiveStruct
@@ -3138,21 +3073,6 @@ impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub struct slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub slang_solidity_v2_ir::ir::VirtualKeywordStruct::range: core::ops::range::Range<usize>
-impl slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::unparse(&self) -> &'static str
-impl core::clone::Clone for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::clone(&self) -> slang_solidity_v2_ir::ir::VirtualKeywordStruct
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::eq(&self, other: &slang_solidity_v2_ir::ir::VirtualKeywordStruct) -> bool
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub slang_solidity_v2_ir::ir::WeeksKeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::WeeksKeywordStruct
@@ -3348,8 +3268,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderV
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderVersion
 pub fn slang_solidity_v2_ir::ir::AbicoderVersion::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbstractKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AbstractKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
@@ -3362,8 +3280,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Ampersand
 pub fn slang_solidity_v2_ir::ir::AmpersandStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AnonymousKeywordStruct
-pub fn slang_solidity_v2_ir::ir::AnonymousKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayExpressionStruct
@@ -3486,8 +3402,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionT
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionVisibility
 pub fn slang_solidity_v2_ir::ir::FunctionVisibility::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GlobalKeywordStruct
-pub fn slang_solidity_v2_ir::ir::GlobalKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
@@ -3522,8 +3436,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDec
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexedKeywordStruct
-pub fn slang_solidity_v2_ir::ir::IndexedKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionStruct
@@ -3724,8 +3636,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionSp
 pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VirtualKeywordStruct
-pub fn slang_solidity_v2_ir::ir::VirtualKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WeiKeywordStruct
@@ -3779,13 +3689,11 @@ pub type slang_solidity_v2_ir::ir::ABIEncoderV2Keyword = alloc::sync::Arc<slang_
 pub type slang_solidity_v2_ir::ir::AbicoderPragma = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbicoderPragmaStruct>
 pub type slang_solidity_v2_ir::ir::AbicoderV1Keyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct>
 pub type slang_solidity_v2_ir::ir::AbicoderV2Keyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct>
-pub type slang_solidity_v2_ir::ir::AbstractKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbstractKeywordStruct>
 pub type slang_solidity_v2_ir::ir::AdditiveExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::AdditiveExpressionStruct>
 pub type slang_solidity_v2_ir::ir::AddressType = alloc::sync::Arc<slang_solidity_v2_ir::ir::AddressTypeStruct>
 pub type slang_solidity_v2_ir::ir::Ampersand = alloc::sync::Arc<slang_solidity_v2_ir::ir::AmpersandStruct>
 pub type slang_solidity_v2_ir::ir::AmpersandEqual = alloc::sync::Arc<slang_solidity_v2_ir::ir::AmpersandEqualStruct>
 pub type slang_solidity_v2_ir::ir::AndExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::AndExpressionStruct>
-pub type slang_solidity_v2_ir::ir::AnonymousKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::AnonymousKeywordStruct>
 pub type slang_solidity_v2_ir::ir::ArrayExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::ArrayExpressionStruct>
 pub type slang_solidity_v2_ir::ir::ArrayTypeName = alloc::sync::Arc<slang_solidity_v2_ir::ir::ArrayTypeNameStruct>
 pub type slang_solidity_v2_ir::ir::ArrayValues = alloc::vec::Vec<slang_solidity_v2_ir::ir::Expression>
@@ -3840,7 +3748,6 @@ pub type slang_solidity_v2_ir::ir::ForStatement = alloc::sync::Arc<slang_solidit
 pub type slang_solidity_v2_ir::ir::FunctionCallExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::FunctionCallExpressionStruct>
 pub type slang_solidity_v2_ir::ir::FunctionDefinition = alloc::sync::Arc<slang_solidity_v2_ir::ir::FunctionDefinitionStruct>
 pub type slang_solidity_v2_ir::ir::FunctionType = alloc::sync::Arc<slang_solidity_v2_ir::ir::FunctionTypeStruct>
-pub type slang_solidity_v2_ir::ir::GlobalKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::GlobalKeywordStruct>
 pub type slang_solidity_v2_ir::ir::GreaterThan = alloc::sync::Arc<slang_solidity_v2_ir::ir::GreaterThanStruct>
 pub type slang_solidity_v2_ir::ir::GreaterThanEqual = alloc::sync::Arc<slang_solidity_v2_ir::ir::GreaterThanEqualStruct>
 pub type slang_solidity_v2_ir::ir::GreaterThanGreaterThan = alloc::sync::Arc<slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct>
@@ -3860,7 +3767,6 @@ pub type slang_solidity_v2_ir::ir::ImportDeconstruction = alloc::sync::Arc<slang
 pub type slang_solidity_v2_ir::ir::ImportDeconstructionSymbol = alloc::sync::Arc<slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct>
 pub type slang_solidity_v2_ir::ir::ImportDeconstructionSymbols = alloc::vec::Vec<slang_solidity_v2_ir::ir::ImportDeconstructionSymbol>
 pub type slang_solidity_v2_ir::ir::IndexAccessExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::IndexAccessExpressionStruct>
-pub type slang_solidity_v2_ir::ir::IndexedKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::IndexedKeywordStruct>
 pub type slang_solidity_v2_ir::ir::InequalityExpression = alloc::sync::Arc<slang_solidity_v2_ir::ir::InequalityExpressionStruct>
 pub type slang_solidity_v2_ir::ir::InheritanceType = alloc::sync::Arc<slang_solidity_v2_ir::ir::InheritanceTypeStruct>
 pub type slang_solidity_v2_ir::ir::InheritanceTypes = alloc::vec::Vec<slang_solidity_v2_ir::ir::InheritanceType>
@@ -3959,7 +3865,6 @@ pub type slang_solidity_v2_ir::ir::VersionPragma = alloc::sync::Arc<slang_solidi
 pub type slang_solidity_v2_ir::ir::VersionRange = alloc::sync::Arc<slang_solidity_v2_ir::ir::VersionRangeStruct>
 pub type slang_solidity_v2_ir::ir::VersionSpecifier = alloc::sync::Arc<slang_solidity_v2_ir::ir::VersionSpecifierStruct>
 pub type slang_solidity_v2_ir::ir::VersionTerm = alloc::sync::Arc<slang_solidity_v2_ir::ir::VersionTermStruct>
-pub type slang_solidity_v2_ir::ir::VirtualKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::VirtualKeywordStruct>
 pub type slang_solidity_v2_ir::ir::WeeksKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::WeeksKeywordStruct>
 pub type slang_solidity_v2_ir::ir::WeiKeyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::WeiKeywordStruct>
 pub type slang_solidity_v2_ir::ir::WhileStatement = alloc::sync::Arc<slang_solidity_v2_ir::ir::WhileStatementStruct>

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -55,15 +55,12 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     ) -> output::AddressType {
         let id = self.next_id();
         let range = source.calculate_text_range().unwrap_or_default();
-        let payable_keyword = source
-            .payable_keyword
-            .as_ref()
-            .map(|value| self.build_payable_keyword(value));
+        let is_payable = source.payable_keyword.is_some();
 
         Arc::new(output::AddressTypeStruct {
             id,
             range,
-            payable_keyword,
+            is_payable,
         })
     }
 
@@ -1100,17 +1097,14 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let range = source.calculate_text_range().unwrap_or_default();
         let clause = self.build_using_clause(&source.clause);
         let target = self.build_using_target(&source.target);
-        let global_keyword = source
-            .global_keyword
-            .as_ref()
-            .map(|value| self.build_global_keyword(value));
+        let is_global = source.global_keyword.is_some();
 
         Arc::new(output::UsingDirectiveStruct {
             id,
             range,
             clause,
             target,
-            global_keyword,
+            is_global,
         })
     }
 
@@ -3088,16 +3082,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         })
     }
 
-    pub(super) fn build_abstract_keyword(
-        &mut self,
-        source: &input::AbstractKeyword,
-    ) -> output::AbstractKeyword {
-        Arc::new(output::AbstractKeywordStruct {
-            id: self.next_id(),
-            range: source.range.clone(),
-        })
-    }
-
     pub(super) fn build_ampersand(&mut self, source: &input::Ampersand) -> output::Ampersand {
         Arc::new(output::AmpersandStruct {
             id: self.next_id(),
@@ -3110,16 +3094,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         source: &input::AmpersandEqual,
     ) -> output::AmpersandEqual {
         Arc::new(output::AmpersandEqualStruct {
-            id: self.next_id(),
-            range: source.range.clone(),
-        })
-    }
-
-    pub(super) fn build_anonymous_keyword(
-        &mut self,
-        source: &input::AnonymousKeyword,
-    ) -> output::AnonymousKeyword {
-        Arc::new(output::AnonymousKeywordStruct {
             id: self.next_id(),
             range: source.range.clone(),
         })
@@ -3291,16 +3265,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         })
     }
 
-    pub(super) fn build_global_keyword(
-        &mut self,
-        source: &input::GlobalKeyword,
-    ) -> output::GlobalKeyword {
-        Arc::new(output::GlobalKeywordStruct {
-            id: self.next_id(),
-            range: source.range.clone(),
-        })
-    }
-
     pub(super) fn build_greater_than(
         &mut self,
         source: &input::GreaterThan,
@@ -3405,16 +3369,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             id: self.next_id(),
             range: source.range.clone(),
             text: self.unparse_range(source.range.clone()),
-        })
-    }
-
-    pub(super) fn build_indexed_keyword(
-        &mut self,
-        source: &input::IndexedKeyword,
-    ) -> output::IndexedKeyword {
-        Arc::new(output::IndexedKeywordStruct {
-            id: self.next_id(),
-            range: source.range.clone(),
         })
     }
 
@@ -3772,16 +3726,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             id: self.next_id(),
             range: source.range.clone(),
             text: self.unparse_range(source.range.clone()),
-        })
-    }
-
-    pub(super) fn build_virtual_keyword(
-        &mut self,
-        source: &input::VirtualKeyword,
-    ) -> output::VirtualKeyword {
-        Arc::new(output::VirtualKeywordStruct {
-            id: self.next_id(),
-            range: source.range.clone(),
         })
     }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.rs.jinja2
@@ -26,9 +26,13 @@ impl<S: Source> CstToIrBuilder<'_, S> {
           {%- if field.field_type.kind == "External" -%}
             {{ throw(message="Cannot auto-build external sequence field") }};
           {%- elif field.is_optional -%}
-            source.{{ field.source_label | snake_case }}.as_ref().map(
-              |value| self.build_{{ field.field_type.name | snake_case }}(value)
-            );
+            {%- if field.target_type.kind == "External" and field.target_type.name == "Boolean" -%}
+              source.{{ field.source_label | snake_case }}.is_some();
+            {%- else -%}
+              source.{{ field.source_label | snake_case }}.as_ref().map(
+                |value| self.build_{{ field.field_type.name | snake_case }}(value)
+              );
+            {%- endif -%}
           {%- else -%}
             {# Non-optional unique terminals should be elided at this point #}
             self.build_{{ field.field_type.name | snake_case }}(&source.{{ field.source_label | snake_case }});

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -110,10 +110,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
     ) -> output::ContractDefinition {
         let id = self.next_id();
         let range = source.calculate_text_range().unwrap_or_default();
-        let abstract_keyword = source
-            .abstract_keyword
-            .as_ref()
-            .map(|abstract_keyword| self.build_abstract_keyword(abstract_keyword));
+        let is_abstract = source.abstract_keyword.is_some();
         let name = self.build_identifier(&source.name);
         let members = self.build_contract_members(&source.members);
         let inheritance_types = source
@@ -139,7 +136,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         Arc::new(output::ContractDefinitionStruct {
             id,
             range,
-            abstract_keyword,
+            is_abstract,
             name,
             inheritance_types,
             storage_layout,
@@ -177,10 +174,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let id = self.next_id();
         let range = source.calculate_text_range().unwrap_or_default();
         let name = self.build_identifier(&source.name);
-        let anonymous_keyword = source
-            .anonymous_keyword
-            .as_ref()
-            .map(|anonymous_keyword| self.build_anonymous_keyword(anonymous_keyword));
+        let is_anonymous = source.anonymous_keyword.is_some();
         let parameters = source
             .parameters
             .parameters
@@ -193,7 +187,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             id,
             range,
             name,
-            anonymous_keyword,
+            is_anonymous,
             parameters,
         })
     }
@@ -218,7 +212,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::NonPayable);
 
-        let virtual_keyword =
+        let is_virtual =
             self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
                 if let input::FunctionAttribute::VirtualKeyword(virtual_keyword) = attribute {
                     Some(virtual_keyword)
@@ -242,7 +236,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             parameters,
             visibility,
             mutability,
-            virtual_keyword,
+            is_virtual,
             override_specifier,
             modifier_invocations,
             returns,
@@ -328,7 +322,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             type_name,
             storage_location,
             name,
-            indexed: None,
+            is_indexed: false,
         })
     }
 
@@ -537,7 +531,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::NonPayable);
         // v2 ConstructorAttribute has no VirtualKeyword
-        let virtual_keyword = None;
+        let is_virtual = false;
         // v2 ConstructorAttribute has no OverrideSpecifier
         let override_specifier = None;
         let modifier_invocations = self.constructor_modifier_invocations(&source.attributes);
@@ -552,7 +546,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             parameters,
             visibility,
             mutability,
-            virtual_keyword,
+            is_virtual,
             override_specifier,
             modifier_invocations,
             returns,
@@ -607,7 +601,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let mutability = self
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::NonPayable);
-        let virtual_keyword =
+        let is_virtual =
             self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
                 if let input::FallbackFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute
                 {
@@ -633,7 +627,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             parameters,
             visibility,
             mutability,
-            virtual_keyword,
+            is_virtual,
             override_specifier,
             modifier_invocations,
             returns,
@@ -686,7 +680,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let mutability = self
             .extract_mutability_specifier(&source.attributes.elements)
             .unwrap_or(output::FunctionMutability::Payable);
-        let virtual_keyword =
+        let is_virtual =
             self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
                 if let input::ReceiveFunctionAttribute::VirtualKeyword(virtual_keyword) = attribute
                 {
@@ -708,7 +702,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             parameters,
             visibility,
             mutability,
-            virtual_keyword,
+            is_virtual,
             override_specifier,
             modifier_invocations,
             returns,
@@ -760,7 +754,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let visibility = output::FunctionVisibility::Internal;
         // mutability is irrelevant for modifiers
         let mutability = output::FunctionMutability::NonPayable;
-        let virtual_keyword =
+        let is_virtual =
             self.extract_first_virtual(source.attributes.elements.iter().filter_map(|attribute| {
                 if let input::ModifierAttribute::VirtualKeyword(virtual_keyword) = attribute {
                     Some(virtual_keyword)
@@ -781,7 +775,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             parameters,
             visibility,
             mutability,
-            virtual_keyword,
+            is_virtual,
             override_specifier,
             modifier_invocations,
             returns,
@@ -885,7 +879,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             type_name,
             storage_location: None,
             name,
-            indexed: None,
+            is_indexed: false,
         })
     }
 
@@ -915,7 +909,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             type_name,
             storage_location: None,
             name,
-            indexed: None,
+            is_indexed: false,
         })
     }
 
@@ -948,10 +942,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let id = self.next_id();
         let range = source.calculate_text_range().unwrap_or_default();
         let type_name = self.build_type_name(&source.type_name);
-        let indexed = source
-            .indexed_keyword
-            .as_ref()
-            .map(|indexed_keyword| self.build_indexed_keyword(indexed_keyword));
+        let is_indexed = source.indexed_keyword.is_some();
         let name = source.name.as_ref().map(|name| self.build_identifier(name));
 
         Arc::new(output::ParameterStruct {
@@ -960,7 +951,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             type_name,
             storage_location: None,
             name,
-            indexed,
+            is_indexed,
         })
     }
 
@@ -976,7 +967,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             type_name,
             storage_location: None,
             name,
-            indexed: None,
+            is_indexed: false,
         })
     }
 
@@ -1007,14 +998,16 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         result
     }
 
-    /// Extracts and transforms the first virtual keyword, emitting an error
-    /// for any subsequent ones.
+    /// Returns whether a `virtual` specifier is present, emitting an error for
+    /// any subsequent ones.
     fn extract_first_virtual<'a>(
         &mut self,
         virtual_kws: impl IntoIterator<Item = &'a input::VirtualKeyword>,
-    ) -> Option<output::VirtualKeyword> {
+    ) -> bool {
         let mut virtual_kws = virtual_kws.into_iter();
-        let first = self.build_virtual_keyword(virtual_kws.next()?);
+        let Some(_first) = virtual_kws.next() else {
+            return false;
+        };
 
         for keyword in virtual_kws {
             self.diagnostics.push(
@@ -1024,7 +1017,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             );
         }
 
-        Some(first)
+        true
     }
 
     /// Extracts and transforms the first `override` specifier, emitting an

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -48,7 +48,7 @@ pub type AddressType = Arc<AddressTypeStruct>;
 pub struct AddressTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
-    pub payable_keyword: Option<PayableKeyword>,
+    pub is_payable: bool,
 }
 
 impl AddressTypeStruct {
@@ -318,7 +318,7 @@ pub type ContractDefinition = Arc<ContractDefinitionStruct>;
 pub struct ContractDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
-    pub abstract_keyword: Option<AbstractKeyword>,
+    pub is_abstract: bool,
     pub name: Identifier,
     pub inheritance_types: InheritanceTypes,
     pub storage_layout: Option<Expression>,
@@ -435,7 +435,7 @@ pub struct EventDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub name: Identifier,
-    pub anonymous_keyword: Option<AnonymousKeyword>,
+    pub is_anonymous: bool,
     pub parameters: Parameters,
 }
 
@@ -536,7 +536,7 @@ pub struct FunctionDefinitionStruct {
     pub parameters: Parameters,
     pub visibility: FunctionVisibility,
     pub mutability: FunctionMutability,
-    pub virtual_keyword: Option<VirtualKeyword>,
+    pub is_virtual: bool,
     pub override_specifier: Option<OverridePaths>,
     pub modifier_invocations: ModifierInvocations,
     pub returns: Option<Parameters>,
@@ -866,7 +866,7 @@ pub struct ParameterStruct {
     pub type_name: TypeName,
     pub storage_location: Option<StorageLocation>,
     pub name: Option<Identifier>,
-    pub indexed: Option<IndexedKeyword>,
+    pub is_indexed: bool,
 }
 
 impl ParameterStruct {
@@ -1202,7 +1202,7 @@ pub struct UsingDirectiveStruct {
     pub range: Range<usize>,
     pub clause: UsingClause,
     pub target: UsingTarget,
-    pub global_keyword: Option<GlobalKeyword>,
+    pub is_global: bool,
 }
 
 impl UsingDirectiveStruct {
@@ -2225,23 +2225,6 @@ impl AbicoderV2KeywordStruct {
     }
 }
 
-pub type AbstractKeyword = Arc<AbstractKeywordStruct>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AbstractKeywordStruct {
-    pub(crate) id: NodeId,
-    pub range: Range<usize>,
-}
-
-impl AbstractKeywordStruct {
-    pub fn id(&self) -> NodeId {
-        self.id
-    }
-    pub fn unparse(&self) -> &'static str {
-        "abstract"
-    }
-}
-
 pub type Ampersand = Arc<AmpersandStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2273,23 +2256,6 @@ impl AmpersandEqualStruct {
     }
     pub fn unparse(&self) -> &'static str {
         "&="
-    }
-}
-
-pub type AnonymousKeyword = Arc<AnonymousKeywordStruct>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AnonymousKeywordStruct {
-    pub(crate) id: NodeId,
-    pub range: Range<usize>,
-}
-
-impl AnonymousKeywordStruct {
-    pub fn id(&self) -> NodeId {
-        self.id
-    }
-    pub fn unparse(&self) -> &'static str {
-        "anonymous"
     }
 }
 
@@ -2619,23 +2585,6 @@ impl FixedKeywordStruct {
     }
 }
 
-pub type GlobalKeyword = Arc<GlobalKeywordStruct>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GlobalKeywordStruct {
-    pub(crate) id: NodeId,
-    pub range: Range<usize>,
-}
-
-impl GlobalKeywordStruct {
-    pub fn id(&self) -> NodeId {
-        self.id
-    }
-    pub fn unparse(&self) -> &'static str {
-        "global"
-    }
-}
-
 pub type GreaterThan = Arc<GreaterThanStruct>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2823,23 +2772,6 @@ impl IdentifierStruct {
     }
     pub fn unparse(&self) -> &str {
         &self.text
-    }
-}
-
-pub type IndexedKeyword = Arc<IndexedKeywordStruct>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct IndexedKeywordStruct {
-    pub(crate) id: NodeId,
-    pub range: Range<usize>,
-}
-
-impl IndexedKeywordStruct {
-    pub fn id(&self) -> NodeId {
-        self.id
-    }
-    pub fn unparse(&self) -> &'static str {
-        "indexed"
     }
 }
 
@@ -3509,23 +3441,6 @@ impl VersionSpecifierStruct {
     }
     pub fn unparse(&self) -> &str {
         &self.text
-    }
-}
-
-pub type VirtualKeyword = Arc<VirtualKeywordStruct>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VirtualKeywordStruct {
-    pub(crate) id: NodeId,
-    pub range: Range<usize>,
-}
-
-impl VirtualKeywordStruct {
-    pub fn id(&self) -> NodeId {
-        self.id
-    }
-    pub fn unparse(&self) -> &'static str {
-        "virtual"
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/text_range.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/text_range.generated.rs
@@ -1317,12 +1317,6 @@ impl TextRange for AbicoderV2KeywordStruct {
     }
 }
 
-impl TextRange for AbstractKeywordStruct {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        Some(self.range.clone())
-    }
-}
-
 impl TextRange for AmpersandStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())
@@ -1330,12 +1324,6 @@ impl TextRange for AmpersandStruct {
 }
 
 impl TextRange for AmpersandEqualStruct {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        Some(self.range.clone())
-    }
-}
-
-impl TextRange for AnonymousKeywordStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())
     }
@@ -1455,12 +1443,6 @@ impl TextRange for FixedKeywordStruct {
     }
 }
 
-impl TextRange for GlobalKeywordStruct {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        Some(self.range.clone())
-    }
-}
-
 impl TextRange for GreaterThanStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())
@@ -1522,12 +1504,6 @@ impl TextRange for HoursKeywordStruct {
 }
 
 impl TextRange for IdentifierStruct {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        Some(self.range.clone())
-    }
-}
-
-impl TextRange for IndexedKeywordStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())
     }
@@ -1762,12 +1738,6 @@ impl TextRange for UnicodeStringLiteralStruct {
 }
 
 impl TextRange for VersionSpecifierStruct {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        Some(self.range.clone())
-    }
-}
-
-impl TextRange for VirtualKeywordStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())
     }

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/visitor.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/visitor.generated.rs
@@ -900,13 +900,9 @@ pub trait Visitor {
 
     fn visit_abicoder_v2_keyword(&mut self, _node: &AbicoderV2Keyword) {}
 
-    fn visit_abstract_keyword(&mut self, _node: &AbstractKeyword) {}
-
     fn visit_ampersand(&mut self, _node: &Ampersand) {}
 
     fn visit_ampersand_equal(&mut self, _node: &AmpersandEqual) {}
-
-    fn visit_anonymous_keyword(&mut self, _node: &AnonymousKeyword) {}
 
     fn visit_asterisk(&mut self, _node: &Asterisk) {}
 
@@ -946,8 +942,6 @@ pub trait Visitor {
 
     fn visit_fixed_keyword(&mut self, _node: &FixedKeyword) {}
 
-    fn visit_global_keyword(&mut self, _node: &GlobalKeyword) {}
-
     fn visit_greater_than(&mut self, _node: &GreaterThan) {}
 
     fn visit_greater_than_equal(&mut self, _node: &GreaterThanEqual) {}
@@ -977,8 +971,6 @@ pub trait Visitor {
     fn visit_hours_keyword(&mut self, _node: &HoursKeyword) {}
 
     fn visit_identifier(&mut self, _node: &Identifier) {}
-
-    fn visit_indexed_keyword(&mut self, _node: &IndexedKeyword) {}
 
     fn visit_int_keyword(&mut self, _node: &IntKeyword) {}
 
@@ -1058,8 +1050,6 @@ pub trait Visitor {
 
     fn visit_version_specifier(&mut self, _node: &VersionSpecifier) {}
 
-    fn visit_virtual_keyword(&mut self, _node: &VirtualKeyword) {}
-
     fn visit_weeks_keyword(&mut self, _node: &WeeksKeyword) {}
 
     fn visit_wei_keyword(&mut self, _node: &WeiKeyword) {}
@@ -1090,9 +1080,6 @@ pub fn accept_additive_expression(node: &AdditiveExpression, visitor: &mut impl 
 pub fn accept_address_type(node: &AddressType, visitor: &mut impl Visitor) {
     if !visitor.enter_address_type(node) {
         return;
-    }
-    if let Some(payable_keyword) = &node.payable_keyword {
-        visitor.visit_payable_keyword(payable_keyword);
     }
     visitor.leave_address_type(node);
 }
@@ -1258,9 +1245,6 @@ pub fn accept_contract_definition(node: &ContractDefinition, visitor: &mut impl 
     if !visitor.enter_contract_definition(node) {
         return;
     }
-    if let Some(abstract_keyword) = &node.abstract_keyword {
-        visitor.visit_abstract_keyword(abstract_keyword);
-    }
     visitor.visit_identifier(&node.name);
     accept_inheritance_types(&node.inheritance_types, visitor);
     if let Some(storage_layout) = &node.storage_layout {
@@ -1335,9 +1319,6 @@ pub fn accept_event_definition(node: &EventDefinition, visitor: &mut impl Visito
         return;
     }
     visitor.visit_identifier(&node.name);
-    if let Some(anonymous_keyword) = &node.anonymous_keyword {
-        visitor.visit_anonymous_keyword(anonymous_keyword);
-    }
     accept_parameters(&node.parameters, visitor);
     visitor.leave_event_definition(node);
 }
@@ -1403,9 +1384,6 @@ pub fn accept_function_definition(node: &FunctionDefinition, visitor: &mut impl 
     accept_parameters(&node.parameters, visitor);
     accept_function_visibility(&node.visibility, visitor);
     accept_function_mutability(&node.mutability, visitor);
-    if let Some(virtual_keyword) = &node.virtual_keyword {
-        visitor.visit_virtual_keyword(virtual_keyword);
-    }
     if let Some(override_specifier) = &node.override_specifier {
         accept_override_paths(override_specifier, visitor);
     }
@@ -1632,9 +1610,6 @@ pub fn accept_parameter(node: &Parameter, visitor: &mut impl Visitor) {
     if let Some(name) = &node.name {
         visitor.visit_identifier(name);
     }
-    if let Some(indexed) = &node.indexed {
-        visitor.visit_indexed_keyword(indexed);
-    }
     visitor.leave_parameter(node);
 }
 
@@ -1848,9 +1823,6 @@ pub fn accept_using_directive(node: &UsingDirective, visitor: &mut impl Visitor)
     }
     accept_using_clause(&node.clause, visitor);
     accept_using_target(&node.target, visitor);
-    if let Some(global_keyword) = &node.global_keyword {
-        visitor.visit_global_keyword(global_keyword);
-    }
     visitor.leave_using_directive(node);
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -431,7 +431,7 @@ impl core::hash::Hash for slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Type
 pub struct slang_solidity_v2_semantic::types::AddressType
-pub slang_solidity_v2_semantic::types::AddressType::payable: bool
+pub slang_solidity_v2_semantic::types::AddressType::is_payable: bool
 impl core::clone::Clone for slang_solidity_v2_semantic::types::AddressType
 pub fn slang_solidity_v2_semantic::types::AddressType::clone(&self) -> slang_solidity_v2_semantic::types::AddressType
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::AddressType
@@ -506,7 +506,7 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::En
 pub struct slang_solidity_v2_semantic::types::FixedPointNumberType
 pub slang_solidity_v2_semantic::types::FixedPointNumberType::bits: u32
 pub slang_solidity_v2_semantic::types::FixedPointNumberType::decimal_places: u32
-pub slang_solidity_v2_semantic::types::FixedPointNumberType::signed: bool
+pub slang_solidity_v2_semantic::types::FixedPointNumberType::is_signed: bool
 impl core::clone::Clone for slang_solidity_v2_semantic::types::FixedPointNumberType
 pub fn slang_solidity_v2_semantic::types::FixedPointNumberType::clone(&self) -> slang_solidity_v2_semantic::types::FixedPointNumberType
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::FixedPointNumberType
@@ -552,7 +552,7 @@ pub fn slang_solidity_v2_semantic::types::FunctionType::hash<__H: core::hash::Ha
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::FunctionType
 pub struct slang_solidity_v2_semantic::types::IntegerType
 pub slang_solidity_v2_semantic::types::IntegerType::bits: u32
-pub slang_solidity_v2_semantic::types::IntegerType::signed: bool
+pub slang_solidity_v2_semantic::types::IntegerType::is_signed: bool
 impl core::clone::Clone for slang_solidity_v2_semantic::types::IntegerType
 pub fn slang_solidity_v2_semantic::types::IntegerType::clone(&self) -> slang_solidity_v2_semantic::types::IntegerType
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::IntegerType

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -347,8 +347,8 @@ impl<'a> BuiltInsResolver<'a> {
     ) -> Option<InternalBuiltIn> {
         let type_ = self.types.get_type_by_id(type_id);
         match type_ {
-            Type::Address(AddressType { payable }) => {
-                Self::lookup_member_of_address(symbol, *payable)
+            Type::Address(AddressType { is_payable }) => {
+                Self::lookup_member_of_address(symbol, *is_payable)
             }
             Type::Array(ArrayType { element_type, .. }) => match symbol {
                 "length" => Some(InternalBuiltIn::Length),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -209,12 +209,12 @@ impl SemanticContext {
             Type::ByteArray(ByteArrayType { width }) => format!("bytes{width}"),
             Type::Bytes(_) => "bytes".to_string(),
             Type::FixedPointNumber(FixedPointNumberType {
-                signed,
+                is_signed,
                 bits,
                 decimal_places,
             }) => format!(
                 "{prefix}{bits}x{decimal_places}",
-                prefix = if *signed { "fixed" } else { "ufixed" },
+                prefix = if *is_signed { "fixed" } else { "ufixed" },
             ),
             Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
@@ -225,9 +225,9 @@ impl SemanticContext {
                 )
             }
             Type::Function(_) => "function".to_string(),
-            Type::Integer(IntegerType { signed, bits }) => format!(
+            Type::Integer(IntegerType { is_signed, bits }) => format!(
                 "{prefix}{bits}",
-                prefix = if *signed { "int" } else { "uint" }
+                prefix = if *is_signed { "int" } else { "uint" }
             ),
             Type::Literal(_) => "literal".to_string(),
             Type::Mapping(MappingType {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -97,7 +97,7 @@ impl Pass<'_> {
         match elementary_type {
             ir::ElementaryType::AddressType(address_type) => {
                 Some(self.types.register_type(Type::Address(AddressType {
-                    payable: address_type.payable_keyword.is_some(),
+                    is_payable: address_type.is_payable,
                 })))
             }
             ir::ElementaryType::BytesKeyword(bytes_keyword) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -404,7 +404,7 @@ impl Visitor for Pass<'_> {
             }
         };
 
-        if node.global_keyword.is_some() {
+        if node.is_global {
             self.binder.insert_global_using_directive(directive);
         } else {
             let current_scope_id = self.current_contract_or_file_scope_id();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -30,7 +30,7 @@ impl Pass<'_> {
 
             // Other special cases
             ir::Expression::PayableKeyword(_) => {
-                Typing::MetaType(Type::Address(AddressType { payable: true }))
+                Typing::MetaType(Type::Address(AddressType { is_payable: true }))
             }
             ir::Expression::SuperKeyword(_) => Typing::Super,
 
@@ -47,7 +47,7 @@ impl Pass<'_> {
     fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
         match elementary_type {
             ir::ElementaryType::AddressType(address_type) => Type::Address(AddressType {
-                payable: address_type.payable_keyword.is_some(),
+                is_payable: address_type.is_payable,
             }),
             ir::ElementaryType::BytesKeyword(terminal) => {
                 Type::from_bytes_keyword(terminal.unparse(), Some(DataLocation::Memory)).unwrap()
@@ -217,7 +217,7 @@ impl Pass<'_> {
             // sign of `left_operand`.
             if left_value.is_negative() {
                 Some(self.types.register_type(Type::Integer(IntegerType {
-                    signed: true,
+                    is_signed: true,
                     bits: 256,
                 })))
             } else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -209,7 +209,7 @@ fn try_type_of_expression_in_context(context: &str, expr: &str) -> (Option<Type>
 
 fn register_uint_type(types: &mut TypeRegistry, bits: u32) -> TypeId {
     types.register_type(Type::Integer(IntegerType {
-        signed: false,
+        is_signed: false,
         bits,
     }))
 }
@@ -457,7 +457,7 @@ fn test_implicit_conversion_uses_literal_value() {
     let (_, mut types) = type_of_expression("0");
 
     let int8 = types.register_type(Type::Integer(IntegerType {
-        signed: true,
+        is_signed: true,
         bits: 8,
     }));
     let uint8 = types.uint8();
@@ -536,7 +536,7 @@ fn test_overload_resolution_unsigned_to_signed_argument_is_version_gated() {
     assert_eq!(
         typings.into_iter().next().unwrap(),
         Some(Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 8,
         })),
     );
@@ -611,7 +611,7 @@ fn test_conditional_expression_unifies_branch_types() {
     assert_eq!(
         type_,
         Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 8,
         })
     );
@@ -621,7 +621,7 @@ fn test_conditional_expression_unifies_branch_types() {
     assert_eq!(
         type_,
         Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 16,
         })
     );
@@ -631,7 +631,7 @@ fn test_conditional_expression_unifies_branch_types() {
     assert_eq!(
         type_,
         Type::Integer(IntegerType {
-            signed: true,
+            is_signed: true,
             bits: 8,
         })
     );
@@ -694,7 +694,7 @@ fn test_array_literal_unifies_element_types() {
     assert_eq!(
         element_type,
         types.register_type(Type::Integer(IntegerType {
-            signed: true,
+            is_signed: true,
             bits: 8,
         }))
     );
@@ -897,7 +897,7 @@ fn test_overload_resolution_widens_byte_array_argument() {
     assert_eq!(
         type_,
         Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 8,
         })
     );
@@ -1086,7 +1086,7 @@ fn test_getter_of_struct_with_function_member() {
             element_types.as_slice(),
             [
                 Type::Integer(IntegerType {
-                    signed: false,
+                    is_signed: false,
                     bits: 256
                 }),
                 Type::Function(_),
@@ -1124,7 +1124,7 @@ fn test_getter_of_struct_with_struct_member() {
             [
                 Type::Struct(_),
                 Type::Integer(IntegerType {
-                    signed: false,
+                    is_signed: false,
                     bits: 256
                 }),
             ]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -296,15 +296,15 @@ pub(crate) fn integer_literal_fits(value: &BigInt, signed: bool, bits: u32) -> b
 }
 
 pub(crate) fn smallest_integer_type_to_fit(value: &BigInt) -> Option<Type> {
-    let signed = value.is_negative();
-    let bits = integer_bits_required(value, signed);
+    let is_signed = value.is_negative();
+    let bits = integer_bits_required(value, is_signed);
 
     if bits > 256 {
         // TODO(validation) SDR[1740]: the integers don't fit in the EVM
         return None;
     }
     let bits = bits.next_multiple_of(8).max(8);
-    Some(Type::Integer(IntegerType { signed, bits }))
+    Some(Type::Integer(IntegerType { is_signed, bits }))
 }
 
 /// Returns the smallest fixed-point type that holds `value`.
@@ -326,7 +326,7 @@ pub(crate) fn smallest_integer_type_to_fit(value: &BigInt) -> Option<Type> {
 pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Type> {
     const MAX_DECIMAL_PLACES: u32 = 80;
 
-    let signed = value.is_negative();
+    let is_signed = value.is_negative();
     let numerator_magnitude = value.numer().abs();
     // `BigRational` normalises to a positive denominator, so `denom()` is
     // always > 0 and carries no sign information.
@@ -335,7 +335,7 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
     // Maximum scaled magnitude that fits in 256 bits with the chosen
     // signedness: `2^255` for signed (reachable by `INT256_MIN`), and
     // `2^256 - 1` for unsigned.
-    let max_magnitude = if signed {
+    let max_magnitude = if is_signed {
         BigInt::from(1u32) << 255
     } else {
         (BigInt::from(1u32) << 256) - BigInt::from(1u32)
@@ -370,16 +370,16 @@ pub(crate) fn smallest_fixed_point_type_to_fit(value: &BigRational) -> Option<Ty
     let threshold = (max_magnitude + BigInt::from(1u32)) * denominator;
 
     let build_result = |scaled_magnitude: BigInt, decimal_places: u32| -> Type {
-        let scaled = if signed {
+        let scaled = if is_signed {
             -scaled_magnitude
         } else {
             scaled_magnitude
         };
-        let bits = integer_bits_required(&scaled, signed);
+        let bits = integer_bits_required(&scaled, is_signed);
         debug_assert!(bits <= 256, "scaled value must fit 256 bits at this point");
         let bits = bits.next_multiple_of(8).max(8);
         Type::FixedPointNumber(FixedPointNumberType {
-            signed,
+            is_signed,
             bits,
             decimal_places,
         })
@@ -438,7 +438,7 @@ mod tests {
 
     fn unsigned_fixed(bits: u32, decimal_places: u32) -> FixedPointNumberType {
         FixedPointNumberType {
-            signed: false,
+            is_signed: false,
             bits,
             decimal_places,
         }
@@ -446,7 +446,7 @@ mod tests {
 
     fn signed_fixed(bits: u32, decimal_places: u32) -> FixedPointNumberType {
         FixedPointNumberType {
-            signed: true,
+            is_signed: true,
             bits,
             decimal_places,
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -42,7 +42,7 @@ pub enum Type {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct AddressType {
-    pub payable: bool,
+    pub is_payable: bool,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -73,7 +73,7 @@ pub struct EnumType {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FixedPointNumberType {
-    pub signed: bool,
+    pub is_signed: bool,
     pub bits: u32,
     pub decimal_places: u32,
 }
@@ -88,7 +88,7 @@ pub struct FixedSizeArrayType {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct IntegerType {
-    pub signed: bool,
+    pub is_signed: bool,
     pub bits: u32,
 }
 
@@ -177,7 +177,7 @@ impl LiteralKind {
                     location: DataLocation::Memory,
                 }))
             }
-            LiteralKind::Address { .. } => Some(Type::Address(AddressType { payable: false })),
+            LiteralKind::Address { .. } => Some(Type::Address(AddressType { is_payable: false })),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
@@ -21,7 +21,10 @@ impl Type {
             .unwrap()
             .parse::<u32>()
             .unwrap_or(256);
-        Self::Integer(IntegerType { signed: true, bits })
+        Self::Integer(IntegerType {
+            is_signed: true,
+            bits,
+        })
     }
 
     pub fn from_uint_keyword(keyword: &str) -> Self {
@@ -31,7 +34,7 @@ impl Type {
             .parse::<u32>()
             .unwrap_or(256);
         Self::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits,
         })
     }
@@ -45,7 +48,7 @@ impl Type {
         let bits = parts.next().unwrap();
         let decimal_places = parts.next().unwrap_or(0);
         Self::FixedPointNumber(FixedPointNumberType {
-            signed: true,
+            is_signed: true,
             bits,
             decimal_places,
         })
@@ -60,7 +63,7 @@ impl Type {
         let bits = parts.next().unwrap();
         let decimal_places = parts.next().unwrap_or(0);
         Self::FixedPointNumber(FixedPointNumberType {
-            signed: false,
+            is_signed: false,
             bits,
             decimal_places,
         })

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -48,9 +48,9 @@ impl TypeRegistry {
     #[allow(clippy::similar_names)]
     pub(crate) fn new(language_version: LanguageVersion) -> Self {
         let mut types = OrderedSet::default();
-        let (address_type, _) = types.insert_full(Type::Address(AddressType { payable: false }));
+        let (address_type, _) = types.insert_full(Type::Address(AddressType { is_payable: false }));
         let (address_payable_type, _) =
-            types.insert_full(Type::Address(AddressType { payable: true }));
+            types.insert_full(Type::Address(AddressType { is_payable: true }));
         let (boolean_type, _) = types.insert_full(Type::Boolean);
         let (bytes_calldata_type, _) = types.insert_full(Type::Bytes(BytesType {
             location: DataLocation::Calldata,
@@ -66,11 +66,11 @@ impl TypeRegistry {
             location: DataLocation::Memory,
         }));
         let (uint256_type, _) = types.insert_full(Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 256,
         }));
         let (uint8_type, _) = types.insert_full(Type::Integer(IntegerType {
-            signed: false,
+            is_signed: false,
             bits: 8,
         }));
         let (void_type, _) = types.insert_full(Type::Void);
@@ -152,18 +152,18 @@ impl TypeRegistry {
         match (from_type, to_type) {
             (
                 Type::Address(AddressType {
-                    payable: from_payable,
+                    is_payable: from_payable,
                 }),
                 Type::Address(_),
             ) => *from_payable,
 
             (
                 Type::Integer(IntegerType {
-                    signed: from_signed,
+                    is_signed: from_signed,
                     bits: from_bits,
                 }),
                 Type::Integer(IntegerType {
-                    signed: to_signed,
+                    is_signed: to_signed,
                     bits: to_bits,
                 }),
             ) => {
@@ -183,13 +183,13 @@ impl TypeRegistry {
 
             (
                 Type::Literal(LiteralKind::Integer { value }),
-                Type::Integer(IntegerType { signed, bits }),
-            ) => numbers::integer_literal_fits(value, *signed, *bits),
+                Type::Integer(IntegerType { is_signed, bits }),
+            ) => numbers::integer_literal_fits(value, *is_signed, *bits),
 
             (
                 Type::Literal(LiteralKind::HexInteger { value, .. }),
-                Type::Integer(IntegerType { signed, bits }),
-            ) => numbers::integer_literal_fits(&BigInt::from(value.clone()), *signed, *bits),
+                Type::Integer(IntegerType { is_signed, bits }),
+            ) => numbers::integer_literal_fits(&BigInt::from(value.clone()), *is_signed, *bits),
 
             // Non-integer rational literals never implicitly convert to an
             // integer type — if a rational reduced to an integer it would have

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -84,7 +84,7 @@ fn test_find_contract_by_name() {
 
     assert_eq!(counter.name().name(), "Counter");
     assert_eq!(ownable.name().name(), "Ownable");
-    assert!(ownable.abstract_keyword().is_some());
+    assert!(ownable.is_abstract());
     assert_eq!(activatable.name().name(), "Activatable");
-    assert!(activatable.abstract_keyword().is_some());
+    assert!(activatable.is_abstract());
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -381,7 +381,7 @@ fn type_or_unresolved(type_: Option<Type>) -> String {
 fn type_display(type_: &Type) -> String {
     match type_ {
         Type::Address(address) => {
-            if address.payable() {
+            if address.is_payable() {
                 "address payable".to_string()
             } else {
                 "address".to_string()
@@ -405,7 +405,7 @@ fn type_display(type_: &Type) -> String {
         Type::FixedPointNumber(fixed) => {
             format!(
                 "{signed}fixed{bits}x{precision_bits}",
-                signed = if fixed.signed() { "" } else { "u" },
+                signed = if fixed.is_signed() { "" } else { "u" },
                 bits = fixed.bits(),
                 precision_bits = fixed.decimal_places(),
             )
@@ -431,7 +431,7 @@ fn type_display(type_: &Type) -> String {
         Type::Integer(integer) => {
             format!(
                 "{signed}int{bits}",
-                signed = if integer.signed() { "" } else { "u" },
+                signed = if integer.is_signed() { "" } else { "u" },
                 bits = integer.bits(),
             )
         }

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -67,7 +67,7 @@ pub fn count_concrete_contracts(source_units: &Vec<SourceUnit>) -> usize {
     for source_unit in source_units {
         for member in &source_unit.members {
             if let SourceUnitMember::ContractDefinition(contract) = member {
-                if contract.abstract_keyword.is_none() {
+                if !contract.is_abstract {
                     count += 1;
                 }
             }


### PR DESCRIPTION
This PR simplifies the IR and AST by converting certain optional fields that represent boolean properties (e.g., `abstract_keyword`) into actual boolean fields (e.g., `is_abstract`), and updates the naming of all such fields across the codebase (IR/AST/ABI types + semantic passes).

Context: https://github.com/NomicFoundation/slang/pull/1832#discussion_r3382509605