### PR TITLE
add `FileId` type

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -95,7 +95,7 @@ pub fn slang_solidity_v2_ast::abi::AbiReceive::fmt(&self, &mut core::fmt::Format
 pub struct slang_solidity_v2_ast::abi::ContractAbi
 impl slang_solidity_v2_ast::abi::ContractAbi
 pub fn slang_solidity_v2_ast::abi::ContractAbi::entries(&self) -> &[slang_solidity_v2_ast::abi::AbiEntry]
-pub fn slang_solidity_v2_ast::abi::ContractAbi::file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::abi::ContractAbi::file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::abi::ContractAbi::name(&self) -> &str
 pub fn slang_solidity_v2_ast::abi::ContractAbi::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::abi::ContractAbi::storage_layout(&self) -> &[slang_solidity_v2_ast::abi::StorageItem]
@@ -1113,7 +1113,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulSwitchCase
 pub fn slang_solidity_v2_ast::ast::YulSwitchCase::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 impl slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
-pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1122,7 +1122,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ABIEncoderV2Keyw
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderPragmaStruct
 impl slang_solidity_v2_ast::ast::AbicoderPragmaStruct
-pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1131,7 +1131,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderPragmaSt
 pub fn slang_solidity_v2_ast::ast::AbicoderPragmaStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct
 impl slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct
-pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1140,7 +1140,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV1Keywor
 pub fn slang_solidity_v2_ast::ast::AbicoderV1KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
 impl slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct
-pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1149,7 +1149,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AbicoderV2Keywor
 pub fn slang_solidity_v2_ast::ast::AbicoderV2KeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 impl slang_solidity_v2_ast::ast::AdditiveExpressionStruct
-pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1165,7 +1165,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::AddressType
 pub fn slang_solidity_v2_ast::ast::AddressType::clone(&self) -> slang_solidity_v2_ast::ast::AddressType
 pub struct slang_solidity_v2_ast::ast::AddressTypeStruct
 impl slang_solidity_v2_ast::ast::AddressTypeStruct
-pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::is_payable(&self) -> bool
@@ -1174,7 +1174,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AddressTypeStruc
 pub fn slang_solidity_v2_ast::ast::AddressTypeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AmpersandEqualStruct
 impl slang_solidity_v2_ast::ast::AmpersandEqualStruct
-pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1183,7 +1183,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandEqualSt
 pub fn slang_solidity_v2_ast::ast::AmpersandEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AmpersandStruct
 impl slang_solidity_v2_ast::ast::AmpersandStruct
-pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1192,7 +1192,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AmpersandStruct
 pub fn slang_solidity_v2_ast::ast::AmpersandStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AndExpressionStruct
 impl slang_solidity_v2_ast::ast::AndExpressionStruct
-pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1202,7 +1202,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AndExpressionStr
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ArrayExpressionStruct
 impl slang_solidity_v2_ast::ast::ArrayExpressionStruct
-pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::items(&self) -> slang_solidity_v2_ast::ast::ArrayValues
@@ -1217,7 +1217,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ArrayType
 pub fn slang_solidity_v2_ast::ast::ArrayType::clone(&self) -> slang_solidity_v2_ast::ast::ArrayType
 pub struct slang_solidity_v2_ast::ast::ArrayTypeNameStruct
 impl slang_solidity_v2_ast::ast::ArrayTypeNameStruct
-pub fn slang_solidity_v2_ast::ast::ArrayTypeNameStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ArrayTypeNameStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ArrayTypeNameStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ArrayTypeNameStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ArrayTypeNameStruct::index(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
@@ -1236,7 +1236,7 @@ pub struct slang_solidity_v2_ast::ast::AssemblyStatementStruct
 impl slang_solidity_v2_ast::ast::AssemblyStatementStruct
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::flags(&self) -> core::option::Option<slang_solidity_v2_ast::ast::YulFlags>
-pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::label(&self) -> core::option::Option<slang_solidity_v2_ast::ast::StringLiteral>
@@ -1247,7 +1247,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AssemblyStatemen
 pub fn slang_solidity_v2_ast::ast::AssemblyStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AssignmentExpressionStruct
 impl slang_solidity_v2_ast::ast::AssignmentExpressionStruct
-pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1258,7 +1258,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AssignmentExpres
 pub fn slang_solidity_v2_ast::ast::AssignmentExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AsteriskEqualStruct
 impl slang_solidity_v2_ast::ast::AsteriskEqualStruct
-pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1267,7 +1267,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskEqualStr
 pub fn slang_solidity_v2_ast::ast::AsteriskEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::AsteriskStruct
 impl slang_solidity_v2_ast::ast::AsteriskStruct
-pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1276,7 +1276,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AsteriskStruct
 pub fn slang_solidity_v2_ast::ast::AsteriskStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangEqualStruct
 impl slang_solidity_v2_ast::ast::BangEqualStruct
-pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1285,7 +1285,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangEqualStruct
 pub fn slang_solidity_v2_ast::ast::BangEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BangStruct
 impl slang_solidity_v2_ast::ast::BangStruct
-pub fn slang_solidity_v2_ast::ast::BangStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BangStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BangStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BangStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1294,7 +1294,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BangStruct
 pub fn slang_solidity_v2_ast::ast::BangStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarEqualStruct
 impl slang_solidity_v2_ast::ast::BarEqualStruct
-pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1303,7 +1303,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarEqualStruct
 pub fn slang_solidity_v2_ast::ast::BarEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BarStruct
 impl slang_solidity_v2_ast::ast::BarStruct
-pub fn slang_solidity_v2_ast::ast::BarStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BarStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BarStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BarStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1312,7 +1312,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BarStruct
 pub fn slang_solidity_v2_ast::ast::BarStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
-pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1322,7 +1322,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseAndExpres
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
-pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1332,7 +1332,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseOrExpress
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
-pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1342,7 +1342,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseXorExpres
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BlockStruct
 impl slang_solidity_v2_ast::ast::BlockStruct
-pub fn slang_solidity_v2_ast::ast::BlockStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BlockStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BlockStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BlockStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BlockStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1351,7 +1351,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BlockStruct
 pub fn slang_solidity_v2_ast::ast::BlockStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::BoolKeywordStruct
 impl slang_solidity_v2_ast::ast::BoolKeywordStruct
-pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BoolKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1363,7 +1363,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::BooleanType
 pub fn slang_solidity_v2_ast::ast::BooleanType::clone(&self) -> slang_solidity_v2_ast::ast::BooleanType
 pub struct slang_solidity_v2_ast::ast::BreakStatementStruct
 impl slang_solidity_v2_ast::ast::BreakStatementStruct
-pub fn slang_solidity_v2_ast::ast::BreakStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BreakStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BreakStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BreakStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BreakStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1376,7 +1376,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ByteArrayType
 pub fn slang_solidity_v2_ast::ast::ByteArrayType::clone(&self) -> slang_solidity_v2_ast::ast::ByteArrayType
 pub struct slang_solidity_v2_ast::ast::BytesKeywordStruct
 impl slang_solidity_v2_ast::ast::BytesKeywordStruct
-pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::BytesKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1390,7 +1390,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::BytesType
 pub fn slang_solidity_v2_ast::ast::BytesType::clone(&self) -> slang_solidity_v2_ast::ast::BytesType
 pub struct slang_solidity_v2_ast::ast::CallDataKeywordStruct
 impl slang_solidity_v2_ast::ast::CallDataKeywordStruct
-pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1399,7 +1399,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CallDataKeywordS
 pub fn slang_solidity_v2_ast::ast::CallDataKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CallOptionsExpressionStruct
 impl slang_solidity_v2_ast::ast::CallOptionsExpressionStruct
-pub fn slang_solidity_v2_ast::ast::CallOptionsExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CallOptionsExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CallOptionsExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CallOptionsExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CallOptionsExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1416,7 +1416,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CallOptionsStruc
 pub fn slang_solidity_v2_ast::ast::CallOptionsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CaretEqualStruct
 impl slang_solidity_v2_ast::ast::CaretEqualStruct
-pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1425,7 +1425,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretEqualStruct
 pub fn slang_solidity_v2_ast::ast::CaretEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CaretStruct
 impl slang_solidity_v2_ast::ast::CaretStruct
-pub fn slang_solidity_v2_ast::ast::CaretStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CaretStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1434,7 +1434,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::CaretStruct
 pub fn slang_solidity_v2_ast::ast::CaretStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::CatchClauseErrorStruct
 impl slang_solidity_v2_ast::ast::CatchClauseErrorStruct
-pub fn slang_solidity_v2_ast::ast::CatchClauseErrorStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CatchClauseErrorStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CatchClauseErrorStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CatchClauseErrorStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CatchClauseErrorStruct::name(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Identifier>
@@ -1446,7 +1446,7 @@ pub struct slang_solidity_v2_ast::ast::CatchClauseStruct
 impl slang_solidity_v2_ast::ast::CatchClauseStruct
 pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::body(&self) -> slang_solidity_v2_ast::ast::Block
 pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::error(&self) -> core::option::Option<slang_solidity_v2_ast::ast::CatchClauseError>
-pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::CatchClauseStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1462,7 +1462,7 @@ pub fn slang_solidity_v2_ast::ast::CatchClausesStruct::serialize<S: serde_core::
 pub struct slang_solidity_v2_ast::ast::ConditionalExpressionStruct
 impl slang_solidity_v2_ast::ast::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::false_expression(&self) -> slang_solidity_v2_ast::ast::Expression
-pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ConditionalExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1477,7 +1477,7 @@ pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::references(&self) -
 impl slang_solidity_v2_ast::ast::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::ConstantDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -1489,7 +1489,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ConstantDefiniti
 pub fn slang_solidity_v2_ast::ast::ConstantDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ContinueStatementStruct
 impl slang_solidity_v2_ast::ast::ContinueStatementStruct
-pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ContinueStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1516,7 +1516,7 @@ pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::linearised_state_va
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::modifiers(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::state_variables(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::StateVariableDefinition>
 impl slang_solidity_v2_ast::ast::ContractDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ContractDefinitionStruct::inheritance_types(&self) -> slang_solidity_v2_ast::ast::InheritanceTypes
@@ -1541,7 +1541,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ContractType
 pub fn slang_solidity_v2_ast::ast::ContractType::clone(&self) -> slang_solidity_v2_ast::ast::ContractType
 pub struct slang_solidity_v2_ast::ast::DaysKeywordStruct
 impl slang_solidity_v2_ast::ast::DaysKeywordStruct
-pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1550,7 +1550,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DaysKeywordStruc
 pub fn slang_solidity_v2_ast::ast::DaysKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DecimalLiteralStruct
 impl slang_solidity_v2_ast::ast::DecimalLiteralStruct
-pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1559,7 +1559,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DecimalLiteralSt
 pub fn slang_solidity_v2_ast::ast::DecimalLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct
 impl slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct
-pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::literal(&self) -> slang_solidity_v2_ast::ast::DecimalLiteral
@@ -1573,7 +1573,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::DecimalNumberExp
 pub fn slang_solidity_v2_ast::ast::DecimalNumberExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::DeleteKeywordStruct
 impl slang_solidity_v2_ast::ast::DeleteKeywordStruct
-pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DeleteKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1584,7 +1584,7 @@ pub struct slang_solidity_v2_ast::ast::DoWhileStatementStruct
 impl slang_solidity_v2_ast::ast::DoWhileStatementStruct
 pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::Statement
 pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::Expression
-pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::DoWhileStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1594,7 +1594,7 @@ pub struct slang_solidity_v2_ast::ast::EmitStatementStruct
 impl slang_solidity_v2_ast::ast::EmitStatementStruct
 pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::arguments(&self) -> slang_solidity_v2_ast::ast::ArgumentsDeclaration
 pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::event(&self) -> slang_solidity_v2_ast::ast::IdentifierPath
-pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EmitStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1607,7 +1607,7 @@ pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::references(&self) -> al
 impl slang_solidity_v2_ast::ast::EnumDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::EnumDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EnumDefinitionStruct::members(&self) -> slang_solidity_v2_ast::ast::EnumMembers
@@ -1629,7 +1629,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::EnumType
 pub fn slang_solidity_v2_ast::ast::EnumType::clone(&self) -> slang_solidity_v2_ast::ast::EnumType
 pub struct slang_solidity_v2_ast::ast::EqualEqualStruct
 impl slang_solidity_v2_ast::ast::EqualEqualStruct
-pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1638,7 +1638,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualEqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualStruct
 impl slang_solidity_v2_ast::ast::EqualStruct
-pub fn slang_solidity_v2_ast::ast::EqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1647,7 +1647,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualStruct
 pub fn slang_solidity_v2_ast::ast::EqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EqualityExpressionStruct
 impl slang_solidity_v2_ast::ast::EqualityExpressionStruct
-pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1668,7 +1668,7 @@ pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::compute_selector(&self
 impl slang_solidity_v2_ast::ast::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::ErrorDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -1678,7 +1678,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ErrorDefinitionS
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::EtherKeywordStruct
 impl slang_solidity_v2_ast::ast::EtherKeywordStruct
-pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EtherKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1697,7 +1697,7 @@ pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::compute_selector(&self
 impl slang_solidity_v2_ast::ast::EventDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::EventDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::is_anonymous(&self) -> bool
@@ -1709,7 +1709,7 @@ pub fn slang_solidity_v2_ast::ast::EventDefinitionStruct::serialize<S: serde_cor
 pub struct slang_solidity_v2_ast::ast::ExperimentalPragmaStruct
 impl slang_solidity_v2_ast::ast::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::feature(&self) -> slang_solidity_v2_ast::ast::ExperimentalFeature
-pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1717,7 +1717,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ExperimentalPrag
 pub fn slang_solidity_v2_ast::ast::ExperimentalPragmaStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
 impl slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
-pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -1728,7 +1728,7 @@ pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::serialize<S: 
 pub struct slang_solidity_v2_ast::ast::ExpressionStatementStruct
 impl slang_solidity_v2_ast::ast::ExpressionStatementStruct
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::Expression
-pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1736,7 +1736,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ExpressionStatem
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::FalseKeywordStruct
 impl slang_solidity_v2_ast::ast::FalseKeywordStruct
-pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1745,7 +1745,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FalseKeywordStru
 pub fn slang_solidity_v2_ast::ast::FalseKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::FixedKeywordStruct
 impl slang_solidity_v2_ast::ast::FixedKeywordStruct
-pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FixedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1770,7 +1770,7 @@ pub struct slang_solidity_v2_ast::ast::ForStatementStruct
 impl slang_solidity_v2_ast::ast::ForStatementStruct
 pub fn slang_solidity_v2_ast::ast::ForStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::Statement
 pub fn slang_solidity_v2_ast::ast::ForStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::ForStatementCondition
-pub fn slang_solidity_v2_ast::ast::ForStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ForStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ForStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ForStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ForStatementStruct::initialization(&self) -> slang_solidity_v2_ast::ast::ForStatementInitialization
@@ -1781,7 +1781,7 @@ pub fn slang_solidity_v2_ast::ast::ForStatementStruct::serialize<S: serde_core::
 pub struct slang_solidity_v2_ast::ast::FunctionCallExpressionStruct
 impl slang_solidity_v2_ast::ast::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::arguments(&self) -> slang_solidity_v2_ast::ast::ArgumentsDeclaration
-pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FunctionCallExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1796,7 +1796,7 @@ pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::as_definition(&self
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::body(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Block>
-pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::is_virtual(&self) -> bool
@@ -1832,7 +1832,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::FunctionType
 pub fn slang_solidity_v2_ast::ast::FunctionType::clone(&self) -> slang_solidity_v2_ast::ast::FunctionType
 pub struct slang_solidity_v2_ast::ast::FunctionTypeStruct
 impl slang_solidity_v2_ast::ast::FunctionTypeStruct
-pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::mutability(&self) -> slang_solidity_v2_ast::ast::FunctionMutability
@@ -1844,7 +1844,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::FunctionTypeStru
 pub fn slang_solidity_v2_ast::ast::FunctionTypeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanEqualStruct
 impl slang_solidity_v2_ast::ast::GreaterThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1853,7 +1853,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanEqual
 pub fn slang_solidity_v2_ast::ast::GreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
 impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1862,7 +1862,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreat
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
 impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1871,7 +1871,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreat
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
 impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1880,7 +1880,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreat
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
 impl slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1889,7 +1889,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanGreat
 pub fn slang_solidity_v2_ast::ast::GreaterThanGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GreaterThanStruct
 impl slang_solidity_v2_ast::ast::GreaterThanStruct
-pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1898,7 +1898,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GreaterThanStruc
 pub fn slang_solidity_v2_ast::ast::GreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::GweiKeywordStruct
 impl slang_solidity_v2_ast::ast::GweiKeywordStruct
-pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1907,7 +1907,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::GweiKeywordStruc
 pub fn slang_solidity_v2_ast::ast::GweiKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HexLiteralStruct
 impl slang_solidity_v2_ast::ast::HexLiteralStruct
-pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1916,7 +1916,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HexLiteralStruct
 pub fn slang_solidity_v2_ast::ast::HexLiteralStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HexNumberExpressionStruct
 impl slang_solidity_v2_ast::ast::HexNumberExpressionStruct
-pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::literal(&self) -> slang_solidity_v2_ast::ast::HexLiteral
@@ -1928,7 +1928,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HexNumberExpress
 pub fn slang_solidity_v2_ast::ast::HexNumberExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HexStringLiteralStruct
 impl slang_solidity_v2_ast::ast::HexStringLiteralStruct
-pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1946,7 +1946,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::HexStringLiteral
 pub fn slang_solidity_v2_ast::ast::HexStringLiteralsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::HoursKeywordStruct
 impl slang_solidity_v2_ast::ast::HoursKeywordStruct
-pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::HoursKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1978,7 +1978,7 @@ pub fn slang_solidity_v2_ast::ast::IdentifierStruct::resolve_to_built_in(&self) 
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::resolve_to_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::resolve_to_immediate_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::IdentifierStruct
-pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::IdentifierStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1990,7 +1990,7 @@ impl slang_solidity_v2_ast::ast::IfStatementStruct
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::Statement
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::Expression
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::else_branch(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Statement>
-pub fn slang_solidity_v2_ast::ast::IfStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::IfStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -1998,7 +1998,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IfStatementStruc
 pub fn slang_solidity_v2_ast::ast::IfStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ImportDeconstructionStruct
 impl slang_solidity_v2_ast::ast::ImportDeconstructionStruct
-pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2009,7 +2009,7 @@ pub fn slang_solidity_v2_ast::ast::ImportDeconstructionStruct::serialize<S: serd
 pub struct slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct
 impl slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::alias(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Identifier>
-pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2029,7 +2029,7 @@ pub fn slang_solidity_v2_ast::ast::ImportDeconstructionSymbolsStruct::serialize<
 pub struct slang_solidity_v2_ast::ast::IndexAccessExpressionStruct
 impl slang_solidity_v2_ast::ast::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::end(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
-pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::is_slice(&self) -> bool
@@ -2040,7 +2040,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::IndexAccessExpre
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::InequalityExpressionStruct
 impl slang_solidity_v2_ast::ast::InequalityExpressionStruct
-pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -2052,7 +2052,7 @@ pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::serialize<S: serd
 pub struct slang_solidity_v2_ast::ast::InheritanceTypeStruct
 impl slang_solidity_v2_ast::ast::InheritanceTypeStruct
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::arguments(&self) -> core::option::Option<slang_solidity_v2_ast::ast::ArgumentsDeclaration>
-pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2068,7 +2068,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::InheritanceTypes
 pub fn slang_solidity_v2_ast::ast::InheritanceTypesStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::IntKeywordStruct
 impl slang_solidity_v2_ast::ast::IntKeywordStruct
-pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::IntKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2086,7 +2086,7 @@ impl slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::inheritance(&self) -> core::option::Option<slang_solidity_v2_ast::ast::InheritanceTypes>
@@ -2109,7 +2109,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::InterfaceType
 pub fn slang_solidity_v2_ast::ast::InterfaceType::clone(&self) -> slang_solidity_v2_ast::ast::InterfaceType
 pub struct slang_solidity_v2_ast::ast::LessThanEqualStruct
 impl slang_solidity_v2_ast::ast::LessThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2118,7 +2118,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanEqualStr
 pub fn slang_solidity_v2_ast::ast::LessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
 impl slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2127,7 +2127,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThan
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanLessThanStruct
 impl slang_solidity_v2_ast::ast::LessThanLessThanStruct
-pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2136,7 +2136,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::LessThanLessThan
 pub fn slang_solidity_v2_ast::ast::LessThanLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::LessThanStruct
 impl slang_solidity_v2_ast::ast::LessThanStruct
-pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2148,7 +2148,7 @@ impl slang_solidity_v2_ast::ast::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::LibraryDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::LibraryDefinitionStruct::members(&self) -> slang_solidity_v2_ast::ast::LibraryMembers
@@ -2177,7 +2177,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::MappingType
 pub fn slang_solidity_v2_ast::ast::MappingType::clone(&self) -> slang_solidity_v2_ast::ast::MappingType
 pub struct slang_solidity_v2_ast::ast::MappingTypeStruct
 impl slang_solidity_v2_ast::ast::MappingTypeStruct
-pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::key_type(&self) -> slang_solidity_v2_ast::ast::Parameter
@@ -2187,7 +2187,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MappingTypeStruc
 pub fn slang_solidity_v2_ast::ast::MappingTypeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MemberAccessExpressionStruct
 impl slang_solidity_v2_ast::ast::MemberAccessExpressionStruct
-pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::member(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2197,7 +2197,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MemberAccessExpr
 pub fn slang_solidity_v2_ast::ast::MemberAccessExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MemoryKeywordStruct
 impl slang_solidity_v2_ast::ast::MemoryKeywordStruct
-pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2206,7 +2206,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MemoryKeywordStr
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusEqualStruct
 impl slang_solidity_v2_ast::ast::MinusEqualStruct
-pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2215,7 +2215,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusEqualStruct
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusMinusStruct
 impl slang_solidity_v2_ast::ast::MinusMinusStruct
-pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2224,7 +2224,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusMinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusMinusStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinusStruct
 impl slang_solidity_v2_ast::ast::MinusStruct
-pub fn slang_solidity_v2_ast::ast::MinusStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MinusStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2233,7 +2233,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MinusStruct
 pub fn slang_solidity_v2_ast::ast::MinusStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MinutesKeywordStruct
 impl slang_solidity_v2_ast::ast::MinutesKeywordStruct
-pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2243,7 +2243,7 @@ pub fn slang_solidity_v2_ast::ast::MinutesKeywordStruct::serialize<S: serde_core
 pub struct slang_solidity_v2_ast::ast::ModifierInvocationStruct
 impl slang_solidity_v2_ast::ast::ModifierInvocationStruct
 pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::arguments(&self) -> core::option::Option<slang_solidity_v2_ast::ast::ArgumentsDeclaration>
-pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ModifierInvocationStruct::name(&self) -> slang_solidity_v2_ast::ast::IdentifierPath
@@ -2259,7 +2259,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ModifierInvocati
 pub fn slang_solidity_v2_ast::ast::ModifierInvocationsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct
 impl slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct
-pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementStruct::member(&self) -> core::option::Option<slang_solidity_v2_ast::ast::VariableDeclaration>
@@ -2276,7 +2276,7 @@ pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationElementsStruct::serializ
 pub struct slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct
 impl slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::elements(&self) -> slang_solidity_v2_ast::ast::MultiTypedDeclarationElements
-pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2285,7 +2285,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MultiTypedDeclar
 pub fn slang_solidity_v2_ast::ast::MultiTypedDeclarationStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
 impl slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
-pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -2296,7 +2296,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MultiplicativeEx
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::NamedArgumentStruct
 impl slang_solidity_v2_ast::ast::NamedArgumentStruct
-pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2313,7 +2313,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::NamedArgumentsSt
 pub fn slang_solidity_v2_ast::ast::NamedArgumentsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::NewExpressionStruct
 impl slang_solidity_v2_ast::ast::NewExpressionStruct
-pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2322,7 +2322,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::NewExpressionStr
 pub fn slang_solidity_v2_ast::ast::NewExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::OrExpressionStruct
 impl slang_solidity_v2_ast::ast::OrExpressionStruct
-pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -2342,7 +2342,7 @@ impl slang_solidity_v2_ast::ast::ParameterStruct
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::ParameterStruct
-pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ParameterStruct::is_indexed(&self) -> bool
@@ -2362,7 +2362,7 @@ pub fn slang_solidity_v2_ast::ast::ParametersStruct::serialize<S: serde_core::se
 pub struct slang_solidity_v2_ast::ast::PathImportStruct
 impl slang_solidity_v2_ast::ast::PathImportStruct
 pub fn slang_solidity_v2_ast::ast::PathImportStruct::alias(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Identifier>
-pub fn slang_solidity_v2_ast::ast::PathImportStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PathImportStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PathImportStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PathImportStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PathImportStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2374,7 +2374,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PathImportStruct
 pub fn slang_solidity_v2_ast::ast::PathImportStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PayableKeywordStruct
 impl slang_solidity_v2_ast::ast::PayableKeywordStruct
-pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2383,7 +2383,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PayableKeywordSt
 pub fn slang_solidity_v2_ast::ast::PayableKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentEqualStruct
 impl slang_solidity_v2_ast::ast::PercentEqualStruct
-pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2392,7 +2392,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentEqualStru
 pub fn slang_solidity_v2_ast::ast::PercentEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PercentStruct
 impl slang_solidity_v2_ast::ast::PercentStruct
-pub fn slang_solidity_v2_ast::ast::PercentStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PercentStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PercentStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PercentStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2401,7 +2401,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PercentStruct
 pub fn slang_solidity_v2_ast::ast::PercentStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusEqualStruct
 impl slang_solidity_v2_ast::ast::PlusEqualStruct
-pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2410,7 +2410,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusEqualStruct
 pub fn slang_solidity_v2_ast::ast::PlusEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusPlusStruct
 impl slang_solidity_v2_ast::ast::PlusPlusStruct
-pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2419,7 +2419,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PlusPlusStruct
 pub fn slang_solidity_v2_ast::ast::PlusPlusStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PlusStruct
 impl slang_solidity_v2_ast::ast::PlusStruct
-pub fn slang_solidity_v2_ast::ast::PlusStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PlusStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PlusStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PlusStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2435,7 +2435,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PositionalArgume
 pub fn slang_solidity_v2_ast::ast::PositionalArgumentsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PostfixExpressionStruct
 impl slang_solidity_v2_ast::ast::PostfixExpressionStruct
-pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2445,7 +2445,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PostfixExpressio
 pub fn slang_solidity_v2_ast::ast::PostfixExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaCaretStruct
 impl slang_solidity_v2_ast::ast::PragmaCaretStruct
-pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2454,7 +2454,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaCaretStruc
 pub fn slang_solidity_v2_ast::ast::PragmaCaretStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaDirectiveStruct
 impl slang_solidity_v2_ast::ast::PragmaDirectiveStruct
-pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2463,7 +2463,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaDirectiveS
 pub fn slang_solidity_v2_ast::ast::PragmaDirectiveStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaEqualStruct
 impl slang_solidity_v2_ast::ast::PragmaEqualStruct
-pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2472,7 +2472,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaEqualStruc
 pub fn slang_solidity_v2_ast::ast::PragmaEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
 impl slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2481,7 +2481,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterTha
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
 impl slang_solidity_v2_ast::ast::PragmaGreaterThanStruct
-pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2490,7 +2490,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaGreaterTha
 pub fn slang_solidity_v2_ast::ast::PragmaGreaterThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
 impl slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct
-pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2499,7 +2499,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanEq
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaLessThanStruct
 impl slang_solidity_v2_ast::ast::PragmaLessThanStruct
-pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2508,7 +2508,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaLessThanSt
 pub fn slang_solidity_v2_ast::ast::PragmaLessThanStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PragmaTildeStruct
 impl slang_solidity_v2_ast::ast::PragmaTildeStruct
-pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2517,7 +2517,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PragmaTildeStruc
 pub fn slang_solidity_v2_ast::ast::PragmaTildeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::PrefixExpressionStruct
 impl slang_solidity_v2_ast::ast::PrefixExpressionStruct
-pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2537,7 +2537,7 @@ pub fn slang_solidity_v2_ast::ast::Reference::clone(&self) -> slang_solidity_v2_
 pub struct slang_solidity_v2_ast::ast::ReturnStatementStruct
 impl slang_solidity_v2_ast::ast::ReturnStatementStruct
 pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::expression(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
-pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ReturnStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2547,7 +2547,7 @@ pub struct slang_solidity_v2_ast::ast::RevertStatementStruct
 impl slang_solidity_v2_ast::ast::RevertStatementStruct
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::arguments(&self) -> slang_solidity_v2_ast::ast::ArgumentsDeclaration
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::error(&self) -> slang_solidity_v2_ast::ast::IdentifierPath
-pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2555,7 +2555,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::RevertStatementS
 pub fn slang_solidity_v2_ast::ast::RevertStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct
 impl slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct
-pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2564,7 +2564,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SMTCheckerKeywor
 pub fn slang_solidity_v2_ast::ast::SMTCheckerKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SecondsKeywordStruct
 impl slang_solidity_v2_ast::ast::SecondsKeywordStruct
-pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2573,7 +2573,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SecondsKeywordSt
 pub fn slang_solidity_v2_ast::ast::SecondsKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SemicolonStruct
 impl slang_solidity_v2_ast::ast::SemicolonStruct
-pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2582,7 +2582,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SemicolonStruct
 pub fn slang_solidity_v2_ast::ast::SemicolonStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ShiftExpressionStruct
 impl slang_solidity_v2_ast::ast::ShiftExpressionStruct
-pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::left_operand(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -2601,7 +2601,7 @@ pub fn slang_solidity_v2_ast::ast::SimpleVersionLiteralStruct::serialize<S: serd
 pub struct slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct
 impl slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::declaration(&self) -> slang_solidity_v2_ast::ast::VariableDeclaration
-pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2610,7 +2610,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SingleTypedDecla
 pub fn slang_solidity_v2_ast::ast::SingleTypedDeclarationStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SlashEqualStruct
 impl slang_solidity_v2_ast::ast::SlashEqualStruct
-pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2619,7 +2619,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SlashEqualStruct
 pub fn slang_solidity_v2_ast::ast::SlashEqualStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::SlashStruct
 impl slang_solidity_v2_ast::ast::SlashStruct
-pub fn slang_solidity_v2_ast::ast::SlashStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SlashStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SlashStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SlashStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2638,9 +2638,9 @@ impl slang_solidity_v2_ast::ast::SourceUnitStruct
 pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::compute_contracts_abi(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::abi::ContractAbi>
 impl slang_solidity_v2_ast::ast::SourceUnitStruct
 pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::contracts(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::ContractDefinition>
-pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::file_id(&self) -> &slang_solidity_v2_common::files::FileId
 impl slang_solidity_v2_ast::ast::SourceUnitStruct
-pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SourceUnitStruct::members(&self) -> slang_solidity_v2_ast::ast::SourceUnitMembers
@@ -2660,7 +2660,7 @@ pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::is_externally_
 impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::mutability(&self) -> slang_solidity_v2_ast::ast::StateVariableMutability
@@ -2681,7 +2681,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StatementsStruct
 pub fn slang_solidity_v2_ast::ast::StatementsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StorageKeywordStruct
 impl slang_solidity_v2_ast::ast::StorageKeywordStruct
-pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2690,7 +2690,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StorageKeywordSt
 pub fn slang_solidity_v2_ast::ast::StorageKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringKeywordStruct
 impl slang_solidity_v2_ast::ast::StringKeywordStruct
-pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2699,7 +2699,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StringKeywordStr
 pub fn slang_solidity_v2_ast::ast::StringKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::StringLiteralStruct
 impl slang_solidity_v2_ast::ast::StringLiteralStruct
-pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2727,7 +2727,7 @@ pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::references(&self) -> 
 impl slang_solidity_v2_ast::ast::StructDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::StructDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StructDefinitionStruct::members(&self) -> slang_solidity_v2_ast::ast::StructMembers
@@ -2742,7 +2742,7 @@ pub fn slang_solidity_v2_ast::ast::StructMemberStruct::references(&self) -> allo
 impl slang_solidity_v2_ast::ast::StructMemberStruct
 pub fn slang_solidity_v2_ast::ast::StructMemberStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::StructMemberStruct
-pub fn slang_solidity_v2_ast::ast::StructMemberStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::StructMemberStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::StructMemberStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::StructMemberStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::StructMemberStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2765,7 +2765,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::StructType
 pub fn slang_solidity_v2_ast::ast::StructType::clone(&self) -> slang_solidity_v2_ast::ast::StructType
 pub struct slang_solidity_v2_ast::ast::SuperKeywordStruct
 impl slang_solidity_v2_ast::ast::SuperKeywordStruct
-pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2774,7 +2774,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::SuperKeywordStru
 pub fn slang_solidity_v2_ast::ast::SuperKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ThisKeywordStruct
 impl slang_solidity_v2_ast::ast::ThisKeywordStruct
-pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2783,7 +2783,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ThisKeywordStruc
 pub fn slang_solidity_v2_ast::ast::ThisKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TildeStruct
 impl slang_solidity_v2_ast::ast::TildeStruct
-pub fn slang_solidity_v2_ast::ast::TildeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TildeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TildeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TildeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2792,7 +2792,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TildeStruct
 pub fn slang_solidity_v2_ast::ast::TildeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TrueKeywordStruct
 impl slang_solidity_v2_ast::ast::TrueKeywordStruct
-pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TrueKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2804,7 +2804,7 @@ impl slang_solidity_v2_ast::ast::TryStatementStruct
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::Block
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::catch_clauses(&self) -> slang_solidity_v2_ast::ast::CatchClauses
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::Expression
-pub fn slang_solidity_v2_ast::ast::TryStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TryStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2813,7 +2813,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TryStatementStru
 pub fn slang_solidity_v2_ast::ast::TryStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TupleExpressionStruct
 impl slang_solidity_v2_ast::ast::TupleExpressionStruct
-pub fn slang_solidity_v2_ast::ast::TupleExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TupleExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TupleExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TupleExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TupleExpressionStruct::items(&self) -> slang_solidity_v2_ast::ast::TupleValues
@@ -2828,7 +2828,7 @@ pub fn slang_solidity_v2_ast::ast::TupleType::clone(&self) -> slang_solidity_v2_
 pub struct slang_solidity_v2_ast::ast::TupleValueStruct
 impl slang_solidity_v2_ast::ast::TupleValueStruct
 pub fn slang_solidity_v2_ast::ast::TupleValueStruct::expression(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>
-pub fn slang_solidity_v2_ast::ast::TupleValueStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TupleValueStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TupleValueStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TupleValueStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TupleValueStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2843,7 +2843,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TupleValuesStruc
 pub fn slang_solidity_v2_ast::ast::TupleValuesStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::TypeExpressionStruct
 impl slang_solidity_v2_ast::ast::TypeExpressionStruct
-pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2852,7 +2852,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::TypeExpressionSt
 pub fn slang_solidity_v2_ast::ast::TypeExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::UfixedKeywordStruct
 impl slang_solidity_v2_ast::ast::UfixedKeywordStruct
-pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2861,7 +2861,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UfixedKeywordStr
 pub fn slang_solidity_v2_ast::ast::UfixedKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::UintKeywordStruct
 impl slang_solidity_v2_ast::ast::UintKeywordStruct
-pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2871,7 +2871,7 @@ pub fn slang_solidity_v2_ast::ast::UintKeywordStruct::serialize<S: serde_core::s
 pub struct slang_solidity_v2_ast::ast::UncheckedBlockStruct
 impl slang_solidity_v2_ast::ast::UncheckedBlockStruct
 pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::block(&self) -> slang_solidity_v2_ast::ast::Block
-pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2879,7 +2879,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UncheckedBlockSt
 pub fn slang_solidity_v2_ast::ast::UncheckedBlockStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct
 impl slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct
-pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UnicodeStringLiteralStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2906,7 +2906,7 @@ impl slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct
-pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2916,7 +2916,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UserDefinedValue
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::UsingDeconstructionStruct
 impl slang_solidity_v2_ast::ast::UsingDeconstructionStruct
-pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2926,7 +2926,7 @@ pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::serialize<S: serde
 pub struct slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct
 impl slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::alias(&self) -> core::option::Option<slang_solidity_v2_ast::ast::UsingOperator>
-pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolStruct::name(&self) -> slang_solidity_v2_ast::ast::IdentifierPath
@@ -2943,7 +2943,7 @@ pub fn slang_solidity_v2_ast::ast::UsingDeconstructionSymbolsStruct::serialize<S
 pub struct slang_solidity_v2_ast::ast::UsingDirectiveStruct
 impl slang_solidity_v2_ast::ast::UsingDirectiveStruct
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::clause(&self) -> slang_solidity_v2_ast::ast::UsingClause
-pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::is_global(&self) -> bool
@@ -2953,7 +2953,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UsingDirectiveSt
 pub fn slang_solidity_v2_ast::ast::UsingDirectiveStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct
 impl slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct
-pub fn slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -2965,7 +2965,7 @@ impl slang_solidity_v2_ast::ast::VariableDeclarationStruct
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::VariableDeclarationStruct
-pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VariableDeclarationStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -2990,7 +2990,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VersionExpressio
 pub fn slang_solidity_v2_ast::ast::VersionExpressionSetsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VersionPragmaStruct
 impl slang_solidity_v2_ast::ast::VersionPragmaStruct
-pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3000,7 +3000,7 @@ pub fn slang_solidity_v2_ast::ast::VersionPragmaStruct::serialize<S: serde_core:
 pub struct slang_solidity_v2_ast::ast::VersionRangeStruct
 impl slang_solidity_v2_ast::ast::VersionRangeStruct
 pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::end(&self) -> slang_solidity_v2_ast::ast::VersionLiteral
-pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3009,7 +3009,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VersionRangeStru
 pub fn slang_solidity_v2_ast::ast::VersionRangeStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VersionSpecifierStruct
 impl slang_solidity_v2_ast::ast::VersionSpecifierStruct
-pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3018,7 +3018,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::VersionSpecifier
 pub fn slang_solidity_v2_ast::ast::VersionSpecifierStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::VersionTermStruct
 impl slang_solidity_v2_ast::ast::VersionTermStruct
-pub fn slang_solidity_v2_ast::ast::VersionTermStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::VersionTermStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::VersionTermStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::VersionTermStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::VersionTermStruct::literal(&self) -> slang_solidity_v2_ast::ast::VersionLiteral
@@ -3031,7 +3031,7 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::VoidType
 pub fn slang_solidity_v2_ast::ast::VoidType::clone(&self) -> slang_solidity_v2_ast::ast::VoidType
 pub struct slang_solidity_v2_ast::ast::WeeksKeywordStruct
 impl slang_solidity_v2_ast::ast::WeeksKeywordStruct
-pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3040,7 +3040,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::WeeksKeywordStru
 pub fn slang_solidity_v2_ast::ast::WeeksKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::WeiKeywordStruct
 impl slang_solidity_v2_ast::ast::WeiKeywordStruct
-pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::WeiKeywordStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3051,7 +3051,7 @@ pub struct slang_solidity_v2_ast::ast::WhileStatementStruct
 impl slang_solidity_v2_ast::ast::WhileStatementStruct
 pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::Statement
 pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::Expression
-pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::WhileStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3066,7 +3066,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulArgumentsStru
 pub fn slang_solidity_v2_ast::ast::YulArgumentsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulBlockStruct
 impl slang_solidity_v2_ast::ast::YulBlockStruct
-pub fn slang_solidity_v2_ast::ast::YulBlockStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulBlockStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulBlockStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulBlockStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulBlockStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3075,7 +3075,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulBlockStruct
 pub fn slang_solidity_v2_ast::ast::YulBlockStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulBreakStatementStruct
 impl slang_solidity_v2_ast::ast::YulBreakStatementStruct
-pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3083,7 +3083,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulBreakStatemen
 pub fn slang_solidity_v2_ast::ast::YulBreakStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulContinueStatementStruct
 impl slang_solidity_v2_ast::ast::YulContinueStatementStruct
-pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3092,7 +3092,7 @@ pub fn slang_solidity_v2_ast::ast::YulContinueStatementStruct::serialize<S: serd
 pub struct slang_solidity_v2_ast::ast::YulDefaultCaseStruct
 impl slang_solidity_v2_ast::ast::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
-pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulDefaultCaseStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3109,7 +3109,7 @@ pub struct slang_solidity_v2_ast::ast::YulForStatementStruct
 impl slang_solidity_v2_ast::ast::YulForStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
 pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::YulExpression
-pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::initialization(&self) -> slang_solidity_v2_ast::ast::YulBlock
@@ -3120,7 +3120,7 @@ pub fn slang_solidity_v2_ast::ast::YulForStatementStruct::serialize<S: serde_cor
 pub struct slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct
 impl slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::arguments(&self) -> slang_solidity_v2_ast::ast::YulArguments
-pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulFunctionCallExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3133,7 +3133,7 @@ pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::as_definition(&s
 pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
-pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulFunctionDefinitionStruct::name(&self) -> slang_solidity_v2_ast::ast::Identifier
@@ -3146,7 +3146,7 @@ pub struct slang_solidity_v2_ast::ast::YulIfStatementStruct
 impl slang_solidity_v2_ast::ast::YulIfStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::condition(&self) -> slang_solidity_v2_ast::ast::YulExpression
-pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3154,7 +3154,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulIfStatementSt
 pub fn slang_solidity_v2_ast::ast::YulIfStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulLeaveStatementStruct
 impl slang_solidity_v2_ast::ast::YulLeaveStatementStruct
-pub fn slang_solidity_v2_ast::ast::YulLeaveStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulLeaveStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulLeaveStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulLeaveStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulLeaveStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3199,7 +3199,7 @@ pub struct slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 impl slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::cases(&self) -> slang_solidity_v2_ast::ast::YulSwitchCases
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::YulExpression
-pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3208,7 +3208,7 @@ pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::serialize<S: serde_
 pub struct slang_solidity_v2_ast::ast::YulValueCaseStruct
 impl slang_solidity_v2_ast::ast::YulValueCaseStruct
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::body(&self) -> slang_solidity_v2_ast::ast::YulBlock
-pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3218,7 +3218,7 @@ pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::serialize<S: serde_core::
 pub struct slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct
 impl slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::YulExpression
-pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3227,7 +3227,7 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulVariableAssig
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct
 impl slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct
-pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
@@ -3238,7 +3238,7 @@ pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct::serial
 pub struct slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct
 impl slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::expression(&self) -> slang_solidity_v2_ast::ast::YulExpression
-pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::get_file_id(&self) -> &str
+pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -7,6 +7,7 @@ use itertools::Either;
 use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::collections::Set;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
@@ -17,7 +18,7 @@ use slang_solidity_v2_semantic::types::{
 pub struct ContractAbi {
     node_id: NodeId,
     name: String,
-    file_id: String,
+    file_id: FileId,
     entries: Vec<AbiEntry>,
     storage_layout: Vec<StorageItem>,
     transient_storage_layout: Vec<StorageItem>,
@@ -32,7 +33,7 @@ impl ContractAbi {
         &self.name
     }
 
-    pub fn file_id(&self) -> &str {
+    pub fn file_id(&self) -> &FileId {
         &self.file_id
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/contract_definition.rs
@@ -8,7 +8,7 @@ use crate::ast::{ContractDefinitionStruct, StateVariableDefinition, StateVariabl
 impl ContractDefinitionStruct {
     pub fn compute_abi(&self) -> Option<ContractAbi> {
         let name = self.ir_node.name.unparse().to_string();
-        let file_id = self.get_file_id().to_string();
+        let file_id = self.get_file_id().clone();
         let entries = self.compute_abi_entries()?;
         let (storage_layout, transient_storage_layout) = self.compute_storage_layout()?;
         Some(ContractAbi {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/source_unit.rs
@@ -1,7 +1,9 @@
+use slang_solidity_v2_common::files::FileId;
+
 use super::super::{ContractDefinition, SourceUnitMember, SourceUnitStruct};
 
 impl SourceUnitStruct {
-    pub fn file_id(&self) -> &str {
+    pub fn file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -4,6 +4,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
@@ -44,7 +45,7 @@ impl AbicoderPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -91,7 +92,7 @@ impl AdditiveExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -130,7 +131,7 @@ impl AddressTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -173,7 +174,7 @@ impl AndExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -212,7 +213,7 @@ impl ArrayExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -258,7 +259,7 @@ impl ArrayTypeNameStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -311,7 +312,7 @@ impl AssemblyStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -358,7 +359,7 @@ impl AssignmentExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -401,7 +402,7 @@ impl BitwiseAndExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -444,7 +445,7 @@ impl BitwiseOrExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -487,7 +488,7 @@ impl BitwiseXorExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -523,7 +524,7 @@ impl BlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -558,7 +559,7 @@ impl BreakStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -601,7 +602,7 @@ impl CallOptionsExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -647,7 +648,7 @@ impl CatchClauseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -693,7 +694,7 @@ impl CatchClauseErrorStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -740,7 +741,7 @@ impl ConditionalExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -797,7 +798,7 @@ impl ConstantDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -832,7 +833,7 @@ impl ContinueStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -890,7 +891,7 @@ impl ContractDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -936,7 +937,7 @@ impl DecimalNumberExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -979,7 +980,7 @@ impl DoWhileStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1022,7 +1023,7 @@ impl EmitStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1065,7 +1066,7 @@ impl EnumDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1112,7 +1113,7 @@ impl EqualityExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1155,7 +1156,7 @@ impl ErrorDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1202,7 +1203,7 @@ impl EventDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1241,7 +1242,7 @@ impl ExperimentalPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1284,7 +1285,7 @@ impl ExponentiationExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1323,7 +1324,7 @@ impl ExpressionStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1377,7 +1378,7 @@ impl ForStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1420,7 +1421,7 @@ impl FunctionCallExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1507,7 +1508,7 @@ impl FunctionDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1561,7 +1562,7 @@ impl FunctionTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1600,7 +1601,7 @@ impl HexNumberExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1650,7 +1651,7 @@ impl IfStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1693,7 +1694,7 @@ impl ImportDeconstructionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1739,7 +1740,7 @@ impl ImportDeconstructionSymbolStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1796,7 +1797,7 @@ impl IndexAccessExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1843,7 +1844,7 @@ impl InequalityExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1889,7 +1890,7 @@ impl InheritanceTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1939,7 +1940,7 @@ impl InterfaceDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -1982,7 +1983,7 @@ impl LibraryDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2025,7 +2026,7 @@ impl MappingTypeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2068,7 +2069,7 @@ impl MemberAccessExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2114,7 +2115,7 @@ impl ModifierInvocationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2157,7 +2158,7 @@ impl MultiTypedDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2199,7 +2200,7 @@ impl MultiTypedDeclarationElementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2246,7 +2247,7 @@ impl MultiplicativeExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2289,7 +2290,7 @@ impl NamedArgumentStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2328,7 +2329,7 @@ impl NewExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2371,7 +2372,7 @@ impl OrExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2425,7 +2426,7 @@ impl ParameterStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2468,7 +2469,7 @@ impl PathImportStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2511,7 +2512,7 @@ impl PostfixExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2550,7 +2551,7 @@ impl PragmaDirectiveStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2593,7 +2594,7 @@ impl PrefixExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2635,7 +2636,7 @@ impl ReturnStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2678,7 +2679,7 @@ impl RevertStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2725,7 +2726,7 @@ impl ShiftExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2771,7 +2772,7 @@ impl SingleTypedDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2807,7 +2808,7 @@ impl SourceUnitStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2872,7 +2873,7 @@ impl StateVariableDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2915,7 +2916,7 @@ impl StructDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -2958,7 +2959,7 @@ impl StructMemberStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3012,7 +3013,7 @@ impl TryStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3051,7 +3052,7 @@ impl TupleExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3090,7 +3091,7 @@ impl TupleValueStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3129,7 +3130,7 @@ impl TypeExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3168,7 +3169,7 @@ impl UncheckedBlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3211,7 +3212,7 @@ impl UserDefinedValueTypeDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3250,7 +3251,7 @@ impl UsingDeconstructionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3296,7 +3297,7 @@ impl UsingDeconstructionSymbolStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3343,7 +3344,7 @@ impl UsingDirectiveStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3393,7 +3394,7 @@ impl VariableDeclarationStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3432,7 +3433,7 @@ impl VariableDeclarationStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3471,7 +3472,7 @@ impl VersionPragmaStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3514,7 +3515,7 @@ impl VersionRangeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3560,7 +3561,7 @@ impl VersionTermStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3603,7 +3604,7 @@ impl WhileStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3639,7 +3640,7 @@ impl YulBlockStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3674,7 +3675,7 @@ impl YulBreakStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3709,7 +3710,7 @@ impl YulContinueStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3748,7 +3749,7 @@ impl YulDefaultCaseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3799,7 +3800,7 @@ impl YulForStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3842,7 +3843,7 @@ impl YulFunctionCallExpressionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3896,7 +3897,7 @@ impl YulFunctionDefinitionStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3939,7 +3940,7 @@ impl YulIfStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -3974,7 +3975,7 @@ impl YulLeaveStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -4017,7 +4018,7 @@ impl YulSwitchStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -4060,7 +4061,7 @@ impl YulValueCaseStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -4103,7 +4104,7 @@ impl YulVariableAssignmentStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -4149,7 +4150,7 @@ impl YulVariableDeclarationStatementStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -4188,7 +4189,7 @@ impl YulVariableDeclarationValueStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6788,7 +6789,7 @@ impl ABIEncoderV2KeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6827,7 +6828,7 @@ impl AbicoderV1KeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6866,7 +6867,7 @@ impl AbicoderV2KeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6905,7 +6906,7 @@ impl AmpersandStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6944,7 +6945,7 @@ impl AmpersandEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -6980,7 +6981,7 @@ impl AsteriskStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7019,7 +7020,7 @@ impl AsteriskEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7055,7 +7056,7 @@ impl BangStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7094,7 +7095,7 @@ impl BangEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7130,7 +7131,7 @@ impl BarStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7169,7 +7170,7 @@ impl BarEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7208,7 +7209,7 @@ impl BoolKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7247,7 +7248,7 @@ impl BytesKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7286,7 +7287,7 @@ impl CallDataKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7322,7 +7323,7 @@ impl CaretStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7361,7 +7362,7 @@ impl CaretEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7400,7 +7401,7 @@ impl DaysKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7439,7 +7440,7 @@ impl DecimalLiteralStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7478,7 +7479,7 @@ impl DeleteKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7514,7 +7515,7 @@ impl EqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7553,7 +7554,7 @@ impl EqualEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7592,7 +7593,7 @@ impl EtherKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7631,7 +7632,7 @@ impl FalseKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7670,7 +7671,7 @@ impl FixedKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7709,7 +7710,7 @@ impl GreaterThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7748,7 +7749,7 @@ impl GreaterThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7787,7 +7788,7 @@ impl GreaterThanGreaterThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7826,7 +7827,7 @@ impl GreaterThanGreaterThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7865,7 +7866,7 @@ impl GreaterThanGreaterThanGreaterThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7904,7 +7905,7 @@ impl GreaterThanGreaterThanGreaterThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7943,7 +7944,7 @@ impl GweiKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -7982,7 +7983,7 @@ impl HexLiteralStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8021,7 +8022,7 @@ impl HexStringLiteralStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8060,7 +8061,7 @@ impl HoursKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8099,7 +8100,7 @@ impl IdentifierStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8138,7 +8139,7 @@ impl IntKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8177,7 +8178,7 @@ impl LessThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8216,7 +8217,7 @@ impl LessThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8255,7 +8256,7 @@ impl LessThanLessThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8294,7 +8295,7 @@ impl LessThanLessThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8333,7 +8334,7 @@ impl MemoryKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8369,7 +8370,7 @@ impl MinusStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8408,7 +8409,7 @@ impl MinusEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8447,7 +8448,7 @@ impl MinusMinusStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8486,7 +8487,7 @@ impl MinutesKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8525,7 +8526,7 @@ impl PayableKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8561,7 +8562,7 @@ impl PercentStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8600,7 +8601,7 @@ impl PercentEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8636,7 +8637,7 @@ impl PlusStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8675,7 +8676,7 @@ impl PlusEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8714,7 +8715,7 @@ impl PlusPlusStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8753,7 +8754,7 @@ impl PragmaCaretStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8792,7 +8793,7 @@ impl PragmaEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8831,7 +8832,7 @@ impl PragmaGreaterThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8870,7 +8871,7 @@ impl PragmaGreaterThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8909,7 +8910,7 @@ impl PragmaLessThanStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8948,7 +8949,7 @@ impl PragmaLessThanEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -8987,7 +8988,7 @@ impl PragmaTildeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9026,7 +9027,7 @@ impl SMTCheckerKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9065,7 +9066,7 @@ impl SecondsKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9104,7 +9105,7 @@ impl SemicolonStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9140,7 +9141,7 @@ impl SlashStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9179,7 +9180,7 @@ impl SlashEqualStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9218,7 +9219,7 @@ impl StorageKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9257,7 +9258,7 @@ impl StringKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9296,7 +9297,7 @@ impl StringLiteralStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9335,7 +9336,7 @@ impl SuperKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9374,7 +9375,7 @@ impl ThisKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9410,7 +9411,7 @@ impl TildeStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9449,7 +9450,7 @@ impl TrueKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9488,7 +9489,7 @@ impl UfixedKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9527,7 +9528,7 @@ impl UintKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9566,7 +9567,7 @@ impl UnicodeStringLiteralStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9605,7 +9606,7 @@ impl VersionSpecifierStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9644,7 +9645,7 @@ impl WeeksKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -9683,7 +9684,7 @@ impl WeiKeywordStruct {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.rs.jinja2
@@ -3,6 +3,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
@@ -58,7 +59,7 @@ use super::types::Type;
       Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 
@@ -185,7 +186,7 @@ use super::types::Type;
       Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }
 
-    pub fn get_file_id(&self) -> &str {
+    pub fn get_file_id(&self) -> &FileId {
         self.semantic.file_id_from_node_id(self.ir_node.id())
     }
 

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -233,7 +233,7 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::MissingFile::c
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::MissingFile::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::MissingFile::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile
-pub slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile::imported_file_id: alloc::string::String
+pub slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile::imported_file_id: slang_solidity_v2_common::files::FileId
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile
 pub fn slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::compilation::MissingImportedFile
@@ -1178,7 +1178,7 @@ impl core::marker::Copy for slang_solidity_v2_common::diagnostics::DiagnosticSev
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::Diagnostic
 impl slang_solidity_v2_common::diagnostics::Diagnostic
-pub fn slang_solidity_v2_common::diagnostics::Diagnostic::file_id(&self) -> &str
+pub fn slang_solidity_v2_common::diagnostics::Diagnostic::file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_common::diagnostics::Diagnostic::kind(&self) -> &slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::Diagnostic::text_range(&self) -> &core::ops::range::Range<usize>
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::Diagnostic
@@ -1205,7 +1205,7 @@ pub struct slang_solidity_v2_common::diagnostics::DiagnosticCollection
 impl slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::is_empty(&self) -> bool
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = &slang_solidity_v2_common::diagnostics::Diagnostic>
-pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::push(&mut self, alloc::string::String, core::ops::range::Range<usize>, impl core::convert::Into<slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind>)
+pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::push(&mut self, slang_solidity_v2_common::files::FileId, core::ops::range::Range<usize>, impl core::convert::Into<slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind>)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::DiagnosticCollection
 pub fn slang_solidity_v2_common::diagnostics::DiagnosticCollection::clone(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticCollection
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::DiagnosticCollection
@@ -1479,6 +1479,30 @@ impl core::hash::Hash for slang_solidity_v2_common::evm_targets::FromStrError
 pub fn slang_solidity_v2_common::evm_targets::FromStrError::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::Copy for slang_solidity_v2_common::evm_targets::FromStrError
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::evm_targets::FromStrError
+pub mod slang_solidity_v2_common::files
+pub struct slang_solidity_v2_common::files::FileId(_)
+impl core::clone::Clone for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::clone(&self) -> slang_solidity_v2_common::files::FileId
+impl core::cmp::Eq for slang_solidity_v2_common::files::FileId
+impl core::cmp::Ord for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::cmp(&self, &slang_solidity_v2_common::files::FileId) -> core::cmp::Ordering
+impl core::cmp::PartialEq for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::eq(&self, &slang_solidity_v2_common::files::FileId) -> bool
+impl core::cmp::PartialOrd for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::partial_cmp(&self, &slang_solidity_v2_common::files::FileId) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<&str> for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::from(alloc::string::String) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::files::FileId
+impl serde_core::ser::Serialize for slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub mod slang_solidity_v2_common::nodes
 #[repr(transparent)] pub struct slang_solidity_v2_common::nodes::NodeId(_)
 impl core::clone::Clone for slang_solidity_v2_common::nodes::NodeId

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/collection.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 
 use crate::diagnostics::diagnostic::Diagnostic;
 use crate::diagnostics::kinds::DiagnosticKind;
+use crate::files::FileId;
 
 /// An ordered collection of [`Diagnostic`] values produced during a single
 /// parse or compilation run.
@@ -16,7 +17,7 @@ impl DiagnosticCollection {
     /// Constructs a new diagnostic from its parts and appends it to the collection.
     pub fn push(
         &mut self,
-        file_id: String,
+        file_id: FileId,
         text_range: Range<usize>,
         kind: impl Into<DiagnosticKind>,
     ) {

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/diagnostic.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use crate::diagnostics::extensions::DiagnosticExtensions;
 use crate::diagnostics::kinds::DiagnosticKind;
 use crate::diagnostics::severity::DiagnosticSeverity;
+use crate::files::FileId;
 
 /// A single diagnostic produced while parsing or compiling a source unit.
 ///
@@ -17,7 +18,7 @@ use crate::diagnostics::severity::DiagnosticSeverity;
 /// conversion via the `From` chain in [`crate::diagnostics::kinds`].
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Diagnostic {
-    file_id: String,
+    file_id: FileId,
     text_range: Range<usize>,
     kind: DiagnosticKind,
 }
@@ -28,7 +29,7 @@ impl Diagnostic {
     /// be passed as `kind` thanks to the `From` chain defined in
     /// [`crate::diagnostics::kinds`].
     pub(super) fn new(
-        file_id: String,
+        file_id: FileId,
         text_range: Range<usize>,
         kind: impl Into<DiagnosticKind>,
     ) -> Self {
@@ -40,7 +41,7 @@ impl Diagnostic {
     }
 
     /// Returns the identifier of the file this diagnostic was emitted for.
-    pub fn file_id(&self) -> &str {
+    pub fn file_id(&self) -> &FileId {
         &self.file_id
     }
 

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/compilation/missing_imported_file.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/compilation/missing_imported_file.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use crate::diagnostics::extensions::DiagnosticExtensions;
 use crate::diagnostics::severity::DiagnosticSeverity;
+use crate::files::FileId;
 
 /// Diagnostic emitted when an `import` directive resolves to a file that the
 /// configured `read_file` callback could not provide. It is anchored at the
@@ -10,7 +11,7 @@ use crate::diagnostics::severity::DiagnosticSeverity;
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct MissingImportedFile {
     /// The resolved identifier of the imported file that is missing.
-    pub imported_file_id: String,
+    pub imported_file_id: FileId,
 }
 
 impl DiagnosticExtensions for MissingImportedFile {

--- a/crates/solidity-v2/outputs/cargo/common/src/files/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/files/mod.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+/// Identifies a source file within a compilation unit.
+///
+/// Wraps the user-provided string identifier (typically a file path or URI) that is
+/// used to reference files throughout the compilation pipeline and AST.
+///
+/// Stored as an [`Arc<str>`] so that cloning a `FileId` during analysis — which
+/// happens for every file, import, and scope — is a cheap reference-count bump
+/// rather than a heap allocation and string copy.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct FileId(Arc<str>);
+
+impl From<String> for FileId {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&str> for FileId {
+    fn from(value: &str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for FileId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/lib.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod built_ins;
 pub mod collections;
 pub mod diagnostics;
 pub mod evm_targets;
+pub mod files;
 pub mod nodes;
 pub mod terminals;
 pub mod utils;

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -3883,7 +3883,7 @@ impl<T: slang_solidity_v2_ir::ir::TextRange> slang_solidity_v2_ir::ir::TextRange
 pub fn alloc::vec::Vec<T>::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl<T: slang_solidity_v2_ir::ir::TextRange> slang_solidity_v2_ir::ir::TextRange for core::option::Option<T>
 pub fn core::option::Option<T>::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub fn slang_solidity_v2_ir::ir::build(&str, &slang_solidity_v2_cst::structured_cst::nodes::SourceUnit, &impl slang_solidity_v2_ir::ir::Source, &mut slang_solidity_v2_ir::ir::NodeIdGenerator) -> slang_solidity_v2_ir::ir::BuildOutput
+pub fn slang_solidity_v2_ir::ir::build(&slang_solidity_v2_common::files::FileId, &slang_solidity_v2_cst::structured_cst::nodes::SourceUnit, &impl slang_solidity_v2_ir::ir::Source, &mut slang_solidity_v2_ir::ir::NodeIdGenerator) -> slang_solidity_v2_ir::ir::BuildOutput
 pub type slang_solidity_v2_ir::ir::ABIEncoderV2Keyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct>
 pub type slang_solidity_v2_ir::ir::AbicoderPragma = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbicoderPragmaStruct>
 pub type slang_solidity_v2_ir::ir::AbicoderV1Keyword = alloc::sync::Arc<slang_solidity_v2_ir::ir::AbicoderV1KeywordStruct>

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_common::diagnostics::kinds::syntax::{
     MultipleMutabilitySpecifiers, MultipleOverrideSpecifiers, MultipleVirtualSpecifiers,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_cst::structured_cst::nodes as input;
 use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
 
@@ -27,7 +28,7 @@ pub struct BuildOutput {
 }
 
 pub fn build_source_unit(
-    file_id: &str,
+    file_id: &FileId,
     source_unit: &input::SourceUnit,
     source: &impl Source,
     id_generator: &mut NodeIdGenerator,
@@ -49,7 +50,7 @@ pub fn build_source_unit(
 
 pub(crate) struct CstToIrBuilder<'a, S: Source> {
     source: &'a S,
-    file_id: &'a str,
+    file_id: &'a FileId,
     id_generator: &'a mut NodeIdGenerator,
     diagnostics: DiagnosticCollection,
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -23,7 +23,7 @@ contract MyContract {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -35,7 +35,12 @@ contract MyContract {
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
 
     assert!(
         diagnostics.is_empty(),
@@ -105,15 +110,19 @@ contract MyContract {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
     assert!(
         diagnostics.is_empty(),
         "Parser diagnostics: {diagnostics:?}"
     );
 
     let mut id_generator = ir::NodeIdGenerator::default();
-    let ir::BuildOutput { diagnostics, .. } =
-        ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    let ir::BuildOutput { diagnostics, .. } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
     assert!(
         diagnostics.is_empty(),
         "IR builder diagnostics: {diagnostics:?}"
@@ -144,7 +153,7 @@ contract Test is Base layout at 0 {}
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -156,7 +165,12 @@ contract Test is Base layout at 0 {}
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
 
     let sentinel_node_id = id_generator.next_id_of(ir::NodeKind::SourceUnit);
 
@@ -214,7 +228,7 @@ contract Test {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -226,7 +240,12 @@ contract Test {
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/text_range.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/text_range.rs
@@ -15,7 +15,7 @@ contract MyContract {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -27,7 +27,12 @@ contract MyContract {
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/visitor.rs
@@ -79,7 +79,7 @@ contract Counter is Ownable {
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+    } = Parser::parse(&"test.sol".into(), CONTENTS, LanguageVersion::LATEST);
 
     assert!(
         diagnostics.is_empty(),
@@ -91,7 +91,12 @@ contract Counter is Ownable {
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+    } = ir::build(
+        &"test.sol".into(),
+        &source_unit,
+        &CONTENTS,
+        &mut id_generator,
+    );
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/parser/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/parser/generated/public_api.txt
@@ -11,6 +11,6 @@ pub fn slang_solidity_v2_parser::ParseOutput::fmt(&self, &mut core::fmt::Formatt
 impl core::marker::StructuralPartialEq for slang_solidity_v2_parser::ParseOutput
 pub struct slang_solidity_v2_parser::Parser
 impl slang_solidity_v2_parser::Parser
-pub fn slang_solidity_v2_parser::Parser::parse(&str, &str, slang_solidity_v2_common::versions::version::LanguageVersion) -> slang_solidity_v2_parser::ParseOutput
+pub fn slang_solidity_v2_parser::Parser::parse(&slang_solidity_v2_common::files::FileId, &str, slang_solidity_v2_common::versions::version::LanguageVersion) -> slang_solidity_v2_parser::ParseOutput
 impl core::default::Default for slang_solidity_v2_parser::Parser
 pub fn slang_solidity_v2_parser::Parser::default() -> slang_solidity_v2_parser::Parser

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
@@ -2,6 +2,7 @@ use lalrpop_util::lalrpop_mod;
 use slang_solidity_v2_common::collections::SortedSet;
 use slang_solidity_v2_common::diagnostics::kinds::syntax::{UnexpectedEof, UnexpectedTerminal};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::terminals::TerminalKind;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_cst::structured_cst::nodes::{
@@ -41,7 +42,7 @@ pub(crate) struct GrammarCtx<'a> {
     /// Source text being parsed (consumed by terminal constructors).
     pub source: &'a str,
     /// Id of the file being parsed, used when reporting diagnostics.
-    pub file_id: &'a str,
+    pub file_id: &'a FileId,
     /// Diagnostics accumulated during parsing.
     pub diagnostics: DiagnosticCollection,
 }
@@ -61,7 +62,7 @@ pub struct ParseOutput {
 pub struct Parser;
 
 impl Parser {
-    pub fn parse(file_id: &str, source: &str, language_version: LanguageVersion) -> ParseOutput {
+    pub fn parse(file_id: &FileId, source: &str, language_version: LanguageVersion) -> ParseOutput {
         let lexer = Lexer::new(source, language_version);
         let parser = grammar::SourceUnitParser::new();
 
@@ -100,7 +101,7 @@ impl Parser {
 
 /// Convert a LALRPOP parse error into a `DiagnosticCollection`.
 fn convert_parse_error(
-    file_id: &str,
+    file_id: &FileId,
     diagnostics: &mut DiagnosticCollection,
     value: lalrpop_util::ParseError<usize, LexemeKind, ()>,
 ) {

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/validation/validate_syntax_version.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/validation/validate_syntax_version.generated.rs
@@ -5,6 +5,7 @@
 
 use slang_solidity_v2_common::diagnostics::kinds::syntax::IncompatibleSyntaxVersion;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::versions::{LanguageVersion, LanguageVersionSpecifier};
 use slang_solidity_v2_cst::structured_cst::nodes::*;
 use slang_solidity_v2_cst::structured_cst::TextRange;
@@ -13,7 +14,7 @@ use slang_solidity_v2_cst::structured_cst::TextRange;
 pub fn validate_syntax_version(
     root: &SourceUnit,
     version: LanguageVersion,
-    file_id: &str,
+    file_id: &FileId,
     diagnostics: &mut DiagnosticCollection,
 ) {
     let mut validator = SyntaxVersionValidator {
@@ -26,7 +27,7 @@ pub fn validate_syntax_version(
 
 struct SyntaxVersionValidator<'a> {
     version: LanguageVersion,
-    file_id: &'a str,
+    file_id: &'a FileId,
     diagnostics: &'a mut DiagnosticCollection,
 }
 

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/validation/validate_syntax_version.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/validation/validate_syntax_version.rs.jinja2
@@ -7,6 +7,7 @@
 
 use slang_solidity_v2_common::diagnostics::kinds::syntax::IncompatibleSyntaxVersion;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::versions::{LanguageVersion, LanguageVersionSpecifier};
 use slang_solidity_v2_cst::structured_cst::nodes::*;
 use slang_solidity_v2_cst::structured_cst::TextRange;
@@ -15,7 +16,7 @@ use slang_solidity_v2_cst::structured_cst::TextRange;
 pub fn validate_syntax_version(
     root: &SourceUnit,
     version: LanguageVersion,
-    file_id: &str,
+    file_id: &FileId,
     diagnostics: &mut DiagnosticCollection,
 ) {
     let mut validator = SyntaxVersionValidator { version, file_id, diagnostics };
@@ -24,7 +25,7 @@ pub fn validate_syntax_version(
 
 struct SyntaxVersionValidator<'a> {
     version: LanguageVersion,
-    file_id: &'a str,
+    file_id: &'a FileId,
     diagnostics: &'a mut DiagnosticCollection,
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -264,7 +264,7 @@ pub mod slang_solidity_v2_semantic::context
 pub struct slang_solidity_v2_semantic::context::SemanticContext
 impl slang_solidity_v2_semantic::context::SemanticContext
 pub const slang_solidity_v2_semantic::context::SemanticContext::SLOT_SIZE: usize
-pub fn slang_solidity_v2_semantic::context::SemanticContext::file_id_from_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> &str
+pub fn slang_solidity_v2_semantic::context::SemanticContext::file_id_from_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_semantic::context::SemanticContext::linearised_errors(&self, slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_ir::ir::nodes::ErrorDefinition]
 pub fn slang_solidity_v2_semantic::context::SemanticContext::linearised_events(&self, slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_ir::ir::nodes::EventDefinition]
 pub fn slang_solidity_v2_semantic::context::SemanticContext::linearised_functions(&self, slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_ir::ir::nodes::FunctionDefinition]
@@ -283,9 +283,9 @@ pub fn slang_solidity_v2_semantic::context::SemanticContext::build_from(slang_so
 pub fn slang_solidity_v2_semantic::context::SemanticContext::find_contract_by_name<'a, 'b>(&'a self, &'b str) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ir::ir::nodes::ContractDefinition> + use<'a> where 'b: 'a
 pub fn slang_solidity_v2_semantic::context::SemanticContext::types(&self) -> &slang_solidity_v2_semantic::types::TypeRegistry
 pub trait slang_solidity_v2_semantic::context::SemanticFile
-pub fn slang_solidity_v2_semantic::context::SemanticFile::id(&self) -> &str
+pub fn slang_solidity_v2_semantic::context::SemanticFile::id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_semantic::context::SemanticFile::ir_root(&self) -> &slang_solidity_v2_ir::ir::nodes::SourceUnit
-pub fn slang_solidity_v2_semantic::context::SemanticFile::resolved_import_by_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&alloc::string::String>
+pub fn slang_solidity_v2_semantic::context::SemanticFile::resolved_import_by_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_common::files::FileId>
 pub fn slang_solidity_v2_semantic::context::extract_import_paths_from_source_unit(&slang_solidity_v2_ir::ir::nodes::SourceUnit) -> alloc::vec::Vec<(slang_solidity_v2_common::nodes::NodeId, alloc::string::String)>
 pub mod slang_solidity_v2_semantic::types
 pub mod slang_solidity_v2_semantic::types::literals

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ruint::aliases::U256;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -84,14 +85,14 @@ pub struct FunctionDefinition {
 #[derive(Debug)]
 pub struct ImportDefinition {
     pub ir_node: ir::PathImport,
-    pub resolved_file_id: Option<String>,
+    pub resolved_file_id: Option<FileId>,
 }
 
 #[derive(Debug)]
 pub struct ImportedSymbolDefinition {
     pub ir_node: ir::ImportDeconstructionSymbol,
     pub symbol: String,
-    pub resolved_file_id: Option<String>,
+    pub resolved_file_id: Option<FileId>,
 }
 
 #[derive(Debug)]
@@ -381,7 +382,7 @@ impl Definition {
         })
     }
 
-    pub(crate) fn new_import(ir_node: &ir::PathImport, resolved_file_id: Option<String>) -> Self {
+    pub(crate) fn new_import(ir_node: &ir::PathImport, resolved_file_id: Option<FileId>) -> Self {
         assert!(
             ir_node.alias.is_some(),
             "Definition can only be created for aliased imports"
@@ -396,7 +397,7 @@ impl Definition {
     pub(crate) fn new_imported_symbol(
         ir_node: &ir::ImportDeconstructionSymbol,
         symbol: String,
-        resolved_file_id: Option<String>,
+        resolved_file_id: Option<FileId>,
     ) -> Self {
         Self::ImportedSymbol(ImportedSymbolDefinition {
             ir_node: Arc::clone(ir_node),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use slang_solidity_v2_common::collections::{DefaultWithCapacity, Map, Set};
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::built_ins::InternalBuiltIn;
@@ -96,7 +97,7 @@ pub struct Binder {
     /// Scopes (set of definitions contained and relationship to other scopes), indexed by `NodeId`
     scopes_by_node_id: Map<NodeId, ScopeId>,
     /// Index of root `FileScope`s for all files in the `CompilationUnit`
-    scopes_by_file_id: Map<String, ScopeId>,
+    scopes_by_file_id: Map<FileId, ScopeId>,
     /// `UsingDirective` objects registered globally (contract level directives
     /// are stored in the corresponding `ContractScope`)
     global_using_directives: Vec<UsingDirective>,
@@ -170,7 +171,7 @@ impl Binder {
         self.scopes_by_node_id.get(&node_id).copied()
     }
 
-    pub(crate) fn scope_id_for_file_id(&self, file_id: &str) -> Option<ScopeId> {
+    pub(crate) fn scope_id_for_file_id(&self, file_id: &FileId) -> Option<ScopeId> {
         self.scopes_by_file_id.get(file_id).copied()
     }
 
@@ -408,7 +409,7 @@ impl Binder {
 
     // File scope resolution context
 
-    pub(crate) fn get_file_scope(&self, file_id: &str) -> &FileScope {
+    pub(crate) fn get_file_scope(&self, file_id: &FileId) -> &FileScope {
         self.scopes_by_file_id
             .get(file_id)
             .and_then(|scope_id| self.scopes.get(scope_id.0))
@@ -422,7 +423,7 @@ impl Binder {
     // Resolving a symbol in a file scope is special because of default imports.
     // We want to find *all* definitions with the given symbol reachable from
     // the file.
-    fn resolve_in_file_scope(&self, file_id: &str, symbol: &str) -> Resolution {
+    fn resolve_in_file_scope(&self, file_id: &FileId, symbol: &str) -> Resolution {
         let mut found_definitions = Vec::new();
         let mut visited_files = Set::default();
         let mut files_to_search = VecDeque::new();
@@ -439,7 +440,7 @@ impl Binder {
                 file_scope
                     .default_imports
                     .iter()
-                    .map(|import| import.file_id.as_str()),
+                    .map(|import| &import.file_id),
             );
         }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use slang_solidity_v2_common::collections::Map;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -57,7 +58,7 @@ pub(crate) struct EnumScope {
 
 pub(crate) struct FileScope {
     pub(crate) node_id: NodeId,
-    pub(crate) file_id: String,
+    pub(crate) file_id: FileId,
     pub(crate) definitions: Map<String, Vec<NodeId>>,
     /// Files brought into scope through (unqualified) default imports, in
     /// source order. The same file may appear more than once if imported by
@@ -70,7 +71,7 @@ pub(crate) struct FileScope {
 /// The directive's text range is kept so that symbol clashes introduced by the
 /// import can be reported on the directive itself.
 pub(crate) struct DefaultImport {
-    pub(crate) file_id: String,
+    pub(crate) file_id: FileId,
     pub(crate) range: Range<usize>,
 }
 
@@ -197,7 +198,7 @@ impl Scope {
         Self::Enum(EnumScope::new(node_id))
     }
 
-    pub(crate) fn new_file(node_id: NodeId, file_id: &str) -> Self {
+    pub(crate) fn new_file(node_id: NodeId, file_id: &FileId) -> Self {
         Self::File(FileScope::new(node_id, file_id))
     }
 
@@ -314,10 +315,10 @@ impl EnumScope {
 }
 
 impl FileScope {
-    fn new(node_id: NodeId, file_id: &str) -> Self {
+    fn new(node_id: NodeId, file_id: &FileId) -> Self {
         Self {
             node_id,
-            file_id: file_id.to_string(),
+            file_id: file_id.clone(),
             definitions: Map::default(),
             default_imports: Vec::new(),
             using_directives: Vec::new(),
@@ -332,7 +333,7 @@ impl FileScope {
         }
     }
 
-    pub(crate) fn add_default_import(&mut self, file_id: String, range: Range<usize>) {
+    pub(crate) fn add_default_import(&mut self, file_id: FileId, range: Range<usize>) {
         self.default_imports.push(DefaultImport { file_id, range });
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/file_node_mapper.rs
@@ -1,10 +1,11 @@
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::SemanticFile;
 
 struct FileNodeInfo {
     /// File ID to map `NodeId`s to
-    file_id: String,
+    file_id: FileId,
     /// `NodeId` of the first node in the file, which should always correspond
     /// to the ID of the root `SourceUnit` (by construction)
     first_node_id: NodeId,
@@ -24,7 +25,7 @@ impl FileNodeMapper {
         let mut files: Vec<FileNodeInfo> = files
             .iter()
             .map(|file| {
-                let file_id = file.id().to_string();
+                let file_id = file.id().clone();
                 let first_node_id = file.ir_root().id();
                 FileNodeInfo {
                     file_id,
@@ -36,7 +37,7 @@ impl FileNodeMapper {
         Self { files }
     }
 
-    pub(crate) fn file_id_from_node_id(&self, node_id: NodeId) -> &str {
+    pub(crate) fn file_id_from_node_id(&self, node_id: NodeId) -> &FileId {
         let index = match self
             .files
             .binary_search_by_key(&node_id, |file| file.first_node_id)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -3,6 +3,7 @@ pub(crate) use file_node_mapper::FileNodeMapper;
 use slang_solidity_v2_common::collections::Set;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::utils::strip_string_literal_quotes;
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -25,13 +26,13 @@ mod file_node_mapper;
 /// Trait for files that can be used as input to the semantic analysis passes.
 pub trait SemanticFile {
     /// Returns the file identifier.
-    fn id(&self) -> &str;
+    fn id(&self) -> &FileId;
 
     /// Returns the root IR node of the file.
     fn ir_root(&self) -> &ir::SourceUnit;
 
     /// Returns the resolved import target file ID for the given import node, if resolved.
-    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String>;
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&FileId>;
 }
 
 pub fn extract_import_paths_from_source_unit(
@@ -146,7 +147,7 @@ impl SemanticContext {
 }
 
 impl SemanticContext {
-    pub fn file_id_from_node_id(&self, node_id: NodeId) -> &str {
+    pub fn file_id_from_node_id(&self, node_id: NodeId) -> &FileId {
         self.file_node_mapper.file_id_from_node_id(node_id)
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/constant_evaluator.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/constant_evaluator.rs
@@ -3,6 +3,7 @@ use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition;
 use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, ConstantDefinition, Definition, Resolution, Scope, ScopeId};
@@ -523,7 +524,7 @@ pub(crate) struct ConstantResolver<'a> {
     /// same-file constants declared past that offset resolve as `Unresolved`.
     /// This is a hack to match solc behaviour: forward references are
     /// rejected in array lengths, but valid in storage base slots (`None`).
-    pub(crate) use_site: Option<(&'a str, usize)>,
+    pub(crate) use_site: Option<(&'a FileId, usize)>,
 }
 
 impl ConstantResolver<'_> {
@@ -707,7 +708,7 @@ mod tests {
         let ParseOutput {
             source_unit,
             diagnostics,
-        } = Parser::parse("test.sol", &source, version);
+        } = Parser::parse(&"test.sol".into(), &source, version);
 
         assert!(
             diagnostics.is_empty(),
@@ -718,7 +719,7 @@ mod tests {
         let ir::BuildOutput {
             ir_root,
             diagnostics,
-        } = ir::build("test.sol", &source_unit, &source, &mut id_generator);
+        } = ir::build(&"test.sol".into(), &source_unit, &source, &mut id_generator);
 
         assert!(
             diagnostics.is_empty(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
@@ -17,6 +17,7 @@ use std::collections::VecDeque;
 use std::ops::Range;
 
 use slang_solidity_v2_common::collections::{Map, Set};
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use crate::binder::{Binder, Definition, FileScope, Scope, ScopeId};
@@ -132,9 +133,9 @@ pub(super) fn find_conflicting_solidity_definition(
 // then symbol name).
 pub(super) fn find_default_import_conflicts<'a>(
     binder: &Binder,
-    file_ids: impl Iterator<Item = &'a str>,
-) -> Vec<(String, Range<usize>)> {
-    let mut conflicts: Vec<(String, Range<usize>)> = Vec::new();
+    file_ids: impl Iterator<Item = &'a FileId>,
+) -> Vec<(FileId, Range<usize>)> {
+    let mut conflicts: Vec<(FileId, Range<usize>)> = Vec::new();
 
     for file_id in file_ids {
         let file_scope = binder.get_file_scope(file_id);
@@ -162,15 +163,14 @@ pub(super) fn find_default_import_conflicts<'a>(
 fn find_imported_symbol_conflicts<'a>(
     binder: &'a Binder,
     file_scope: &'a FileScope,
-    conflicts: &mut Vec<(String, Range<usize>)>,
+    conflicts: &mut Vec<(FileId, Range<usize>)>,
 ) {
     // All the symbols imported by the directives processed so far.
     let mut seen: Map<&'a str, Vec<NodeId>> = Map::default();
 
     let mut import_iter = file_scope.default_imports.iter().peekable();
     while let Some(import) = import_iter.next() {
-        let imported_scopes =
-            transitive_file_scopes(binder, import.file_id.as_str(), &file_scope.file_id);
+        let imported_scopes = transitive_file_scopes(binder, &import.file_id, &file_scope.file_id);
 
         // Gather the symbols this directive brings in. We don't care about them
         // being sorted because if there's any conflict we will report the
@@ -231,17 +231,14 @@ fn find_imported_symbol_conflicts<'a>(
 fn find_local_definition_conflicts(
     binder: &Binder,
     file_scope: &FileScope,
-    conflicts: &mut Vec<(String, Range<usize>)>,
+    conflicts: &mut Vec<(FileId, Range<usize>)>,
 ) {
     let default_imports_scopes: Vec<_> = file_scope
         .default_imports
         .iter()
         .map(|default_import| {
-            let imported_scopes = transitive_file_scopes(
-                binder,
-                default_import.file_id.as_str(),
-                file_scope.file_id.as_str(),
-            );
+            let imported_scopes =
+                transitive_file_scopes(binder, &default_import.file_id, &file_scope.file_id);
             (default_import, imported_scopes)
         })
         .collect();
@@ -291,14 +288,14 @@ fn find_local_definition_conflicts(
 // reached through a cycle).
 fn transitive_file_scopes<'a>(
     binder: &'a Binder,
-    starting_file_id: &str,
-    excluded_file_id: &str,
+    starting_file_id: &FileId,
+    excluded_file_id: &FileId,
 ) -> Vec<&'a FileScope> {
     let mut found = Vec::new();
     let mut visited = Set::default();
     visited.insert(excluded_file_id);
 
-    let mut queue: VecDeque<&str> = [starting_file_id].into_iter().collect();
+    let mut queue: VecDeque<&FileId> = [starting_file_id].into_iter().collect();
 
     while let Some(imported_file_id) = queue.pop_front() {
         if !visited.insert(imported_file_id) {
@@ -315,7 +312,7 @@ fn transitive_file_scopes<'a>(
             imported_scope
                 .default_imports
                 .iter()
-                .map(|import| import.file_id.as_str()),
+                .map(|import| &import.file_id),
         );
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -6,6 +6,7 @@ use slang_solidity_v2_common::diagnostics::kinds::structure::{
     InvalidUsingDirectiveContainer, MultipleConstructors,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
@@ -159,7 +160,7 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
         self.binder.insert_definition_in_scope(definition, scope_id);
     }
 
-    fn resolve_import_path(&self, import_node_id: NodeId) -> Option<String> {
+    fn resolve_import_path(&self, import_node_id: NodeId) -> Option<FileId> {
         self.current_file
             .resolved_import_by_node_id(import_node_id)
             .cloned()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p2_linearise_contracts/mod.rs
@@ -5,6 +5,7 @@ use slang_solidity_v2_common::diagnostics::kinds::semantic::{
 };
 use slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -32,32 +33,32 @@ pub fn run(
 struct Pass<'a> {
     binder: &'a mut Binder,
     diagnostics: &'a mut DiagnosticCollection,
-    file_id: String,
+    file_id: &'a FileId,
 }
 
 impl<'a> Pass<'a> {
     fn visit_file_collect_bases(
-        file: &impl SemanticFile,
+        file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         diagnostics: &'a mut DiagnosticCollection,
     ) {
         let mut pass = Self {
             binder,
             diagnostics,
-            file_id: file.id().to_owned(),
+            file_id: file.id(),
         };
         pass.collect_bases_from(file.ir_root());
     }
 
     fn visit_file_linearise_contracts(
-        file: &impl SemanticFile,
+        file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         diagnostics: &'a mut DiagnosticCollection,
     ) {
         let mut pass = Self {
             binder,
             diagnostics,
-            file_id: file.id().to_owned(),
+            file_id: file.id(),
         };
         pass.linearise_contracts_from(file.ir_root());
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -38,13 +39,13 @@ struct Pass<'a> {
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
     diagnostics: &'a mut DiagnosticCollection,
-    file_id: String,
+    file_id: &'a FileId,
     current_receiver_type: Option<TypeId>,
 }
 
 impl<'a> Pass<'a> {
     fn visit_file(
-        file: &impl SemanticFile,
+        file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
         diagnostics: &'a mut DiagnosticCollection,
@@ -54,7 +55,7 @@ impl<'a> Pass<'a> {
             binder,
             types,
             diagnostics,
-            file_id: file.id().to_owned(),
+            file_id: file.id(),
             current_receiver_type: None,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
@@ -68,7 +69,7 @@ impl<'a> Pass<'a> {
     // cannot happen concurrently with the typing of the definitions in the main
     // pass.
     fn visit_file_type_getters(
-        file: &impl SemanticFile,
+        file: &'a impl SemanticFile,
         binder: &'a mut Binder,
         types: &'a mut TypeRegistry,
         diagnostics: &'a mut DiagnosticCollection,
@@ -78,7 +79,7 @@ impl<'a> Pass<'a> {
             binder,
             types,
             diagnostics,
-            file_id: file.id().to_owned(),
+            file_id: file.id(),
             current_receiver_type: None,
         };
         pass.type_getters_from(file.ir_root());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -61,7 +61,7 @@ impl Pass<'_> {
                                     self.types,
                                     &ConstantResolver {
                                         binder: self.binder,
-                                        use_site: Some((&self.file_id, range.start)),
+                                        use_site: Some((self.file_id, range.start)),
                                     },
                                 ) {
                                     Ok(size) => size,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
@@ -1,4 +1,5 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
@@ -41,7 +42,7 @@ struct Pass<'a> {
     binder: &'a mut Binder,
     types: &'a mut TypeRegistry,
     diagnostics: &'a mut DiagnosticCollection,
-    file_id: String,
+    file_id: FileId,
 }
 
 impl<'a> Pass<'a> {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/constant_cycles/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/constant_cycles/mod.rs
@@ -3,6 +3,7 @@ use slang_solidity_v2_common::diagnostics::kinds::semantic::{
     CyclicConstantDependency, CyclicDependencyValidatorExhausted,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
@@ -161,7 +162,7 @@ fn constant_definition(binder: &Binder, constant_id: NodeId) -> &ConstantDefinit
     }
 }
 
-fn file_id(binder: &Binder, constant: &ConstantDefinition) -> String {
+fn file_id(binder: &Binder, constant: &ConstantDefinition) -> FileId {
     match binder.get_scope_by_id(constant.enclosing_scope_id) {
         Scope::File(file_scope) => file_scope.file_id.clone(),
         Scope::Contract(contract_scope) => {
@@ -171,7 +172,9 @@ fn file_id(binder: &Binder, constant: &ConstantDefinition) -> String {
             };
             file_scope.file_id.clone()
         }
-        _ => String::new(),
+        _ => {
+            unreachable!("constant definitions can only be declared in a file or a contract scope")
+        }
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -23,7 +23,7 @@ contract Test is Base layout at 0 {}
 
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
-        "test.sol",
+        "test.sol".into(),
         CONTENTS,
         &mut id_generator,
         LanguageVersion::LATEST,
@@ -86,7 +86,7 @@ interface A is C {}
 
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
-        "test.sol",
+        "test.sol".into(),
         CONTENTS,
         &mut id_generator,
         LanguageVersion::LATEST,
@@ -135,7 +135,7 @@ contract B {}
 
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
-        "test.sol",
+        "test.sol".into(),
         CONTENTS,
         &mut id_generator,
         LanguageVersion::LATEST,
@@ -175,7 +175,7 @@ contract Test is Base, Foo { // Base should resolve to the contract, not the var
 
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
-        "test.sol",
+        "test.sol".into(),
         CONTENTS,
         &mut id_generator,
         LanguageVersion::LATEST,
@@ -245,7 +245,12 @@ contract Test is Base {
 
     let mut id_generator = NodeIdGenerator::default();
     let language_version = LanguageVersion::LATEST;
-    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
+    let file = build_file(
+        "test.sol".into(),
+        CONTENTS,
+        &mut id_generator,
+        language_version,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -305,7 +310,12 @@ contract Test is Base {
     let language_version = LanguageVersion::LATEST;
 
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
+    let file = build_file(
+        "test.sol".into(),
+        CONTENTS,
+        &mut id_generator,
+        language_version,
+    );
 
     let files = [file];
     let mut binder = Binder::default();
@@ -352,7 +362,12 @@ contract Test {
 
     let mut id_generator = NodeIdGenerator::default();
     let language_version = LanguageVersion::LATEST;
-    let file = build_file("test.sol", CONTENTS, &mut id_generator, language_version);
+    let file = build_file(
+        "test.sol".into(),
+        CONTENTS,
+        &mut id_generator,
+        language_version,
+    );
 
     let files = [file];
     let mut binder = Binder::default();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -1,6 +1,7 @@
 mod binder;
 mod typing;
 
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
@@ -9,12 +10,12 @@ use slang_solidity_v2_parser::{ParseOutput, Parser};
 use crate::context::SemanticFile;
 
 struct TestFile {
-    id: String,
+    id: FileId,
     ir_root: ir::SourceUnit,
 }
 
 impl SemanticFile for TestFile {
-    fn id(&self) -> &str {
+    fn id(&self) -> &FileId {
         &self.id
     }
 
@@ -22,13 +23,13 @@ impl SemanticFile for TestFile {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&String> {
+    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&FileId> {
         None
     }
 }
 
 fn build_file(
-    name: &str,
+    file_id: FileId,
     contents: &str,
     id_generator: &mut NodeIdGenerator,
     language_version: LanguageVersion,
@@ -36,7 +37,7 @@ fn build_file(
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = Parser::parse(name, contents, language_version);
+    } = Parser::parse(&file_id, contents, language_version);
 
     assert!(
         diagnostics.is_empty(),
@@ -46,7 +47,7 @@ fn build_file(
     let ir::BuildOutput {
         ir_root,
         diagnostics,
-    } = ir::build(name, &source_unit, &contents, id_generator);
+    } = ir::build(&file_id, &source_unit, &contents, id_generator);
 
     assert!(
         diagnostics.is_empty(),
@@ -54,7 +55,7 @@ fn build_file(
     );
 
     TestFile {
-        id: name.to_string(),
+        id: file_id,
         ir_root,
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -26,7 +26,12 @@ struct TypeAnalysis {
 /// Builds and runs every semantic pass over an arbitrary Solidity `source`,
 fn analyze(language_version: LanguageVersion, source: &str) -> TypeAnalysis {
     let mut id_generator = NodeIdGenerator::default();
-    let file = build_file("test.sol", source, &mut id_generator, language_version);
+    let file = build_file(
+        "test.sol".into(),
+        source,
+        &mut id_generator,
+        language_version,
+    );
     let files = vec![file];
 
     let mut binder = Binder::default();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -12,9 +12,10 @@ pub use slang_solidity_v2::ast::FunctionTypeVisibility
 pub use slang_solidity_v2::ast::NodeId
 pub use slang_solidity_v2::ast::TypeId
 pub mod slang_solidity_v2::compilation
+pub use slang_solidity_v2::compilation::FileId
 pub struct slang_solidity_v2::compilation::CompilationBuilder<C: slang_solidity_v2::compilation::CompilationBuilderConfig>
 impl<C: slang_solidity_v2::compilation::CompilationBuilderConfig> slang_solidity_v2::compilation::CompilationBuilder<C>
-pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::add_file(&mut self, alloc::string::String)
+pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::add_file(&mut self, slang_solidity_v2_common::files::FileId)
 pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::build(self) -> slang_solidity_v2::compilation::CompilationUnit
 pub fn slang_solidity_v2::compilation::CompilationBuilder<C>::create(slang_solidity_v2_common::versions::version::LanguageVersion, slang_solidity_v2_common::evm_targets::target::EvmTarget, C) -> slang_solidity_v2::compilation::CompilationBuilder<C>
 pub struct slang_solidity_v2::compilation::CompilationUnit
@@ -25,18 +26,17 @@ pub fn slang_solidity_v2::compilation::CompilationUnit::all_references(&self) ->
 pub fn slang_solidity_v2::compilation::CompilationUnit::compute_contracts_abi(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::abi::ContractAbi>
 pub fn slang_solidity_v2::compilation::CompilationUnit::diagnostics(&self) -> &slang_solidity_v2_common::diagnostics::collection::DiagnosticCollection
 pub fn slang_solidity_v2::compilation::CompilationUnit::evm_target(&self) -> slang_solidity_v2_common::evm_targets::target::EvmTarget
-pub fn slang_solidity_v2::compilation::CompilationUnit::file(&self, &str) -> core::option::Option<slang_solidity_v2::compilation::File>
-pub fn slang_solidity_v2::compilation::CompilationUnit::file_ids(&self) -> alloc::vec::Vec<alloc::string::String>
-pub fn slang_solidity_v2::compilation::CompilationUnit::files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + use<'_>
+pub fn slang_solidity_v2::compilation::CompilationUnit::file(&self, &slang_solidity_v2_common::files::FileId) -> core::option::Option<slang_solidity_v2::compilation::File>
+pub fn slang_solidity_v2::compilation::CompilationUnit::files(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2::compilation::File> + '_
 pub fn slang_solidity_v2::compilation::CompilationUnit::find_contract_by_name<'a, 'b>(&'a self, &'b str) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::nodes::ContractDefinition> + use<'a> where 'b: 'a
 pub fn slang_solidity_v2::compilation::CompilationUnit::language_version(&self) -> slang_solidity_v2_common::versions::version::LanguageVersion
 pub struct slang_solidity_v2::compilation::FileStruct
 impl slang_solidity_v2::compilation::FileStruct
 pub fn slang_solidity_v2::compilation::FileStruct::ast(&self) -> slang_solidity_v2_ast::ast::nodes::SourceUnit
-pub fn slang_solidity_v2::compilation::FileStruct::id(&self) -> &str
+pub fn slang_solidity_v2::compilation::FileStruct::id(&self) -> &slang_solidity_v2_common::files::FileId
 pub trait slang_solidity_v2::compilation::CompilationBuilderConfig
-pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::read_file(&mut self, &str) -> core::result::Result<alloc::string::String, slang_solidity_v2_common::diagnostics::kinds::compilation::missing_file::MissingFile>
-pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::resolve_import(&mut self, &str, &str) -> core::result::Result<alloc::string::String, slang_solidity_v2_common::diagnostics::kinds::compilation::unresolved_import::UnresolvedImport>
+pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::read_file(&mut self, &slang_solidity_v2_common::files::FileId) -> core::result::Result<alloc::string::String, slang_solidity_v2_common::diagnostics::kinds::compilation::missing_file::MissingFile>
+pub fn slang_solidity_v2::compilation::CompilationBuilderConfig::resolve_import(&mut self, &slang_solidity_v2_common::files::FileId, &str) -> core::result::Result<slang_solidity_v2_common::files::FileId, slang_solidity_v2_common::diagnostics::kinds::compilation::unresolved_import::UnresolvedImport>
 pub type slang_solidity_v2::compilation::File = alloc::sync::Arc<slang_solidity_v2::compilation::FileStruct>
 pub mod slang_solidity_v2::diagnostics
 pub use slang_solidity_v2::diagnostics::Diagnostic

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/builder.rs
@@ -6,6 +6,7 @@ use slang_solidity_v2_common::diagnostics::kinds::compilation::{
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::utils::strip_string_literal_quotes;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_cst::structured_cst::nodes as cst;
@@ -25,7 +26,7 @@ pub trait CompilationBuilderConfig {
     /// The user is responsible for fetching the file from the filesystem. The
     /// returned [`MissingFile`] is surfaced as a compilation diagnostic on the
     /// [`CompilationUnit`].
-    fn read_file(&mut self, file_id: &str) -> Result<String, MissingFile>;
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile>;
 
     /// Callback used by this builder to resolve an import path.
     /// For example, if a source file contains the following statement:
@@ -42,15 +43,15 @@ pub trait CompilationBuilderConfig {
     /// compilation diagnostic on the [`CompilationUnit`].
     fn resolve_import(
         &mut self,
-        source_file_id: &str,
+        source_file_id: &FileId,
         import_path: &str,
-    ) -> Result<String, UnresolvedImport>;
+    ) -> Result<FileId, UnresolvedImport>;
 }
 
 struct BuilderFile {
     source_unit: cst::SourceUnit,
     contents: String,
-    resolved_imports: SortedMap<String, String>,
+    resolved_imports: SortedMap<String, FileId>,
 }
 
 /// A builder for creating compilation units.
@@ -62,9 +63,9 @@ pub struct CompilationBuilder<C: CompilationBuilderConfig> {
 
     diagnostics: DiagnosticCollection,
 
-    files: SortedMap<String, BuilderFile>,
-    seen_files: Set<String>,
-    missing_files: Set<String>,
+    files: SortedMap<FileId, BuilderFile>,
+    seen_files: Set<FileId>,
+    missing_files: Set<FileId>,
 }
 
 impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
@@ -102,7 +103,7 @@ impl<C: CompilationBuilderConfig> CompilationBuilder<C> {
     /// Parse errors, unresolvable imports, and missing files are collected as
     /// diagnostics on the resulting [`CompilationUnit`] — see
     /// [`CompilationUnit::diagnostics`].
-    pub fn add_file(&mut self, file_id: String) {
+    pub fn add_file(&mut self, file_id: FileId) {
         if !self.seen_files.insert(file_id.clone()) {
             return;
         }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use slang_solidity_v2_common::collections::Map;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
@@ -8,14 +9,13 @@ use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
 use crate::ast;
 
 pub(crate) struct InternalFile {
-    // TODO(v2): abstract this into a `FileId` type
-    id: String,
+    id: FileId,
     ir_root: ir::SourceUnit,
-    resolved_imports: Map<NodeId, String>,
+    resolved_imports: Map<NodeId, FileId>,
 }
 
 impl InternalFile {
-    pub(crate) fn new(id: String, ir_root: ir::SourceUnit) -> Self {
+    pub(crate) fn new(id: FileId, ir_root: ir::SourceUnit) -> Self {
         Self {
             id,
             ir_root,
@@ -23,13 +23,13 @@ impl InternalFile {
         }
     }
 
-    pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
+    pub(crate) fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: FileId) {
         self.resolved_imports.insert(node_id, target_file_id);
     }
 }
 
 impl SemanticFile for InternalFile {
-    fn id(&self) -> &str {
+    fn id(&self) -> &FileId {
         &self.id
     }
 
@@ -37,7 +37,7 @@ impl SemanticFile for InternalFile {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String> {
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&FileId> {
         self.resolved_imports.get(&node_id)
     }
 }
@@ -57,7 +57,7 @@ impl FileStruct {
         })
     }
 
-    pub fn id(&self) -> &str {
+    pub fn id(&self) -> &FileId {
         &self.file.id
     }
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/mod.rs
@@ -4,4 +4,5 @@ mod unit;
 
 pub use builder::{CompilationBuilder, CompilationBuilderConfig};
 pub use file::{File, FileStruct};
+pub use slang_solidity_v2_common::files::FileId;
 pub use unit::CompilationUnit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/unit.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_ast::{abi, ast};
 use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
 
@@ -13,7 +14,7 @@ use super::{File, FileStruct};
 pub struct CompilationUnit {
     language_version: LanguageVersion,
     evm_target: EvmTarget,
-    files: SortedMap<String, Arc<InternalFile>>,
+    files: SortedMap<FileId, Arc<InternalFile>>,
     semantic: Arc<SemanticContext>,
     diagnostics: DiagnosticCollection,
 }
@@ -26,9 +27,9 @@ impl CompilationUnit {
         semantic: SemanticContext,
         diagnostics: DiagnosticCollection,
     ) -> Self {
-        let files: SortedMap<String, Arc<InternalFile>> = files
+        let files: SortedMap<FileId, Arc<InternalFile>> = files
             .into_iter()
-            .map(|file| (file.id().to_string(), Arc::new(file)))
+            .map(|file| (file.id().clone(), Arc::new(file)))
             .collect();
         Self {
             language_version,
@@ -54,18 +55,13 @@ impl CompilationUnit {
         self.evm_target
     }
 
-    /// Returns a list of all file IDs in the compilation unit.
-    pub fn file_ids(&self) -> Vec<String> {
-        self.files.keys().cloned().collect()
-    }
-
-    pub fn files(&self) -> impl Iterator<Item = File> + use<'_> {
+    pub fn files(&self) -> impl Iterator<Item = File> + '_ {
         self.files
             .values()
             .map(|internal_file| FileStruct::create(internal_file, &self.semantic))
     }
 
-    pub fn file(&self, id: &str) -> Option<File> {
+    pub fn file(&self, id: &FileId) -> Option<File> {
         self.files
             .get(id)
             .map(|internal_file| FileStruct::create(internal_file, &self.semantic))

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
@@ -90,7 +90,7 @@ fn test_get_contracts_abi() {
     let contracts = unit.compute_contracts_abi();
     assert_eq!(1, contracts.len());
     assert_eq!("Counter", contracts[0].name());
-    assert_eq!("main.sol", contracts[0].file_id());
+    assert_eq!("main.sol", contracts[0].file_id().to_string());
     assert_eq!(7, contracts[0].entries().len());
 
     let entries = contracts[0].entries();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/assembly_references.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/assembly_references.rs
@@ -38,7 +38,7 @@ impl ast::visitor::Visitor for AssemblyCollector {
 #[test]
 fn test_assembly_referenced_definitions() {
     let unit = AssemblyReferences::build_compilation_unit();
-    let main_ast = unit.file("main.sol").unwrap().ast();
+    let main_ast = unit.file(&"main.sol".into()).unwrap().ast();
 
     let mut collector = AssemblyCollector::default();
     ast::visitor::accept_source_unit(&main_ast, &mut collector);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/built_in_resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/built_in_resolution.rs
@@ -7,7 +7,7 @@ fn test_resolve_to_built_in() {
 
     // Collect all identifiers that resolve to built-ins from the ownable.sol file,
     // which contains `msg.sender` and `require`.
-    let ownable_ast = unit.file("ownable.sol").unwrap().ast();
+    let ownable_ast = unit.file(&"ownable.sol".into()).unwrap().ast();
 
     let mut built_in_collector = BuiltInCollector::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut built_in_collector);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/identifier_path_resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/identifier_path_resolution.rs
@@ -19,7 +19,7 @@ contract B3 {}
 #[test]
 fn test_build_chained_imports_fixture() {
     let unit = ChainedImports::build_compilation_unit();
-    assert_eq!(3, unit.file_ids().len());
+    assert_eq!(3, unit.files().count());
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/json.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/json.rs
@@ -5,7 +5,7 @@ use super::fixtures;
 #[test]
 fn source_unit_serializes_to_json_with_expected_shape() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.file("main.sol").unwrap().ast();
+    let source_unit = unit.file(&"main.sol".into()).unwrap().ast();
 
     let json = serde_json::to_value(&source_unit).expect("serialization succeeds");
 
@@ -37,7 +37,7 @@ fn source_unit_serializes_to_json_with_expected_shape() {
 #[test]
 fn function_definition_field_kind_does_not_collide_with_discriminator() {
     let unit = fixtures::Counter::build_compilation_unit();
-    let source_unit = unit.file("ownable.sol").unwrap().ast();
+    let source_unit = unit.file(&"ownable.sol".into()).unwrap().ast();
 
     let json = serde_json::to_value(&source_unit).unwrap();
     let function =

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/node_location.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/node_location.rs
@@ -9,7 +9,7 @@ fn test_get_file_id_and_text_range() {
         .find_contract_by_name("Ownable")
         .next()
         .expect("contract is found");
-    assert_eq!(ownable.get_file_id(), "ownable.sol");
+    assert_eq!(ownable.get_file_id().to_string(), "ownable.sol");
 
     let owner = ownable
         .members()
@@ -23,7 +23,7 @@ fn test_get_file_id_and_text_range() {
         })
         .expect("_owner state variable is found");
     assert_eq!(owner.name().name(), "_owner");
-    assert_eq!(owner.get_file_id(), "ownable.sol");
+    assert_eq!(owner.get_file_id().to_string(), "ownable.sol");
 
     // The state variable's range must sit within the enclosing contract's range.
     assert!(ownable.get_text_range().start <= owner.get_text_range().start);
@@ -33,11 +33,11 @@ fn test_get_file_id_and_text_range() {
         .find_contract_by_name("Activatable")
         .next()
         .expect("contract is found");
-    assert_eq!(activatable.get_file_id(), "activatable.sol");
+    assert_eq!(activatable.get_file_id().to_string(), "activatable.sol");
 
     let counter = unit
         .find_contract_by_name("Counter")
         .next()
         .expect("contract is found");
-    assert_eq!(counter.get_file_id(), "main.sol");
+    assert_eq!(counter.get_file_id().to_string(), "main.sol");
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/number_literals.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/number_literals.rs
@@ -79,7 +79,7 @@ fn rational(numerator: i64, denominator: u64) -> Number {
 #[test]
 fn test_hex_number_expression_value() {
     let unit = NumberLiterals::build_compilation_unit();
-    let ast = unit.file("main.sol").unwrap().ast();
+    let ast = unit.file(&"main.sol".into()).unwrap().ast();
 
     let mut collector = NumberLiteralCollector::default();
     ast::visitor::accept_source_unit(&ast, &mut collector);
@@ -113,7 +113,7 @@ fn test_hex_number_expression_value() {
 #[test]
 fn test_decimal_number_expression_value() {
     let unit = NumberLiterals::build_compilation_unit();
-    let ast = unit.file("main.sol").unwrap().ast();
+    let ast = unit.file(&"main.sol".into()).unwrap().ast();
 
     let mut collector = NumberLiteralCollector::default();
     ast::visitor::accept_source_unit(&ast, &mut collector);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/visitor.rs
@@ -24,7 +24,7 @@ impl ast::visitor::Visitor for IdentifierCounter {
 fn test_ast_visitor() {
     let unit = fixtures::Counter::build_compilation_unit();
 
-    let main_ast = unit.file("main.sol").unwrap().ast();
+    let main_ast = unit.file(&"main.sol".into()).unwrap().ast();
 
     let mut main_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&main_ast, &mut main_visitor);
@@ -33,7 +33,7 @@ fn test_ast_visitor() {
     assert_eq!(main_visitor.definitions, 9);
     assert_eq!(main_visitor.references, 18);
 
-    let ownable_ast = unit.file("ownable.sol").unwrap().ast();
+    let ownable_ast = unit.file(&"ownable.sol".into()).unwrap().ast();
 
     let mut ownable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&ownable_ast, &mut ownable_visitor);
@@ -42,7 +42,7 @@ fn test_ast_visitor() {
     assert_eq!(ownable_visitor.definitions, 3);
     assert_eq!(ownable_visitor.references, 8);
 
-    let activatable_ast = unit.file("activatable.sol").unwrap().ast();
+    let activatable_ast = unit.file(&"activatable.sol".into()).unwrap().ast();
 
     let mut activatable_visitor = IdentifierCounter::default();
     ast::visitor::accept_source_unit(&activatable_ast, &mut activatable_visitor);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/yul_literals.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/yul_literals.rs
@@ -34,7 +34,7 @@ impl ast::visitor::Visitor for YulLiteralValues {
 #[test]
 fn test_yul_literal_value() {
     let unit = YulLiterals::build_compilation_unit();
-    let main_ast = unit.file("main.sol").unwrap().ast();
+    let main_ast = unit.file(&"main.sol".into()).unwrap().ast();
 
     let mut visitor = YulLiteralValues::default();
     ast::visitor::accept_source_unit(&main_ast, &mut visitor);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 
-use crate::compilation::{CompilationBuilder, CompilationBuilderConfig, CompilationUnit};
+use crate::compilation::{CompilationBuilder, CompilationBuilderConfig, CompilationUnit, FileId};
 use crate::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 use crate::utils::LanguageVersion;
 
@@ -10,9 +10,9 @@ mod counter;
 
 pub(super) use counter::Counter;
 
-pub(super) struct FixtureFile<'a> {
-    pub(crate) id: &'a str,
-    pub(crate) contents: &'a str,
+pub(super) struct FixtureFile {
+    pub(crate) id: FileId,
+    pub(crate) contents: &'static str,
 }
 
 #[macro_export]
@@ -20,7 +20,7 @@ macro_rules! define_fixture {
     // Recursive case: consume one file definition
     (@accum [$($acc:expr),*] ; $name:ident ; file : $k:literal, $v:literal $(, $($rest:tt)*)?) => {
         define_fixture!(
-            @accum [$($acc,)* $crate::tests::fixtures::FixtureFile { id: $k, contents: $v }] ;
+            @accum [$($acc,)* $crate::tests::fixtures::FixtureFile { id: $k.into(), contents: $v }] ;
             $name ;
             $($($rest)*)?);
     };
@@ -30,11 +30,10 @@ macro_rules! define_fixture {
         pub(crate) struct $name;
 
         impl $name {
-            const FILES: &[$crate::tests::fixtures::FixtureFile<'_>] = &[$($acc),*];
-
             pub(crate) fn build_compilation_unit(
             ) -> std::sync::Arc<$crate::compilation::CompilationUnit> {
-                $crate::tests::fixtures::build_compilation_unit_from_fixture(Self::FILES)
+                let files = vec![$($acc),*];
+                $crate::tests::fixtures::build_compilation_unit_from_fixture(&files)
             }
         }
     };
@@ -46,14 +45,14 @@ macro_rules! define_fixture {
 }
 
 struct FixtureBuildConfig<'a> {
-    files: &'a [FixtureFile<'a>],
+    files: &'a [FixtureFile],
 }
 
 impl CompilationBuilderConfig for FixtureBuildConfig<'_> {
-    fn read_file(&mut self, file_id: &str) -> Result<String, MissingFile> {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         self.files
             .iter()
-            .find(|file| file.id == file_id)
+            .find(|file| file.id == *file_id)
             .map(|file| file.contents.to_owned())
             .ok_or_else(|| MissingFile {
                 reason: "Fixture file not found".to_string(),
@@ -62,22 +61,20 @@ impl CompilationBuilderConfig for FixtureBuildConfig<'_> {
 
     fn resolve_import(
         &mut self,
-        _source_file_id: &str,
+        _source_file_id: &FileId,
         import_path: &str,
-    ) -> Result<String, UnresolvedImport> {
-        Ok(import_path.to_owned())
+    ) -> Result<FileId, UnresolvedImport> {
+        Ok(import_path.into())
     }
 }
 
-pub(super) fn build_compilation_unit_from_fixture(
-    files: &[FixtureFile<'_>],
-) -> Arc<CompilationUnit> {
+pub(super) fn build_compilation_unit_from_fixture(files: &[FixtureFile]) -> Arc<CompilationUnit> {
     let version = LanguageVersion::LATEST;
     let target = EvmTarget::LATEST;
     let mut builder = CompilationBuilder::create(version, target, FixtureBuildConfig { files });
 
     for file in files {
-        builder.add_file(file.id.to_owned());
+        builder.add_file(file.id.clone());
     }
 
     let unit = builder.build();
@@ -96,5 +93,5 @@ pub(super) fn build_compilation_unit_from_fixture(
 #[test]
 fn test_build_counter_fixture() {
     let unit = Counter::build_compilation_unit();
-    assert_eq!(3, unit.file_ids().len());
+    assert_eq!(3, unit.files().count());
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -15,7 +15,7 @@ fn parallel_access_via_arc_consistent_with_serial_baseline() {
     let serial_definitions = unit.all_definitions().count();
     let serial_references = unit.all_references().count();
     let serial_contract_abis = unit.compute_contracts_abi().len();
-    let serial_file_ids: Vec<_> = unit.file_ids();
+    let serial_file_ids: Vec<_> = unit.files().map(|f| f.id().clone()).collect();
 
     assert_eq!(serial_definitions, EXPECTED_DEFINITIONS);
     assert_eq!(serial_references, EXPECTED_REFERENCES);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -5,24 +5,24 @@ use crate::ast::Definition;
 fn test_get_file_ast_root() {
     let unit = fixtures::Counter::build_compilation_unit();
 
-    assert_eq!(unit.file_ids().len(), 3);
+    assert_eq!(unit.files().count(), 3);
 
     let main_ast = unit
-        .file("main.sol")
+        .file(&"main.sol".into())
         .expect("main.sol is a file of the compilation unit")
         .ast();
     let ownable_ast = unit
-        .file("ownable.sol")
+        .file(&"ownable.sol".into())
         .expect("ownable.sol is a file in the compilation unit")
         .ast();
     let activatable_ast = unit
-        .file("activatable.sol")
+        .file(&"activatable.sol".into())
         .expect("activatable.sol is a file in the compilation unit")
         .ast();
 
-    assert_eq!(main_ast.file_id(), "main.sol");
-    assert_eq!(ownable_ast.file_id(), "ownable.sol");
-    assert_eq!(activatable_ast.file_id(), "activatable.sol");
+    assert_eq!(main_ast.file_id().to_string(), "main.sol");
+    assert_eq!(ownable_ast.file_id().to_string(), "ownable.sol");
+    assert_eq!(activatable_ast.file_id().to_string(), "activatable.sol");
 
     assert_eq!(main_ast.contracts().len(), 1);
     assert_eq!(ownable_ast.contracts().len(), 1);

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 
 use anyhow::Result;
 use ariadne::{Color, Config, Label, Report, ReportBuilder, ReportKind, Source};
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::collections::SortedMap;
 use solidity_v2_testing_utils::reporting::diagnostic;
@@ -43,13 +44,13 @@ pub(crate) fn binder_report(report_data: &'_ ReportData<'_>) -> Result<String> {
 
     report_unbound_identifiers(&mut report, unbound_identifiers)?;
 
-    for file_id in &compilation.file_ids() {
+    for file in compilation.files() {
         writeln!(report, "{SEPARATOR}")?;
 
-        if let Some(contents) = files.get(file_id) {
+        if let Some(contents) = files.get(file.id()) {
             render_bindings_for_file(
                 &mut report,
-                file_id,
+                file.id(),
                 contents,
                 all_definitions,
                 all_references,
@@ -106,13 +107,13 @@ fn report_unbound_identifiers(
 fn report_diagnostics(
     report: &mut String,
     diagnostics: &DiagnosticCollection,
-    file_contents: &SortedMap<String, String>,
+    file_contents: &SortedMap<FileId, String>,
 ) -> Result<()> {
     writeln!(report, "Parse errors:")?;
     for diagnostic in diagnostics {
         let file_id = diagnostic.file_id();
         let source = file_contents.get(file_id).cloned().unwrap_or_default();
-        let rendered = diagnostic::render(diagnostic, file_id, &source, false);
+        let rendered = diagnostic::render(diagnostic, &file_id.to_string(), &source, false);
         writeln!(report, "{rendered}")?;
     }
     Ok(())
@@ -120,14 +121,16 @@ fn report_diagnostics(
 
 fn render_bindings_for_file(
     report: &mut String,
-    file_id: &str,
+    file_id: &FileId,
     contents: &str,
     all_definitions: &[CollectedDefinition],
     all_references: &[CollectedReference],
     unbound_identifiers: &[CollectedIdentifier],
 ) -> Result<()> {
+    let file_id_str = file_id.to_string();
+    let file_id_str = file_id_str.as_str();
     let mut builder: BuilderType<'_> =
-        Report::build(ReportKind::Custom("Bindings", Color::Unset), file_id, 0)
+        Report::build(ReportKind::Custom("Bindings", Color::Unset), file_id_str, 0)
             .with_config(Config::default().with_color(false));
 
     let new_label = |range: &Range<usize>, message: &str| -> Label<Span<'_>> {
@@ -140,7 +143,7 @@ fn render_bindings_for_file(
             let end = contents[..range.end].chars().count();
             start..end
         };
-        Label::new((file_id, char_range)).with_message(message)
+        Label::new((file_id_str, char_range)).with_message(message)
     };
 
     for definition in all_definitions {
@@ -181,7 +184,7 @@ fn render_bindings_for_file(
     let mut buffer = Vec::<u8>::new();
     builder
         .finish()
-        .write((file_id, Source::from(contents)), &mut buffer)?;
+        .write((file_id_str, Source::from(contents)), &mut buffer)?;
     report.extend(String::from_utf8(buffer));
 
     Ok(())

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 
 use slang_solidity_v2::ast::visitor::{accept_source_unit, Visitor};
 use slang_solidity_v2::ast::{DataLocation, Definition, Identifier, LiteralKind, NodeId, Type};
-use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2::compilation::{CompilationUnit, FileId};
 use slang_solidity_v2_common::collections::{Map, SortedMap};
 
 // Types
 
-type FileSourceMap = SortedMap<String, String>;
+type FileSourceMap = SortedMap<FileId, String>;
 
 pub(crate) struct ReportData<'a> {
     pub(crate) compilation: &'a CompilationUnit,
@@ -31,7 +31,7 @@ pub(crate) struct CollectedIdentifier {
 }
 
 impl CollectedIdentifier {
-    pub(crate) fn file_id(&self) -> &str {
+    pub(crate) fn file_id(&self) -> &FileId {
         self.node.get_file_id()
     }
     pub(crate) fn range(&self) -> &Range<usize> {
@@ -95,7 +95,7 @@ impl<'a> ReportData<'a> {
 // Identifier collector trait, to allow reuse in the two collectors
 
 trait IdentifierCollector {
-    fn file_contents(&self, file_id: &str) -> &str;
+    fn file_contents(&self, file_id: &FileId) -> &str;
 
     fn collect_identifier(&self, node: &Identifier) -> CollectedIdentifier {
         let range = node.get_text_range().clone();
@@ -138,7 +138,7 @@ struct DefinitionCollector<'a> {
 impl<'a> DefinitionCollector<'a> {
     fn collect_from(
         compilation: &CompilationUnit,
-        files: &'a SortedMap<String, String>,
+        files: &'a SortedMap<FileId, String>,
     ) -> Vec<CollectedDefinition> {
         let mut collector = Self {
             files,
@@ -167,7 +167,7 @@ impl Visitor for DefinitionCollector<'_> {
 }
 
 impl IdentifierCollector for DefinitionCollector<'_> {
-    fn file_contents(&self, file_id: &str) -> &str {
+    fn file_contents(&self, file_id: &FileId) -> &str {
         &self.files[file_id]
     }
 }
@@ -175,7 +175,7 @@ impl IdentifierCollector for DefinitionCollector<'_> {
 // Identifiers collection and classification
 
 struct ReferenceCollector<'a> {
-    files: &'a SortedMap<String, String>,
+    files: &'a SortedMap<FileId, String>,
     definitions_by_node_id: &'a Map<NodeId, DefinitionId>,
     all_references: Vec<CollectedReference>,
     unbound_identifiers: Vec<CollectedIdentifier>,
@@ -242,7 +242,7 @@ impl Visitor for ReferenceCollector<'_> {
 }
 
 impl IdentifierCollector for ReferenceCollector<'_> {
-    fn file_contents(&self, file_id: &str) -> &str {
+    fn file_contents(&self, file_id: &FileId) -> &str {
         &self.files[file_id]
     }
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
-use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
+use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig, FileId};
 use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 
@@ -13,11 +13,11 @@ use crate::utils::multi_part_file::split_multi_file;
 use crate::utils::path_resolver;
 
 struct TestConfig {
-    files: SortedMap<String, String>,
+    files: SortedMap<FileId, String>,
 }
 
 impl CompilationBuilderConfig for TestConfig {
-    fn read_file(&mut self, file_id: &str) -> Result<String, MissingFile> {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
             reason: "File not found".to_string(),
         })
@@ -25,9 +25,9 @@ impl CompilationBuilderConfig for TestConfig {
 
     fn resolve_import(
         &mut self,
-        source_file_id: &str,
+        source_file_id: &FileId,
         import_path: &str,
-    ) -> Result<String, UnresolvedImport> {
+    ) -> Result<FileId, UnresolvedImport> {
         path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
             reason: "Unresolved import".to_string(),
         })
@@ -46,10 +46,10 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
 
     let multi_part = split_multi_file(&contents);
 
-    let files: SortedMap<String, String> = multi_part
+    let files: SortedMap<FileId, String> = multi_part
         .parts
         .iter()
-        .map(|part| (part.name.to_string(), part.contents.to_string()))
+        .map(|part| (part.name.into(), part.contents.to_string()))
         .collect();
 
     snapshots::generate_snapshots(&test_dir, &mut fs, "generated", |version, target| {

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/runner.rs
@@ -14,14 +14,15 @@ pub fn run(parser_name: &str, test_name: &str) -> Result<()> {
         .join(test_name);
 
     let input_path = test_dir.join("input.sol");
-    let source_id = input_path.strip_repo_root()?.unwrap_str().to_owned();
+    let source_id = input_path.strip_repo_root()?.unwrap_str();
+    let file_id = source_id.into();
     let source = input_path.read_to_string()?;
 
     let mut fs = CodegenFileSystem::default();
 
     snapshots::generate_snapshots(&test_dir, &mut fs, "generated", |version, target| {
-        let output = V2Parser::parse(&source_id, &source, version);
-        let (ok, contents) = render(&source, &source_id, &output);
+        let output = V2Parser::parse(&file_id, &source, version);
+        let (ok, contents) = render(&source, source_id, &output);
         let status = if ok {
             SnapshotStatus::Success
         } else {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
@@ -5,6 +5,7 @@ use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
 use semver::Version;
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2_common::collections::{SortedMap, SortedSet};
 use slang_solidity_v2_common::versions::LanguageVersion;
 
@@ -25,10 +26,10 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
     let multi_part = split_multi_file(&contents);
 
     // Use a sorted map so file iteration order is deterministic across runs.
-    let files: SortedMap<String, String> = multi_part
+    let files: SortedMap<FileId, String> = multi_part
         .parts
         .iter()
-        .map(|part| (part.name.to_string(), part.contents.to_string()))
+        .map(|part| (part.name.into(), part.contents.to_string()))
         .collect();
 
     let config = TestConfig::resolve(&test_dir)?;

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/mod.rs
@@ -3,6 +3,7 @@ mod solc;
 
 use anyhow::Result;
 pub(crate) use slang::SlangTarget;
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -13,7 +14,7 @@ pub(crate) trait TestTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &SortedMap<String, String>,
+        files: &SortedMap<FileId, String>,
         version: LanguageVersion,
         evm_target: EvmTarget,
     ) -> Result<Vec<String>>;

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
+use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig, FileId};
 use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 use slang_solidity_v2_common::evm_targets::EvmTarget;
@@ -18,7 +18,7 @@ impl TestTarget for SlangTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &SortedMap<String, String>,
+        files: &SortedMap<FileId, String>,
         version: LanguageVersion,
         evm_target: EvmTarget,
     ) -> Result<Vec<String>> {
@@ -38,7 +38,12 @@ impl TestTarget for SlangTarget {
         for diagnostic in diagnostics {
             let file_id = diagnostic.file_id();
             let source = files.get(file_id).cloned().unwrap_or_default();
-            rendered.push(diagnostic::render(diagnostic, file_id, &source, false));
+            rendered.push(diagnostic::render(
+                diagnostic,
+                &file_id.to_string(),
+                &source,
+                false,
+            ));
         }
 
         Ok(rendered)
@@ -46,11 +51,11 @@ impl TestTarget for SlangTarget {
 }
 
 struct TestConfig {
-    files: SortedMap<String, String>,
+    files: SortedMap<FileId, String>,
 }
 
 impl CompilationBuilderConfig for TestConfig {
-    fn read_file(&mut self, file_id: &str) -> Result<String, MissingFile> {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
             reason: "File not found.".to_string(),
         })
@@ -58,9 +63,9 @@ impl CompilationBuilderConfig for TestConfig {
 
     fn resolve_import(
         &mut self,
-        source_file_id: &str,
+        source_file_id: &FileId,
         import_path: &str,
-    ) -> Result<String, UnresolvedImport> {
+    ) -> Result<FileId, UnresolvedImport> {
         path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
             reason: "Unresolved import.".to_string(),
         })

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
@@ -4,6 +4,7 @@ use infra_utils::solc::{
     render_solc_error, Binary, CliInput, CliSettings, InputSource, LanguageSelector,
 };
 use semver::Version;
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -29,7 +30,7 @@ impl TestTarget for SolcTarget {
 
     fn collect_diagnostics(
         &self,
-        files: &SortedMap<String, String>,
+        files: &SortedMap<FileId, String>,
         version: LanguageVersion,
         evm_target: EvmTarget,
     ) -> Result<Vec<String>> {
@@ -39,9 +40,15 @@ impl TestTarget for SolcTarget {
             .get(&semver_version)
             .ok_or_else(|| anyhow!("no solc binary fetched for version {semver_version}"))?;
 
+        // `solc` works with string file names, so convert from `FileId` keys.
+        let sources: SortedMap<String, String> = files
+            .iter()
+            .map(|(file_id, content)| (file_id.to_string(), content.clone()))
+            .collect();
+
         let input = CliInput {
             language: LanguageSelector::Solidity,
-            sources: files
+            sources: sources
                 .iter()
                 .map(|(name, content)| {
                     (
@@ -62,7 +69,7 @@ impl TestTarget for SolcTarget {
 
         let rendered = errors
             .into_iter()
-            .map(|error| render_solc_error(&error, files).unwrap())
+            .map(|error| render_solc_error(&error, &sources).unwrap())
             .collect();
 
         Ok(rendered)

--- a/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
@@ -1,12 +1,14 @@
+use slang_solidity_v2::compilation::FileId;
+
 /// Resolve an import path relative to a source file.
 ///
 /// `import_path` is the unquoted import path as provided by the v2
 /// `CompilationBuilderConfig::resolve_import` callback.
-pub(crate) fn resolve_import(source_file_id: &str, import_path: &str) -> Option<String> {
+pub(crate) fn resolve_import(source_file_id: &FileId, import_path: &str) -> Option<FileId> {
     if is_relative_path(import_path) {
-        normalize_path(import_path, get_parent_path(source_file_id))
+        normalize_path(import_path, get_parent_path(&source_file_id.to_string())).map(FileId::from)
     } else {
-        Some(import_path.to_owned())
+        Some(import_path.into())
     }
 }
 

--- a/crates/solidity-v2/testing/utils/src/v1_comparison/parser/mod.rs
+++ b/crates/solidity-v2/testing/utils/src/v1_comparison/parser/mod.rs
@@ -51,7 +51,7 @@ pub fn compare_with_v1_cursor(
     let ParseOutput {
         source_unit,
         diagnostics,
-    } = V2Parser::parse("v1_comparison", source, lang_version);
+    } = V2Parser::parse(&"v1_comparison".into(), source, lang_version);
 
     if !diagnostics.is_empty() {
         return diagnostics

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ir_builder.rs
@@ -41,7 +41,7 @@ pub fn test(input: Input) -> Output {
         let ir::BuildOutput {
             ir_root,
             diagnostics,
-        } = ir::build(&name, &source, contents, &mut id_generator);
+        } = ir::build(&name.as_str().into(), &source, contents, &mut id_generator);
 
         assert!(
             diagnostics.is_empty(),

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/parser.rs
@@ -18,7 +18,7 @@ pub fn run(project: Input) -> Output {
         let ParseOutput {
             source_unit,
             diagnostics,
-        } = Parser::parse(key, source, lang_version);
+        } = Parser::parse(&key.as_str().into(), source, lang_version);
         assert!(diagnostics.is_empty());
 
         source_units.push((key.clone(), source_unit));

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/semantic.rs
@@ -1,5 +1,6 @@
 use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 use slang_solidity_v2_semantic::binder::{self, Resolution};
@@ -12,19 +13,19 @@ use crate::tests::slang_v2::common::{parse_evm_target, parse_version};
 
 #[derive(Clone)]
 pub struct File {
-    id: String,
+    id: FileId,
     ir_root: ir::SourceUnit,
-    resolved_imports: Map<NodeId, String>,
+    resolved_imports: Map<NodeId, FileId>,
 }
 
 impl File {
-    pub fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: String) {
+    pub fn add_resolved_import(&mut self, node_id: NodeId, target_file_id: FileId) {
         self.resolved_imports.insert(node_id, target_file_id);
     }
 }
 
 impl SemanticFile for File {
-    fn id(&self) -> &str {
+    fn id(&self) -> &FileId {
         &self.id
     }
 
@@ -32,7 +33,7 @@ impl SemanticFile for File {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&String> {
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&FileId> {
         self.resolved_imports.get(&node_id)
     }
 }
@@ -74,11 +75,11 @@ pub fn build_files(
                         .import_resolver
                         .resolve_import(file_id, import_path)
                         .expect("files to be resolved");
-                    (*node_id, resolved_file_id)
+                    (*node_id, resolved_file_id.into())
                 })
                 .collect();
             File {
-                id: file_id.to_owned(),
+                id: file_id.as_str().into(),
                 ir_root,
                 resolved_imports,
             }


### PR DESCRIPTION
Replacing all the `String` copies we have in the `CompilationUnit` and binder with cheap `Arc<str>` reference counters.