### PR TITLE
feat(v2): validate array lengths and storage layout base slots

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -927,26 +927,56 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal:
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::type_system
 pub enum slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthFractional(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthNegative(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthNotConstant(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthTooLarge(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthZero(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ConstantArithmeticError(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionMutability(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionSignature(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::IncompatibleConstantOperator(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::InvalidBase(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::InvalidFunctionTypeVisibility(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ReceiveFunctionParameters(slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::StorageLayoutBaseNonInteger(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::StorageLayoutBaseNotConstant(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::StorageLayoutBaseOutOfRange(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
@@ -958,6 +988,120 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::mutability: alloc::string::String
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
@@ -997,6 +1141,28 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::left_type: alloc::string::String
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::operator: alloc::string::String
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::right_type: alloc::string::String
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
@@ -1054,6 +1220,64 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::value: alloc::string::String
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub enum slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Compilation(slang_solidity_v2_common::diagnostics::kinds::compilation::CompilationDiagnosticKind)
 pub slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::Resolution(slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind)
@@ -1138,16 +1362,36 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::U
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1374,6 +1618,30 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNotConstant::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthTooLarge::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::message(&self) -> alloc::string::String
@@ -1382,6 +1650,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::message(&self) -> alloc::string::String
@@ -1394,6 +1666,18 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ReceiveFunctionParameters::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNonInteger::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseNotConstant::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::StorageLayoutBaseOutOfRange::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_fractional.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_fractional.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an array length expression evaluates to a
+/// fractional value.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArrayLengthFractional;
+
+impl DiagnosticExtensions for ArrayLengthFractional {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/array-length-fractional"
+    }
+
+    fn message(&self) -> String {
+        "Array with fractional length specified.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_negative.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_negative.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an array length expression evaluates to a negative
+/// value.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArrayLengthNegative;
+
+impl DiagnosticExtensions for ArrayLengthNegative {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/array-length-negative"
+    }
+
+    fn message(&self) -> String {
+        "Array with negative length specified.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_not_constant.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_not_constant.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an array length expression is not a compile-time
+/// constant integer (for example a non-constant variable, or an expression the
+/// constant evaluator cannot fold).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArrayLengthNotConstant;
+
+impl DiagnosticExtensions for ArrayLengthNotConstant {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/array-length-not-constant"
+    }
+
+    fn message(&self) -> String {
+        "Invalid array length, expected integer literal or constant expression.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_too_large.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_too_large.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an array length expression evaluates to a value
+/// larger than `2**256 - 1`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArrayLengthTooLarge;
+
+impl DiagnosticExtensions for ArrayLengthTooLarge {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/array-length-too-large"
+    }
+
+    fn message(&self) -> String {
+        // TODO: Change message to `2**256 - 1`, when `FixedSizeArrayType`
+        // size field is changed to u256.
+        "Array length too large, maximum is 2**64 - 1.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_zero.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/array_length_zero.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an array length expression evaluates to zero.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArrayLengthZero;
+
+impl DiagnosticExtensions for ArrayLengthZero {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/array-length-zero"
+    }
+
+    fn message(&self) -> String {
+        "Array with zero length specified.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/constant_arithmetic_error.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/constant_arithmetic_error.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when compile-time evaluation of a constant expression
+/// produces a value that does not fit the result type of an arithmetic or
+/// bitwise operator.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConstantArithmeticError;
+
+impl DiagnosticExtensions for ConstantArithmeticError {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/constant-arithmetic-error"
+    }
+
+    fn message(&self) -> String {
+        "Arithmetic error when computing constant value.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/incompatible_constant_operator.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/incompatible_constant_operator.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a binary operator in a compile-time constant
+/// expression that has no result type for its operand types (e.g. a bitwise
+/// operator on a fractional value).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IncompatibleConstantOperator {
+    /// The operator symbol, e.g. `/`.
+    pub operator: String,
+    /// Display name of the left operand's type, e.g. `int_const -7`.
+    pub left_type: String,
+    /// Display name of the right operand's type, e.g. `uint256`.
+    pub right_type: String,
+}
+
+impl DiagnosticExtensions for IncompatibleConstantOperator {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/incompatible-constant-operator"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Operator {} not compatible with types {} and {}",
+            self.operator, self.left_type, self.right_type,
+        )
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
@@ -1,15 +1,35 @@
+mod array_length_fractional;
+mod array_length_negative;
+mod array_length_not_constant;
+mod array_length_too_large;
+mod array_length_zero;
+mod constant_arithmetic_error;
 mod fallback_function_mutability;
 mod fallback_function_signature;
+mod incompatible_constant_operator;
 mod invalid_base;
 mod invalid_function_type_visibility;
 mod receive_function_parameters;
+mod storage_layout_base_non_integer;
+mod storage_layout_base_not_constant;
+mod storage_layout_base_out_of_range;
 
+pub use array_length_fractional::ArrayLengthFractional;
+pub use array_length_negative::ArrayLengthNegative;
+pub use array_length_not_constant::ArrayLengthNotConstant;
+pub use array_length_too_large::ArrayLengthTooLarge;
+pub use array_length_zero::ArrayLengthZero;
+pub use constant_arithmetic_error::ConstantArithmeticError;
 pub use fallback_function_mutability::FallbackFunctionMutability;
 pub use fallback_function_signature::FallbackFunctionSignature;
+pub use incompatible_constant_operator::IncompatibleConstantOperator;
 pub use invalid_base::InvalidBase;
 pub use invalid_function_type_visibility::InvalidFunctionTypeVisibility;
 pub use receive_function_parameters::ReceiveFunctionParameters;
 use serde::Serialize;
+pub use storage_layout_base_non_integer::StorageLayoutBaseNonInteger;
+pub use storage_layout_base_not_constant::StorageLayoutBaseNotConstant;
+pub use storage_layout_base_out_of_range::StorageLayoutBaseOutOfRange;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
 use crate::diagnostics::kinds::DiagnosticKind;
@@ -33,5 +53,30 @@ define_diagnostic_kind! {
         FallbackFunctionSignature(FallbackFunctionSignature),
         /// A receive function declares parameters.
         ReceiveFunctionParameters(ReceiveFunctionParameters),
+        /// A binary operator in a compile-time constant expression has no
+        /// result type for its operand types.
+        IncompatibleConstantOperator(IncompatibleConstantOperator),
+        /// Compile-time constant evaluation produced a value that doesn't fit the
+        /// result type of an arithmetic or bitwise operator.
+        ConstantArithmeticError(ConstantArithmeticError),
+        /// An array length expression is not a compile-time constant.
+        ArrayLengthNotConstant(ArrayLengthNotConstant),
+        /// An array length expression evaluates to zero.
+        ArrayLengthZero(ArrayLengthZero),
+        /// An array length expression evaluates to a fractional value.
+        ArrayLengthFractional(ArrayLengthFractional),
+        /// An array length expression evaluates to a negative value.
+        ArrayLengthNegative(ArrayLengthNegative),
+        /// An array length expression evaluates to a value larger than
+        /// `2**256 - 1`.
+        ArrayLengthTooLarge(ArrayLengthTooLarge),
+        /// A storage layout base slot expression is not a compile-time constant.
+        StorageLayoutBaseNotConstant(StorageLayoutBaseNotConstant),
+        /// A storage layout base slot expression evaluates to a non-integer
+        /// (e.g. fractional) value.
+        StorageLayoutBaseNonInteger(StorageLayoutBaseNonInteger),
+        /// A storage layout base slot expression evaluates to a value outside
+        /// the range of `uint256`.
+        StorageLayoutBaseOutOfRange(StorageLayoutBaseOutOfRange),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_non_integer.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_non_integer.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when the base slot expression of a contract's storage
+/// layout (`layout at <expr>`) evaluates to a non-integer (e.g. fractional)
+/// value.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StorageLayoutBaseNonInteger;
+
+impl DiagnosticExtensions for StorageLayoutBaseNonInteger {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/storage-layout-base-non-integer"
+    }
+
+    fn message(&self) -> String {
+        "The base slot of the storage layout must evaluate to an integer.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_not_constant.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_not_constant.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when the base slot expression of a contract's storage
+/// layout (`layout at <expr>`) is not a compile-time constant expression, or
+/// cannot be folded by the constant evaluator.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StorageLayoutBaseNotConstant;
+
+impl DiagnosticExtensions for StorageLayoutBaseNotConstant {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/storage-layout-base-not-constant"
+    }
+
+    fn message(&self) -> String {
+        "The base slot of the storage layout must be a compile-time constant expression.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_out_of_range.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/storage_layout_base_out_of_range.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when the base slot expression of a contract's storage
+/// layout (`layout at <expr>`) evaluates to an integer that is negative or
+/// larger than `2**256 - 1`, i.e. outside the range of `uint256`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StorageLayoutBaseOutOfRange {
+    /// The decimal representation of the offending value.
+    pub value: String,
+}
+
+impl DiagnosticExtensions for StorageLayoutBaseOutOfRange {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/storage-layout-base-out-of-range"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "The base slot of the storage layout evaluates to {}, which is outside the range of type uint256.",
+            self.value
+        )
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -561,6 +561,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::AbicoderVersion
 pub fn slang_solidity_v2_ir::ir::AbicoderVersion::clone(&self) -> slang_solidity_v2_ir::ir::AbicoderVersion
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderVersion
 pub fn slang_solidity_v2_ir::ir::AbicoderVersion::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderVersion
+pub fn slang_solidity_v2_ir::ir::AbicoderVersion::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderVersion
 pub fn slang_solidity_v2_ir::ir::AbicoderVersion::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::AdditiveExpressionOperator
@@ -572,6 +574,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ArgumentsDeclaration
@@ -581,6 +585,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::clone(&self) -> slang_solidity_v2_ir::ir::ArgumentsDeclaration
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArgumentsDeclaration
+pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::AssignmentExpressionOperator
@@ -602,6 +608,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::AssignmentExpressionOperat
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ContractMember
@@ -618,6 +626,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::clone(&self) -> slang_solidity_v2_ir::ir::ContractMember
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractMember
+pub fn slang_solidity_v2_ir::ir::ContractMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ElementaryType
@@ -633,6 +643,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::clone(&self) -> slang_solidity_v2_ir::ir::ElementaryType
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ElementaryType
+pub fn slang_solidity_v2_ir::ir::ElementaryType::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::EqualityExpressionOperator
@@ -644,6 +656,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::EqualityExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ExperimentalFeature
@@ -656,6 +670,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ExperimentalFeature
 pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::clone(&self) -> slang_solidity_v2_ir::ir::ExperimentalFeature
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExperimentalFeature
 pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalFeature
+pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExperimentalFeature
 pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::Expression
@@ -696,6 +712,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::clone(&self) -> slang_solidity_v2_ir::ir::Expression
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Expression
+pub fn slang_solidity_v2_ir::ir::Expression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ForStatementCondition
@@ -705,6 +723,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementCondition
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementCondition
+pub fn slang_solidity_v2_ir::ir::ForStatementCondition::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ForStatementInitialization
@@ -715,6 +735,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementInitialization
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementInitialization
+pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::FunctionKind
@@ -734,6 +756,8 @@ impl core::hash::Hash for slang_solidity_v2_ir::ir::FunctionKind
 pub fn slang_solidity_v2_ir::ir::FunctionKind::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_ir::ir::FunctionKind
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionKind
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionKind
+pub fn slang_solidity_v2_ir::ir::FunctionKind::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionKind
 pub fn slang_solidity_v2_ir::ir::FunctionKind::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::FunctionMutability
@@ -767,6 +791,8 @@ impl core::hash::Hash for slang_solidity_v2_ir::ir::FunctionMutability
 pub fn slang_solidity_v2_ir::ir::FunctionMutability::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_ir::ir::FunctionMutability
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionMutability
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionMutability
+pub fn slang_solidity_v2_ir::ir::FunctionMutability::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionMutability
 pub fn slang_solidity_v2_ir::ir::FunctionMutability::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::FunctionVisibility
@@ -785,6 +811,8 @@ impl core::hash::Hash for slang_solidity_v2_ir::ir::FunctionVisibility
 pub fn slang_solidity_v2_ir::ir::FunctionVisibility::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_ir::ir::FunctionVisibility
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionVisibility
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionVisibility
+pub fn slang_solidity_v2_ir::ir::FunctionVisibility::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionVisibility
 pub fn slang_solidity_v2_ir::ir::FunctionVisibility::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ImportClause
@@ -794,6 +822,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::clone(&self) -> slang_solidity_v2_ir::ir::ImportClause
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportClause
+pub fn slang_solidity_v2_ir::ir::ImportClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::InequalityExpressionOperator
@@ -807,6 +837,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::InequalityExpressionOperat
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::InequalityExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
@@ -819,6 +851,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::MultiplicativeExpressionOp
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 #[repr(u16)] pub enum slang_solidity_v2_ir::ir::NodeKind
@@ -1020,6 +1054,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::clone(&self) -> slang_solidity_v2_ir::ir::NumberUnit
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NumberUnit
+pub fn slang_solidity_v2_ir::ir::NumberUnit::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::PostfixExpressionOperator
@@ -1031,6 +1067,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PostfixExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::Pragma
@@ -1041,6 +1079,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::clone(&self) -> slang_solidity_v2_ir::ir::Pragma
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Pragma
+pub fn slang_solidity_v2_ir::ir::Pragma::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::PrefixExpressionOperator
@@ -1056,6 +1096,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PrefixExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::ShiftExpressionOperator
@@ -1068,6 +1110,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::ShiftExpressionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionOperator
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::SourceUnitMember
@@ -1088,6 +1132,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::clone(&self) -> slang_solidity_v2_ir::ir::SourceUnitMember
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitMember
+pub fn slang_solidity_v2_ir::ir::SourceUnitMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::StateVariableMutability
@@ -1109,6 +1155,8 @@ impl core::hash::Hash for slang_solidity_v2_ir::ir::StateVariableMutability
 pub fn slang_solidity_v2_ir::ir::StateVariableMutability::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_ir::ir::StateVariableMutability
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableMutability
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableMutability
+pub fn slang_solidity_v2_ir::ir::StateVariableMutability::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableMutability
 pub fn slang_solidity_v2_ir::ir::StateVariableMutability::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::StateVariableVisibility
@@ -1126,6 +1174,8 @@ impl core::hash::Hash for slang_solidity_v2_ir::ir::StateVariableVisibility
 pub fn slang_solidity_v2_ir::ir::StateVariableVisibility::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_ir::ir::StateVariableVisibility
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableVisibility
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableVisibility
+pub fn slang_solidity_v2_ir::ir::StateVariableVisibility::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableVisibility
 pub fn slang_solidity_v2_ir::ir::StateVariableVisibility::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::Statement
@@ -1148,6 +1198,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::clone(&self) -> slang_solidity_v2_ir::ir::Statement
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Statement
+pub fn slang_solidity_v2_ir::ir::Statement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::StorageLocation
@@ -1160,6 +1212,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::clone(&self) -> slang_solidity_v2_ir::ir::StorageLocation
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageLocation
+pub fn slang_solidity_v2_ir::ir::StorageLocation::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::StringExpression
@@ -1170,6 +1224,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::clone(&self) -> slang_solidity_v2_ir::ir::StringExpression
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringExpression
+pub fn slang_solidity_v2_ir::ir::StringExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::TypeName
@@ -1182,6 +1238,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::clone(&self) -> slang_solidity_v2_ir::ir::TypeName
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeName
+pub fn slang_solidity_v2_ir::ir::TypeName::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::UsingClause
@@ -1191,6 +1249,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::clone(&self) -> slang_solidity_v2_ir::ir::UsingClause
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingClause
+pub fn slang_solidity_v2_ir::ir::UsingClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::UsingOperator
@@ -1215,6 +1275,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::clone(&self) -> slang_solidity_v2_ir::ir::UsingOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingOperator
+pub fn slang_solidity_v2_ir::ir::UsingOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::UsingTarget
@@ -1224,6 +1286,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::clone(&self) -> slang_solidity_v2_ir::ir::UsingTarget
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingTarget
+pub fn slang_solidity_v2_ir::ir::UsingTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::VariableDeclarationTarget
@@ -1233,6 +1297,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::clone(&self) -> slang_solidity_v2_ir::ir::VariableDeclarationTarget
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationTarget
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::VersionExpression
@@ -1242,6 +1308,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::clone(&self) -> slang_solidity_v2_ir::ir::VersionExpression
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionExpression
+pub fn slang_solidity_v2_ir::ir::VersionExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::VersionLiteral
@@ -1251,6 +1319,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::clone(&self) -> slang_solidity_v2_ir::ir::VersionLiteral
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionLiteral
+pub fn slang_solidity_v2_ir::ir::VersionLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::VersionOperator
@@ -1267,6 +1337,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::clone(&self) -> slang_solidity_v2_ir::ir::VersionOperator
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionOperator
+pub fn slang_solidity_v2_ir::ir::VersionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::YulExpression
@@ -1277,6 +1349,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::clone(&self) -> slang_solidity_v2_ir::ir::YulExpression
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulExpression
+pub fn slang_solidity_v2_ir::ir::YulExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::YulLiteral
@@ -1292,6 +1366,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::clone(&self) -> slang_solidity_v2_ir::ir::YulLiteral
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLiteral
+pub fn slang_solidity_v2_ir::ir::YulLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::YulStatement
@@ -1310,6 +1386,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::clone(&self) -> slang_solidity_v2_ir::ir::YulStatement
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulStatement
+pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub enum slang_solidity_v2_ir::ir::YulSwitchCase
@@ -1319,6 +1397,8 @@ impl core::clone::Clone for slang_solidity_v2_ir::ir::YulSwitchCase
 pub fn slang_solidity_v2_ir::ir::YulSwitchCase::clone(&self) -> slang_solidity_v2_ir::ir::YulSwitchCase
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchCase
 pub fn slang_solidity_v2_ir::ir::YulSwitchCase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchCase
+pub fn slang_solidity_v2_ir::ir::YulSwitchCase::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchCase
 pub fn slang_solidity_v2_ir::ir::YulSwitchCase::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
@@ -1334,6 +1414,8 @@ pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::eq(&self, &slang_sol
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
+pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AbicoderPragmaStruct
@@ -1343,6 +1425,8 @@ impl slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
@@ -1358,6 +1442,8 @@ pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::eq(&self, &slang_solid
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
@@ -1373,6 +1459,8 @@ pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::eq(&self, &slang_solid
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AdditiveExpressionStruct
@@ -1384,6 +1472,8 @@ impl slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AddressTypeStruct
@@ -1393,6 +1483,8 @@ impl slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AddressTypeStruct
+pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AmpersandEqualStruct
@@ -1408,6 +1500,8 @@ pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AmpersandEqualStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AmpersandEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AmpersandEqualStruct
+pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AmpersandEqualStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AmpersandStruct
@@ -1423,6 +1517,8 @@ pub fn slang_solidity_v2_ir::ir::AmpersandStruct::eq(&self, &slang_solidity_v2_i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AmpersandStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AmpersandStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AmpersandStruct
+pub fn slang_solidity_v2_ir::ir::AmpersandStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AmpersandStruct
 pub fn slang_solidity_v2_ir::ir::AmpersandStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AndExpressionStruct
@@ -1433,6 +1529,8 @@ impl slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ArrayExpressionStruct
@@ -1442,6 +1540,8 @@ impl slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ArrayTypeNameStruct
@@ -1452,6 +1552,8 @@ impl slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
+pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AssemblyStatementStruct
@@ -1463,6 +1565,8 @@ impl slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssemblyStatementStruct
+pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AssignmentExpressionStruct
@@ -1474,6 +1578,8 @@ impl slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AsteriskEqualStruct
@@ -1489,6 +1595,8 @@ pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AsteriskEqualStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AsteriskEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AsteriskEqualStruct
+pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AsteriskEqualStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::AsteriskStruct
@@ -1504,6 +1612,8 @@ pub fn slang_solidity_v2_ir::ir::AsteriskStruct::eq(&self, &slang_solidity_v2_ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AsteriskStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AsteriskStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AsteriskStruct
+pub fn slang_solidity_v2_ir::ir::AsteriskStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AsteriskStruct
 pub fn slang_solidity_v2_ir::ir::AsteriskStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BangEqualStruct
@@ -1519,6 +1629,8 @@ pub fn slang_solidity_v2_ir::ir::BangEqualStruct::eq(&self, &slang_solidity_v2_i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BangEqualStruct
 pub fn slang_solidity_v2_ir::ir::BangEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BangEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BangEqualStruct
+pub fn slang_solidity_v2_ir::ir::BangEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BangEqualStruct
 pub fn slang_solidity_v2_ir::ir::BangEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BangStruct
@@ -1534,6 +1646,8 @@ pub fn slang_solidity_v2_ir::ir::BangStruct::eq(&self, &slang_solidity_v2_ir::ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BangStruct
 pub fn slang_solidity_v2_ir::ir::BangStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BangStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BangStruct
+pub fn slang_solidity_v2_ir::ir::BangStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BangStruct
 pub fn slang_solidity_v2_ir::ir::BangStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BarEqualStruct
@@ -1549,6 +1663,8 @@ pub fn slang_solidity_v2_ir::ir::BarEqualStruct::eq(&self, &slang_solidity_v2_ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BarEqualStruct
 pub fn slang_solidity_v2_ir::ir::BarEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BarEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BarEqualStruct
+pub fn slang_solidity_v2_ir::ir::BarEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BarEqualStruct
 pub fn slang_solidity_v2_ir::ir::BarEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BarStruct
@@ -1564,6 +1680,8 @@ pub fn slang_solidity_v2_ir::ir::BarStruct::eq(&self, &slang_solidity_v2_ir::ir:
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BarStruct
 pub fn slang_solidity_v2_ir::ir::BarStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BarStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BarStruct
+pub fn slang_solidity_v2_ir::ir::BarStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BarStruct
 pub fn slang_solidity_v2_ir::ir::BarStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
@@ -1574,6 +1692,8 @@ impl slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
@@ -1584,6 +1704,8 @@ impl slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
@@ -1594,6 +1716,8 @@ impl slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BlockStruct
@@ -1603,6 +1727,8 @@ impl slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BlockStruct
+pub fn slang_solidity_v2_ir::ir::BlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BoolKeywordStruct
@@ -1618,6 +1744,8 @@ pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BoolKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BoolKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BoolKeywordStruct
+pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BoolKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BreakStatementStruct
@@ -1626,6 +1754,8 @@ impl slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::BuildOutput
@@ -1645,6 +1775,8 @@ pub fn slang_solidity_v2_ir::ir::BytesKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BytesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BytesKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BytesKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BytesKeywordStruct
+pub fn slang_solidity_v2_ir::ir::BytesKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BytesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::BytesKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CallDataKeywordStruct
@@ -1660,6 +1792,8 @@ pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::eq(&self, &slang_solidit
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CallDataKeywordStruct
 pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CallDataKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallDataKeywordStruct
+pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CallDataKeywordStruct
 pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
@@ -1670,6 +1804,8 @@ impl slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
+pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CaretEqualStruct
@@ -1685,6 +1821,8 @@ pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CaretEqualStruct
 pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CaretEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CaretEqualStruct
+pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CaretEqualStruct
 pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CaretStruct
@@ -1700,6 +1838,8 @@ pub fn slang_solidity_v2_ir::ir::CaretStruct::eq(&self, &slang_solidity_v2_ir::i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CaretStruct
 pub fn slang_solidity_v2_ir::ir::CaretStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CaretStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CaretStruct
+pub fn slang_solidity_v2_ir::ir::CaretStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CaretStruct
 pub fn slang_solidity_v2_ir::ir::CaretStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CatchClauseErrorStruct
@@ -1710,6 +1850,8 @@ impl slang_solidity_v2_ir::ir::CatchClauseErrorStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseErrorStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CatchClauseErrorStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseErrorStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseErrorStruct
+pub fn slang_solidity_v2_ir::ir::CatchClauseErrorStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CatchClauseErrorStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseErrorStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::CatchClauseStruct
@@ -1720,6 +1862,8 @@ impl slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseStruct
+pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ConditionalExpressionStruct
@@ -1731,6 +1875,8 @@ impl slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ConstantDefinitionStruct
@@ -1743,6 +1889,8 @@ impl slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ContinueStatementStruct
@@ -1751,6 +1899,8 @@ impl slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ContractDefinitionStruct
@@ -1764,6 +1914,8 @@ impl slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::DaysKeywordStruct
@@ -1779,6 +1931,8 @@ pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DaysKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DaysKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DaysKeywordStruct
+pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DaysKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::DecimalLiteralStruct
@@ -1795,6 +1949,8 @@ pub fn slang_solidity_v2_ir::ir::DecimalLiteralStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DecimalLiteralStruct
 pub fn slang_solidity_v2_ir::ir::DecimalLiteralStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DecimalLiteralStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalLiteralStruct
+pub fn slang_solidity_v2_ir::ir::DecimalLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DecimalLiteralStruct
 pub fn slang_solidity_v2_ir::ir::DecimalLiteralStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
@@ -1805,6 +1961,8 @@ impl slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::DeleteKeywordStruct
@@ -1820,6 +1978,8 @@ pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DeleteKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DeleteKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DeleteKeywordStruct
+pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DeleteKeywordStruct
 pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::DoWhileStatementStruct
@@ -1830,6 +1990,8 @@ impl slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DoWhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EmitStatementStruct
@@ -1840,6 +2002,8 @@ impl slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EmitStatementStruct
+pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EnumDefinitionStruct
@@ -1850,6 +2014,8 @@ impl slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EnumDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EqualEqualStruct
@@ -1865,6 +2031,8 @@ pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualEqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualEqualStruct
+pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualEqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EqualStruct
@@ -1880,6 +2048,8 @@ pub fn slang_solidity_v2_ir::ir::EqualStruct::eq(&self, &slang_solidity_v2_ir::i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualStruct
+pub fn slang_solidity_v2_ir::ir::EqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualStruct
 pub fn slang_solidity_v2_ir::ir::EqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EqualityExpressionStruct
@@ -1891,6 +2061,8 @@ impl slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ErrorDefinitionStruct
@@ -1901,6 +2073,8 @@ impl slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EtherKeywordStruct
@@ -1916,6 +2090,8 @@ pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EtherKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EtherKeywordStruct
+pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EtherKeywordStruct
 pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::EventDefinitionStruct
@@ -1927,6 +2103,8 @@ impl slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EventDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
@@ -1936,6 +2114,8 @@ impl slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
+pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
@@ -1946,6 +2126,8 @@ impl slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ExpressionStatementStruct
@@ -1955,6 +2137,8 @@ impl slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExpressionStatementStruct
+pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FalseKeywordStruct
@@ -1970,6 +2154,8 @@ pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FalseKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FalseKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FalseKeywordStruct
+pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FalseKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FixedKeywordStruct
@@ -1986,6 +2172,8 @@ pub fn slang_solidity_v2_ir::ir::FixedKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FixedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FixedKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FixedKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FixedKeywordStruct
+pub fn slang_solidity_v2_ir::ir::FixedKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FixedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::FixedKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ForStatementStruct
@@ -1998,6 +2186,8 @@ impl slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementStruct
+pub fn slang_solidity_v2_ir::ir::ForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
@@ -2008,6 +2198,8 @@ impl slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FunctionDefinitionStruct
@@ -2028,6 +2220,8 @@ impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::signature_text_range(&self) -> core::ops::range::Range<usize>
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::FunctionTypeStruct
@@ -2040,6 +2234,8 @@ impl slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeStruct
+pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanEqualStruct
@@ -2055,6 +2251,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::eq(&self, &slang_solidi
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
@@ -2070,6 +2268,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::eq(&self, &s
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
@@ -2085,6 +2285,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::e
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
@@ -2100,6 +2302,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::eq(&se
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
@@ -2115,6 +2319,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::eq(&self, &slang_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GreaterThanStruct
@@ -2130,6 +2336,8 @@ pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GreaterThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::GweiKeywordStruct
@@ -2145,6 +2353,8 @@ pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::GweiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::GweiKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GweiKeywordStruct
+pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::GweiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::HexLiteralStruct
@@ -2161,6 +2371,8 @@ pub fn slang_solidity_v2_ir::ir::HexLiteralStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HexLiteralStruct
 pub fn slang_solidity_v2_ir::ir::HexLiteralStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::HexLiteralStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexLiteralStruct
+pub fn slang_solidity_v2_ir::ir::HexLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HexLiteralStruct
 pub fn slang_solidity_v2_ir::ir::HexLiteralStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::HexNumberExpressionStruct
@@ -2170,6 +2382,8 @@ impl slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::HexStringLiteralStruct
@@ -2186,6 +2400,8 @@ pub fn slang_solidity_v2_ir::ir::HexStringLiteralStruct::eq(&self, &slang_solidi
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HexStringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::HexStringLiteralStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::HexStringLiteralStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexStringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::HexStringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HexStringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::HexStringLiteralStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::HoursKeywordStruct
@@ -2201,6 +2417,8 @@ pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HoursKeywordStruct
 pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::HoursKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HoursKeywordStruct
+pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HoursKeywordStruct
 pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::IdentifierStruct
@@ -2217,6 +2435,8 @@ pub fn slang_solidity_v2_ir::ir::IdentifierStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IdentifierStruct
 pub fn slang_solidity_v2_ir::ir::IdentifierStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IdentifierStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IdentifierStruct
+pub fn slang_solidity_v2_ir::ir::IdentifierStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IdentifierStruct
 pub fn slang_solidity_v2_ir::ir::IdentifierStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::IfStatementStruct
@@ -2228,6 +2448,8 @@ impl slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IfStatementStruct
+pub fn slang_solidity_v2_ir::ir::IfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ImportDeconstructionStruct
@@ -2238,6 +2460,8 @@ impl slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
@@ -2248,6 +2472,8 @@ impl slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
@@ -2260,6 +2486,8 @@ impl slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::InequalityExpressionStruct
@@ -2271,6 +2499,8 @@ impl slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::InheritanceTypeStruct
@@ -2281,6 +2511,8 @@ impl slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InheritanceTypeStruct
+pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::IntKeywordStruct
@@ -2297,6 +2529,8 @@ pub fn slang_solidity_v2_ir::ir::IntKeywordStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IntKeywordStruct
 pub fn slang_solidity_v2_ir::ir::IntKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IntKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IntKeywordStruct
+pub fn slang_solidity_v2_ir::ir::IntKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IntKeywordStruct
 pub fn slang_solidity_v2_ir::ir::IntKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
@@ -2308,6 +2542,8 @@ impl slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::LessThanEqualStruct
@@ -2323,6 +2559,8 @@ pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LessThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
@@ -2338,6 +2576,8 @@ pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::eq(&self, &slang_s
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::LessThanLessThanStruct
@@ -2353,6 +2593,8 @@ pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::eq(&self, &slang_solidi
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LessThanLessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LessThanLessThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanLessThanStruct
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LessThanLessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::LessThanStruct
@@ -2368,6 +2610,8 @@ pub fn slang_solidity_v2_ir::ir::LessThanStruct::eq(&self, &slang_solidity_v2_ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LessThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanStruct
+pub fn slang_solidity_v2_ir::ir::LessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LessThanStruct
 pub fn slang_solidity_v2_ir::ir::LessThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::LibraryDefinitionStruct
@@ -2378,6 +2622,8 @@ impl slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MappingTypeStruct
@@ -2388,6 +2634,8 @@ impl slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MappingTypeStruct
+pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
@@ -2398,6 +2646,8 @@ impl slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MemoryKeywordStruct
@@ -2413,6 +2663,8 @@ pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MemoryKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MemoryKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemoryKeywordStruct
+pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MemoryKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MinusEqualStruct
@@ -2428,6 +2680,8 @@ pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MinusEqualStruct
 pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MinusEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusEqualStruct
+pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MinusEqualStruct
 pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MinusMinusStruct
@@ -2443,6 +2697,8 @@ pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MinusMinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MinusMinusStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusMinusStruct
+pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MinusMinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MinusStruct
@@ -2458,6 +2714,8 @@ pub fn slang_solidity_v2_ir::ir::MinusStruct::eq(&self, &slang_solidity_v2_ir::i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MinusStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusStruct
+pub fn slang_solidity_v2_ir::ir::MinusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MinusStruct
 pub fn slang_solidity_v2_ir::ir::MinusStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MinutesKeywordStruct
@@ -2473,6 +2731,8 @@ pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MinutesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MinutesKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinutesKeywordStruct
+pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MinutesKeywordStruct
 pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ModifierInvocationStruct
@@ -2483,6 +2743,8 @@ impl slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ModifierInvocationStruct
+pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
@@ -2492,6 +2754,8 @@ impl slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
@@ -2502,6 +2766,8 @@ impl slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
@@ -2513,6 +2779,8 @@ impl slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::NamedArgumentStruct
@@ -2523,6 +2791,8 @@ impl slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NamedArgumentStruct
+pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::NewExpressionStruct
@@ -2532,6 +2802,8 @@ impl slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NewExpressionStruct
+pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::NodeIdGenerator
@@ -2559,6 +2831,8 @@ impl slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::OrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ParameterStruct
@@ -2571,6 +2845,8 @@ impl slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ParameterStruct
+pub fn slang_solidity_v2_ir::ir::ParameterStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PathImportStruct
@@ -2581,6 +2857,8 @@ impl slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PathImportStruct
+pub fn slang_solidity_v2_ir::ir::PathImportStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PayableKeywordStruct
@@ -2596,6 +2874,8 @@ pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PayableKeywordStruct
 pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PayableKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PayableKeywordStruct
+pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PayableKeywordStruct
 pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PercentEqualStruct
@@ -2611,6 +2891,8 @@ pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PercentEqualStruct
 pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PercentEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PercentEqualStruct
+pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PercentEqualStruct
 pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PercentStruct
@@ -2626,6 +2908,8 @@ pub fn slang_solidity_v2_ir::ir::PercentStruct::eq(&self, &slang_solidity_v2_ir:
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PercentStruct
 pub fn slang_solidity_v2_ir::ir::PercentStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PercentStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PercentStruct
+pub fn slang_solidity_v2_ir::ir::PercentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PercentStruct
 pub fn slang_solidity_v2_ir::ir::PercentStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PlusEqualStruct
@@ -2641,6 +2925,8 @@ pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::eq(&self, &slang_solidity_v2_i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PlusEqualStruct
 pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PlusEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusEqualStruct
+pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PlusEqualStruct
 pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PlusPlusStruct
@@ -2656,6 +2942,8 @@ pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::eq(&self, &slang_solidity_v2_ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PlusPlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PlusPlusStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusPlusStruct
+pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PlusPlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PlusStruct
@@ -2671,6 +2959,8 @@ pub fn slang_solidity_v2_ir::ir::PlusStruct::eq(&self, &slang_solidity_v2_ir::ir
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PlusStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusStruct
+pub fn slang_solidity_v2_ir::ir::PlusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PlusStruct
 pub fn slang_solidity_v2_ir::ir::PlusStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PostfixExpressionStruct
@@ -2681,6 +2971,8 @@ impl slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaCaretStruct
@@ -2696,6 +2988,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaCaretStruct
 pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaCaretStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaCaretStruct
+pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaCaretStruct
 pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaDirectiveStruct
@@ -2705,6 +2999,8 @@ impl slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaEqualStruct
@@ -2720,6 +3016,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
@@ -2735,6 +3033,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::eq(&self, &slang_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
@@ -2750,6 +3050,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::eq(&self, &slang_solid
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
@@ -2765,6 +3067,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::eq(&self, &slang_sol
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaLessThanStruct
@@ -2780,6 +3084,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaLessThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaLessThanStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaLessThanStruct
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaLessThanStruct
 pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PragmaTildeStruct
@@ -2795,6 +3101,8 @@ pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaTildeStruct
 pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaTildeStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaTildeStruct
+pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaTildeStruct
 pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::PrefixExpressionStruct
@@ -2805,6 +3113,8 @@ impl slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ReturnStatementStruct
@@ -2814,6 +3124,8 @@ impl slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ReturnStatementStruct
+pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::RevertStatementStruct
@@ -2824,6 +3136,8 @@ impl slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::RevertStatementStruct
+pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
@@ -2839,6 +3153,8 @@ pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::eq(&self, &slang_solid
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SecondsKeywordStruct
@@ -2854,6 +3170,8 @@ pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SecondsKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SecondsKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SecondsKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SecondsKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SemicolonStruct
@@ -2869,6 +3187,8 @@ pub fn slang_solidity_v2_ir::ir::SemicolonStruct::eq(&self, &slang_solidity_v2_i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SemicolonStruct
 pub fn slang_solidity_v2_ir::ir::SemicolonStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SemicolonStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SemicolonStruct
+pub fn slang_solidity_v2_ir::ir::SemicolonStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SemicolonStruct
 pub fn slang_solidity_v2_ir::ir::SemicolonStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ShiftExpressionStruct
@@ -2880,6 +3200,8 @@ impl slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
@@ -2890,6 +3212,8 @@ impl slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SlashEqualStruct
@@ -2905,6 +3229,8 @@ pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SlashEqualStruct
 pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SlashEqualStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SlashEqualStruct
+pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SlashEqualStruct
 pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SlashStruct
@@ -2920,6 +3246,8 @@ pub fn slang_solidity_v2_ir::ir::SlashStruct::eq(&self, &slang_solidity_v2_ir::i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SlashStruct
 pub fn slang_solidity_v2_ir::ir::SlashStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SlashStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SlashStruct
+pub fn slang_solidity_v2_ir::ir::SlashStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SlashStruct
 pub fn slang_solidity_v2_ir::ir::SlashStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SourceUnitStruct
@@ -2929,6 +3257,8 @@ impl slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitStruct
+pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
@@ -2943,6 +3273,8 @@ impl slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StorageKeywordStruct
@@ -2958,6 +3290,8 @@ pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::eq(&self, &slang_solidity
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StorageKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StorageKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageKeywordStruct
+pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StorageKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StringKeywordStruct
@@ -2973,6 +3307,8 @@ pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StringKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StringKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringKeywordStruct
+pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StringKeywordStruct
 pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StringLiteralStruct
@@ -2989,6 +3325,8 @@ pub fn slang_solidity_v2_ir::ir::StringLiteralStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::StringLiteralStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StringLiteralStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::StringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::StringLiteralStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StructDefinitionStruct
@@ -2999,6 +3337,8 @@ impl slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::StructMemberStruct
@@ -3009,6 +3349,8 @@ impl slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructMemberStruct
+pub fn slang_solidity_v2_ir::ir::StructMemberStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::SuperKeywordStruct
@@ -3024,6 +3366,8 @@ pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SuperKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SuperKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SuperKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SuperKeywordStruct
 pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ThisKeywordStruct
@@ -3039,6 +3383,8 @@ pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ThisKeywordStruct
 pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ThisKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ThisKeywordStruct
+pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ThisKeywordStruct
 pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TildeStruct
@@ -3054,6 +3400,8 @@ pub fn slang_solidity_v2_ir::ir::TildeStruct::eq(&self, &slang_solidity_v2_ir::i
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TildeStruct
 pub fn slang_solidity_v2_ir::ir::TildeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TildeStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TildeStruct
+pub fn slang_solidity_v2_ir::ir::TildeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TildeStruct
 pub fn slang_solidity_v2_ir::ir::TildeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TrueKeywordStruct
@@ -3069,6 +3417,8 @@ pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TrueKeywordStruct
 pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TrueKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TrueKeywordStruct
+pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TrueKeywordStruct
 pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TryStatementStruct
@@ -3081,6 +3431,8 @@ impl slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TryStatementStruct
+pub fn slang_solidity_v2_ir::ir::TryStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TupleExpressionStruct
@@ -3090,6 +3442,8 @@ impl slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TupleValueStruct
@@ -3099,6 +3453,8 @@ impl slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleValueStruct
+pub fn slang_solidity_v2_ir::ir::TupleValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::TypeExpressionStruct
@@ -3108,6 +3464,8 @@ impl slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UfixedKeywordStruct
@@ -3124,6 +3482,8 @@ pub fn slang_solidity_v2_ir::ir::UfixedKeywordStruct::eq(&self, &slang_solidity_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UfixedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::UfixedKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UfixedKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UfixedKeywordStruct
+pub fn slang_solidity_v2_ir::ir::UfixedKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UfixedKeywordStruct
 pub fn slang_solidity_v2_ir::ir::UfixedKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UintKeywordStruct
@@ -3140,6 +3500,8 @@ pub fn slang_solidity_v2_ir::ir::UintKeywordStruct::eq(&self, &slang_solidity_v2
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UintKeywordStruct
 pub fn slang_solidity_v2_ir::ir::UintKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UintKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UintKeywordStruct
+pub fn slang_solidity_v2_ir::ir::UintKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UintKeywordStruct
 pub fn slang_solidity_v2_ir::ir::UintKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UncheckedBlockStruct
@@ -3149,6 +3511,8 @@ impl slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UncheckedBlockStruct
+pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
@@ -3165,6 +3529,8 @@ pub fn slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct::eq(&self, &slang_so
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
 pub fn slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
@@ -3175,6 +3541,8 @@ impl slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UsingDeconstructionStruct
@@ -3184,6 +3552,8 @@ impl slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
@@ -3194,6 +3564,8 @@ impl slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::UsingDirectiveStruct
@@ -3205,6 +3577,8 @@ impl slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
@@ -3214,6 +3588,8 @@ impl slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VariableDeclarationStruct
@@ -3225,6 +3601,8 @@ impl slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VersionPragmaStruct
@@ -3234,6 +3612,8 @@ impl slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionPragmaStruct
+pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VersionRangeStruct
@@ -3244,6 +3624,8 @@ impl slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionRangeStruct
+pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VersionSpecifierStruct
@@ -3260,6 +3642,8 @@ pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::eq(&self, &slang_solidi
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionSpecifierStruct
 pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionSpecifierStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionSpecifierStruct
+pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionSpecifierStruct
 pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::VersionTermStruct
@@ -3270,6 +3654,8 @@ impl slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionTermStruct
+pub fn slang_solidity_v2_ir::ir::VersionTermStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::WeeksKeywordStruct
@@ -3285,6 +3671,8 @@ pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::eq(&self, &slang_solidity_v
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::WeeksKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WeeksKeywordStruct
+pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WeeksKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::WeiKeywordStruct
@@ -3300,6 +3688,8 @@ pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::eq(&self, &slang_solidity_v2_
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::WeiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::WeiKeywordStruct
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WeiKeywordStruct
+pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WeiKeywordStruct
 pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::WhileStatementStruct
@@ -3310,6 +3700,8 @@ impl slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulBlockStruct
@@ -3319,6 +3711,8 @@ impl slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBlockStruct
+pub fn slang_solidity_v2_ir::ir::YulBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulBreakStatementStruct
@@ -3327,6 +3721,8 @@ impl slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulContinueStatementStruct
@@ -3335,6 +3731,8 @@ impl slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulDefaultCaseStruct
@@ -3344,6 +3742,8 @@ impl slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulForStatementStruct
@@ -3356,6 +3756,8 @@ impl slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulForStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
@@ -3366,6 +3768,8 @@ impl slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
@@ -3378,6 +3782,8 @@ impl slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulIfStatementStruct
@@ -3388,6 +3794,8 @@ impl slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulIfStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulLeaveStatementStruct
@@ -3396,6 +3804,8 @@ impl slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulSwitchStatementStruct
@@ -3406,6 +3816,8 @@ impl slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulValueCaseStruct
@@ -3416,6 +3828,8 @@ impl slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulValueCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
@@ -3426,6 +3840,8 @@ impl slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
@@ -3436,6 +3852,8 @@ impl slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
@@ -3445,8 +3863,438 @@ impl slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
+pub trait slang_solidity_v2_ir::ir::NodeIdentity
+pub fn slang_solidity_v2_ir::ir::NodeIdentity::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
+pub fn slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderV2KeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderVersion
+pub fn slang_solidity_v2_ir::ir::AbicoderVersion::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AddressTypeStruct
+pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AmpersandEqualStruct
+pub fn slang_solidity_v2_ir::ir::AmpersandEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AmpersandStruct
+pub fn slang_solidity_v2_ir::ir::AmpersandStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArgumentsDeclaration
+pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
+pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssemblyStatementStruct
+pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AsteriskEqualStruct
+pub fn slang_solidity_v2_ir::ir::AsteriskEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AsteriskStruct
+pub fn slang_solidity_v2_ir::ir::AsteriskStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BangEqualStruct
+pub fn slang_solidity_v2_ir::ir::BangEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BangStruct
+pub fn slang_solidity_v2_ir::ir::BangStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BarEqualStruct
+pub fn slang_solidity_v2_ir::ir::BarEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BarStruct
+pub fn slang_solidity_v2_ir::ir::BarStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BlockStruct
+pub fn slang_solidity_v2_ir::ir::BlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BoolKeywordStruct
+pub fn slang_solidity_v2_ir::ir::BoolKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BytesKeywordStruct
+pub fn slang_solidity_v2_ir::ir::BytesKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallDataKeywordStruct
+pub fn slang_solidity_v2_ir::ir::CallDataKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
+pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CaretEqualStruct
+pub fn slang_solidity_v2_ir::ir::CaretEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CaretStruct
+pub fn slang_solidity_v2_ir::ir::CaretStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseErrorStruct
+pub fn slang_solidity_v2_ir::ir::CatchClauseErrorStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseStruct
+pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractMember
+pub fn slang_solidity_v2_ir::ir::ContractMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DaysKeywordStruct
+pub fn slang_solidity_v2_ir::ir::DaysKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalLiteralStruct
+pub fn slang_solidity_v2_ir::ir::DecimalLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DeleteKeywordStruct
+pub fn slang_solidity_v2_ir::ir::DeleteKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DoWhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ElementaryType
+pub fn slang_solidity_v2_ir::ir::ElementaryType::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EmitStatementStruct
+pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EnumDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualEqualStruct
+pub fn slang_solidity_v2_ir::ir::EqualEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualStruct
+pub fn slang_solidity_v2_ir::ir::EqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EtherKeywordStruct
+pub fn slang_solidity_v2_ir::ir::EtherKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EventDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalFeature
+pub fn slang_solidity_v2_ir::ir::ExperimentalFeature::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
+pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Expression
+pub fn slang_solidity_v2_ir::ir::Expression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExpressionStatementStruct
+pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FalseKeywordStruct
+pub fn slang_solidity_v2_ir::ir::FalseKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FixedKeywordStruct
+pub fn slang_solidity_v2_ir::ir::FixedKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementCondition
+pub fn slang_solidity_v2_ir::ir::ForStatementCondition::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementInitialization
+pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementStruct
+pub fn slang_solidity_v2_ir::ir::ForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionKind
+pub fn slang_solidity_v2_ir::ir::FunctionKind::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionMutability
+pub fn slang_solidity_v2_ir::ir::FunctionMutability::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeStruct
+pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionVisibility
+pub fn slang_solidity_v2_ir::ir::FunctionVisibility::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::GreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::GweiKeywordStruct
+pub fn slang_solidity_v2_ir::ir::GweiKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexLiteralStruct
+pub fn slang_solidity_v2_ir::ir::HexLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexStringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::HexStringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HoursKeywordStruct
+pub fn slang_solidity_v2_ir::ir::HoursKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IdentifierStruct
+pub fn slang_solidity_v2_ir::ir::IdentifierStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IfStatementStruct
+pub fn slang_solidity_v2_ir::ir::IfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportClause
+pub fn slang_solidity_v2_ir::ir::ImportClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InheritanceTypeStruct
+pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IntKeywordStruct
+pub fn slang_solidity_v2_ir::ir::IntKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::LessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanLessThanStruct
+pub fn slang_solidity_v2_ir::ir::LessThanLessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LessThanStruct
+pub fn slang_solidity_v2_ir::ir::LessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MappingTypeStruct
+pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemoryKeywordStruct
+pub fn slang_solidity_v2_ir::ir::MemoryKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusEqualStruct
+pub fn slang_solidity_v2_ir::ir::MinusEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusMinusStruct
+pub fn slang_solidity_v2_ir::ir::MinusMinusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinusStruct
+pub fn slang_solidity_v2_ir::ir::MinusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MinutesKeywordStruct
+pub fn slang_solidity_v2_ir::ir::MinutesKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ModifierInvocationStruct
+pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NamedArgumentStruct
+pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NewExpressionStruct
+pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NumberUnit
+pub fn slang_solidity_v2_ir::ir::NumberUnit::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::OrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ParameterStruct
+pub fn slang_solidity_v2_ir::ir::ParameterStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PathImportStruct
+pub fn slang_solidity_v2_ir::ir::PathImportStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PayableKeywordStruct
+pub fn slang_solidity_v2_ir::ir::PayableKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PercentEqualStruct
+pub fn slang_solidity_v2_ir::ir::PercentEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PercentStruct
+pub fn slang_solidity_v2_ir::ir::PercentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusEqualStruct
+pub fn slang_solidity_v2_ir::ir::PlusEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusPlusStruct
+pub fn slang_solidity_v2_ir::ir::PlusPlusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PlusStruct
+pub fn slang_solidity_v2_ir::ir::PlusStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Pragma
+pub fn slang_solidity_v2_ir::ir::Pragma::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaCaretStruct
+pub fn slang_solidity_v2_ir::ir::PragmaCaretStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaGreaterThanStruct
+pub fn slang_solidity_v2_ir::ir::PragmaGreaterThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaLessThanStruct
+pub fn slang_solidity_v2_ir::ir::PragmaLessThanStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaTildeStruct
+pub fn slang_solidity_v2_ir::ir::PragmaTildeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ReturnStatementStruct
+pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::RevertStatementStruct
+pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SMTCheckerKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SecondsKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SecondsKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SemicolonStruct
+pub fn slang_solidity_v2_ir::ir::SemicolonStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionOperator
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SlashEqualStruct
+pub fn slang_solidity_v2_ir::ir::SlashEqualStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SlashStruct
+pub fn slang_solidity_v2_ir::ir::SlashStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitMember
+pub fn slang_solidity_v2_ir::ir::SourceUnitMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitStruct
+pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableMutability
+pub fn slang_solidity_v2_ir::ir::StateVariableMutability::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableVisibility
+pub fn slang_solidity_v2_ir::ir::StateVariableVisibility::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Statement
+pub fn slang_solidity_v2_ir::ir::Statement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageKeywordStruct
+pub fn slang_solidity_v2_ir::ir::StorageKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageLocation
+pub fn slang_solidity_v2_ir::ir::StorageLocation::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringExpression
+pub fn slang_solidity_v2_ir::ir::StringExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringKeywordStruct
+pub fn slang_solidity_v2_ir::ir::StringKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::StringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructMemberStruct
+pub fn slang_solidity_v2_ir::ir::StructMemberStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SuperKeywordStruct
+pub fn slang_solidity_v2_ir::ir::SuperKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ThisKeywordStruct
+pub fn slang_solidity_v2_ir::ir::ThisKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TildeStruct
+pub fn slang_solidity_v2_ir::ir::TildeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TrueKeywordStruct
+pub fn slang_solidity_v2_ir::ir::TrueKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TryStatementStruct
+pub fn slang_solidity_v2_ir::ir::TryStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleValueStruct
+pub fn slang_solidity_v2_ir::ir::TupleValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeName
+pub fn slang_solidity_v2_ir::ir::TypeName::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UfixedKeywordStruct
+pub fn slang_solidity_v2_ir::ir::UfixedKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UintKeywordStruct
+pub fn slang_solidity_v2_ir::ir::UintKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UncheckedBlockStruct
+pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct
+pub fn slang_solidity_v2_ir::ir::UnicodeStringLiteralStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingClause
+pub fn slang_solidity_v2_ir::ir::UsingClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingOperator
+pub fn slang_solidity_v2_ir::ir::UsingOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingTarget
+pub fn slang_solidity_v2_ir::ir::UsingTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationTarget
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionExpression
+pub fn slang_solidity_v2_ir::ir::VersionExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionLiteral
+pub fn slang_solidity_v2_ir::ir::VersionLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionOperator
+pub fn slang_solidity_v2_ir::ir::VersionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionPragmaStruct
+pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionRangeStruct
+pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionSpecifierStruct
+pub fn slang_solidity_v2_ir::ir::VersionSpecifierStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionTermStruct
+pub fn slang_solidity_v2_ir::ir::VersionTermStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WeeksKeywordStruct
+pub fn slang_solidity_v2_ir::ir::WeeksKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WeiKeywordStruct
+pub fn slang_solidity_v2_ir::ir::WeiKeywordStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBlockStruct
+pub fn slang_solidity_v2_ir::ir::YulBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulExpression
+pub fn slang_solidity_v2_ir::ir::YulExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulForStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulIfStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLiteral
+pub fn slang_solidity_v2_ir::ir::YulLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulStatement
+pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchCase
+pub fn slang_solidity_v2_ir::ir::YulSwitchCase::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulValueCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl<T: slang_solidity_v2_ir::ir::NodeIdentity> slang_solidity_v2_ir::ir::NodeIdentity for alloc::sync::Arc<T>
+pub fn alloc::sync::Arc<T>::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl<T: slang_solidity_v2_ir::ir::NodeIdentity> slang_solidity_v2_ir::ir::NodeIdentity for alloc::vec::Vec<T>
+pub fn alloc::vec::Vec<T>::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
+impl<T: slang_solidity_v2_ir::ir::NodeIdentity> slang_solidity_v2_ir::ir::NodeIdentity for core::option::Option<T>
+pub fn core::option::Option<T>::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub trait slang_solidity_v2_ir::ir::Source
 pub fn slang_solidity_v2_ir::ir::Source::text(&self, core::ops::range::Range<usize>) -> &str
 impl slang_solidity_v2_ir::ir::Source for &str

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/mod.rs
@@ -5,6 +5,10 @@ mod kinds;
 mod nodes;
 pub use nodes::*;
 
+#[path = "node_identity.generated.rs"]
+mod node_identity;
+pub use node_identity::NodeIdentity;
+
 #[path = "text_range.generated.rs"]
 mod text_range;
 pub use text_range::TextRange;

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.generated.rs
@@ -1,0 +1,1745 @@
+// This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+#![allow(clippy::wildcard_imports)]
+
+use std::sync::Arc;
+
+use slang_solidity_v2_common::nodes::NodeId;
+
+use super::nodes::*;
+
+/// A trait for IR nodes that can report the `NodeId` that identifies them.
+///
+/// It returns `None` for nodes that can be legitimately
+/// empty, ie. collections (eg. the positional arguments of `f()`),
+/// and for nodes that may not be represented in the source code,
+/// ie. external nodes.
+pub trait NodeIdentity {
+    /// Returns the `NodeId` of this node, or `None` if the node is empty
+    /// or not represented in the source code.
+    fn node_id(&self) -> Option<NodeId>;
+}
+
+impl<T: NodeIdentity> NodeIdentity for Arc<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.as_ref().node_id()
+    }
+}
+
+impl<T: NodeIdentity> NodeIdentity for Option<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.as_ref().and_then(NodeIdentity::node_id)
+    }
+}
+
+impl<T: NodeIdentity> NodeIdentity for Vec<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.first()?.node_id()
+    }
+}
+
+impl NodeIdentity for AbicoderPragmaStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AdditiveExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AddressTypeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AndExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ArrayExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ArrayTypeNameStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AssemblyStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AssignmentExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BitwiseAndExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BitwiseOrExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BitwiseXorExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BlockStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BreakStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CallOptionsExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CatchClauseStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CatchClauseErrorStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ConditionalExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ConstantDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ContinueStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ContractDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for DecimalNumberExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for DoWhileStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EmitStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EnumDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EqualityExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ErrorDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EventDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ExperimentalPragmaStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ExponentiationExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ExpressionStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ForStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for FunctionCallExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for FunctionDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for FunctionTypeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for HexNumberExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for IfStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ImportDeconstructionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ImportDeconstructionSymbolStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for IndexAccessExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for InequalityExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for InheritanceTypeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for InterfaceDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for LibraryDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MappingTypeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MemberAccessExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ModifierInvocationStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MultiTypedDeclarationStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MultiTypedDeclarationElementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MultiplicativeExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for NamedArgumentStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for NewExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for OrExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ParameterStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PathImportStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PostfixExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaDirectiveStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PrefixExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ReturnStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for RevertStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ShiftExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SingleTypedDeclarationStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SourceUnitStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StateVariableDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StructDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StructMemberStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TryStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TupleExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TupleValueStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TypeExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UncheckedBlockStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UserDefinedValueTypeDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UsingDeconstructionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UsingDeconstructionSymbolStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UsingDirectiveStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VariableDeclarationStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VariableDeclarationStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VersionPragmaStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VersionRangeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VersionTermStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for WhileStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulBlockStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulBreakStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulContinueStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulDefaultCaseStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulForStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulFunctionCallExpressionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulFunctionDefinitionStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulIfStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulLeaveStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulSwitchStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulValueCaseStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulVariableAssignmentStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulVariableDeclarationStatementStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for YulVariableDeclarationValueStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AbicoderVersion {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            AbicoderVersion::AbicoderV1Keyword(inner) => inner.node_id(),
+
+            AbicoderVersion::AbicoderV2Keyword(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for AdditiveExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            AdditiveExpressionOperator::Minus(inner) => inner.node_id(),
+
+            AdditiveExpressionOperator::Plus(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ArgumentsDeclaration {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ArgumentsDeclaration::PositionalArguments(inner) => inner.node_id(),
+
+            ArgumentsDeclaration::NamedArguments(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for AssignmentExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            AssignmentExpressionOperator::AmpersandEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::AsteriskEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::BarEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::CaretEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::Equal(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::GreaterThanGreaterThanEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(inner) => {
+                inner.node_id()
+            }
+
+            AssignmentExpressionOperator::LessThanLessThanEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::MinusEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::PercentEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::PlusEqual(inner) => inner.node_id(),
+
+            AssignmentExpressionOperator::SlashEqual(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ContractMember {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ContractMember::UsingDirective(inner) => inner.node_id(),
+
+            ContractMember::FunctionDefinition(inner) => inner.node_id(),
+
+            ContractMember::StructDefinition(inner) => inner.node_id(),
+
+            ContractMember::EnumDefinition(inner) => inner.node_id(),
+
+            ContractMember::EventDefinition(inner) => inner.node_id(),
+
+            ContractMember::ErrorDefinition(inner) => inner.node_id(),
+
+            ContractMember::UserDefinedValueTypeDefinition(inner) => inner.node_id(),
+
+            ContractMember::StateVariableDefinition(inner) => inner.node_id(),
+
+            ContractMember::ConstantDefinition(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ElementaryType {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ElementaryType::BoolKeyword(inner) => inner.node_id(),
+
+            ElementaryType::StringKeyword(inner) => inner.node_id(),
+
+            ElementaryType::AddressType(inner) => inner.node_id(),
+
+            ElementaryType::BytesKeyword(inner) => inner.node_id(),
+
+            ElementaryType::IntKeyword(inner) => inner.node_id(),
+
+            ElementaryType::UintKeyword(inner) => inner.node_id(),
+
+            ElementaryType::FixedKeyword(inner) => inner.node_id(),
+
+            ElementaryType::UfixedKeyword(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for EqualityExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            EqualityExpressionOperator::BangEqual(inner) => inner.node_id(),
+
+            EqualityExpressionOperator::EqualEqual(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ExperimentalFeature {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ExperimentalFeature::ABIEncoderV2Keyword(inner) => inner.node_id(),
+
+            ExperimentalFeature::SMTCheckerKeyword(inner) => inner.node_id(),
+
+            ExperimentalFeature::StringLiteral(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for Expression {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            Expression::AssignmentExpression(inner) => inner.node_id(),
+
+            Expression::ConditionalExpression(inner) => inner.node_id(),
+
+            Expression::OrExpression(inner) => inner.node_id(),
+
+            Expression::AndExpression(inner) => inner.node_id(),
+
+            Expression::EqualityExpression(inner) => inner.node_id(),
+
+            Expression::InequalityExpression(inner) => inner.node_id(),
+
+            Expression::BitwiseOrExpression(inner) => inner.node_id(),
+
+            Expression::BitwiseXorExpression(inner) => inner.node_id(),
+
+            Expression::BitwiseAndExpression(inner) => inner.node_id(),
+
+            Expression::ShiftExpression(inner) => inner.node_id(),
+
+            Expression::AdditiveExpression(inner) => inner.node_id(),
+
+            Expression::MultiplicativeExpression(inner) => inner.node_id(),
+
+            Expression::ExponentiationExpression(inner) => inner.node_id(),
+
+            Expression::PostfixExpression(inner) => inner.node_id(),
+
+            Expression::PrefixExpression(inner) => inner.node_id(),
+
+            Expression::FunctionCallExpression(inner) => inner.node_id(),
+
+            Expression::CallOptionsExpression(inner) => inner.node_id(),
+
+            Expression::MemberAccessExpression(inner) => inner.node_id(),
+
+            Expression::IndexAccessExpression(inner) => inner.node_id(),
+
+            Expression::NewExpression(inner) => inner.node_id(),
+
+            Expression::TupleExpression(inner) => inner.node_id(),
+
+            Expression::TypeExpression(inner) => inner.node_id(),
+
+            Expression::ArrayExpression(inner) => inner.node_id(),
+
+            Expression::HexNumberExpression(inner) => inner.node_id(),
+
+            Expression::DecimalNumberExpression(inner) => inner.node_id(),
+
+            Expression::StringExpression(inner) => inner.node_id(),
+
+            Expression::ElementaryType(inner) => inner.node_id(),
+
+            Expression::PayableKeyword(inner) => inner.node_id(),
+
+            Expression::ThisKeyword(inner) => inner.node_id(),
+
+            Expression::SuperKeyword(inner) => inner.node_id(),
+
+            Expression::TrueKeyword(inner) => inner.node_id(),
+
+            Expression::FalseKeyword(inner) => inner.node_id(),
+
+            Expression::Identifier(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ForStatementCondition {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ForStatementCondition::ExpressionStatement(inner) => inner.node_id(),
+
+            ForStatementCondition::Semicolon(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ForStatementInitialization {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ForStatementInitialization::VariableDeclarationStatement(inner) => inner.node_id(),
+
+            ForStatementInitialization::ExpressionStatement(inner) => inner.node_id(),
+
+            ForStatementInitialization::Semicolon(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for FunctionKind {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            FunctionKind::Regular => None,
+
+            FunctionKind::Constructor => None,
+
+            FunctionKind::Fallback => None,
+
+            FunctionKind::Receive => None,
+
+            FunctionKind::Modifier => None,
+        }
+    }
+}
+
+impl NodeIdentity for FunctionMutability {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            FunctionMutability::Pure => None,
+
+            FunctionMutability::View => None,
+
+            FunctionMutability::NonPayable => None,
+
+            FunctionMutability::Payable => None,
+        }
+    }
+}
+
+impl NodeIdentity for FunctionVisibility {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            FunctionVisibility::Public => None,
+
+            FunctionVisibility::Private => None,
+
+            FunctionVisibility::Internal => None,
+
+            FunctionVisibility::External => None,
+        }
+    }
+}
+
+impl NodeIdentity for ImportClause {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ImportClause::PathImport(inner) => inner.node_id(),
+
+            ImportClause::ImportDeconstruction(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for InequalityExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            InequalityExpressionOperator::GreaterThan(inner) => inner.node_id(),
+
+            InequalityExpressionOperator::GreaterThanEqual(inner) => inner.node_id(),
+
+            InequalityExpressionOperator::LessThan(inner) => inner.node_id(),
+
+            InequalityExpressionOperator::LessThanEqual(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for MultiplicativeExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            MultiplicativeExpressionOperator::Asterisk(inner) => inner.node_id(),
+
+            MultiplicativeExpressionOperator::Percent(inner) => inner.node_id(),
+
+            MultiplicativeExpressionOperator::Slash(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for NumberUnit {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            NumberUnit::WeiKeyword(inner) => inner.node_id(),
+
+            NumberUnit::GweiKeyword(inner) => inner.node_id(),
+
+            NumberUnit::EtherKeyword(inner) => inner.node_id(),
+
+            NumberUnit::SecondsKeyword(inner) => inner.node_id(),
+
+            NumberUnit::MinutesKeyword(inner) => inner.node_id(),
+
+            NumberUnit::HoursKeyword(inner) => inner.node_id(),
+
+            NumberUnit::DaysKeyword(inner) => inner.node_id(),
+
+            NumberUnit::WeeksKeyword(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for PostfixExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            PostfixExpressionOperator::MinusMinus(inner) => inner.node_id(),
+
+            PostfixExpressionOperator::PlusPlus(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for Pragma {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            Pragma::VersionPragma(inner) => inner.node_id(),
+
+            Pragma::AbicoderPragma(inner) => inner.node_id(),
+
+            Pragma::ExperimentalPragma(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for PrefixExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            PrefixExpressionOperator::Bang(inner) => inner.node_id(),
+
+            PrefixExpressionOperator::DeleteKeyword(inner) => inner.node_id(),
+
+            PrefixExpressionOperator::Minus(inner) => inner.node_id(),
+
+            PrefixExpressionOperator::MinusMinus(inner) => inner.node_id(),
+
+            PrefixExpressionOperator::PlusPlus(inner) => inner.node_id(),
+
+            PrefixExpressionOperator::Tilde(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ShiftExpressionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            ShiftExpressionOperator::GreaterThanGreaterThan(inner) => inner.node_id(),
+
+            ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(inner) => inner.node_id(),
+
+            ShiftExpressionOperator::LessThanLessThan(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for SourceUnitMember {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            SourceUnitMember::PragmaDirective(inner) => inner.node_id(),
+
+            SourceUnitMember::ImportClause(inner) => inner.node_id(),
+
+            SourceUnitMember::ContractDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::InterfaceDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::LibraryDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::StructDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::EnumDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::FunctionDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::ErrorDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::UserDefinedValueTypeDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::UsingDirective(inner) => inner.node_id(),
+
+            SourceUnitMember::EventDefinition(inner) => inner.node_id(),
+
+            SourceUnitMember::ConstantDefinition(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for StateVariableMutability {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            StateVariableMutability::Mutable => None,
+
+            StateVariableMutability::Constant => None,
+
+            StateVariableMutability::Immutable => None,
+
+            StateVariableMutability::Transient => None,
+        }
+    }
+}
+
+impl NodeIdentity for StateVariableVisibility {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            StateVariableVisibility::Public => None,
+
+            StateVariableVisibility::Private => None,
+
+            StateVariableVisibility::Internal => None,
+        }
+    }
+}
+
+impl NodeIdentity for Statement {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            Statement::IfStatement(inner) => inner.node_id(),
+
+            Statement::ForStatement(inner) => inner.node_id(),
+
+            Statement::WhileStatement(inner) => inner.node_id(),
+
+            Statement::DoWhileStatement(inner) => inner.node_id(),
+
+            Statement::ContinueStatement(inner) => inner.node_id(),
+
+            Statement::BreakStatement(inner) => inner.node_id(),
+
+            Statement::ReturnStatement(inner) => inner.node_id(),
+
+            Statement::EmitStatement(inner) => inner.node_id(),
+
+            Statement::TryStatement(inner) => inner.node_id(),
+
+            Statement::RevertStatement(inner) => inner.node_id(),
+
+            Statement::AssemblyStatement(inner) => inner.node_id(),
+
+            Statement::Block(inner) => inner.node_id(),
+
+            Statement::UncheckedBlock(inner) => inner.node_id(),
+
+            Statement::VariableDeclarationStatement(inner) => inner.node_id(),
+
+            Statement::ExpressionStatement(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for StorageLocation {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            StorageLocation::MemoryKeyword(inner) => inner.node_id(),
+
+            StorageLocation::StorageKeyword(inner) => inner.node_id(),
+
+            StorageLocation::CallDataKeyword(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for StringExpression {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            StringExpression::StringLiterals(inner) => inner.node_id(),
+
+            StringExpression::HexStringLiterals(inner) => inner.node_id(),
+
+            StringExpression::UnicodeStringLiterals(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for TypeName {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            TypeName::ArrayTypeName(inner) => inner.node_id(),
+
+            TypeName::FunctionType(inner) => inner.node_id(),
+
+            TypeName::MappingType(inner) => inner.node_id(),
+
+            TypeName::ElementaryType(inner) => inner.node_id(),
+
+            TypeName::IdentifierPath(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for UsingClause {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            UsingClause::IdentifierPath(inner) => inner.node_id(),
+
+            UsingClause::UsingDeconstruction(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for UsingOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            UsingOperator::Ampersand(inner) => inner.node_id(),
+
+            UsingOperator::Asterisk(inner) => inner.node_id(),
+
+            UsingOperator::BangEqual(inner) => inner.node_id(),
+
+            UsingOperator::Bar(inner) => inner.node_id(),
+
+            UsingOperator::Caret(inner) => inner.node_id(),
+
+            UsingOperator::EqualEqual(inner) => inner.node_id(),
+
+            UsingOperator::GreaterThan(inner) => inner.node_id(),
+
+            UsingOperator::GreaterThanEqual(inner) => inner.node_id(),
+
+            UsingOperator::LessThan(inner) => inner.node_id(),
+
+            UsingOperator::LessThanEqual(inner) => inner.node_id(),
+
+            UsingOperator::Minus(inner) => inner.node_id(),
+
+            UsingOperator::Percent(inner) => inner.node_id(),
+
+            UsingOperator::Plus(inner) => inner.node_id(),
+
+            UsingOperator::Slash(inner) => inner.node_id(),
+
+            UsingOperator::Tilde(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for UsingTarget {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            UsingTarget::TypeName(inner) => inner.node_id(),
+
+            UsingTarget::Asterisk(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for VariableDeclarationTarget {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            VariableDeclarationTarget::SingleTypedDeclaration(inner) => inner.node_id(),
+
+            VariableDeclarationTarget::MultiTypedDeclaration(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for VersionExpression {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            VersionExpression::VersionRange(inner) => inner.node_id(),
+
+            VersionExpression::VersionTerm(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for VersionLiteral {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            VersionLiteral::SimpleVersionLiteral(inner) => inner.node_id(),
+
+            VersionLiteral::StringLiteral(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for VersionOperator {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            VersionOperator::PragmaCaret(inner) => inner.node_id(),
+
+            VersionOperator::PragmaTilde(inner) => inner.node_id(),
+
+            VersionOperator::PragmaEqual(inner) => inner.node_id(),
+
+            VersionOperator::PragmaLessThan(inner) => inner.node_id(),
+
+            VersionOperator::PragmaGreaterThan(inner) => inner.node_id(),
+
+            VersionOperator::PragmaLessThanEqual(inner) => inner.node_id(),
+
+            VersionOperator::PragmaGreaterThanEqual(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for YulExpression {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            YulExpression::YulFunctionCallExpression(inner) => inner.node_id(),
+
+            YulExpression::YulLiteral(inner) => inner.node_id(),
+
+            YulExpression::YulPath(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for YulLiteral {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            YulLiteral::TrueKeyword(inner) => inner.node_id(),
+
+            YulLiteral::FalseKeyword(inner) => inner.node_id(),
+
+            YulLiteral::DecimalLiteral(inner) => inner.node_id(),
+
+            YulLiteral::HexLiteral(inner) => inner.node_id(),
+
+            YulLiteral::HexStringLiteral(inner) => inner.node_id(),
+
+            YulLiteral::StringLiteral(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for YulStatement {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            YulStatement::YulBlock(inner) => inner.node_id(),
+
+            YulStatement::YulFunctionDefinition(inner) => inner.node_id(),
+
+            YulStatement::YulIfStatement(inner) => inner.node_id(),
+
+            YulStatement::YulForStatement(inner) => inner.node_id(),
+
+            YulStatement::YulSwitchStatement(inner) => inner.node_id(),
+
+            YulStatement::YulLeaveStatement(inner) => inner.node_id(),
+
+            YulStatement::YulBreakStatement(inner) => inner.node_id(),
+
+            YulStatement::YulContinueStatement(inner) => inner.node_id(),
+
+            YulStatement::YulVariableAssignmentStatement(inner) => inner.node_id(),
+
+            YulStatement::YulVariableDeclarationStatement(inner) => inner.node_id(),
+
+            YulStatement::YulExpression(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for YulSwitchCase {
+    fn node_id(&self) -> Option<NodeId> {
+        match self {
+            YulSwitchCase::YulDefaultCase(inner) => inner.node_id(),
+
+            YulSwitchCase::YulValueCase(inner) => inner.node_id(),
+        }
+    }
+}
+
+impl NodeIdentity for ABIEncoderV2KeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AbicoderV1KeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AbicoderV2KeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AmpersandStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AmpersandEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AsteriskStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for AsteriskEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BangStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BangEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BarStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BarEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BoolKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for BytesKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CallDataKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CaretStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for CaretEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for DaysKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for DecimalLiteralStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for DeleteKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EqualEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for EtherKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for FalseKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for FixedKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanGreaterThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanGreaterThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanGreaterThanGreaterThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GreaterThanGreaterThanGreaterThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for GweiKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for HexLiteralStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for HexStringLiteralStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for HoursKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for IdentifierStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for IntKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for LessThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for LessThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for LessThanLessThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for LessThanLessThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MemoryKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MinusStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MinusEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MinusMinusStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for MinutesKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PayableKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PercentStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PercentEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PlusStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PlusEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PlusPlusStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaCaretStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaGreaterThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaGreaterThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaLessThanStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaLessThanEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for PragmaTildeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SMTCheckerKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SecondsKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SemicolonStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SlashStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SlashEqualStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StorageKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StringKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for StringLiteralStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for SuperKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for ThisKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TildeStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for TrueKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UfixedKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UintKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for UnicodeStringLiteralStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for VersionSpecifierStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for WeeksKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}
+
+impl NodeIdentity for WeiKeywordStruct {
+    fn node_id(&self) -> Option<NodeId> {
+        Some(self.id)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.rs.jinja2
@@ -1,0 +1,71 @@
+{%- set target = model.ir_language_model.target -%}
+
+#![allow(clippy::wildcard_imports)]
+
+use std::sync::Arc;
+
+use slang_solidity_v2_common::nodes::NodeId;
+
+use super::nodes::*;
+
+/// A trait for IR nodes that can report the `NodeId` that identifies them.
+///
+/// It returns `None` for nodes that can be legitimately
+/// empty, ie. collections (eg. the positional arguments of `f()`),
+/// and for nodes that may not be represented in the source code,
+/// ie. external nodes.
+pub trait NodeIdentity {
+    /// Returns the `NodeId` of this node, or `None` if the node is empty
+    /// or not represented in the source code.
+    fn node_id(&self) -> Option<NodeId>;
+}
+
+impl<T: NodeIdentity> NodeIdentity for Arc<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.as_ref().node_id()
+    }
+}
+
+impl<T: NodeIdentity> NodeIdentity for Option<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.as_ref().and_then(NodeIdentity::node_id)
+    }
+}
+
+impl<T: NodeIdentity> NodeIdentity for Vec<T> {
+    fn node_id(&self) -> Option<NodeId> {
+        self.first()?.node_id()
+    }
+}
+
+{% for parent_type, sequence in target.sequences %}
+    impl NodeIdentity for {{ parent_type }}Struct {
+        fn node_id(&self) -> Option<NodeId> {
+            Some(self.id)
+        }
+    }
+{% endfor %}
+
+{% for parent_type, choice in target.choices %}
+    impl NodeIdentity for {{ parent_type }} {
+        fn node_id(&self) -> Option<NodeId> {
+            match self {
+                {% for variant in choice.variants -%}
+                    {% if variant.is_external %}
+                    {{ parent_type }}::{{ variant.name }} => None,
+                    {% else %}
+                    {{ parent_type }}::{{ variant.name }}(inner) => inner.node_id(),
+                    {% endif %}
+                {%- endfor %}
+            }
+        }
+    }
+{% endfor %}
+
+{% for terminal_type, terminal in target.terminals %}
+    impl NodeIdentity for {{ terminal_type }}Struct {
+        fn node_id(&self) -> Option<NodeId> {
+            Some(self.id)
+        }
+    }
+{% endfor %}

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -387,6 +387,8 @@ impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::Number
 pub fn slang_solidity_v2_semantic::types::Number::eq(&self, &slang_solidity_v2_semantic::types::Number) -> bool
 impl core::fmt::Debug for slang_solidity_v2_semantic::types::Number
 pub fn slang_solidity_v2_semantic::types::Number::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for slang_solidity_v2_semantic::types::Number
+pub fn slang_solidity_v2_semantic::types::Number::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Number
 pub enum slang_solidity_v2_semantic::types::Type
 pub slang_solidity_v2_semantic::types::Type::Address(slang_solidity_v2_semantic::types::AddressType)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -85,10 +85,22 @@ impl SemanticContext {
 
         p1_collect_definitions::run(files, &mut binder, diagnostics);
         p2_linearise_contracts::run(files, &mut binder, diagnostics);
-        p3_type_definitions::run(files, &mut binder, &mut types, diagnostics);
+        p3_type_definitions::run(
+            files,
+            &mut binder,
+            &mut types,
+            &file_node_mapper,
+            diagnostics,
+        );
 
         let contract_data = p4_compute_linearisations::run(&binder, &types);
-        p5_resolve_references::run(files, &mut binder, &mut types, diagnostics);
+        p5_resolve_references::run(
+            files,
+            &mut binder,
+            &mut types,
+            &file_node_mapper,
+            diagnostics,
+        );
         p6_resolve_yul::run(&mut binder, &types, &file_node_mapper, diagnostics);
         p7_code_analysis::run(
             &binder,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/constant_evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/constant_evaluator.rs
@@ -2,6 +2,9 @@ use num_bigint::{BigInt, Sign};
 use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    ConstantArithmeticError, IncompatibleConstantOperator, TypeSystemDiagnosticKind,
+};
 use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_ir::ir;
@@ -18,40 +21,30 @@ use crate::types::{
 #[derive(Debug)]
 pub(crate) enum EvaluationError {
     /// The failure has a diagnostic.
-    Diagnostic(DiagnosticKind),
-    /// TODO(validation): Add diagnostics for the other cases, and remove this.
-    Other,
+    Diagnostic {
+        /// The diagnostic to report.
+        kind: DiagnosticKind,
+        /// The operation that raised the failure. In some cases we want to
+        /// point at the exact expression that produced the error instead of
+        /// the caller's own location. `None` means the caller should attach
+        /// its own location.
+        expression: Option<ir::Expression>,
+    },
+    /// Evaluation did not produce a constant value (e.g. the expression is
+    /// not a compile-time constant).
+    CouldNotEvaluate,
 }
 
 impl From<DiagnosticKind> for EvaluationError {
     fn from(kind: DiagnosticKind) -> Self {
-        Self::Diagnostic(kind)
+        Self::Diagnostic {
+            kind,
+            expression: None,
+        }
     }
 }
 
-pub(crate) fn evaluate_compile_time_usize_constant<Scope>(
-    expression: &ir::Expression,
-    start_scope: Scope,
-    types: &mut TypeRegistry,
-    identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
-) -> Result<usize, EvaluationError> {
-    let value =
-        evaluate_compile_time_number_constant(expression, start_scope, types, identifier_resolver)?;
-    value.as_usize().ok_or(EvaluationError::Other)
-}
-
-pub(crate) fn evaluate_compile_time_integer_constant<Scope>(
-    expression: &ir::Expression,
-    start_scope: Scope,
-    types: &mut TypeRegistry,
-    identifier_resolver: &dyn ConstantIdentifierResolver<Scope>,
-) -> Result<BigInt, EvaluationError> {
-    let value =
-        evaluate_compile_time_number_constant(expression, start_scope, types, identifier_resolver)?;
-    value.into_integer().ok_or(EvaluationError::Other)
-}
-
-fn evaluate_compile_time_number_constant<Scope>(
+pub(crate) fn evaluate_compile_time_constant<Scope>(
     expression: &ir::Expression,
     start_scope: Scope,
     types: &mut TypeRegistry,
@@ -89,6 +82,18 @@ impl TypedValue {
         }
     }
 
+    /// Describes the operand for a diagnostic. A typed integer as
+    /// `uint256`/`int8`, and an untyped literal by value as
+    /// `int_const N` or `rational_const N / D`.
+    fn describe(&self) -> String {
+        match self {
+            Self::Literal(value) => value.to_string(),
+            Self::Integer(_, IntegerType { is_signed, bits }) => {
+                format!("{}{bits}", if *is_signed { "int" } else { "uint" })
+            }
+        }
+    }
+
     /// Evaluates an arithmetic, bitwise, shift or exponentiation operator.
     fn binary(
         &self,
@@ -100,7 +105,13 @@ impl TypedValue {
         let right = types.register_type(rhs.to_type());
         let result_id = types
             .type_of_binary_operator(left, right, op)
-            .ok_or(EvaluationError::Other)?;
+            .ok_or_else(|| {
+                EvaluationError::from(DiagnosticKind::from(IncompatibleConstantOperator {
+                    operator: op.as_str().to_owned(),
+                    left_type: self.describe(),
+                    right_type: rhs.describe(),
+                }))
+            })?;
         Self::from_result_type(result_id, types, |integer| {
             let left = self.value().coerce_to_integer(integer)?;
             let right = rhs.value().coerce_to_integer(integer)?;
@@ -113,7 +124,7 @@ impl TypedValue {
         let operand = types.register_type(self.to_type());
         let result_id = types
             .type_of_unary_operator(operand, op)
-            .ok_or(EvaluationError::Other)?;
+            .ok_or(EvaluationError::CouldNotEvaluate)?;
         Self::from_result_type(result_id, types, |integer| {
             let operand = self.value().coerce_to_integer(integer)?;
             op.fold(operand.value())
@@ -134,17 +145,17 @@ impl TypedValue {
                 LiteralKind::Integer { .. } | LiteralKind::Rational { .. } => {
                     Number::from_literal_kind(kind)
                         .map(Self::Literal)
-                        .ok_or(EvaluationError::Other)
+                        .ok_or(EvaluationError::CouldNotEvaluate)
                 }
                 _ => unreachable!("literal operator result is always integer or rational"),
             },
             Type::Integer(integer) => {
-                let result = fold_at(integer).ok_or(EvaluationError::Other)?;
+                let result = fold_at(integer).ok_or(EvaluationError::CouldNotEvaluate)?;
                 result
                     .coerce_to_integer(integer)
-                    .ok_or(EvaluationError::Other)
+                    .ok_or_else(|| DiagnosticKind::from(ConstantArithmeticError).into())
             }
-            _ => Err(EvaluationError::Other),
+            _ => Err(EvaluationError::CouldNotEvaluate),
         }
     }
 }
@@ -223,7 +234,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         &mut self,
         expression: &ir::Expression,
     ) -> Result<TypedValue, EvaluationError> {
-        match expression {
+        let result = match expression {
             ir::Expression::BitwiseOrExpression(bitwise_or_expression) => self.evaluate_binary(
                 &bitwise_or_expression.left_operand,
                 &bitwise_or_expression.right_operand,
@@ -251,7 +262,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                     BinaryOperator::Shr,
                 ),
                 ir::ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => {
-                    Err(EvaluationError::Other)
+                    Err(EvaluationError::CouldNotEvaluate)
                 }
             },
             ir::Expression::AdditiveExpression(additive_expression) => {
@@ -302,18 +313,18 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                     ir::PrefixExpressionOperator::Tilde(_) => {
                         self.evaluate_unary(&prefix_expression.operand, UnaryOperator::BitNot)
                     }
-                    _ => Err(EvaluationError::Other),
+                    _ => Err(EvaluationError::CouldNotEvaluate),
                 }
             }
             ir::Expression::HexNumberExpression(hex_number_expression) => {
                 Number::from_hex_number_expression(hex_number_expression)
                     .map(TypedValue::Literal)
-                    .ok_or(EvaluationError::Other)
+                    .ok_or(EvaluationError::CouldNotEvaluate)
             }
             ir::Expression::DecimalNumberExpression(decimal_number_expression) => {
                 Number::from_decimal_number_expression(decimal_number_expression)
                     .map(TypedValue::Literal)
-                    .ok_or(EvaluationError::Other)
+                    .ok_or(EvaluationError::CouldNotEvaluate)
             }
             ir::Expression::Identifier(identifier) => self.evaluate_identifier(identifier),
             ir::Expression::TupleExpression(tuple_expression) => {
@@ -326,9 +337,28 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
                 // all other variants of expression cannot be evaluated at
                 // compile time, or are not relevant for computing constant
                 // integers (eg. string literals)
-                Err(EvaluationError::Other)
+                Err(EvaluationError::CouldNotEvaluate)
             }
-        }
+        };
+
+        // For operator errors we attach the innermost expression where the
+        // error happened. A cyclic constant definition is left for the caller
+        // to locate, as the `constant_cycles` analysis emits a more helpful
+        // diagnostic for it.
+        result.map_err(|error| match error {
+            EvaluationError::Diagnostic {
+                kind:
+                    kind @ DiagnosticKind::TypeSystem(
+                        TypeSystemDiagnosticKind::IncompatibleConstantOperator(_)
+                        | TypeSystemDiagnosticKind::ConstantArithmeticError(_),
+                    ),
+                expression: None,
+            } => EvaluationError::Diagnostic {
+                kind,
+                expression: Some(expression.clone()),
+            },
+            other => other,
+        })
     }
 
     fn evaluate_binary(
@@ -364,15 +394,15 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             .identifier_resolver
             .resolve_identifier_in_scope(identifier.unparse(), current_scope)
         else {
-            return Err(EvaluationError::Other);
+            return Err(EvaluationError::CouldNotEvaluate);
         };
         // Reject constants that are not declared with an integer type.
-        let integer_type = integer_type.ok_or(EvaluationError::Other)?;
+        let integer_type = integer_type.ok_or(EvaluationError::CouldNotEvaluate)?;
         let evaluated = self.evaluate_expression_in_scope(&target_expression, target_scope)?;
         evaluated
             .value()
             .coerce_to_integer(&integer_type)
-            .ok_or(EvaluationError::Other)
+            .ok_or(EvaluationError::CouldNotEvaluate)
     }
 
     fn evaluate_tuple_expression(
@@ -383,10 +413,10 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             let inner_expression = tuple_expression.items[0]
                 .expression
                 .as_ref()
-                .ok_or(EvaluationError::Other)?;
+                .ok_or(EvaluationError::CouldNotEvaluate)?;
             self.evaluate_expression(inner_expression)
         } else {
-            Err(EvaluationError::Other)
+            Err(EvaluationError::CouldNotEvaluate)
         }
     }
 
@@ -397,7 +427,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         call: &ir::FunctionCallExpression,
     ) -> Result<TypedValue, EvaluationError> {
         let ir::Expression::Identifier(operand) = &call.operand else {
-            return Err(EvaluationError::Other);
+            return Err(EvaluationError::CouldNotEvaluate);
         };
         let scope = self.scope_stack.last().expect("scope stack is empty");
         let resolution = self
@@ -407,7 +437,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             ComptimeResolution::BuiltIn(InternalBuiltIn::Erc7201) => {
                 self.evaluate_erc7201_built_in_call(&call.arguments)
             }
-            _ => Err(EvaluationError::Other),
+            _ => Err(EvaluationError::CouldNotEvaluate),
         }
     }
 
@@ -416,11 +446,11 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
         arguments: &ir::ArgumentsDeclaration,
     ) -> Result<TypedValue, EvaluationError> {
         let ir::ArgumentsDeclaration::PositionalArguments(arguments) = arguments else {
-            return Err(EvaluationError::Other);
+            return Err(EvaluationError::CouldNotEvaluate);
         };
         let [argument] = arguments.as_slice() else {
             // Reject other arities
-            return Err(EvaluationError::Other);
+            return Err(EvaluationError::CouldNotEvaluate);
         };
         let value = self.evaluate_expression_as_string(argument)?;
         Ok(TypedValue::Integer(
@@ -454,7 +484,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             ir::Expression::Identifier(identifier) => {
                 self.evaluate_identifier_as_string(identifier)
             }
-            _ => Err(EvaluationError::Other),
+            _ => Err(EvaluationError::CouldNotEvaluate),
         }
     }
 
@@ -471,7 +501,7 @@ impl<Scope> CompileConstantEvaluator<'_, Scope> {
             .identifier_resolver
             .resolve_identifier_in_scope(identifier.unparse(), current_scope)
         else {
-            return Err(EvaluationError::Other);
+            return Err(EvaluationError::CouldNotEvaluate);
         };
         if self.scope_stack.len() >= Self::MAX_SCOPE_DEPTH {
             return Err(DiagnosticKind::from(CyclicConstantDefinition).into());
@@ -746,8 +776,7 @@ mod tests {
         let resolver = MapResolver::with_context(context);
         let expression = parse_expression(input);
 
-        evaluate_compile_time_number_constant(&expression, String::new(), &mut types, &resolver)
-            .ok()
+        evaluate_compile_time_constant(&expression, String::new(), &mut types, &resolver).ok()
     }
 
     fn eval_string(input: &str) -> Option<Number> {
@@ -1002,8 +1031,7 @@ mod tests {
         let mut types = TypeRegistry::new(LanguageVersion::LATEST);
         let resolver = MapResolver::recognise_erc7201_with_context(context);
         let expression = parse_expression(input);
-        evaluate_compile_time_number_constant(&expression, String::new(), &mut types, &resolver)
-            .ok()
+        evaluate_compile_time_constant(&expression, String::new(), &mut types, &resolver).ok()
     }
 
     fn eval_string_with_erc7201(input: &str) -> Option<Number> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
@@ -15,7 +15,7 @@ mod node_extensions;
 mod resolution;
 
 pub(crate) use node_extensions::{
-    node_id_for_expression_typing, node_id_for_string_expression_typing,
+    node_id_for_expression_typing, node_id_for_string_expression_typing, node_location,
 };
 pub(crate) use resolution::{
     filter_overriden_definitions, find_definition_namespace_scope_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
@@ -1,5 +1,24 @@
+use std::ops::Range;
+
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
+
+use crate::context::FileNodeMapper;
+
+/// Returns the source location of a node: the file it belongs to and the
+/// text range within it.
+pub(crate) fn node_location(
+    node: &(impl NodeIdentity + TextRange),
+    file_node_mapper: &FileNodeMapper,
+) -> (FileId, Range<usize>) {
+    let file_id = file_node_mapper
+        .file_id_from_node_id(node.node_id().expect("node has an id"))
+        .to_owned();
+    let range = node.calculate_text_range().expect("node has a text range");
+    (file_id, range)
+}
 
 /// Since `StringExpression` nodes are plain enums and each variant is in
 /// turn a collection of terminals, they don't have a `NodeId`. So we pick

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,10 +1,9 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
-use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
-use crate::context::SemanticFile;
+use crate::context::{FileNodeMapper, SemanticFile};
 use crate::types::{ContractType, Type, TypeId, TypeRegistry};
 
 mod resolution;
@@ -24,13 +23,14 @@ pub fn run(
     files: &[impl SemanticFile],
     binder: &mut Binder,
     types: &mut TypeRegistry,
+    file_node_mapper: &FileNodeMapper,
     diagnostics: &mut DiagnosticCollection,
 ) {
     for file in files {
-        Pass::visit_file(file, binder, types, diagnostics);
+        Pass::visit_file(file, binder, types, file_node_mapper, diagnostics);
     }
     for file in files {
-        Pass::visit_file_type_getters(file, binder, types, diagnostics);
+        Pass::visit_file_type_getters(file, binder, types, file_node_mapper, diagnostics);
     }
 }
 
@@ -38,8 +38,8 @@ struct Pass<'a> {
     scope_stack: Vec<ScopeId>,
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
+    file_node_mapper: &'a FileNodeMapper,
     diagnostics: &'a mut DiagnosticCollection,
-    file_id: &'a FileId,
     current_receiver_type: Option<TypeId>,
 }
 
@@ -48,14 +48,15 @@ impl<'a> Pass<'a> {
         file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
+        file_node_mapper: &'a FileNodeMapper,
         diagnostics: &'a mut DiagnosticCollection,
     ) {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
             types,
+            file_node_mapper,
             diagnostics,
-            file_id: file.id(),
             current_receiver_type: None,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
@@ -72,14 +73,15 @@ impl<'a> Pass<'a> {
         file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
+        file_node_mapper: &'a FileNodeMapper,
         diagnostics: &'a mut DiagnosticCollection,
     ) {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
             types,
+            file_node_mapper,
             diagnostics,
-            file_id: file.id(),
             current_receiver_type: None,
         };
         pass.type_getters_from(file.ir_root());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -1,13 +1,18 @@
-use slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility;
+use num_traits::{Signed, ToPrimitive};
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    ArrayLengthFractional, ArrayLengthNegative, ArrayLengthNotConstant, ArrayLengthTooLarge,
+    ArrayLengthZero, InvalidFunctionTypeVisibility,
+};
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_ir::ir::TextRange;
+use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 
 use super::Pass;
 use crate::binder::{Definition, Resolution, ScopeId};
 use crate::passes::common::constant_evaluator::{
-    evaluate_compile_time_usize_constant, ConstantResolver, EvaluationError,
+    evaluate_compile_time_constant, ConstantResolver, EvaluationError,
 };
-use crate::passes::common::resolve_identifier_path_in_scope;
+use crate::passes::common::{node_location, resolve_identifier_path_in_scope};
 use crate::types::{
     ArrayType, DataLocation, FixedSizeArrayType, FunctionType, MappingType, TupleType, Type, TypeId,
 };
@@ -38,6 +43,66 @@ impl Pass<'_> {
         Some(parameter_types)
     }
 
+    /// Resolves a fixed-size array length expression, and emits diagnostics
+    /// if errors are found. On error, returns `usize::default()` so type
+    /// construction can proceed.
+    /// TODO: Change return to u256, when `FixedSizeArrayType` size field
+    /// is changed to u256.
+    fn resolve_array_length(&mut self, size_expression: &ir::Expression) -> usize {
+        let (file_id, range) = node_location(size_expression, self.file_node_mapper);
+        let value = match evaluate_compile_time_constant(
+            size_expression,
+            self.current_contract_or_file_scope_id(),
+            self.types,
+            &ConstantResolver {
+                binder: self.binder,
+                use_site: Some((&file_id, range.start)),
+            },
+        ) {
+            Ok(value) => value,
+            Err(EvaluationError::Diagnostic { kind, expression }) => {
+                // Report at the failing operation, falling back to the length
+                // expression when the evaluator didn't attach one.
+                self.push_diagnostic(expression.as_ref().unwrap_or(size_expression), kind);
+                return usize::default();
+            }
+            Err(EvaluationError::CouldNotEvaluate) => {
+                self.push_diagnostic(size_expression, ArrayLengthNotConstant);
+                return usize::default();
+            }
+        };
+
+        // Classify the value: zero, then fractional, then negative and then too large.
+        if value.is_zero() {
+            self.push_diagnostic(size_expression, ArrayLengthZero);
+            return usize::default();
+        }
+        let Some(integer) = value.as_integer() else {
+            self.push_diagnostic(size_expression, ArrayLengthFractional);
+            return usize::default();
+        };
+        if integer.is_negative() {
+            self.push_diagnostic(size_expression, ArrayLengthNegative);
+            return usize::default();
+        }
+        // TODO: Accept u256, when `FixedSizeArrayType` size field is changed to u256.
+        let Some(size) = integer.to_usize() else {
+            self.push_diagnostic(size_expression, ArrayLengthTooLarge);
+            return usize::default();
+        };
+        size
+    }
+
+    /// Emits `kind` located at `node`.
+    fn push_diagnostic(
+        &mut self,
+        node: &(impl NodeIdentity + TextRange),
+        kind: impl Into<DiagnosticKind>,
+    ) {
+        let (file_id, range) = node_location(node, self.file_node_mapper);
+        self.diagnostics.push(file_id, range, kind);
+    }
+
     pub(super) fn resolve_type_name(
         &mut self,
         type_name: &ir::TypeName,
@@ -49,33 +114,7 @@ impl Pass<'_> {
                     self.resolve_type_name(&array_type_name.operand, Some(data_location))
                         .map(|element_type| {
                             if let Some(size_expression) = &array_type_name.index {
-                                // TODO(validation) SDR[27]: if the size of the array
-                                // cannot be evaluated it's not a compile-time
-                                // constant, or it doesn't fit in `usize`.
-                                let range = size_expression
-                                    .calculate_text_range()
-                                    .expect("expression has a text range");
-                                let size = match evaluate_compile_time_usize_constant(
-                                    size_expression,
-                                    self.current_contract_or_file_scope_id(),
-                                    self.types,
-                                    &ConstantResolver {
-                                        binder: self.binder,
-                                        use_site: Some((self.file_id, range.start)),
-                                    },
-                                ) {
-                                    Ok(size) => size,
-                                    Err(error) => {
-                                        if let EvaluationError::Diagnostic(kind) = error {
-                                            self.diagnostics.push(
-                                                self.file_id.clone(),
-                                                range,
-                                                kind,
-                                            );
-                                        }
-                                        usize::default()
-                                    }
-                                };
+                                let size = self.resolve_array_length(size_expression);
                                 self.types
                                     .register_type(Type::FixedSizeArray(FixedSizeArrayType {
                                         element_type,
@@ -98,11 +137,7 @@ impl Pass<'_> {
                     function_type.visibility,
                     ir::FunctionVisibility::Internal | ir::FunctionVisibility::External
                 ) {
-                    self.diagnostics.push(
-                        self.file_id.clone(),
-                        function_type.range.clone(),
-                        InvalidFunctionTypeVisibility,
-                    );
+                    self.push_diagnostic(function_type, InvalidFunctionTypeVisibility);
                 }
 
                 // NOTE: Keep in sync with `type_of_function_definition`

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
@@ -1,11 +1,10 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
-use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Scope, ScopeId};
 use crate::built_ins::BuiltInsResolver;
-use crate::context::SemanticFile;
+use crate::context::{FileNodeMapper, SemanticFile};
 use crate::types::TypeRegistry;
 
 mod disambiguation;
@@ -22,10 +21,11 @@ pub fn run(
     files: &[impl SemanticFile],
     binder: &mut Binder,
     types: &mut TypeRegistry,
+    file_node_mapper: &FileNodeMapper,
     diagnostics: &mut DiagnosticCollection,
 ) {
     for file in files {
-        Pass::visit_file(file, binder, types, diagnostics);
+        Pass::visit_file(file, binder, types, file_node_mapper, diagnostics);
     }
 }
 
@@ -41,8 +41,8 @@ struct Pass<'a> {
     scope_stack: Vec<ScopeFrame>,
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
+    file_node_mapper: &'a FileNodeMapper,
     diagnostics: &'a mut DiagnosticCollection,
-    file_id: FileId,
 }
 
 impl<'a> Pass<'a> {
@@ -50,14 +50,15 @@ impl<'a> Pass<'a> {
         file: &impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
+        file_node_mapper: &'a FileNodeMapper,
         diagnostics: &'a mut DiagnosticCollection,
     ) {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
             types,
+            file_node_mapper,
             diagnostics,
-            file_id: file.id().to_owned(),
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
         assert!(pass.scope_stack.is_empty());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -2,9 +2,13 @@ use std::sync::Arc;
 
 use ruint::aliases::U256;
 use slang_solidity_v2_common::collections::Set;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    StorageLayoutBaseNonInteger, StorageLayoutBaseNotConstant, StorageLayoutBaseOutOfRange,
+};
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_ir::ir::TextRange;
+use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 
 use super::{Pass, ScopeFrame};
 use crate::binder::{
@@ -12,9 +16,9 @@ use crate::binder::{
 };
 use crate::built_ins::BuiltInsResolver;
 use crate::passes::common::constant_evaluator::{
-    evaluate_compile_time_integer_constant, ConstantResolver, EvaluationError,
+    evaluate_compile_time_constant, ConstantResolver, EvaluationError,
 };
-use crate::passes::common::find_definition_namespace_scope_id;
+use crate::passes::common::{find_definition_namespace_scope_id, node_location};
 use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId};
 
 /// Lexical style resolution of symbols
@@ -361,17 +365,14 @@ impl Pass<'_> {
         }
     }
 
-    /// Resolves a contract's `layout at <expr>` storage base slot via the
-    /// constant evaluator.
+    /// Resolves and validates a contract's `layout at <expr>` storage base
+    /// slot via the constant evaluator, emitting diagnostics on failure.
     pub(super) fn resolve_storage_base_slot(
         &mut self,
         node: &ir::ContractDefinition,
         base_slot_expression: &ir::Expression,
     ) {
-        // TODO(validation) SDR[30]: if the base slot expression cannot be computed
-        // at this time, it's not a compile time constant and hence it's an
-        // error
-        let base_slot = match evaluate_compile_time_integer_constant(
+        let value = match evaluate_compile_time_constant(
             base_slot_expression,
             self.current_scope_id(),
             self.types,
@@ -381,30 +382,51 @@ impl Pass<'_> {
                 use_site: None,
             },
         ) {
-            // TODO(validation) SDR[1733]: if conversion fails the constant is
-            // negative or exceeds the 256 bit range
-            Ok(value) => U256::try_from(value).ok(),
-            Err(error) => {
-                if let EvaluationError::Diagnostic(kind) = error {
-                    self.diagnostics.push(
-                        self.file_id.clone(),
-                        base_slot_expression
-                            .calculate_text_range()
-                            .expect("expression has a text range"),
-                        kind,
-                    );
-                }
-                None
+            Ok(value) => value,
+            Err(EvaluationError::Diagnostic { kind, expression }) => {
+                // Report at the failing operation, falling back to the base
+                // slot expression when the evaluator didn't attach one.
+                self.push_diagnostic(expression.as_ref().unwrap_or(base_slot_expression), kind);
+                return;
+            }
+            Err(EvaluationError::CouldNotEvaluate) => {
+                self.push_diagnostic(base_slot_expression, StorageLayoutBaseNotConstant);
+                return;
             }
         };
 
-        if let Some(base_slot) = base_slot {
-            let Definition::Contract(contract_definition) =
-                self.binder.get_definition_mut(node.id())
-            else {
-                unreachable!("the definition is not a contract");
-            };
-            contract_definition.base_slot = Some(base_slot);
-        }
+        // Classify the value: non-integer, then out of range (negative or too large).
+        let Some(integer) = value.into_integer() else {
+            self.push_diagnostic(base_slot_expression, StorageLayoutBaseNonInteger);
+            return;
+        };
+        let Ok(base_slot) = U256::try_from(&integer) else {
+            self.push_diagnostic(
+                base_slot_expression,
+                StorageLayoutBaseOutOfRange {
+                    value: integer.to_string(),
+                },
+            );
+            return;
+        };
+
+        // TODO(validation) SDR[743]: When this function is called after `ir::visitor::accept_expression`
+        // check if type is implicitly convertable to uint256.
+
+        let Definition::Contract(contract_definition) = self.binder.get_definition_mut(node.id())
+        else {
+            unreachable!("the definition is not a contract");
+        };
+        contract_definition.base_slot = Some(base_slot);
+    }
+
+    /// Emits `kind` located at `node`.
+    fn push_diagnostic(
+        &mut self,
+        node: &(impl NodeIdentity + TextRange),
+        kind: impl Into<DiagnosticKind>,
+    ) {
+        let (file_id, range) = node_location(node, self.file_node_mapper);
+        self.diagnostics.push(file_id, range, kind);
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -261,7 +261,14 @@ contract Test is Base {
     p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
 
     let types_before = types.iter_types().count();
-    p3_type_definitions::run(&files, &mut binder, &mut types, &mut diagnostics);
+    let file_node_mapper = FileNodeMapper::build_from(&files);
+    p3_type_definitions::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
@@ -324,8 +331,21 @@ contract Test is Base {
     let mut diagnostics = DiagnosticCollection::default();
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
     p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
-    p3_type_definitions::run(&files, &mut binder, &mut types, &mut diagnostics);
-    p5_resolve_references::run(&files, &mut binder, &mut types, &mut diagnostics);
+    let file_node_mapper = FileNodeMapper::build_from(&files);
+    p3_type_definitions::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
+    p5_resolve_references::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
     assert!(
         diagnostics.is_empty(),
         "Semantic diagnostics: {diagnostics:?}"
@@ -377,7 +397,13 @@ contract Test {
 
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
     p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
-    p3_type_definitions::run(&files, &mut binder, &mut types, &mut diagnostics);
+    p3_type_definitions::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
     p6_resolve_yul::run(&mut binder, &types, &file_node_mapper, &mut diagnostics);
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1,13 +1,18 @@
 use num_bigint::{BigInt, BigUint};
 use num_rational::BigRational;
 use ruint::aliases::U256;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    ArrayLengthFractional, ArrayLengthNotConstant, ArrayLengthZero, ConstantArithmeticError,
+    IncompatibleConstantOperator, StorageLayoutBaseNotConstant,
+};
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 
 use super::{build_file, TestFile};
 use crate::binder::{Binder, Definition};
-use crate::context::SemanticFile;
+use crate::context::{FileNodeMapper, SemanticFile};
 use crate::passes::common::node_id_for_expression_typing;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
@@ -21,10 +26,12 @@ struct TypeAnalysis {
     file: TestFile,
     binder: Binder,
     types: TypeRegistry,
+    diagnostics: DiagnosticCollection,
 }
 
 /// Builds and runs every semantic pass over an arbitrary Solidity `source`,
-fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
+/// returning the analysis, including any diagnostics produced.
+fn analyze_with_diagnostics(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
         "test.sol".into(),
@@ -37,20 +44,42 @@ fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
     let mut binder = Binder::default();
     let mut types = TypeRegistry::new(language_version);
     let mut diagnostics = DiagnosticCollection::default();
+    let file_node_mapper = FileNodeMapper::build_from(&files);
     p1_collect_definitions::run(&files, &mut binder, &mut diagnostics);
     p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
-    p3_type_definitions::run(&files, &mut binder, &mut types, &mut diagnostics);
-    p5_resolve_references::run(&files, &mut binder, &mut types, &mut diagnostics);
-    assert!(
-        diagnostics.is_empty(),
-        "Semantic diagnostics: {diagnostics:?}"
+    p3_type_definitions::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
+    p5_resolve_references::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
     );
 
     TypeAnalysis {
         file: files.into_iter().next().unwrap(),
         binder,
         types,
+        diagnostics,
     }
+}
+
+/// Builds and runs every semantic pass over an arbitrary Solidity `source`,
+/// asserting that no diagnostics were produced.
+fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
+    let analysis = analyze_with_diagnostics(language_version, source);
+    assert!(
+        analysis.diagnostics.is_empty(),
+        "Semantic diagnostics: {:?}",
+        analysis.diagnostics
+    );
+    analysis
 }
 
 /// Recovers the typing recorded for an expression `node`, resolved to a
@@ -161,6 +190,7 @@ fn type_of_expressions(
         file,
         binder,
         types,
+        ..
     } = analyze(language_version, &source);
 
     let contract = find_contract(&file, contract_name);
@@ -214,26 +244,43 @@ fn register_uint_type(types: &mut TypeRegistry, bits: u32) -> TypeId {
     }))
 }
 
+/// Returns the kind of the single emitted diagnostic, if any. The inputs in
+/// these tests produce at most one diagnostic.
+fn diagnostic_kind(diagnostics: &DiagnosticCollection) -> Option<DiagnosticKind> {
+    assert!(
+        diagnostics.iter().count() <= 1,
+        "expected at most one diagnostic: {diagnostics:?}"
+    );
+    diagnostics.iter().next().map(|d| d.kind().clone())
+}
+
 /// Runs the full pipeline over `source` and returns contract `name`'s folded
-/// storage base slot.
-fn contract_base_slot(source: &str, name: &str) -> Option<U256> {
-    let TypeAnalysis { file, binder, .. } = analyze(LanguageVersion::LATEST, source);
+/// storage base slot together with the diagnostic emitted, if any. A rejected base
+/// slot is reported as a diagnostic and leaves `base_slot` unset.
+fn contract_base_slot(source: &str, name: &str) -> (Option<U256>, Option<DiagnosticKind>) {
+    let TypeAnalysis {
+        file,
+        binder,
+        diagnostics,
+        ..
+    } = analyze_with_diagnostics(LanguageVersion::LATEST, source);
     let contract = find_contract(&file, name);
-    match binder
+    let base_slot = match binder
         .find_definition_by_id(contract.id())
         .expect("contract definition is registered")
     {
         Definition::Contract(contract_definition) => contract_definition.base_slot,
         _ => panic!("expected a contract definition"),
-    }
+    };
+    (base_slot, diagnostic_kind(&diagnostics))
 }
 
 /// Folds a fixed-size-array length through the real pipeline, returning the
-/// computed `FixedSizeArrayType.size`. `context` holds any contract-level
-/// constants the length references; `array_type` is the variable type (e.g.
-/// `"uint256[10 / B]"`). A rejected length reads back as `0`, same as a length
-/// that genuinely folds to `0`.
-fn folded_array_length(context: &str, array_type: &str) -> usize {
+/// computed `FixedSizeArrayType.size` together with the diagnostic emitted, if any.
+/// `context` holds any contract-level constants the length references;
+/// `array_type` is the variable type (e.g. `"uint256[10 / B]"`). A rejected
+/// length reads back as `0`, same as a length that genuinely folds to `0`.
+fn folded_array_length(context: &str, array_type: &str) -> (usize, Option<DiagnosticKind>) {
     let source = format!(
         r#"
         contract Test {{
@@ -247,7 +294,8 @@ fn folded_array_length(context: &str, array_type: &str) -> usize {
         file,
         binder,
         types,
-    } = analyze(LanguageVersion::LATEST, &source);
+        diagnostics,
+    } = analyze_with_diagnostics(LanguageVersion::LATEST, &source);
 
     let contract = find_contract(&file, "Test");
     let state_variable = contract
@@ -267,10 +315,11 @@ fn folded_array_length(context: &str, array_type: &str) -> usize {
         .node_typing(state_variable.id())
         .as_type_id()
         .expect("state variable has a resolved type");
-    match types.get_type_by_id(type_id) {
+    let size = match types.get_type_by_id(type_id) {
         Type::FixedSizeArray(FixedSizeArrayType { size, .. }) => *size,
         other => panic!("expected a FixedSizeArray type, got {other:?}"),
-    }
+    };
+    (size, diagnostic_kind(&diagnostics))
 }
 
 #[test]
@@ -1097,6 +1146,7 @@ fn test_cast_address_to_library_is_library_typed() {
         file,
         binder,
         types,
+        ..
     } = analyze(LanguageVersion::LATEST, source);
 
     let contract = find_contract(&file, "Test");
@@ -1209,6 +1259,7 @@ fn test_this_in_library_is_library_typed() {
         file,
         binder,
         types,
+        ..
     } = analyze(LanguageVersion::LATEST, source);
 
     let library = find_library(&file, "MyLib");
@@ -1237,6 +1288,7 @@ fn test_this_inside_contract() {
         file,
         binder,
         types,
+        ..
     } = analyze(LanguageVersion::LATEST, source);
 
     let contract = find_contract(&file, "MyContract");
@@ -1276,6 +1328,7 @@ fn test_partially_applied_function_does_not_unify_into_array() {
         file,
         binder,
         types,
+        ..
     } = analyze(LanguageVersion::LATEST, source);
 
     let contract = find_contract(&file, "Test");
@@ -1348,6 +1401,7 @@ fn test_partially_applied_function_is_not_convertible() {
         file,
         binder,
         types,
+        ..
     } = analyze(LanguageVersion::LATEST, source);
 
     let contract = find_contract(&file, "Test");
@@ -1389,37 +1443,46 @@ fn test_array_length_folds_with_typed_constants() {
     let uint256_b = |value: &str| format!("uint256 constant B = {value};");
 
     // Division by a typed integer constant truncates toward zero (`10 / 3 = 3`).
-    assert_eq!(folded_array_length(&uint256_b("3"), "uint256[10 / B]"), 3);
+    assert_eq!(
+        folded_array_length(&uint256_b("3"), "uint256[10 / B]"),
+        (3, None)
+    );
     // `7 / 3` truncates to `2`.
-    assert_eq!(folded_array_length(&uint256_b("3"), "uint256[7 / B]"), 2);
+    assert_eq!(
+        folded_array_length(&uint256_b("3"), "uint256[7 / B]"),
+        (2, None)
+    );
     // The fractional intermediate of `(1 / B) * B` is discarded at the typed
-    // division, folding to `0` rather than `1`.
+    // division, folding to `0` rather than `1`, which is then a zero length.
     assert_eq!(
         folded_array_length(&uint256_b("2"), "uint256[(1 / B) * B]"),
-        0
+        (0, Some(ArrayLengthZero.into())),
     );
     // Whole literals combine with a typed integer fine: `2 * 7 / 2 = 7`.
     assert_eq!(
         folded_array_length(&uint256_b("2"), "uint256[(B * 7) / 2]"),
-        7
+        (7, None)
     );
     // Exponentiation with a typed base: `3 ** 2 = 9`.
-    assert_eq!(folded_array_length(&uint256_b("3"), "uint256[B ** 2]"), 9);
+    assert_eq!(
+        folded_array_length(&uint256_b("3"), "uint256[B ** 2]"),
+        (9, None)
+    );
 
     // A small integer type widens the result to the literal's mobile type, so
     // `300 / B` (`B: uint8`) is `uint16` and folds to `100` instead of
     // overflowing `uint8`.
     assert_eq!(
         folded_array_length("uint8 constant B = 3;", "uint256[300 / B]"),
-        100,
+        (100, None),
     );
 
     // But when no widening applies, an overflow of the result type is rejected:
     // `A + 255` (`A: uint8`) has common type `uint8` (255 fits `uint8`), and
-    // `1 + 255 = 256` does not fit `uint8`, so the length folds to `0`.
+    // `1 + 255 = 256` does not fit `uint8`, so it is an arithmetic overflow.
     assert_eq!(
         folded_array_length("uint8 constant A = 1;", "uint256[A + 255]"),
-        0,
+        (0, Some(ConstantArithmeticError.into())),
     );
 }
 
@@ -1427,8 +1490,11 @@ fn test_array_length_folds_with_typed_constants() {
 fn test_array_length_folds_all_literal_arithmetic() {
     // No typed constant: exact rational arithmetic, then the whole result feeds
     // the length. `100 / 8 * 2 = 25` (`100 / 8` is the exact `25/2`).
-    assert_eq!(folded_array_length("", "uint256[(100 / 8) * 2]"), 25);
-    assert_eq!(folded_array_length("", "uint256[2 ** 8]"), 256);
+    assert_eq!(
+        folded_array_length("", "uint256[(100 / 8) * 2]"),
+        (25, None)
+    );
+    assert_eq!(folded_array_length("", "uint256[2 ** 8]"), (256, None));
 }
 
 #[test]
@@ -1436,23 +1502,55 @@ fn test_array_length_rejected_inputs_default_to_zero() {
     let uint256_b = |value: &str| format!("uint256 constant B = {value};");
 
     // A negative literal has no common type with an unsigned integer, so the
-    // operator has no result type.
+    // operator has no result type and is reported as incompatible.
     assert_eq!(
         folded_array_length(&uint256_b("2"), "uint256[(0 - 7) / B]"),
-        0
+        (
+            0,
+            Some(
+                IncompatibleConstantOperator {
+                    operator: "/".to_owned(),
+                    left_type: "int_const -7".to_owned(),
+                    right_type: "uint256".to_owned(),
+                }
+                .into()
+            ),
+        ),
     );
-    // `~B` over `uint256` is negative and out of range for the unsigned type.
-    assert_eq!(folded_array_length(&uint256_b("3"), "uint256[~B]"), 0);
+    // `~B` over `uint256` folds to a negative value that overflows the
+    // unsigned result type: an arithmetic error, not a plain non-constant
+    // length.
+    assert_eq!(
+        folded_array_length(&uint256_b("3"), "uint256[~B]"),
+        (0, Some(ConstantArithmeticError.into())),
+    );
     // Unary negation of an unsigned integer has no result type.
-    assert_eq!(folded_array_length(&uint256_b("3"), "uint256[-B]"), 0);
-    // A literal exceeding 256 bits cannot meet a typed integer.
+    assert_eq!(
+        folded_array_length(&uint256_b("3"), "uint256[-B]"),
+        (0, Some(ArrayLengthNotConstant.into())),
+    );
+    // A literal exceeding 256 bits cannot meet a typed integer, so the
+    // operator has no result type and is reported as incompatible.
     assert_eq!(
         folded_array_length(&uint256_b("3"), "uint256[(2 ** 256) / B]"),
-        0
+        (
+            0,
+            Some(
+                IncompatibleConstantOperator {
+                    operator: "/".to_owned(),
+                    left_type: "int_const 1157...(70 digits omitted)...9936".to_owned(),
+                    right_type: "uint256".to_owned(),
+                }
+                .into()
+            ),
+        ),
     );
     // All-literal division stays an exact rational, which is not a valid
     // (integer) length.
-    assert_eq!(folded_array_length("", "uint256[10 / 4]"), 0);
+    assert_eq!(
+        folded_array_length("", "uint256[10 / 4]"),
+        (0, Some(ArrayLengthFractional.into())),
+    );
 }
 
 #[test]
@@ -1462,24 +1560,24 @@ fn test_storage_base_slot_evaluation() {
     // constant is typed.
     assert_eq!(
         contract_base_slot("contract C layout at N {} uint256 constant N = 42;", "C"),
-        Some(U256::from(42u64)),
+        (Some(U256::from(42u64)), None),
     );
     // Backward reference and a plain literal still resolve.
     assert_eq!(
         contract_base_slot("uint256 constant N = 42; contract C layout at N {}", "C"),
-        Some(U256::from(42u64)),
+        (Some(U256::from(42u64)), None),
     );
     assert_eq!(
         contract_base_slot("contract C layout at 7 {}", "C"),
-        Some(U256::from(7u64)),
+        (Some(U256::from(7u64)), None),
     );
-    // A non-integer constant (here `address`) is not a valid base slot, even
-    // when forward-referenced.
+    // A non-integer constant (here `address`) is not foldable to an integer, so
+    // it is rejected as a non-constant base slot, even when forward-referenced.
     assert_eq!(
         contract_base_slot(
             "contract C layout at N {} address constant N = address(0);",
             "C",
         ),
-        None,
+        (None, Some(StorageLayoutBaseNotConstant.into())),
     );
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/literals/numbers.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str::FromStr;
 
 use num_bigint::BigInt;
@@ -87,10 +88,6 @@ impl Number {
             Self::Integer(value) => Some(value),
             Self::Rational(_) => None,
         }
-    }
-
-    pub(crate) fn as_usize(&self) -> Option<usize> {
-        self.as_integer()?.to_usize()
     }
 
     pub(crate) fn to_literal_kind(&self) -> LiteralKind {
@@ -249,6 +246,37 @@ impl Number {
         match (self, other) {
             (Self::Integer(lhs), Self::Integer(rhs)) => Some(Self::Integer(lhs >> rhs.to_u32()?)),
             _ => None,
+        }
+    }
+}
+
+/// Human-readable form used in diagnostics: `int_const N` for an integer and
+/// `rational_const N / D` for a rational. A value whose decimal form exceeds
+/// 32 digits is abbreviated to its first and last four digits.
+impl fmt::Display for Number {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn readable_digits(value: &BigInt) -> String {
+            let digits = value.to_string();
+            if digits.len() > 32 {
+                let omitted = digits.len() - 8;
+                format!(
+                    "{}...({omitted} digits omitted)...{}",
+                    &digits[..4],
+                    &digits[digits.len() - 4..],
+                )
+            } else {
+                digits
+            }
+        }
+
+        match self {
+            Self::Integer(value) => write!(f, "int_const {}", readable_digits(value)),
+            Self::Rational(value) => write!(
+                f,
+                "rational_const {} / {}",
+                readable_digits(value.numer()),
+                readable_digits(value.denom()),
+            ),
         }
     }
 }
@@ -494,6 +522,30 @@ mod tests {
         // but the rational is below int8's min, so it is rejected.
         let under_min = BigRational::new(BigInt::from(-1285), BigInt::from(10));
         assert!(!rational_literal_fits(&under_min, true, 8));
+    }
+
+    #[test]
+    fn display_abbreviates_long_integers() {
+        assert_eq!(integer(-7).to_string(), "int_const -7");
+        // 10^40 has 41 digits, over the 32-digit limit.
+        assert_eq!(
+            Number::Integer(pow10(40)).to_string(),
+            "int_const 1000...(33 digits omitted)...0000"
+        );
+    }
+
+    #[test]
+    fn display_renders_rationals_as_fractions() {
+        assert_eq!(rational(5, 2).to_string(), "rational_const 5 / 2");
+        // The sign lives on the numerator.
+        assert_eq!(rational(-1, 3).to_string(), "rational_const -1 / 3");
+        // The fraction is normalised.
+        assert_eq!(rational(2, 6).to_string(), "rational_const 1 / 3");
+        // A huge numerator is abbreviated like an integer.
+        assert_eq!(
+            Number::Rational(BigRational::new(pow10(40) + 1, BigInt::from(2))).to_string(),
+            "rational_const 1000...(33 digits omitted)...0001 / 2"
+        );
     }
 
     fn fit(numerator: BigInt, denominator: BigInt) -> Option<FixedPointNumberType> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/operator_typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/operator_typing.rs
@@ -44,6 +44,23 @@ impl BinaryOperator {
     fn is_left_typed(self) -> bool {
         matches!(self, Self::Shl | Self::Shr | Self::Pow)
     }
+
+    /// The operator as written in source (e.g. `/`), used in diagnostics.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Mul => "*",
+            Self::Div => "/",
+            Self::Rem => "%",
+            Self::BitOr => "|",
+            Self::BitXor => "^",
+            Self::BitAnd => "&",
+            Self::Shl => "<<",
+            Self::Shr => ">>",
+            Self::Pow => "**",
+        }
+    }
 }
 
 /// A unary operator on numbers that can be evaluated at compile time.

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -968,6 +968,125 @@ mod syntax {
 mod type_system {
     use super::*;
 
+    mod array_length {
+        use super::*;
+
+        #[test]
+        fn address_constant_length() -> Result<()> {
+            run("type_system/array_length", "address_constant_length")
+        }
+
+        #[test]
+        fn arithmetic_overflow() -> Result<()> {
+            run("type_system/array_length", "arithmetic_overflow")
+        }
+
+        #[test]
+        fn arithmetic_overflow_binary() -> Result<()> {
+            run("type_system/array_length", "arithmetic_overflow_binary")
+        }
+
+        #[test]
+        fn cast() -> Result<()> {
+            run("type_system/array_length", "cast")
+        }
+
+        #[test]
+        fn compound_expression() -> Result<()> {
+            run("type_system/array_length", "compound_expression")
+        }
+
+        #[test]
+        fn division_by_zero() -> Result<()> {
+            run("type_system/array_length", "division_by_zero")
+        }
+
+        #[test]
+        fn exceeds_usize() -> Result<()> {
+            run("type_system/array_length", "exceeds_usize")
+        }
+
+        #[test]
+        fn forward_reference() -> Result<()> {
+            run("type_system/array_length", "forward_reference")
+        }
+
+        #[test]
+        fn fractional() -> Result<()> {
+            run("type_system/array_length", "fractional")
+        }
+
+        #[test]
+        fn function_call_constant() -> Result<()> {
+            run("type_system/array_length", "function_call_constant")
+        }
+
+        #[test]
+        fn function_value() -> Result<()> {
+            run("type_system/array_length", "function_value")
+        }
+
+        #[test]
+        fn huge_scientific_literal() -> Result<()> {
+            run("type_system/array_length", "huge_scientific_literal")
+        }
+
+        #[test]
+        fn incompatible_operator() -> Result<()> {
+            run("type_system/array_length", "incompatible_operator")
+        }
+
+        #[test]
+        fn incompatible_operator_rational() -> Result<()> {
+            run("type_system/array_length", "incompatible_operator_rational")
+        }
+
+        #[test]
+        fn innermost_operation() -> Result<()> {
+            run("type_system/array_length", "innermost_operation")
+        }
+
+        #[test]
+        fn literal_fractional_division() -> Result<()> {
+            run("type_system/array_length", "literal_fractional_division")
+        }
+
+        #[test]
+        fn negative() -> Result<()> {
+            run("type_system/array_length", "negative")
+        }
+
+        #[test]
+        fn negative_exponent() -> Result<()> {
+            run("type_system/array_length", "negative_exponent")
+        }
+
+        #[test]
+        fn non_integer_value() -> Result<()> {
+            run("type_system/array_length", "non_integer_value")
+        }
+
+        #[test]
+        fn not_constant() -> Result<()> {
+            run("type_system/array_length", "not_constant")
+        }
+
+        #[test]
+        fn too_large() -> Result<()> {
+            run("type_system/array_length", "too_large")
+        }
+
+        #[test]
+        fn valid() -> Result<()> {
+            run("type_system/array_length", "valid")
+        }
+
+        #[test]
+        fn zero() -> Result<()> {
+            run("type_system/array_length", "zero")
+        }
+    }
+
     #[test]
     fn fallback_function_mutability() -> Result<()> {
         run("type_system", "fallback_function_mutability")
@@ -1057,6 +1176,145 @@ mod type_system {
         #[test]
         fn interface() -> Result<()> {
             run("type_system/receive_function_parameters", "interface")
+        }
+    }
+
+    mod storage_layout_base_slot {
+        use super::*;
+
+        #[test]
+        fn address_constant() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "address_constant")
+        }
+
+        #[test]
+        fn arithmetic_overflow() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "arithmetic_overflow",
+            )
+        }
+
+        #[test]
+        fn bitwise_negation_after_cast() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "bitwise_negation_after_cast",
+            )
+        }
+
+        #[test]
+        fn bitwise_negation_literal() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "bitwise_negation_literal",
+            )
+        }
+
+        #[test]
+        fn bytes_constant() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "bytes_constant")
+        }
+
+        #[test]
+        fn cast() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "cast")
+        }
+
+        #[test]
+        fn constant_initialized_from_cast() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "constant_initialized_from_cast",
+            )
+        }
+
+        #[test]
+        fn constant_member_access() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "constant_member_access",
+            )
+        }
+
+        #[test]
+        fn fractional() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "fractional")
+        }
+
+        #[test]
+        fn int_constant_negative() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "int_constant_negative",
+            )
+        }
+
+        #[test]
+        fn integer_valued_rational() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "integer_valued_rational",
+            )
+        }
+
+        #[test]
+        fn negative() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "negative")
+        }
+
+        #[test]
+        fn non_integer_type() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "non_integer_type")
+        }
+
+        #[test]
+        fn not_constant() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "not_constant")
+        }
+
+        #[test]
+        fn out_of_range() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "out_of_range")
+        }
+
+        #[test]
+        fn out_of_range_expressions() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "out_of_range_expressions",
+            )
+        }
+
+        #[test]
+        fn type_max() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "type_max")
+        }
+
+        #[test]
+        fn units() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "units")
+        }
+
+        #[test]
+        fn unlimited_arithmetic() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "unlimited_arithmetic",
+            )
+        }
+
+        #[test]
+        fn user_defined_value_type() -> Result<()> {
+            run(
+                "type_system/storage_layout_base_slot",
+                "user_defined_value_type",
+            )
+        }
+
+        #[test]
+        fn valid() -> Result<()> {
+            run("type_system/storage_layout_base_slot", "valid")
         }
     }
 }

--- a/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_forward_constants/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_forward_constants/generated/0.8.0-failure.txt
@@ -1,5 +1,30 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+Parse errors:
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[E] chained;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:11:13]
+    │
+ 11 │     uint256[N] file_level;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:12:13]
+    │
+ 12 │     uint256[M] contract_level;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯
+
+------------------------------------------------------------------------
+
 Definitions (9):
 - Def: #1 ["P" @ input.sol:5:18] (constant, type: uint256)
 - Def: #2 ["E" @ input.sol:6:18] (constant, type: uint256)

--- a/crates/solidity-v2/testing/snapshots/binder_output/contracts/storage_layout_inner_constant/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/contracts/storage_layout_inner_constant/generated/0.8.0-failure.txt
@@ -8,6 +8,13 @@ Parse errors:
    │             ──────┬─────  
    │                   ╰─────── Error occurred here.
 ───╯
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:1:23]
+   │
+ 1 │ contract X2 layout at C2 { // should not bind to a constant defined in the contract
+   │                       ─┬  
+   │                        ╰── Error occurred here.
+───╯
 
 ------------------------------------------------------------------------
 

--- a/crates/solidity-v2/testing/snapshots/binder_output/contracts/storage_layout_inner_constant/generated/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/contracts/storage_layout_inner_constant/generated/0.8.29-failure.txt
@@ -1,5 +1,16 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
+Parse errors:
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:1:23]
+   │
+ 1 │ contract X2 layout at C2 { // should not bind to a constant defined in the contract
+   │                       ─┬  
+   │                        ╰── Error occurred here.
+───╯
+
+------------------------------------------------------------------------
+
 Definitions (2):
 - Def: #1 ["X2" @ input.sol:1:10] (contract)
 - Def: #2 ["C2" @ input.sol:2:22] (constant, type: uint256)

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[n] arr;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[n] arr;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/address_constant_length/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    address constant n = 3;
+    uint256[n] arr;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/constant-arithmetic-error] Error: Arithmetic error when computing constant value.
+   ╭─[constants.sol:7:24]
+   │
+ 7 │ uint256 constant LEN = ~B;
+   │                        ─┬  
+   │                         ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3667] Error: Arithmetic error when computing constant value.
+   ╭─[constants.sol:7:24]
+   │
+ 7 │ uint256 constant LEN = ~B;
+   │                        ─┬  
+   │                         ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow/input.sol
@@ -1,0 +1,22 @@
+// --- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./constants.sol";
+
+contract Example {
+    // The length references the imported constant `LEN`, whose value
+    // expression `~B` (in constants.sol) is where the overflow actually
+    // happens. The error should point at `~B` in constants.sol, not at this
+    // use site.
+    uint256[LEN] x;
+}
+
+// --- path: constants.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+uint256 constant B = 3;
+
+// `~B` folds to a negative value that does not fit the unsigned result type.
+uint256 constant LEN = ~B;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/constant-arithmetic-error] Error: Arithmetic error when computing constant value.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[B + 1] x;
+   │             ──┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2643] Error: Arithmetic error when computing constant value.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[B + 1] x;
+   │             ──┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/arithmetic_overflow_binary/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    uint8 constant B = 255;
+
+    // `B + 1` folds to `256`, which does not fit the common type `uint8` of
+    // the operands, so the addition is an arithmetic error.
+    uint256[B + 1] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[uint256(1)] a;
+   │             ─────┬────  
+   │                  ╰────── Error occurred here.
+───╯
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[int256(2)] b;
+   │             ────┬────  
+   │                 ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[uint256(1)] a;
+   │             ─────┬────  
+   │                  ╰────── Error occurred here.
+───╯
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[int256(2)] b;
+   │             ────┬────  
+   │                 ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/cast/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // An explicit type conversion is not folded by the constant evaluator, so
+    // it is not accepted as an array length even when the operand is a valid
+    // literal.
+    uint256[uint256(1)] a;
+    uint256[int256(2)] b;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[[2]] a;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[(1, 2)] b;
+   │             ───┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[[2]] a;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[(1, 2)] b;
+   │             ───┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/compound_expression/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Neither an inline array nor a tuple is a foldable integer length.
+    uint256[[2]] a;
+    uint256[(1, 2)] b;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[A] x;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[A] x;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/division_by_zero/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The length divides by a constant equal to zero, which cannot be folded.
+    // The zero is routed through a typed constant: a literal `4 / 0` would be
+    // rejected as an incompatible operator instead of an invalid length.
+    uint256 constant A = 4 / B;
+    uint256 constant B = 0;
+    uint256[A] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-too-large] Error: Array length too large, maximum is 2**64 - 1.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** 64] x;
+   │             ───┬───  
+   │                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 7325] Warning: Type uint256[18446744073709551616] covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     uint256[2 ** 64] x;
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/exceeds_usize/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // slang currently rejects array lengths above 2**64 - 1.
+    uint256[2 ** 64] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[LEN] x;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[LEN] x;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/forward_reference/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The length references a constant declared later in the file. The
+    // constant evaluator only folds constants declared before the use site,
+    // so the length is not a compile-time constant.
+    uint256[LEN] x;
+}
+
+uint256 constant LEN = 5;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-fractional] Error: Array with fractional length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[1.5] x;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3208] Error: Array with fractional length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[1.5] x;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/fractional/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A fractional length is not allowed.
+    uint256[1.5] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:11:13]
+    │
+ 11 │     uint256[LEN] a;
+    │             ─┬─  
+    │              ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:11:13]
+    │
+ 11 │     uint256[LEN] a;
+    │             ─┬─  
+    │              ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_call_constant/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f() public pure returns (uint256) {
+        return 1;
+    }
+    // A constant initialized from a function call cannot be folded, so it is
+    // not a valid array length.
+    uint256 constant LEN = f();
+    uint256[LEN] a;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[f] a;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[f] a;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/function_value/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f() public {}
+    // A function reference is not a compile-time constant.
+    uint256[f] a;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[1.111111E1111111111111] a;
+   │             ───────────┬──────────  
+   │                        ╰──────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[1.111111E1111111111111] a;
+   │             ───────────┬──────────  
+   │                        ╰──────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/huge_scientific_literal/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A scientific literal whose value is too large to represent is rejected
+    // as an invalid array length (and must not be expensive to evaluate).
+    uint256[1.111111E1111111111111] a;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/incompatible-constant-operator] Error: Operator / not compatible with types int_const -7 and uint256
+   ╭─[constants.sol:8:24]
+   │
+ 8 │ uint256 constant LEN = (0 - 7) / B;
+   │                        ─────┬─────  
+   │                             ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6020] Error: Operator / not compatible with types int_const -7 and uint256
+   ╭─[constants.sol:8:24]
+   │
+ 8 │ uint256 constant LEN = (0 - 7) / B;
+   │                        ─────┬─────  
+   │                             ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator/input.sol
@@ -1,0 +1,23 @@
+// --- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./constants.sol";
+
+contract Example {
+    // The length references the imported constant `LEN`, whose value
+    // expression `(0 - 7) / B` (in constants.sol) is where the incompatible
+    // operator actually occurs. The error should point there, not at this use
+    // site.
+    uint256[LEN] x;
+}
+
+// --- path: constants.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+uint256 constant B = 2;
+
+// A negative literal has no common type with the unsigned constant `B`, so the
+// division operator has no result type.
+uint256 constant LEN = (0 - 7) / B;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/incompatible-constant-operator] Error: Operator / not compatible with types rational_const 1 / 3 and uint256
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[(2 / 6) / B] x;
+    │             ─────┬─────  
+    │                  ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6020] Error: Operator / not compatible with types rational_const 1 / 3 and uint256
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[(2 / 6) / B] x;
+    │             ─────┬─────  
+    │                  ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/incompatible_operator_rational/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    uint256 constant B = 2;
+
+    // A fractional literal cannot meet a typed integer, so the division has
+    // no result type. The rational operand is rendered as a normalised
+    // fraction: `rational_const 1 / 3` for the source text `2 / 6`.
+    uint256[(2 / 6) / B] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/incompatible-constant-operator] Error: Operator / not compatible with types int_const 1 and int_const 0
+   ╭─[input.sol:7:14]
+   │
+ 7 │     uint256[(1 / 0) * 2] x;
+   │              ──┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6020] Error: Operator / not compatible with types int_const 1 and int_const 0
+   ╭─[input.sol:7:14]
+   │
+ 7 │     uint256[(1 / 0) * 2] x;
+   │              ──┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/innermost_operation/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The failing operation is the inner `1 / 0`; the enclosing `* 2` and the
+    // length use itself must not relocate the diagnostic.
+    uint256[(1 / 0) * 2] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-fractional] Error: Array with fractional length specified.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[10 / 4] x;
+   │             ───┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3208] Error: Array with fractional length specified.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256[10 / 4] x;
+   │             ───┬──  
+   │                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/literal_fractional_division/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // All-literal division stays an exact rational (`10 / 4` is `5/2`), which
+    // is not a valid (integer) length.
+    uint256[10 / 4] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-negative] Error: Array with negative length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[-1] x;
+   │             ─┬  
+   │              ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3658] Error: Array with negative length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[-1] x;
+   │             ─┬  
+   │              ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A negative length is not allowed.
+    uint256[-1] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-fractional] Error: Array with fractional length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** -1] x;
+   │             ───┬───  
+   │                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3208] Error: Array with fractional length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** -1] x;
+   │             ───┬───  
+   │                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/negative_exponent/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A negative exponent folds to a non-integer (1/2) length.
+    uint256[2 ** -1] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[true] a;
+   │             ──┬─  
+   │               ╰─── Error occurred here.
+───╯
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256["x"] b;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[B] c;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:11:13]
+    │
+ 11 │     uint256[S] d;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:8:13]
+   │
+ 8 │     uint256[true] a;
+   │             ──┬─  
+   │               ╰─── Error occurred here.
+───╯
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256["x"] b;
+   │             ─┬─  
+   │              ╰─── Error occurred here.
+───╯
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:10:13]
+    │
+ 10 │     uint256[B] c;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+    ╭─[input.sol:11:13]
+    │
+ 11 │     uint256[S] d;
+    │             ┬  
+    │             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/non_integer_value/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    bool constant B = true;
+    string constant S = "x";
+    // Boolean and string literals/constants do not fold to an integer length.
+    uint256[true] a;
+    uint256["x"] b;
+    uint256[B] c;
+    uint256[S] d;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-not-constant] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[n] x;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:9:13]
+   │
+ 9 │     uint256[n] x;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/not_constant/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    uint256 n;
+
+    // The length is a non-constant state variable, so it is not a
+    // compile-time constant.
+    uint256[n] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-too-large] Error: Array length too large, maximum is 2**64 - 1.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** 256] x;
+   │             ────┬───  
+   │                 ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5462] Error: Invalid array length, expected integer literal or constant expression.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** 256] x;
+   │             ────┬───  
+   │                 ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/solc/0.8.14-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/generated/solc/0.8.14-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1847] Error: Array length too large, maximum is 2**256 - 1.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[2 ** 256] x;
+   │             ────┬───  
+   │                 ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/too_large/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A length larger than 2**256 - 1 is not allowed.
+    uint256[2 ** 256] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/valid/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    uint256 constant N = 3;
+
+    // A literal and constant expressions (addition, division, exponentiation)
+    // that fold to a valid integer length are all accepted.
+    uint256[5] x;
+    uint256[N + 1] y;
+    uint256[100 / 4] z;
+    uint256[2 ** 4] w;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/array-length-zero] Error: Array with zero length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[0] x;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1406] Error: Array with zero length specified.
+   ╭─[input.sol:6:13]
+   │
+ 6 │     uint256[0] x;
+   │             ┬  
+   │             ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/array_length/zero/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Zero-length arrays are not allowed.
+    uint256[0] x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer (the type is 'address' instead).
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/address_constant/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant has type `address`, not an integer, so the constant evaluator
+// treats it as non-foldable and reports a non-constant base slot.
+address constant x = 0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF;
+contract C layout at x {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/constant-arithmetic-error] Error: Arithmetic error when computing constant value.
+   ╭─[constants.sol:7:25]
+   │
+ 7 │ uint256 constant SLOT = ~B;
+   │                         ─┬  
+   │                          ╰── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[main.sol:9:18]
+   │
+ 9 │ contract Example layout at SLOT {}
+   │                  ───────┬──────  
+   │                         ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/constant-arithmetic-error] Error: Arithmetic error when computing constant value.
+   ╭─[constants.sol:7:25]
+   │
+ 7 │ uint256 constant SLOT = ~B;
+   │                         ─┬  
+   │                          ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[main.sol:9:18]
+   │
+ 9 │ contract Example layout at SLOT {}
+   │                  ───┬──  
+   │                     ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[main.sol:9:28]
+   │
+ 9 │ contract Example layout at SLOT {}
+   │                            ──┬─  
+   │                              ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3667] Error: Arithmetic error when computing constant value.
+   ╭─[constants.sol:7:25]
+   │
+ 7 │ uint256 constant SLOT = ~B;
+   │                         ─┬  
+   │                          ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/arithmetic_overflow/input.sol
@@ -1,0 +1,19 @@
+// --- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./constants.sol";
+
+// The base slot references the imported constant `SLOT`, whose value
+// expression `~B` (in constants.sol) is where the overflow actually happens.
+// The error should point at `~B` in constants.sol, not at this use site.
+contract Example layout at SLOT {}
+
+// --- path: constants.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+uint256 constant B = 3;
+
+// `~B` folds to a negative value that does not fit the unsigned result type.
+uint256 constant SLOT = ~B;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │            ───────────────────────────────────────────┬──────────────────────────────────────────  
+   │                                                       ╰──────────────────────────────────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │                      ──────────────────────────────────────┬─────────────────────────────────────  
+   │                                                            ╰─────────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │                      ──────────────────────────────────────┬─────────────────────────────────────  
+   │                                                            ╰─────────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │                      ──────────────────────────────────────┬─────────────────────────────────────  
+   │                                                            ╰─────────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1505] Error: The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}
+   │                      ──────────────────────────────────────┬─────────────────────────────────────  
+   │                                                            ╰─────────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_after_cast/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The cast inside the bitwise negation prevents the evaluator from folding the
+// base slot expression.
+contract C layout at ~uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   │            ──────────────────────────────────────┬──────────────────────────────────────  
+   │                                                  ╰──────────────────────────────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -115792089237316195423570985008687907853269984665640564039457584007913129639935, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   │                      ─────────────────────────────────┬─────────────────────────────────  
+   │                                                       ╰─────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -115792089237316195423570985008687907853269984665640564039457584007913129639935, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   │                      ─────────────────────────────────┬─────────────────────────────────  
+   │                                                       ╰─────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to -2**256 + 1, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   │                      ─────────────────────────────────┬─────────────────────────────────  
+   │                                                       ╰─────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bitwise_negation_literal/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Bitwise negation of a literal folds to a negative value, which is outside the
+// uint256 range.
+contract C layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer (the type is 'bytes32' instead).
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/bytes_constant/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant has type `bytes32`, not an integer, so the constant evaluator
+// treats it as non-foldable and reports a non-constant base slot.
+bytes32 constant x = 0x000000000000000000000000dcad3a6d3569ded06cb7a1b2ccd1d3afdeadbeef;
+contract C layout at x {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │            ──────────┬──────────  
+   │                      ╰──────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │                      ─────┬─────  
+   │                           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │                      ─────┬─────  
+   │                           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │                      ─────┬─────  
+   │                           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1505] Error: The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at uint256(42) {}
+   │                      ─────┬─────  
+   │                           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/cast/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// An explicit type conversion is not folded by the constant evaluator, so the
+// base slot cannot be evaluated at compile time.
+contract C layout at uint256(42) {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1505] Error: The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_initialized_from_cast/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant is initialized from a cast, which the evaluator cannot fold, so
+// the base slot is not a compile-time constant.
+uint256 constant x = uint256(42);
+contract C layout at x {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+    ╭─[input.sol:10:17]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                 ──────┬──────  
+    │                       ╰──────── Error occurred here.
+────╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+    ╭─[input.sol:10:27]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                           ─┬─  
+    │                            ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+    ╭─[input.sol:10:27]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                           ─┬─  
+    │                            ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+    ╭─[input.sol:10:17]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                 ───┬──  
+    │                    ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+    ╭─[input.sol:10:27]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                           ─┬─  
+    │                            ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1505] Error: The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.
+    ╭─[input.sol:10:27]
+    │
+ 10 │ contract C is A layout at A.X {}
+    │                           ─┬─  
+    │                            ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/constant_member_access/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {
+    uint256 constant X = 10;
+}
+
+// The base slot references a constant through member access, which the
+// constant evaluator cannot fold.
+contract C is A layout at A.X {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 1.5 {}
+   │            ──────┬──────  
+   │                  ╰──────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-non-integer] Error: The base slot of the storage layout must evaluate to an integer.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 1.5 {}
+   │                      ─┬─  
+   │                       ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-non-integer] Error: The base slot of the storage layout must evaluate to an integer.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 1.5 {}
+   │                      ─┬─  
+   │                       ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 1.5 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 1.5 {}
+   │                      ─┬─  
+   │                       ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/fractional/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A fractional base slot does not evaluate to an integer.
+contract C layout at 1.5 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -42, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -42, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at x {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to -42, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/int_constant_negative/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A signed constant that folds to a negative value is outside the uint256
+// range.
+int256 constant x = -42;
+contract C layout at x {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract A layout at 42.0 {}
+   │            ───────┬──────  
+   │                   ╰──────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract B layout at 2.5e10 {}
+   │            ────────┬───────  
+   │                    ╰───────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract C layout at 12 / 3 {}
+   │            ────────┬───────  
+   │                    ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/slang/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/slang/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract A layout at 42.0 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/solc/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/generated/solc/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/integer_valued_rational/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Rational expressions whose value has no fractional part are valid base slots.
+contract A layout at 42.0 {}
+contract B layout at 2.5e10 {}
+contract C layout at 12 / 3 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at -100000 {}
+   │            ────────┬────────  
+   │                    ╰────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -100000, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at -100000 {}
+   │                      ───┬───  
+   │                         ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -100000, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at -100000 {}
+   │                      ───┬───  
+   │                         ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at -100000 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to -100000, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at -100000 {}
+   │                      ───┬───  
+   │                         ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/negative/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A negative base slot is outside the uint256 range.
+contract C layout at -100000 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract A layout at true {}
+   │            ───────┬──────  
+   │                   ╰──────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract A layout at true {}
+   │                      ──┬─  
+   │                        ╰─── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract B layout at "abc" {}
+   │            ───────┬───────  
+   │                   ╰───────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract B layout at "abc" {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract A layout at true {}
+   │                      ──┬─  
+   │                        ╰─── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract B layout at "abc" {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract A layout at true {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract A layout at true {}
+   │                      ──┬─  
+   │                        ╰─── Error occurred here.
+───╯
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract B layout at "abc" {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract A layout at true {}
+   │                      ──┬─  
+   │                        ╰─── Error occurred here.
+───╯
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract B layout at "abc" {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/non_integer_type/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Boolean and string base slots do not evaluate to an integer.
+contract A layout at true {}
+contract B layout at "abc" {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at block.timestamp {}
+   │            ────────────┬────────────  
+   │                        ╰────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at block.timestamp {}
+   │                      ───────┬───────  
+   │                             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at block.timestamp {}
+   │                      ───────┬───────  
+   │                             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract C layout at block.timestamp {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1139] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract C layout at block.timestamp {}
+   │                      ───────┬───────  
+   │                             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/not_constant/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The base slot is a runtime value, so it is not a compile-time constant
+// expression.
+contract C layout at block.timestamp {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 2 ** 256 {}
+   │            ─────────┬────────  
+   │                     ╰────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 2 ** 256 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to 2**256, which is outside the range of type uint256.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The base slot exceeds the uint256 range.
+contract C layout at 2 ** 256 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,67 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 8
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   │            ────────────────────────────────────────┬───────────────────────────────────────  
+   │                                                    ╰───────────────────────────────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   │                      ───────────────────────────────────┬──────────────────────────────────  
+   │                                                         ╰──────────────────────────────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract B layout at 2 ** 256 {}
+   │            ─────────┬────────  
+   │                     ╰────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract B layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:8:12]
+   │
+ 8 │ contract C layout at 0 - 1 {}
+   │            ───────┬───────  
+   │                   ╰───────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -1, which is outside the range of type uint256.
+   ╭─[input.sol:8:22]
+   │
+ 8 │ contract C layout at 0 - 1 {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:9:12]
+   │
+ 9 │ contract D layout at 2 ** 8 - 2 ** 16 {}
+   │            ─────────────┬────────────  
+   │                         ╰────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -65280, which is outside the range of type uint256.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract D layout at 2 ** 8 - 2 ** 16 {}
+   │                      ────────┬───────  
+   │                              ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   │                      ───────────────────────────────────┬──────────────────────────────────  
+   │                                                         ╰──────────────────────────────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to 115792089237316195423570985008687907853269984665640564039457584007913129639936, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract B layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -1, which is outside the range of type uint256.
+   ╭─[input.sol:8:22]
+   │
+ 8 │ contract C layout at 0 - 1 {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-out-of-range] Error: The base slot of the storage layout evaluates to -65280, which is outside the range of type uint256.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract D layout at 2 ** 8 - 2 ** 16 {}
+   │                      ────────┬───────  
+   │                              ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to 2**256, which is outside the range of type uint256.
+   ╭─[input.sol:6:22]
+   │
+ 6 │ contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   │                      ───────────────────────────────────┬──────────────────────────────────  
+   │                                                         ╰──────────────────────────────────── Error occurred here.
+───╯
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to 2**256, which is outside the range of type uint256.
+   ╭─[input.sol:7:22]
+   │
+ 7 │ contract B layout at 2 ** 256 {}
+   │                      ────┬───  
+   │                          ╰───── Error occurred here.
+───╯
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to -1, which is outside the range of type uint256.
+   ╭─[input.sol:8:22]
+   │
+ 8 │ contract C layout at 0 - 1 {}
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯
+
+[TypeError 6753] Error: The base slot of the storage layout evaluates to -65280, which is outside the range of type uint256.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract D layout at 2 ** 8 - 2 ** 16 {}
+   │                      ────────┬───────  
+   │                              ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/out_of_range_expressions/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Expressions that fold above 2**256 - 1 or below zero are outside the uint256
+// range.
+contract A layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+contract B layout at 2 ** 256 {}
+contract C layout at 0 - 1 {}
+contract D layout at 2 ** 8 - 2 ** 16 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │            ────────────┬───────────  
+   │                        ╰───────────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │                      ───────┬──────  
+   │                             ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │                      ───────┬──────  
+   │                             ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │                      ───────┬──────  
+   │                             ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1505] Error: The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.
+   ╭─[input.sol:5:22]
+   │
+ 5 │ contract C layout at type(uint).max {}
+   │                      ───────┬──────  
+   │                             ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/type_max/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `type(uint).max` is not folded by the constant evaluator.
+contract C layout at type(uint).max {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 5 minutes {}
+   │            ─────────┬─────────  
+   │                     ╰─────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:6:12]
+   │
+ 6 │ contract D layout at 2 gwei {}
+   │            ────────┬───────  
+   │                    ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/slang/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/slang/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 5 minutes {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/solc/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/generated/solc/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/units/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Number literals with time and ether units fold to integers.
+contract C layout at 5 minutes {}
+contract D layout at 2 gwei {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract A layout at 1.23e100 / 2e50 {}
+   │            ────────────┬────────────  
+   │                        ╰────────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:8:12]
+   │
+ 8 │ contract B layout at 2 ** 256 * (500e-3) {}
+   │            ──────────────┬──────────────  
+   │                          ╰──────────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:9:12]
+   │
+ 9 │ contract D layout at (2 ** 255 * 2) - (2 ** 256 + 1) + 1 {}
+   │            ──────────────────────┬──────────────────────  
+   │                                  ╰──────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/slang/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/slang/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:7:12]
+   │
+ 7 │ contract A layout at 1.23e100 / 2e50 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/solc/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/generated/solc/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/unlimited_arithmetic/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Intermediate results are computed with unlimited precision, so expressions
+// that fold to an in-range integer are valid base slots even when intermediate
+// values overflow uint256.
+contract A layout at 1.23e100 / 2e50 {}
+contract B layout at 2 ** 256 * (500e-3) {}
+contract D layout at (2 ** 255 * 2) - (2 ** 256 + 1) + 1 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:7:1]
+   │
+ 7 │ type MyType is uint256;
+   │ ───────────┬───────────  
+   │            ╰───────────── Error occurred here.
+───╯
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.8'.
+   ╭─[input.sol:8:28]
+   │
+ 8 │ MyType constant x = MyType.wrap(5);
+   │                            ──┬─  
+   │                              ╰─── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:9:12]
+   │
+ 9 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/slang/0.8.8-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:9:12]
+   │
+ 9 │ contract C layout at x {}
+   │            ─────┬─────  
+   │                 ╰─────── Error occurred here.
+───╯
+
+[type-system/storage-layout-base-not-constant] Error: The base slot of the storage layout must be a compile-time constant expression.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:7:1]
+   │
+ 7 │ type MyType is uint256;
+   │ ──┬─  
+   │   ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6396] Error: The base slot of the storage layout must evaluate to a rational number.
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 1763] Error: The base slot of the storage layout must evaluate to an integer (the type is 'MyType' instead).
+   ╭─[input.sol:9:22]
+   │
+ 9 │ contract C layout at x {}
+   │                      ┬  
+   │                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/generated/solc/0.8.8-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:9:12]
+   │
+ 9 │ contract C layout at x {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/user_defined_value_type/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant's type is the user-defined value type `MyType`, not an
+// integer, and `MyType.wrap(5)` cannot be folded, so the base slot is
+// reported as non-constant.
+type MyType is uint256;
+MyType constant x = MyType.wrap(5);
+contract C layout at x {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 0x1000 {}
+   │            ────────┬───────  
+   │                    ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/slang/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/slang/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:12]
+   │
+ 5 │ contract C layout at 0x1000 {}
+   │            ───┬──  
+   │               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/solc/0.8.29-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/generated/solc/0.8.29-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/storage_layout_base_slot/valid/input.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A constant base slot within the uint256 range is valid.
+contract C layout at 0x1000 {}


### PR DESCRIPTION
This commit adds:
1) Validation of fixed-size array lengths in p3: the length expression
   is folded with the compile-time constant evaluator and rejected when
   it is not a constant, zero, non-integer, negative, or too large,
   instead of being silently ignored.
2) Validation of `layout at` storage base slots in p5, rejecting base
   slots that are not compile-time constants, non-integer, or outside
   the uint256 range.
3) Error locations that point at the failing operation itself:
   EvaluationError carries the expression that raised it, so a nested
   failure keeps the innermost operation's location, even across files
   (e.g. an imported constant's initializer).
4) A Display rendering for evaluated numbers used in diagnostics:
   integers as `int_const N` (abbreviated past 32 digits), rationals as
   `rational_const N.NN`, truncated to two decimals with `...` marking
   inexact renders.