### PR TITLE
fix(ir): Distinguish between single index and slices in `IndexAccessExpression`

### DIFF
--- a/crates/codegen-v2/semantic/src/ir/builder.rs
+++ b/crates/codegen-v2/semantic/src/ir/builder.rs
@@ -292,6 +292,7 @@ fn collapse_redundant_node_types(mutator: &mut IrModelMutator) {
     // complicates automatic code generation in the transformer.
     mutator.remove_type("IndexAccessEnd");
     mutator.add_sequence_field("IndexAccessExpression", "end", "Expression", true);
+    mutator.add_sequence_boolean("IndexAccessExpression", "is_slice");
 
     // Collapse the middle node in ArgumentsDeclaration
     mutator.remove_type("PositionalArgumentsDeclaration");

--- a/crates/codegen-v2/semantic/src/ir/mutator.rs
+++ b/crates/codegen-v2/semantic/src/ir/mutator.rs
@@ -728,4 +728,33 @@ impl IrModelMutator {
 
         self.external_types.insert("Boolean".into());
     }
+
+    // Adds a new boolean field to a sequence by using the synthetic `External`
+    // "Boolean" type.
+    pub fn add_sequence_boolean(&mut self, sequence_id: &str, field_label: &str) {
+        let sequence_id: model::Identifier = sequence_id.into();
+        let field_label: model::Identifier = field_label.into();
+
+        let Some(sequence) = self.sequences.get_mut(&sequence_id) else {
+            panic!("Sequence {sequence_id} not found in IR model");
+        };
+        assert!(
+            sequence
+                .fields
+                .iter()
+                .find(|field| field.label == field_label)
+                .is_none(),
+            "The sequence {sequence_id} already has a {field_label} field",
+        );
+        let target_type = NodeType::External("Boolean".into());
+        sequence.fields.push(MutatedField {
+            label: field_label.clone(),
+            source_label: field_label,
+            field_type: target_type.clone(),
+            is_optional: true,
+            target_type,
+        });
+
+        self.external_types.insert("Boolean".into());
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -2017,6 +2017,7 @@ pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::end(&self) -> co
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_file_id(&self) -> &str
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::is_slice(&self) -> bool
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::operand(&self) -> slang_solidity_v2_ast::ast::Expression
 pub fn slang_solidity_v2_ast::ast::IndexAccessExpressionStruct::start(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Expression>

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -1788,6 +1788,10 @@ impl IndexAccessExpressionStruct {
             .map(|ir_node| create_expression(ir_node, &self.semantic))
     }
 
+    pub fn is_slice(&self) -> bool {
+        self.ir_node.is_slice
+    }
+
     pub fn get_type(&self) -> Option<Type> {
         Type::try_create_for_node_id(self.ir_node.id(), &self.semantic)
     }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
@@ -532,7 +532,7 @@ impl Serialize for ImportDeconstructionSymbolStruct {
 
 impl Serialize for IndexAccessExpressionStruct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(7))?;
+        let mut map = serializer.serialize_map(Some(8))?;
         map.serialize_entry("id", &self.node_id())?;
         map.serialize_entry("type", "IndexAccessExpression")?;
         map.serialize_entry("range", &SerializeRange(self.get_text_range()))?;
@@ -540,6 +540,7 @@ impl Serialize for IndexAccessExpressionStruct {
         map.serialize_entry("operand", &self.operand())?;
         map.serialize_entry("start", &self.start())?;
         map.serialize_entry("end", &self.end())?;
+        map.serialize_entry("is_slice", &self.is_slice())?;
         map.end()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -2066,6 +2066,7 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDec
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::end: core::option::Option<slang_solidity_v2_ir::ir::Expression>
+pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::is_slice: bool
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::operand: slang_solidity_v2_ir::ir::Expression
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::start: core::option::Option<slang_solidity_v2_ir::ir::Expression>

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -278,6 +278,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             .start
             .as_ref()
             .map(|start| self.build_expression(start));
+        let is_slice = source.end.is_some();
         let end = source
             .end
             .as_ref()
@@ -289,6 +290,7 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             operand,
             start,
             end,
+            is_slice,
         })
     }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -640,6 +640,7 @@ pub struct IndexAccessExpressionStruct {
     pub operand: Expression,
     pub start: Option<Expression>,
     pub end: Option<Expression>,
+    pub is_slice: bool,
 }
 
 impl IndexAccessExpressionStruct {

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -43,41 +43,36 @@ contract MyContract {
     );
 
     assert_eq!(2, ir_root.members.len());
-    assert!(matches!(
-        ir_root.members[0],
-        ir::SourceUnitMember::PragmaDirective(_)
-    ));
-    assert!(matches!(
-        ir_root.members[1],
-        ir::SourceUnitMember::ContractDefinition(_)
-    ));
+    expect_variant!(&ir_root.members[0], ir::SourceUnitMember::PragmaDirective);
+    expect_variant!(
+        &ir_root.members[1],
+        ir::SourceUnitMember::ContractDefinition
+    );
 
     // MyContract contract
-    let ir::SourceUnitMember::ContractDefinition(ref contract) = ir_root.members[1] else {
-        panic!("Expected ContractDefinition");
-    };
+    let contract = expect_variant!(
+        &ir_root.members[1],
+        ir::SourceUnitMember::ContractDefinition
+    );
     assert_eq!("MyContract", contract.name.unparse());
     assert_eq!(3, contract.members.len());
 
     // MyContract.owner state variable
-    let ir::ContractMember::StateVariableDefinition(ref state_var) = contract.members[0] else {
-        panic!("Expected StateVariableDefinition");
-    };
+    let state_var = expect_variant!(
+        &contract.members[0],
+        ir::ContractMember::StateVariableDefinition
+    );
     assert_eq!("owner", state_var.name.unparse());
 
     // MyContract constructor
-    let ir::ContractMember::FunctionDefinition(ref constructor) = contract.members[1] else {
-        panic!("Expected FunctionDefinition for constructor");
-    };
+    let constructor = expect_variant!(&contract.members[1], ir::ContractMember::FunctionDefinition);
     assert_eq!(constructor.kind, ir::FunctionKind::Constructor);
     assert!(constructor.body.is_some());
     let constructor_body = constructor.body.as_ref().unwrap();
     assert_eq!(1, constructor_body.statements.len());
 
     // MyContract.test() function
-    let ir::ContractMember::FunctionDefinition(ref function) = contract.members[2] else {
-        panic!("Expected FunctionDefinition");
-    };
+    let function = expect_variant!(&contract.members[2], ir::ContractMember::FunctionDefinition);
     assert_eq!(function.kind, ir::FunctionKind::Regular);
     let function_name = function.name.as_ref().expect("function has a name");
     assert_eq!("test", function_name.unparse());
@@ -127,18 +122,20 @@ contract Test is Base layout at 0 {}
 
     assert_eq!(2, ir_root.members.len());
 
-    let ir::SourceUnitMember::ContractDefinition(base_contract) = &ir_root.members[0] else {
-        panic!("Expected ContractDefinition");
-    };
+    let base_contract = expect_variant!(
+        &ir_root.members[0],
+        ir::SourceUnitMember::ContractDefinition
+    );
     assert_eq!("Base", base_contract.name.unparse());
     assert!(base_contract.inheritance_types.is_empty());
     assert!(base_contract.storage_layout.is_none());
     assert!(base_contract.id() < sentinel_node_id);
     assert!(base_contract.name.id() < sentinel_node_id);
 
-    let ir::SourceUnitMember::ContractDefinition(test_contract) = &ir_root.members[1] else {
-        panic!("Expected ContractDefinition");
-    };
+    let test_contract = expect_variant!(
+        &ir_root.members[1],
+        ir::SourceUnitMember::ContractDefinition
+    );
     assert_eq!("Test", test_contract.name.unparse());
     assert_eq!(1, test_contract.inheritance_types.len());
     assert_eq!(
@@ -188,18 +185,18 @@ contract Test {
         "IR builder diagnostics: {diagnostics:?}"
     );
 
-    let ir::SourceUnitMember::ContractDefinition(ref contract) = ir_root.members[0] else {
-        panic!("Expected ContractDefinition");
-    };
-
-    let ir::ContractMember::FunctionDefinition(ref function) = contract.members[0] else {
-        panic!("Expected FunctionDefinition");
-    };
+    let contract = expect_variant!(
+        &ir_root.members[0],
+        ir::SourceUnitMember::ContractDefinition
+    );
+    let function = expect_variant!(&contract.members[0], ir::ContractMember::FunctionDefinition);
     let body = function.body.as_ref().expect("function has a body");
     assert_eq!(2, body.statements.len());
 
     // `a[1]` is a plain index access, not a slice.
-    let index_access = expect_index_access(&body.statements[0]);
+    let statement = expect_variant!(&body.statements[0], ir::Statement::ExpressionStatement);
+    let index_access =
+        expect_variant!(&statement.expression, ir::Expression::IndexAccessExpression);
     assert!(
         !index_access.is_slice,
         "`a[1]` should not be a slice expression"
@@ -208,22 +205,13 @@ contract Test {
     assert!(index_access.end.is_none());
 
     // `a[1:]` is a slice expression.
-    let slice_access = expect_index_access(&body.statements[1]);
+    let statement = expect_variant!(&body.statements[1], ir::Statement::ExpressionStatement);
+    let slice_access =
+        expect_variant!(&statement.expression, ir::Expression::IndexAccessExpression);
     assert!(
         slice_access.is_slice,
         "`a[1:]` should be a slice expression"
     );
     assert!(slice_access.start.is_some());
     assert!(slice_access.end.is_none());
-}
-
-fn expect_index_access(statement: &ir::Statement) -> &ir::IndexAccessExpression {
-    let ir::Statement::ExpressionStatement(ref expression_statement) = statement else {
-        panic!("Expected ExpressionStatement");
-    };
-    let ir::Expression::IndexAccessExpression(ref index_access) = expression_statement.expression
-    else {
-        panic!("Expected IndexAccessExpression");
-    };
-    index_access
 }

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/builder.rs
@@ -154,3 +154,76 @@ contract Test is Base layout at 0 {}
     assert!(test_contract.id() < sentinel_node_id);
     assert!(test_contract.name.id() < sentinel_node_id);
 }
+
+#[test]
+fn test_build_ir_distinguishes_index_access_and_slice() {
+    const CONTENTS: &str = r###"
+contract Test {
+    function test(bytes calldata a) public pure {
+        a[1];
+        a[1:];
+    }
+}
+    "###;
+
+    let ParseOutput {
+        source_unit,
+        diagnostics,
+    } = Parser::parse("test.sol", CONTENTS, LanguageVersion::LATEST);
+
+    assert!(
+        diagnostics.is_empty(),
+        "Parser diagnostics: {diagnostics:?}"
+    );
+
+    let mut id_generator = ir::NodeIdGenerator::default();
+
+    let ir::BuildOutput {
+        ir_root,
+        diagnostics,
+    } = ir::build("test.sol", &source_unit, &CONTENTS, &mut id_generator);
+
+    assert!(
+        diagnostics.is_empty(),
+        "IR builder diagnostics: {diagnostics:?}"
+    );
+
+    let ir::SourceUnitMember::ContractDefinition(ref contract) = ir_root.members[0] else {
+        panic!("Expected ContractDefinition");
+    };
+
+    let ir::ContractMember::FunctionDefinition(ref function) = contract.members[0] else {
+        panic!("Expected FunctionDefinition");
+    };
+    let body = function.body.as_ref().expect("function has a body");
+    assert_eq!(2, body.statements.len());
+
+    // `a[1]` is a plain index access, not a slice.
+    let index_access = expect_index_access(&body.statements[0]);
+    assert!(
+        !index_access.is_slice,
+        "`a[1]` should not be a slice expression"
+    );
+    assert!(index_access.start.is_some());
+    assert!(index_access.end.is_none());
+
+    // `a[1:]` is a slice expression.
+    let slice_access = expect_index_access(&body.statements[1]);
+    assert!(
+        slice_access.is_slice,
+        "`a[1:]` should be a slice expression"
+    );
+    assert!(slice_access.start.is_some());
+    assert!(slice_access.end.is_none());
+}
+
+fn expect_index_access(statement: &ir::Statement) -> &ir::IndexAccessExpression {
+    let ir::Statement::ExpressionStatement(ref expression_statement) = statement else {
+        panic!("Expected ExpressionStatement");
+    };
+    let ir::Expression::IndexAccessExpression(ref index_access) = expression_statement.expression
+    else {
+        panic!("Expected IndexAccessExpression");
+    };
+    index_access
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/tests/mod.rs
@@ -1,3 +1,20 @@
+/// Extracts the payload of an enum variant, panicking with a descriptive
+/// message if the value matches a different variant.
+///
+/// Works on owned values and references alike (via match ergonomics), so
+/// `expect_variant!(&foo, my::Enum::Variant)` yields a reference to the payload.
+macro_rules! expect_variant {
+    ($value:expr, $variant:path) => {
+        match $value {
+            $variant(inner) => inner,
+            other => panic!(
+                concat!("expected ", stringify!($variant), ", got {:?}"),
+                other
+            ),
+        }
+    };
+}
+
 mod builder;
 mod text_range;
 mod visitor;


### PR DESCRIPTION
As reported by @hedgar2017, the IR was not able to distinguish between `a[1]` and `a[1:]`. This PR adds a boolean `is_slice` to the `IndexAccessExpression` type.
