### PR TITLE
[v2] feat(typing): Function type carry partial application

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -536,6 +536,7 @@ pub slang_solidity_v2_semantic::types::FunctionType::definition_id: core::option
 pub slang_solidity_v2_semantic::types::FunctionType::implicit_receiver_type: core::option::Option<slang_solidity_v2_semantic::types::TypeId>
 pub slang_solidity_v2_semantic::types::FunctionType::mutability: slang_solidity_v2_semantic::types::FunctionTypeMutability
 pub slang_solidity_v2_semantic::types::FunctionType::parameter_types: alloc::vec::Vec<slang_solidity_v2_semantic::types::TypeId>
+pub slang_solidity_v2_semantic::types::FunctionType::partially_applied: bool
 pub slang_solidity_v2_semantic::types::FunctionType::return_type: slang_solidity_v2_semantic::types::TypeId
 pub slang_solidity_v2_semantic::types::FunctionType::visibility: slang_solidity_v2_semantic::types::FunctionTypeVisibility
 impl slang_solidity_v2_semantic::types::FunctionType

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -122,6 +122,7 @@ impl Pass<'_> {
                     return_type,
                     visibility: (&function_type.visibility).into(),
                     mutability: (&function_type.mutability).into(),
+                    partially_applied: false,
                 })))
             }
             ir::TypeName::MappingType(mapping_type) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -159,6 +159,7 @@ impl Pass<'_> {
             return_type,
             visibility: (&function_definition.visibility).into(),
             mutability: (&function_definition.mutability).into(),
+            partially_applied: false,
         })))
     }
 
@@ -275,6 +276,7 @@ impl Pass<'_> {
             return_type,
             visibility: FunctionTypeVisibility::Public,
             mutability: FunctionTypeMutability::View,
+            partially_applied: false,
         });
         Some(self.types.register_type(getter_type))
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -343,7 +343,7 @@ impl Visitor for Pass<'_> {
 
         // Special cases
         if let Some(type_id) = typing.as_type_id() {
-            let type_ = self.types.get_type_by_id(type_id).clone();
+            let type_ = self.types.get_type_by_id(type_id);
 
             if type_.is_inherited_location() {
                 // If the type is a reference type with location "inherited", we
@@ -357,12 +357,10 @@ impl Visitor for Pass<'_> {
                         .register_type_with_data_location(type_.clone(), operand_location);
                     typing = Typing::Resolved(type_id_with_location);
                 }
-            }
-
-            // If this member is a function attached via `using for`, accessing it
-            // on a value binds the receiver as its first argument, producing a
-            // partially applied function (which has no mobile type).
-            if let Type::Function(function_type) = type_ {
+            } else if let Type::Function(function_type) = type_ {
+                // If this member is a function attached via `using for`, accessing it
+                // on a value binds the receiver as its first argument, producing a
+                // partially applied function (which has no mobile type).
                 if let Some(receiver_type_id) = operand_typing.as_type_id() {
                     if function_type.implicit_receiver_type.is_none()
                         && function_type.parameter_types.first().is_some_and(|first| {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -343,7 +343,8 @@ impl Visitor for Pass<'_> {
 
         // Special cases
         if let Some(type_id) = typing.as_type_id() {
-            let type_ = self.types.get_type_by_id(type_id);
+            let type_ = self.types.get_type_by_id(type_id).clone();
+
             if type_.is_inherited_location() {
                 // If the type is a reference type with location "inherited", we
                 // use the operand's location for the resulting typing
@@ -355,6 +356,27 @@ impl Visitor for Pass<'_> {
                         .types
                         .register_type_with_data_location(type_.clone(), operand_location);
                     typing = Typing::Resolved(type_id_with_location);
+                }
+            }
+
+            // If this member is a function attached via `using for`, accessing it
+            // on a value binds the receiver as its first argument, producing a
+            // partially applied function (which has no mobile type).
+            if let Type::Function(function_type) = type_ {
+                if let Some(receiver_type_id) = operand_typing.as_type_id() {
+                    if function_type.implicit_receiver_type.is_none()
+                        && function_type.parameter_types.first().is_some_and(|first| {
+                            self.types.implicitly_convertible_to_for_external_call(
+                                receiver_type_id,
+                                *first,
+                            )
+                        })
+                    {
+                        let function_type = function_type.clone();
+                        typing = Typing::Resolved(
+                            self.types.partially_apply_function_type(function_type),
+                        );
+                    }
                 }
             }
         }
@@ -478,7 +500,20 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_call_options_expression(&mut self, node: &ir::CallOptionsExpression) {
-        let typing = self.typing_of_expression(&node.operand);
+        let operand_typing = self.typing_of_expression(&node.operand);
+
+        // Pre-applying call options (eg. `foo{value: 3}`) partially applies the
+        // function.
+        let typing = match operand_typing.as_type_id() {
+            Some(type_id) => match self.types.get_type_by_id(type_id) {
+                Type::Function(function_type) => {
+                    let function_type = function_type.clone();
+                    Typing::Resolved(self.types.partially_apply_function_type(function_type))
+                }
+                _ => operand_typing,
+            },
+            None => operand_typing,
+        };
         self.binder.set_node_typing(node.id(), typing);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -12,9 +12,8 @@ use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
 };
 use crate::types::{
-    ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
-    FunctionTypeMutability, FunctionTypeVisibility, IntegerType, LibraryType, LiteralKind,
-    MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
+    ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType, IntegerType,
+    LibraryType, LiteralKind, MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
 };
 
 struct TypeAnalysis {
@@ -1193,34 +1192,6 @@ fn test_this_inside_contract() {
 }
 
 #[test]
-fn test_partially_applied_function_not_convertible_to_plain_pointer() {
-    // A partially applied function (bound first argument or pre-applied call
-    // options) is not
-    // implicitly convertible to its plain function pointer counterpart, even
-    // though they share the same signature.
-    let mut types = TypeRegistry::new(LanguageVersion::LATEST);
-    let uint = register_uint_type(&mut types, 256);
-
-    let pointer = FunctionType {
-        definition_id: None,
-        implicit_receiver_type: None,
-        parameter_types: vec![uint],
-        return_type: uint,
-        visibility: FunctionTypeVisibility::Internal,
-        mutability: FunctionTypeMutability::Pure,
-        partially_applied: false,
-    };
-    let pointer_id = types.register_type(Type::Function(pointer.clone()));
-    let applied_id = types.partially_apply_function_type(pointer);
-
-    // They are distinct interned types...
-    assert_ne!(pointer_id, applied_id);
-    // ...and neither is implicitly convertible to the other.
-    assert!(!types.implicitly_convertible_to(applied_id, pointer_id));
-    assert!(!types.implicitly_convertible_to(pointer_id, applied_id));
-}
-
-#[test]
 fn test_partially_applied_function_does_not_unify_into_array() {
     // `L.inc` is attached to `uint` via `using for`, so `t.inc` binds the
     // receiver and becomes a partially applied function with no mobile type.
@@ -1280,5 +1251,69 @@ fn test_partially_applied_function_does_not_unify_into_array() {
         typings.next(),
         Some(None::<Type>),
         "an array with a partially applied element should not type",
+    );
+}
+
+// A partially applied function (bound first argument or pre-applied call
+// options) is not
+// implicitly convertible to its plain function pointer counterpart, even
+// though they share the same signature.
+#[test]
+fn test_partially_applied_function_is_not_convertible() {
+    let source = r#"
+        library L {
+            function inc(uint x) internal pure {}
+        }
+        contract Test {
+            using L for uint;
+            function foo() external {}
+            
+            function take_internal(function(uint) internal pure f) internal pure returns (bool) {}
+            function take_internal(uint f) internal pure returns (uint) {}
+            
+            function take_external(function() external g) internal pure returns (bool) {}
+            function take_external(uint g) internal pure returns (uint) {}
+            
+            function __test() internal view {
+                uint t = 1;
+        
+                take_internal(L.inc); // <------------- works
+                take_internal(t.inc); // <------------- fails
+                take_external(this.foo); // <---------- works
+                take_external(this.foo{gas: 4}); // <-- fails
+            }
+        }        
+        "#;
+
+    let TypeAnalysis {
+        file,
+        binder,
+        types,
+    } = analyze(LanguageVersion::LATEST, source);
+
+    let contract = find_contract(&file, "Test");
+    let function = find_function(&contract.members, "__test").expect("__test function");
+    let body = function.body.as_ref().expect("__test has a body");
+
+    let mut typings = expression_statement_types(body, &binder, &types).into_iter();
+
+    assert!(
+        matches!(typings.next(), Some(Some(Type::Boolean))),
+        "plain library function should be convertible",
+    );
+
+    assert!(
+        matches!(typings.next(), Some(None)),
+        "partially applied function pointers should not be convertible",
+    );
+
+    assert!(
+        matches!(typings.next(), Some(Some(Type::Boolean))),
+        "plain function pointers should be convertible",
+    );
+
+    assert!(
+        matches!(typings.next(), Some(None)),
+        "partially applied function pointers should not be convertible",
     );
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -12,8 +12,9 @@ use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
 };
 use crate::types::{
-    ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType, IntegerType,
-    LibraryType, LiteralKind, MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
+    ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
+    FunctionTypeMutability, FunctionTypeVisibility, IntegerType, LibraryType, LiteralKind,
+    MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
 };
 
 struct TypeAnalysis {
@@ -1188,5 +1189,96 @@ fn test_this_inside_contract() {
 
     assert!(
         matches!(typings.as_slice(), [Some(Type::Contract(ContractType { definition_id }))] if definition_id == &contract.id())
+    );
+}
+
+#[test]
+fn test_partially_applied_function_not_convertible_to_plain_pointer() {
+    // A partially applied function (bound first argument or pre-applied call
+    // options) is not
+    // implicitly convertible to its plain function pointer counterpart, even
+    // though they share the same signature.
+    let mut types = TypeRegistry::new(LanguageVersion::LATEST);
+    let uint = register_uint_type(&mut types, 256);
+
+    let pointer = FunctionType {
+        definition_id: None,
+        implicit_receiver_type: None,
+        parameter_types: vec![uint],
+        return_type: uint,
+        visibility: FunctionTypeVisibility::Internal,
+        mutability: FunctionTypeMutability::Pure,
+        partially_applied: false,
+    };
+    let pointer_id = types.register_type(Type::Function(pointer.clone()));
+    let applied_id = types.partially_apply_function_type(pointer);
+
+    // They are distinct interned types...
+    assert_ne!(pointer_id, applied_id);
+    // ...and neither is implicitly convertible to the other.
+    assert!(!types.implicitly_convertible_to(applied_id, pointer_id));
+    assert!(!types.implicitly_convertible_to(pointer_id, applied_id));
+}
+
+#[test]
+fn test_partially_applied_function_does_not_unify_into_array() {
+    // `L.inc` is attached to `uint` via `using for`, so `t.inc` binds the
+    // receiver and becomes a partially applied function with no mobile type.
+    let source = r#"
+        library L {
+            function inc(uint x) internal pure returns (uint) { return x + 1; }
+        }
+        contract Test {
+            using L for uint;
+            function inc_method(uint x) internal pure returns (uint) { return x; }
+            function foo() external {}
+            function __test() internal {
+                uint t = 1;
+                [inc_method, inc_method];
+                [inc_method, t.inc];
+                [this.foo, this.foo];
+                [this.foo, this.foo{ gas: 4 }];
+            }
+        }
+        "#;
+
+    let TypeAnalysis {
+        file,
+        binder,
+        types,
+    } = analyze(LanguageVersion::LATEST, source);
+
+    let contract = find_contract(&file, "Test");
+    let function = find_function(&contract.members, "__test").expect("__test function");
+    let body = function.body.as_ref().expect("__test has a body");
+
+    let mut typings = expression_statement_types(body, &binder, &types).into_iter();
+
+    // Control: plain function pointers of the same signature still unify into a
+    // fixed-size array.
+    assert!(
+        matches!(typings.next(), Some(Some(Type::FixedSizeArray(_)))),
+        "plain function pointers should unify into an array",
+    );
+
+    // The bound element has no mobile type, so the array does not type.
+    assert_eq!(
+        typings.next(),
+        Some(None::<Type>),
+        "an array with a partially applied element should not type",
+    );
+
+    // Control: plain function pointers of the same signature still unify into a
+    // fixed-size array.
+    assert!(
+        matches!(typings.next(), Some(Some(Type::FixedSizeArray(_)))),
+        "plain function pointers should unify into an array",
+    );
+
+    // The bound element has no mobile type, so the array does not type.
+    assert_eq!(
+        typings.next(),
+        Some(None::<Type>),
+        "an array with a partially applied element should not type",
     );
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -193,8 +193,9 @@ pub struct FunctionType {
     /// methods (ie. the type of `this`)
     pub implicit_receiver_type: Option<TypeId>,
     /// Whether this function has been partially applied.
-    /// This happens when its first argument is bound (eg. `a.foo`), or when call options are
-    /// pre-applied (eg. `foo{value: 3}`).
+    /// This happens when its first argument is bound, eg. `a.foo`
+    /// where `foo` is from a `using` directive on the type of `a`,
+    /// or when call options are pre-applied (eg. `foo{value: 3}`).
     pub partially_applied: bool,
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -185,11 +185,17 @@ impl LiteralKind {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FunctionType {
     pub definition_id: Option<NodeId>, // this may point to a FunctionDefinition
-    pub implicit_receiver_type: Option<TypeId>,
     pub parameter_types: Vec<TypeId>,
     pub return_type: TypeId,
     pub visibility: FunctionTypeVisibility,
     pub mutability: FunctionTypeMutability,
+    /// The type of the implicit receiver in contract or interface
+    /// methods (ie. the type of `this`)
+    pub implicit_receiver_type: Option<TypeId>,
+    /// Whether this function has been partially applied.
+    /// This happens when its first argument is bound (eg. `a.foo`), or when call options are
+    /// pre-applied (eg. `foo{value: 3}`).
+    pub partially_applied: bool,
 }
 
 impl FunctionType {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -304,9 +304,16 @@ impl TypeRegistry {
 
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
                 // This is full equality except for visibility and mutability
-                // which can be converted to, and definition_id and
-                // implicit_receiver_type which can differ.
-                from_function_type.partially_applied == to_function_type.partially_applied
+                // which can be converted to, partially_applied which must be `false`,
+                // and definition_id and implicit_receiver_type which can differ.
+                //
+                // Note: solc checks that the `from` and `to` function types have
+                // the same call options or bound argument applied in the same way,
+                // but that is not observable from Solidity source code.
+                // Therefore we have a stronger check here that has the same effect
+                // for users.
+                !from_function_type.partially_applied
+                    && !to_function_type.partially_applied
                     && from_function_type
                         .visibility
                         .implicitly_convertible_to(to_function_type.visibility)
@@ -436,8 +443,9 @@ impl TypeRegistry {
         }
     }
 
-    // Marks a function type as partially applied (its first argument is bound,
-    // or call options have been pre-applied).
+    // Marks a function type as partially applied:
+    // - a function from a `using` directive applied on a value
+    // - call options have been pre-applied in an external call
     pub(crate) fn partially_apply_function_type(&mut self, function_type: FunctionType) -> TypeId {
         self.register_type(Type::Function(FunctionType {
             partially_applied: true,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -434,6 +434,15 @@ impl TypeRegistry {
         }
     }
 
+    // Marks a function type as partially applied (its first argument is bound,
+    // or call options have been pre-applied).
+    pub(crate) fn partially_apply_function_type(&mut self, function_type: FunctionType) -> TypeId {
+        self.register_type(Type::Function(FunctionType {
+            partially_applied: true,
+            ..function_type
+        }))
+    }
+
     pub(crate) fn find_canonical_type_id(&self, type_id: TypeId) -> Option<TypeId> {
         let canonical_type = match self.get_type_by_id(type_id) {
             Type::Array(ArrayType { element_type, .. }) => {
@@ -476,6 +485,7 @@ impl TypeRegistry {
                 return_type: *return_type,
                 visibility: *visibility,
                 mutability: *mutability,
+                partially_applied: false,
             }),
 
             Type::Address(_)
@@ -569,6 +579,11 @@ impl TypeRegistry {
                     .collect();
                 Some(self.register_type(Type::Tuple(TupleType { types: mobile_ids? })))
             }
+            // A partially applied function (bound first argument or pre-applied
+            // call options) doesn't have a mobile type.
+            //
+            // Matches solc behaviour
+            Type::Function(function_type) if function_type.partially_applied => None,
             _ => Some(type_id),
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -304,10 +304,12 @@ impl TypeRegistry {
 
             (Type::Function(from_function_type), Type::Function(to_function_type)) => {
                 // This is full equality except for visibility and mutability
-                // which can be converted to, and definition_id which can differ
-                from_function_type
-                    .visibility
-                    .implicitly_convertible_to(to_function_type.visibility)
+                // which can be converted to, and definition_id and
+                // implicit_receiver_type which can differ.
+                from_function_type.partially_applied == to_function_type.partially_applied
+                    && from_function_type
+                        .visibility
+                        .implicitly_convertible_to(to_function_type.visibility)
                     && from_function_type
                         .mutability
                         .implicitly_convertible_to(to_function_type.mutability)


### PR DESCRIPTION
In Solidity, the type of a partially applied function (either with call options `foo{ value: 3}`, or with a receiver `x.inc()`) is different than an unapplied one, in particular it doesn't have a mobile type.

A partially applied function resembles a literal value, so there's a valid question on why it's not implemented as one with its own internal type in the type system. The main reason is that a partially applied function has the same type shape as its original function type, where as literal values can take multiple (diverse) types. 

This PR makes a minimal change to distinguish them, it's an early design and we may need to tune it as we find applications for it.
