### PR TITLE
fix(semantic): Follow aliases in `using` attached functions and modifier invocations

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -567,11 +567,22 @@ impl Binder {
     // definitions can occur along the followed aliases, so there is no
     // guarantee that a `Resolved` resolution will yield another `Resolved`
     // resolution.
-    pub(crate) fn follow_symbol_aliases(&self, resolution: &Resolution) -> Resolution {
-        match resolution {
-            Resolution::Unresolved | Resolution::BuiltIn(_) => return resolution.clone(),
-            _ => {}
-        }
+    pub(crate) fn follow_symbol_aliases(&self, resolution: Resolution) -> Resolution {
+        let is_imported_symbol = |id| {
+            matches!(
+                self.find_definition_by_id(id),
+                Some(Definition::ImportedSymbol(_))
+            )
+        };
+        let mut working_set = match resolution {
+            Resolution::Definition(id) if is_imported_symbol(id) => vec![id],
+            Resolution::Ambiguous(ids) if ids.iter().copied().any(is_imported_symbol) => ids,
+            _ => {
+                // Short-circuit if there are no aliases to follow and avoid
+                // unnecessary allocations
+                return resolution;
+            }
+        };
 
         // TODO: since this function uses the results from other resolution
         // functions, we making more allocations than necessary; it may be worth
@@ -579,7 +590,6 @@ impl Binder {
         // resolution functions
         let mut found_ids = Vec::new();
         let mut seen_ids = Set::default();
-        let mut working_set = resolution.get_definition_ids();
 
         while let Some(definition_id) = working_set.pop() {
             if !seen_ids.insert(definition_id) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -13,9 +13,7 @@ mod scopes;
 
 pub(crate) use assembly::AssemblyBlock;
 pub use definitions::Definition;
-pub(crate) use definitions::{
-    ConstantDefinition, ContractDefinition, ImportDefinition, InterfaceDefinition,
-};
+pub(crate) use definitions::{ConstantDefinition, ContractDefinition, InterfaceDefinition};
 pub use references::{Reference, Resolution};
 use scopes::ContractScope;
 pub(crate) use scopes::{FileScope, ParameterDefinition, ParametersScope, Scope, UsingDirective};
@@ -631,6 +629,10 @@ impl Binder {
                 ResolveOptions::Qualified,
             ),
             Scope::Enum(enum_scope) => enum_scope.definitions.get(symbol).into(),
+            Scope::File(file_scope) => {
+                // We can get here by a file named file import
+                self.resolve_in_file_scope(&file_scope.file_id, symbol)
+            }
             Scope::Struct(struct_scope) => struct_scope.definitions.get(symbol).into(),
             Scope::Using(using_scope) => using_scope
                 .symbols
@@ -643,7 +645,6 @@ impl Binder {
 
             Scope::Block(_)
             | Scope::Chained(_)
-            | Scope::File(_)
             | Scope::Function(_)
             | Scope::Modifier(_)
             | Scope::YulBlock(_)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -182,7 +182,7 @@ impl SemanticContext {
             .binder()
             .find_reference_by_identifier_node_id(node_id)?;
         self.binder()
-            .follow_symbol_aliases(&reference.resolution)
+            .follow_symbol_aliases(reference.resolution.clone())
             .as_definition_id()
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
@@ -13,4 +13,7 @@ mod resolution;
 pub(crate) use node_extensions::{
     node_id_for_expression_typing, node_id_for_string_expression_typing,
 };
-pub(crate) use resolution::{filter_overriden_definitions, resolve_identifier_path_in_scope};
+pub(crate) use resolution::{
+    filter_overriden_definitions, find_definition_namespace_scope_id,
+    resolve_identifier_path_in_scope,
+};

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
+use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
-use crate::binder::{Binder, Definition, ImportDefinition, Reference, Resolution, ScopeId, Typing};
+use crate::binder::{Binder, Definition, Reference, Resolution, ScopeId, Typing};
 use crate::types::{FunctionType, Type, TypeRegistry};
 
 /// Resolves an `IdentifierPath` starting from the given scope, creating
@@ -15,13 +16,13 @@ pub(crate) fn resolve_identifier_path_in_scope(
     starting_scope_id: ScopeId,
 ) -> Resolution {
     let mut scope_id = Some(starting_scope_id);
-    let mut use_lexical_resolution = true;
-    let mut last_resolution: Resolution = Resolution::Unresolved;
+    let mut resolution = Resolution::Unresolved;
 
-    for identifier in identifier_path {
+    for (index, identifier) in identifier_path.iter().enumerate() {
         let symbol = identifier.unparse();
-        let resolution = if let Some(scope_id) = scope_id {
-            if use_lexical_resolution {
+        resolution = if let Some(scope_id) = scope_id {
+            if index == 0 {
+                // we use lexical resolution only in the first segment of the identifier path
                 binder.resolve_in_scope(scope_id, symbol)
             } else {
                 binder.resolve_in_scope_as_namespace(scope_id, symbol)
@@ -33,39 +34,15 @@ pub(crate) fn resolve_identifier_path_in_scope(
         let reference = Reference::new(Arc::clone(identifier), resolution.clone());
         binder.insert_reference(reference);
 
-        // Unless we used namespace resolution and in order to continue
-        // resolving the identifier path, we should ensure we've followed
-        // through any symbol alias (ie. import deconstruction symbol). This
-        // is not needed for namespaced resolution because there cannot be
-        // import directives inside contracts, interfaces or libraries which
-        // changes the lookup mode (see below).
-        let resolution = if use_lexical_resolution {
-            binder.follow_symbol_aliases(&resolution)
-        } else {
-            resolution
-        };
+        resolution = binder.follow_symbol_aliases(&resolution);
 
-        // recurse into file scopes pointed by the resolved definition
-        // to resolve the next identifier in the path
+        // Change the resolution scope to be that of the last resolved
+        // definition, so we can resolve the next identifier in the path.
         scope_id = resolution
             .as_definition_id()
-            .and_then(|node_id| binder.find_definition_by_id(node_id))
-            .and_then(|definition| match definition {
-                Definition::Import(ImportDefinition {
-                    resolved_file_id, ..
-                }) => resolved_file_id
-                    .as_ref()
-                    .and_then(|resolved_file_id| binder.scope_id_for_file_id(resolved_file_id)),
-                Definition::Contract(_) | Definition::Interface(_) | Definition::Library(_) => {
-                    use_lexical_resolution = false;
-                    binder.scope_id_for_node_id(definition.node_id())
-                }
-                _ => None,
-            });
-
-        last_resolution = resolution;
+            .and_then(|definition_id| find_definition_namespace_scope_id(binder, definition_id));
     }
-    last_resolution
+    resolution
 }
 
 /// When a symbol resolves to an ambiguous set of Solidity functions
@@ -115,4 +92,28 @@ pub(crate) fn filter_overriden_definitions(
         filtered_definitions.push(definition_id);
     }
     Resolution::from(filtered_definitions)
+}
+
+/// Given a `Definition`'s `NodeId`, find the scope where we should resolve
+/// symbols if the definition acts as a namespace. This is typically used when
+/// resolving `MemberAccessExpression`s with a `UserMetatype` operand. Returns
+/// `None` if the definition cannot be used as a namespace.
+pub(crate) fn find_definition_namespace_scope_id(
+    binder: &Binder,
+    node_id: NodeId,
+) -> Option<ScopeId> {
+    match binder.find_definition_by_id(node_id)? {
+        Definition::Import(import_definition) => import_definition
+            .resolved_file_id
+            .as_ref()
+            .and_then(|file_id| binder.scope_id_for_file_id(file_id)),
+        Definition::Contract(_)
+        | Definition::Enum(_)
+        | Definition::Interface(_)
+        | Definition::Library(_) => {
+            // this is a "namespace" lookup
+            binder.scope_id_for_node_id(node_id)
+        }
+        _ => None,
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
@@ -34,7 +34,7 @@ pub(crate) fn resolve_identifier_path_in_scope(
         let reference = Reference::new(Arc::clone(identifier), resolution.clone());
         binder.insert_reference(reference);
 
-        resolution = binder.follow_symbol_aliases(&resolution);
+        resolution = binder.follow_symbol_aliases(resolution);
 
         // Change the resolution scope to be that of the last resolved
         // definition, so we can resolve the next identifier in the path.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -160,7 +160,7 @@ impl Pass<'_> {
                 // reference may resolve to an imported library, so we need to
                 // follow aliases
                 self.binder
-                    .follow_symbol_aliases(&reference.resolution)
+                    .follow_symbol_aliases(reference.resolution.clone())
                     .as_definition_id()
             })?;
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -26,7 +26,7 @@ impl Pass<'_> {
                 // if the path has a single element, as in other cases symbols
                 // cannot be aliased.
                 self.binder
-                    .follow_symbol_aliases(&reference.resolution)
+                    .follow_symbol_aliases(reference.resolution.clone())
                     .as_definition_id()
             })
             .and_then(|node_id| self.type_of_definition(node_id, data_location))

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -9,6 +9,7 @@ use crate::binder::{
     Definition, Reference, Resolution, ResolveOptions, ScopeId, Typing, UsingDirective,
 };
 use crate::built_ins::BuiltInsResolver;
+use crate::passes::common::find_definition_namespace_scope_id;
 use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId};
 
 /// Lexical style resolution of symbols
@@ -155,31 +156,10 @@ impl Pass<'_> {
                 let Some(definition) = self.binder.find_definition_by_id(*node_id) else {
                     return Resolution::Unresolved;
                 };
-                match definition {
-                    Definition::Import(import_definition) => {
-                        if let Some(scope_id) = import_definition
-                            .resolved_file_id
-                            .as_ref()
-                            .and_then(|file_id| self.binder.scope_id_for_file_id(file_id))
-                        {
-                            self.binder.resolve_in_scope(scope_id, symbol)
-                        } else {
-                            Resolution::Unresolved
-                        }
-                    }
-                    Definition::Contract(_)
-                    | Definition::Enum(_)
-                    | Definition::Interface(_)
-                    | Definition::Library(_) => {
-                        // this is a "namespace" lookup
-                        if let Some(scope_id) = self.binder.scope_id_for_node_id(*node_id) {
-                            self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
-                        } else {
-                            Resolution::Unresolved
-                        }
-                    }
-                    _ => BuiltInsResolver::lookup_member_of_user_definition(definition, symbol)
-                        .into(),
+                if let Some(scope_id) = find_definition_namespace_scope_id(self.binder, *node_id) {
+                    self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
+                } else {
+                    BuiltInsResolver::lookup_member_of_user_definition(definition, symbol).into()
                 }
             }
             Typing::BuiltIn(built_in) => self
@@ -236,9 +216,10 @@ impl Pass<'_> {
         let mut seen_ids = Set::default();
         for directive in active_directives {
             let scope_id = directive.get_scope_id();
+            let resolution = self.binder.resolve_in_scope_as_namespace(scope_id, symbol);
             let ids = self
                 .binder
-                .resolve_in_scope_as_namespace(scope_id, symbol)
+                .follow_symbol_aliases(&resolution)
                 .get_definition_ids();
             for id in &ids {
                 // Avoid returning duplicate definition IDs. That may happen
@@ -313,12 +294,11 @@ impl Pass<'_> {
     ) {
         let identifier_path = &modifier_invocation.name;
         let mut scope_id = self.current_contract_scope_id();
-        let mut use_contract_lookup = true;
         for (index, identifier) in identifier_path.iter().enumerate() {
             let resolution = if let Some(scope_id) = scope_id {
                 let symbol = identifier.unparse();
-                if use_contract_lookup {
-                    use_contract_lookup = false;
+                if index == 0 {
+                    // we use lexical/contract resolution only for the first segment in the path
                     self.resolve_symbol_in_scope(scope_id, symbol)
                 } else {
                     self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
@@ -340,15 +320,17 @@ impl Pass<'_> {
                 resolution
             };
 
+            let reference = Reference::new(Arc::clone(identifier), resolution.clone());
+            self.binder.insert_reference(reference);
+
             // NOTE: we need to follow symbol aliases to resolve the next scope to use
             scope_id = self
                 .binder
                 .follow_symbol_aliases(&resolution)
                 .as_definition_id()
-                .and_then(|definition_id| self.binder.scope_id_for_node_id(definition_id));
-
-            let reference = Reference::new(Arc::clone(identifier), resolution);
-            self.binder.insert_reference(reference);
+                .and_then(|definition_id| {
+                    find_definition_namespace_scope_id(self.binder, definition_id)
+                });
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -219,7 +219,7 @@ impl Pass<'_> {
             let resolution = self.binder.resolve_in_scope_as_namespace(scope_id, symbol);
             let ids = self
                 .binder
-                .follow_symbol_aliases(&resolution)
+                .follow_symbol_aliases(resolution)
                 .get_definition_ids();
             for id in &ids {
                 // Avoid returning duplicate definition IDs. That may happen
@@ -326,7 +326,7 @@ impl Pass<'_> {
             // NOTE: we need to follow symbol aliases to resolve the next scope to use
             scope_id = self
                 .binder
-                .follow_symbol_aliases(&resolution)
+                .follow_symbol_aliases(resolution)
                 .as_definition_id()
                 .and_then(|definition_id| {
                     find_definition_namespace_scope_id(self.binder, definition_id)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -111,7 +111,7 @@ impl Visitor for Pass<'_> {
             // Set the typing for the `Identifier` node.
             // The resolution may point to an imported symbol, so we need to
             // follow through in order to get to the actual typing.
-            let followed_resolution = self.binder.follow_symbol_aliases(&resolution);
+            let followed_resolution = self.binder.follow_symbol_aliases(resolution.clone());
             let typing = self.typing_of_resolution(&followed_resolution);
             self.binder.set_node_typing(identifier.id(), typing);
 
@@ -575,7 +575,7 @@ impl Visitor for Pass<'_> {
                     // Follow symbol aliases as the error type argument to
                     // revert could be an imported symbol
                     self.binder
-                        .follow_symbol_aliases(&reference.resolution)
+                        .follow_symbol_aliases(reference.resolution.clone())
                         .as_definition_id()
                 });
             self.resolve_named_arguments(named_arguments, definition_id);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/constant_cycles/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/constant_cycles/mod.rs
@@ -202,7 +202,10 @@ impl Visitor for DependencyCollector<'_> {
         if let Some(definition_id) = self
             .binder
             .find_reference_by_identifier_node_id(node.id())
-            .map(|reference| self.binder.follow_symbol_aliases(&reference.resolution))
+            .map(|reference| {
+                self.binder
+                    .follow_symbol_aliases(reference.resolution.clone())
+            })
             .and_then(|resolution| resolution.as_definition_id())
             .filter(|&id| {
                 matches!(

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -928,6 +928,11 @@ mod modifiers {
     use super::*;
 
     #[test]
+    fn base_constructor_via_import_alias() -> Result<()> {
+        run("modifiers", "base_constructor_via_import_alias")
+    }
+
+    #[test]
     fn diamond() -> Result<()> {
         run("modifiers", "diamond")
     }
@@ -1081,6 +1086,11 @@ mod using {
     #[test]
     fn address() -> Result<()> {
         run("using", "address")
+    }
+
+    #[test]
+    fn aliased_attached_function() -> Result<()> {
+        run("using", "aliased_attached_function")
     }
 
     #[test]

--- a/crates/solidity-v2/testing/snapshots/binder_output/modifiers/base_constructor_via_import_alias/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/modifiers/base_constructor_via_import_alias/generated/0.8.0-success.txt
@@ -1,0 +1,55 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (4):
+- Def: #1 ["Base" @ base.sol:1:10] (contract)
+- Def: #2 ["x" @ base.sol:2:25] (parameter, type: uint256)
+- Def: #3 ["M" @ main.sol:1:22] (import)
+- Def: #4 ["Derived" @ main.sol:3:10] (contract)
+
+------------------------------------------------------------------------
+
+References (4):
+- Ref: ["M" @ main.sol:3:21] -> #3
+- Ref: ["Base" @ main.sol:3:23] -> #1
+- Ref: ["M" @ main.sol:4:19] -> #3
+- Ref: ["Base" @ main.sol:4:21] -> #1
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[base.sol:1:1]
+   │
+ 1 │ contract Base {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     constructor(uint256 x) {}
+   │                         ┬  
+   │                         ╰── name: 2
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import "base.sol" as M;
+   │                      ┬  
+   │                      ╰── name: 3
+   │ 
+ 3 │ contract Derived is M.Base {
+   │          ───┬───    ┬ ──┬─  
+   │             ╰─────────────── name: 4
+   │                     │   │   
+   │                     ╰─────── ref: 3
+   │                         │   
+   │                         ╰─── ref: 1
+ 4 │     constructor() M.Base(1) {}
+   │                   ┬ ──┬─  
+   │                   ╰─────── ref: 3
+   │                       │   
+   │                       ╰─── ref: 1
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/modifiers/base_constructor_via_import_alias/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/modifiers/base_constructor_via_import_alias/input.sol
@@ -1,0 +1,11 @@
+// ---- path: base.sol
+contract Base {
+    constructor(uint256 x) {}
+}
+
+// ---- path: main.sol
+import "base.sol" as M;
+
+contract Derived is M.Base {
+    constructor() M.Base(1) {}
+}

--- a/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/generated/0.8.0-failure.txt
@@ -1,0 +1,74 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+Error: This syntax was introduced in version '0.8.13'.
+   ╭─[main.sol:3:1]
+   │
+ 3 │ using {f} for uint;
+   │ ─────────┬─────────  
+   │          ╰─────────── Error occurred here.
+───╯
+
+------------------------------------------------------------------------
+
+Definitions (6):
+- Def: #1 ["f" @ main.sol:1:14] (imported symbol)
+- Def: #2 ["Test" @ main.sol:5:10] (contract)
+- Def: #3 ["test" @ main.sol:6:14] (function, type: function (uint256) returns void)
+- Def: #4 ["a" @ main.sol:6:24] (parameter, type: uint256)
+- Def: #5 ["g" @ other.sol:1:10] (function, type: function (uint256) returns void)
+- Def: #6 ["a" @ other.sol:1:17] (parameter, type: uint256)
+
+------------------------------------------------------------------------
+
+References (4):
+- Ref: ["g" @ main.sol:1:9] -> #5
+- Ref: ["f" @ main.sol:3:8] -> #1
+- Ref: ["a" @ main.sol:7:9] -> #4
+- Ref: ["f" @ main.sol:7:11] -> #5
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {g as f} from "other.sol";
+   │         ┬    ┬  
+   │         ╰─────── ref: 5
+   │              │  
+   │              ╰── name: 1
+   │ 
+ 3 │ using {f} for uint;
+   │        ┬  
+   │        ╰── ref: 1
+   │ 
+ 5 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 2
+ 6 │     function test(uint a) public {
+   │              ──┬─      ┬  
+   │                ╰────────── name: 3
+   │                        │  
+   │                        ╰── name: 4
+ 7 │         a.f();
+   │         ┬ ┬  
+   │         ╰──── ref: 4
+   │           │  
+   │           ╰── ref: 5
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function g(uint a) {}
+   │          ┬      ┬  
+   │          ╰───────── name: 5
+   │                 │  
+   │                 ╰── name: 6
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/generated/0.8.13-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/generated/0.8.13-success.txt
@@ -1,0 +1,63 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (6):
+- Def: #1 ["f" @ main.sol:1:14] (imported symbol)
+- Def: #2 ["Test" @ main.sol:5:10] (contract)
+- Def: #3 ["test" @ main.sol:6:14] (function, type: function (uint256) returns void)
+- Def: #4 ["a" @ main.sol:6:24] (parameter, type: uint256)
+- Def: #5 ["g" @ other.sol:1:10] (function, type: function (uint256) returns void)
+- Def: #6 ["a" @ other.sol:1:17] (parameter, type: uint256)
+
+------------------------------------------------------------------------
+
+References (4):
+- Ref: ["g" @ main.sol:1:9] -> #5
+- Ref: ["f" @ main.sol:3:8] -> #1
+- Ref: ["a" @ main.sol:7:9] -> #4
+- Ref: ["f" @ main.sol:7:11] -> #5
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import {g as f} from "other.sol";
+   │         ┬    ┬  
+   │         ╰─────── ref: 5
+   │              │  
+   │              ╰── name: 1
+   │ 
+ 3 │ using {f} for uint;
+   │        ┬  
+   │        ╰── ref: 1
+   │ 
+ 5 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 2
+ 6 │     function test(uint a) public {
+   │              ──┬─      ┬  
+   │                ╰────────── name: 3
+   │                        │  
+   │                        ╰── name: 4
+ 7 │         a.f();
+   │         ┬ ┬  
+   │         ╰──── ref: 4
+   │           │  
+   │           ╰── ref: 5
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[other.sol:1:1]
+   │
+ 1 │ function g(uint a) {}
+   │          ┬      ┬  
+   │          ╰───────── name: 5
+   │                 │  
+   │                 ╰── name: 6
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/using/aliased_attached_function/input.sol
@@ -1,0 +1,13 @@
+// ---- path: main.sol
+import {g as f} from "other.sol";
+
+using {f} for uint;
+
+contract Test {
+    function test(uint a) public {
+        a.f();
+    }
+}
+
+// ---- path: other.sol
+function g(uint a) {}


### PR DESCRIPTION
This was raised by @hedgar2017 and the changes are based on his commit [here](https://github.com/NomicFoundation/slang/commit/c45311fe664ef2e52fdd0a61e01e5512d5775350).

I noticed that identifier path resolution and modifier invocation resolution are very similar, although not quite the same, so they remain separate for now. It's also a similar mechanism as the resolution of `MemberAccessExpression`, except in that case it's done via typing, and it's not an explicit loop because the IR tree structure is different. In any case, there's some common logic extracted (eg. `find_definition_namespace_scope_id`).

I also took the opportunity to optimize `follow_symbol_aliases` and short-circuit it for the common case where there are no aliases to follow. According the Claude's analysis, this improves instruction count for semantic by 4-9% (btw, this is a separate optimization from #1880).
