### PR TITLE
update `bencher_cli` dependency

### DIFF
--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: "read"
       pull-requests: "write"
+      checks: "write"
 
     # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
     if: >-

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: "read"
       pull-requests: "write"
+      checks: "write"
 
     # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
     if: >-

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       contents: "read"
       pull-requests: "write"
+      checks: "write"
 
     # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
     if: >-

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: "read"
       pull-requests: "write"
+      checks: "write"
 
     # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
     if: >-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ solidity_v2_cargo_tests = { path = "crates/solidity-v2/outputs/cargo/tests", ver
 #
 anyhow = { version = "1.0.102", features = ["backtrace", "std"] }
 ariadne = { version = "0.2.0" }
-# __SLANG_BENCHER_CLI_RELEASE__ (keep in sync) https://github.com/bencherdev/bencher/releases/tag/v0.6.5
-bencher_cli = { git = "https://github.com/bencherdev/bencher", rev = "99117a626dc634b8ad817f38abcf4876b3b0668b" } # __SLANG_BENCHER_CLI_RELEASE__
+# __SLANG_BENCHER_CLI_RELEASE__ (keep in sync) https://github.com/bencherdev/bencher/releases/tag/v0.6.7
+bencher_cli = { git = "https://github.com/bencherdev/bencher", rev = "ec56bb69a7f34096002ca3384d10e2f6676b063e" } # __SLANG_BENCHER_CLI_RELEASE__
 bitvec = { version = "1.0.1" }
 cargo-edit = { version = "0.13.0" }
 cargo-nextest = { version = "0.9.72" }

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
@@ -70,23 +70,7 @@ impl Parser {
             file_id,
             diagnostics: DiagnosticCollection::default(),
         };
-        let mut result = parser.parse(&mut ctx, lexer);
-        println!("Parser result: {:#?}", result.is_ok());
-
-        // double parse to trigger the benchmark failures
-        {
-            let lexer = Lexer::new(source, language_version);
-            let parser = grammar::SourceUnitParser::new();
-
-            let mut ctx = GrammarCtx {
-                source,
-                file_id,
-                diagnostics: DiagnosticCollection::default(),
-            };
-
-            result = parser.parse(&mut ctx, lexer);
-        }
-
+        let result = parser.parse(&mut ctx, lexer);
         match result {
             Ok(source_unit) => {
                 // TODO(v2): these tests should really go through 'CompilationUnit' once it is ready.

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
@@ -70,7 +70,23 @@ impl Parser {
             file_id,
             diagnostics: DiagnosticCollection::default(),
         };
-        let result = parser.parse(&mut ctx, lexer);
+        let mut result = parser.parse(&mut ctx, lexer);
+        println!("Parser result: {:#?}", result.is_ok());
+
+        // double parse to trigger the benchmark failures
+        {
+            let lexer = Lexer::new(source, language_version);
+            let parser = grammar::SourceUnitParser::new();
+
+            let mut ctx = GrammarCtx {
+                source,
+                file_id,
+                diagnostics: DiagnosticCollection::default(),
+            };
+
+            result = parser.parse(&mut ctx, lexer);
+        }
+
         match result {
             Ok(source_unit) => {
                 // TODO(v2): these tests should really go through 'CompilationUnit' once it is ready.


### PR DESCRIPTION
Enable GitHub checks for benchmark runs, to differentiate between a benchmark alert (perf regression) and the runner/tests themselves failing.

Context: https://github.com/bencherdev/bencher/issues/894

I tested this by adding [a commit that slows down the parser](https://github.com/NomicFoundation/slang/pull/1873/changes/90241a95b290885a796f45685c4c5eb28123ca99), and noticed a new `Bencher Report` check [reported on the PR as failure](https://github.com/NomicFoundation/slang/pull/1873/checks?check_run_id=81898228531). PRs can still get merged since the new check is not required in this repo branch protection rules.