### PR TITLE
[v2] fix(parser): Removed invalid `TODO` from parser

### DIFF
--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/parser_helpers.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/parser_helpers.rs
@@ -11,7 +11,7 @@ use slang_solidity_v2_cst::structured_cst::nodes::{
     new_function_type, new_function_type_attributes, new_index_access_expression,
     new_member_access_expression, new_type_name_array_type_name, new_type_name_elementary_type,
     new_type_name_identifier_path, CloseBracket, ElementaryType, Expression, FunctionType,
-    FunctionTypeAttribute, FunctionTypeStruct, Identifier, IdentifierPath, IdentifierPathElement,
+    FunctionTypeAttribute, FunctionTypeStruct, IdentifierPath, IdentifierPathElement,
     IndexAccessEnd, OpenBracket, Period, StateVariableAttribute, TypeName,
 };
 
@@ -155,9 +155,7 @@ pub(crate) fn new_expression_identifier_path(identifier_path: IdentifierPath) ->
             match acc {
                 None => Some(match id {
                     IdentifierPathElement::AddressKeyword(_) => {
-                        // TODO(v2) we should validate that this is not the case and fail gracefully
-                        // instead of returning a wrong identifier
-                        new_expression_identifier(Identifier { range: 0..0 })
+                        unreachable!("Address should never be the first element in an identifier path, the parser shouldn't allow it");
                     }
                     IdentifierPathElement::Identifier(id) => new_expression_identifier(id),
                 }),

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -830,6 +830,11 @@ mod expression {
     }
 
     #[test]
+    fn member_access_elementary_type() -> Result<()> {
+        run("Expression", "member_access_elementary_type")
+    }
+
+    #[test]
     fn member_access_function_call() -> Result<()> {
         run("Expression", "member_access_function_call")
     }

--- a/crates/solidity-v2/testing/snapshots/cst_output/Expression/member_access_elementary_type/generated/0.8.0-success.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/Expression/member_access_elementary_type/generated/0.8.0-success.yml
@@ -1,0 +1,47 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                                                     │ 0..12
+  2  │     function f() {                                                                                               │ 13..31
+  3  │         // The `address` below should be parsed as an elementary type, rather than as an identifier path element │ 32..144
+  4  │         address.x;                                                                                               │ 145..163
+  5  │         // This one is an identifier path element                                                                │ 164..213
+  6  │         int.address;                                                                                             │ 214..234
+  7  │     }                                                                                                            │ 235..240
+  8  │ }                                                                                                                │ 241..242
+
+Tree:
+  - (root꞉ SourceUnit): # "contract C {\n    function f() {\n        // The `ad..." (0..242)
+      - (members꞉ SourceUnitMembers): # "contract C {\n    function f() {\n        // The `ad..." (0..242)
+          - (item꞉ SourceUnitMember) ► (contract_definition꞉ ContractDefinition): # "contract C {\n    function f() {\n        // The `ad..." (0..242)
+              - (contract_keyword꞉ ContractKeyword): "contract" # (0..8)
+              - (name꞉ Identifier): "C" # (9..10)
+              - (specifiers꞉ ContractSpecifiers): []
+              - (open_brace꞉ OpenBrace): "{" # (11..12)
+              - (members꞉ ContractMembers): # "function f() {\n        // The `address` below shou..." (17..240)
+                  - (item꞉ ContractMember) ► (function_definition꞉ FunctionDefinition): # "function f() {\n        // The `address` below shou..." (17..240)
+                      - (function_keyword꞉ FunctionKeyword): "function" # (17..25)
+                      - (name꞉ FunctionName) ► (identifier꞉ Identifier): "f" # (26..27)
+                      - (parameters꞉ ParametersDeclaration): # "()" (27..29)
+                          - (open_paren꞉ OpenParen): "(" # (27..28)
+                          - (parameters꞉ Parameters): []
+                          - (close_paren꞉ CloseParen): ")" # (28..29)
+                      - (attributes꞉ FunctionAttributes): []
+                      - (body꞉ FunctionBody) ► (block꞉ Block): # "{\n        // The `address` below should be parsed ..." (30..240)
+                          - (open_brace꞉ OpenBrace): "{" # (30..31)
+                          - (statements꞉ Statements): # "address.x;\n        // This one is an identifier pa..." (153..234)
+                              - (item꞉ Statement) ► (expression_statement꞉ ExpressionStatement): # "address.x;" (153..163)
+                                  - (expression꞉ Expression) ► (member_access_expression꞉ MemberAccessExpression): # "address.x" (153..162)
+                                      - (operand꞉ Expression) ► (elementary_type꞉ ElementaryType) ► (address_type꞉ AddressType): # "address" (153..160)
+                                          - (address_keyword꞉ AddressKeyword): "address" # (153..160)
+                                      - (period꞉ Period): "." # (160..161)
+                                      - (member꞉ IdentifierPathElement) ► (identifier꞉ Identifier): "x" # (161..162)
+                                  - (semicolon꞉ Semicolon): ";" # (162..163)
+                              - (item꞉ Statement) ► (expression_statement꞉ ExpressionStatement): # "int.address;" (222..234)
+                                  - (expression꞉ Expression) ► (member_access_expression꞉ MemberAccessExpression): # "int.address" (222..233)
+                                      - (operand꞉ Expression) ► (elementary_type꞉ ElementaryType) ► (int_keyword꞉ IntKeyword): "int" # (222..225)
+                                      - (period꞉ Period): "." # (225..226)
+                                      - (member꞉ IdentifierPathElement) ► (address_keyword꞉ AddressKeyword): "address" # (226..233)
+                                  - (semicolon꞉ Semicolon): ";" # (233..234)
+                          - (close_brace꞉ CloseBrace): "}" # (239..240)
+              - (close_brace꞉ CloseBrace): "}" # (241..242)

--- a/crates/solidity-v2/testing/snapshots/cst_output/Expression/member_access_elementary_type/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/Expression/member_access_elementary_type/input.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() {
+        // The `address` below should be parsed as an elementary type, rather than as an identifier path element
+        address.x;
+        // This one is an identifier path element
+        int.address;
+    }
+}


### PR DESCRIPTION
There was an old TODO in the parser regarding validation, but is actually not reachable (because of the grammar).

Added a test that would reach it with a different grammar, but, expectedly, it doesn't.
