### PR TITLE
fix(benchmark): Improve DHAT usage

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
     "contentful",
     "cooldown",
     "devcontainer",
+    "dhat",
     "doxygen",
     "ebnf",
     "finalizer",

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -65,12 +65,12 @@ jobs:
           sfw-optional: "true"
 
       - name: "Smoke Test > infra perf cargo --smoke comparison"
-        if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
+        if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') && !contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         run: "./scripts/bin/infra perf cargo --smoke comparison"
 
       - name: "Benchmark > infra perf cargo comparison"
-        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
-        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} comparison"
+        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
+        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:perf:full') && '--pr-benchmark=full' || '--pr-benchmark') || (inputs.dryRun == true && '--dry-run' || '') }} comparison"
         env:
           SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Benchmark > Upload Benchmarking Data"
-        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
+        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
         with:
           name: "benchmarking-data"

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -65,12 +65,12 @@ jobs:
           sfw-optional: "true"
 
       - name: "Smoke Test > infra perf cargo --smoke slang"
-        if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
+        if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci:perf') && !contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         run: "./scripts/bin/infra perf cargo --smoke slang"
 
       - name: "Benchmark > infra perf cargo slang"
-        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
-        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} slang"
+        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
+        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:perf:full') && '--pr-benchmark=full' || '--pr-benchmark') || (inputs.dryRun == true && '--dry-run' || '') }} slang"
         env:
           SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Benchmark > Upload Benchmarking Data"
-        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
+        if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
         with:
           name: "benchmarking-data"

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -68,7 +68,7 @@ jobs:
         run: "./scripts/bin/infra perf cargo --smoke slang-v2"
 
       - name: "Benchmark > infra perf cargo slang-v2"
-        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }} slang-v2"
+        run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark=full' || (inputs.dryRun == true && '--dry-run' || '') }} slang-v2"
         env:
           SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
           BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -113,8 +113,8 @@ impl CargoController {
     fn run_iai_bench(&self, package_name: &str, bench_name: &str, bencher_project: &str) {
         let test_runner = format!("cargo bench --package {package_name} --bench {bench_name}");
 
-        // iai-callgrind uses deterministic hardware counters (not wall clock),
-        // so any change reflects a real code change, not noise.
+        // iai-callgrind's metrics come from valgrind's simulation, so they're deterministic: any change reflects a
+        // real code change, not noise.
         // We also keep the window small (only 1 measurement), for the same reason.
         let threshold = |measure, upper_boundary| {
             BencherThreshold::new(measure, upper_boundary).with_max_sample_size("1")
@@ -142,16 +142,25 @@ impl CargoController {
                 threshold("total-read-write", "0.01"),
                 threshold("total-bytes", "0.01"),
                 threshold("total-blocks", "0.01"),
-                threshold("at-t-gmax-bytes", "0.01"),
-                threshold("at-t-gmax-blocks", "0.01"),
                 threshold("at-t-end-bytes", "0.01"),
                 threshold("at-t-end-blocks", "0.01"),
-                threshold("reads-bytes", "0.01"),
-                threshold("writes-bytes", "0.01"),
-                // l1-hits, l2-hits, and ram-hits instead use 100%, since there's not a simple
-                // rule that could catch all cases  (ie more l1-hits is better if total bytes read remains the same,
-                // but less l1-hits is  also better if it decreases total bytes read).
-                // We still track them, but only alert on drastic (2x) regressions.
+                // The following metrics are alerted at 100% rather than 1%,
+                // we still track them, but only alert on drastic (2x) regressions.
+                //
+                // These metrics are not particularly meaningful to us:
+                //  - `t-gmax` is a whole-process instant; if the global heap peak happens outside our
+                //    benchmarking function (e.g. during `setup`), none of our blocks are alive then and
+                //    the filtered value is 0.
+                //  - `reads-bytes` and `writes-bytes` are attributed by allocation site, not access site,
+                //    so they miss reads/writes to memory allocated outside the benchmark and include those
+                //    done in `setup`/`teardown` to memory the benchmark allocated.
+                threshold("at-t-gmax-bytes", "1"),
+                threshold("at-t-gmax-blocks", "1"),
+                threshold("reads-bytes", "1"),
+                threshold("writes-bytes", "1"),
+                // l1-hits, l2-hits, and ram-hits have no simple
+                // rule that could catch all cases (ie more l1-hits is better if total bytes read remains the same,
+                // but less l1-hits is also better if it decreases total bytes read).
                 threshold("l1-hits", "1"),
                 threshold("l2-hits", "1"),
                 threshold("ram-hits", "1"),

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -23,14 +23,14 @@ pub struct CargoController {
     dry_run: DryRun,
     /// Run as a PR benchmark with regression detection via bencher start points.
     ///
-    /// Defaults to "standard" mode (DHAT skipped, Callgrind only). Pass
+    /// Defaults to "fast" mode (DHAT skipped, Callgrind only). Pass
     /// "--pr-benchmark=full" to also run DHAT.
     #[arg(
         long,
         value_name = "MODE",
         num_args = 0..=1,
         require_equals = true,
-        default_missing_value = "standard",
+        default_missing_value = "fast",
         conflicts_with = "dry_run"
     )]
     pr_benchmark: Option<PrBenchmarkMode>,
@@ -58,7 +58,7 @@ enum Benches {
 enum PrBenchmarkMode {
     /// Skip DHAT (run Callgrind only) to keep PRs fast.
     #[default]
-    Standard,
+    Fast,
     /// Run DHAT too, matching what `main` measures.
     Full,
 }
@@ -120,10 +120,10 @@ impl CargoController {
             BencherThreshold::new(measure, upper_boundary).with_max_sample_size("1")
         };
 
-        // DHAT is much slower than Callgrind, so standard PR benchmarks skip it and
+        // DHAT is much slower than Callgrind, so fast PR benchmarks skip it and
         // run Callgrind only.
         // __SLANG_PERF_SKIP_DHAT_ENV__ (keep in sync)
-        let skip_dhat = matches!(self.pr_benchmark, Some(PrBenchmarkMode::Standard));
+        let skip_dhat = matches!(self.pr_benchmark, Some(PrBenchmarkMode::Fast));
         let bench_env: &[(&str, &str)] = if skip_dhat {
             &[("SLANG_PERF_SKIP_DHAT", "1")]
         } else {

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use infra_utils::commands::Command;
 use infra_utils::paths::{FileWalker, PathExtensions};
 
@@ -22,8 +22,18 @@ pub struct CargoController {
     #[command(flatten)]
     dry_run: DryRun,
     /// Run as a PR benchmark with regression detection via bencher start points.
-    #[arg(long)]
-    pr_benchmark: bool,
+    ///
+    /// Defaults to "standard" mode (DHAT skipped, Callgrind only). Pass
+    /// "--pr-benchmark=full" to also run DHAT.
+    #[arg(
+        long,
+        value_name = "MODE",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "standard",
+        conflicts_with = "dry_run"
+    )]
+    pr_benchmark: Option<PrBenchmarkMode>,
     #[arg(long)]
     no_deps: bool,
     /// Skip installing apt-managed deps (valgrind, graphviz).
@@ -42,6 +52,15 @@ enum Benches {
     Comparison,
     /// Performs the slang v2 benchmarks
     SlangV2,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+enum PrBenchmarkMode {
+    /// Skip DHAT (run Callgrind only) to keep PRs fast.
+    #[default]
+    Standard,
+    /// Run DHAT too, matching what `main` measures.
+    Full,
 }
 
 impl CargoController {
@@ -101,9 +120,19 @@ impl CargoController {
             BencherThreshold::new(measure, upper_boundary).with_max_sample_size("1")
         };
 
+        // DHAT is much slower than Callgrind, so standard PR benchmarks skip it and
+        // run Callgrind only.
+        // __SLANG_PERF_SKIP_DHAT_ENV__ (keep in sync)
+        let skip_dhat = matches!(self.pr_benchmark, Some(PrBenchmarkMode::Standard));
+        let bench_env: &[(&str, &str)] = if skip_dhat {
+            &[("SLANG_PERF_SKIP_DHAT", "1")]
+        } else {
+            &[]
+        };
+
         run_bench(
             self.dry_run.get(),
-            self.pr_benchmark,
+            self.pr_benchmark.is_some(),
             bencher_project,
             "rust_iai_callgrind",
             &[
@@ -127,6 +156,7 @@ impl CargoController {
                 threshold("l2-hits", "1"),
                 threshold("ram-hits", "1"),
             ],
+            bench_env,
             &test_runner,
         );
 

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -51,6 +51,7 @@ impl NpmController {
             DEFAULT_BENCHER_PROJECT,
             "json",
             &[BencherThreshold::new("duration", "0.15")],
+            &[],
             &test_runner,
         );
     }

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -40,6 +40,9 @@ pub(crate) fn run_bench(
     project: &str,
     adapter: &str,
     thresholds: &[BencherThreshold],
+    // Extra environment variables to set on the benchmark command. These
+    // propagate through `bencher run` to the spawned `cargo bench` process.
+    bench_env: &[(&str, &str)],
     test_runner: &str,
 ) {
     assert!(
@@ -73,6 +76,10 @@ pub(crate) fn run_bench(
         .property("--adapter", adapter)
         .property("--testbed", testbed)
         .secret("BENCHER_API_TOKEN", token);
+
+    for (key, value) in bench_env {
+        command = command.env(*key, *value);
+    }
 
     if dry_run {
         command = command.flag("--dry-run");

--- a/crates/solidity/testing/perf/README.md
+++ b/crates/solidity/testing/perf/README.md
@@ -14,6 +14,18 @@ The cargo crate contains three different entry points, each serving its purpose:
 
 [projects]: #projects
 
+### Callgrind vs DHAT
+
+Every cargo benchmark always runs [`callgrind`](https://kcachegrind.github.io/html/Home.html) (instructions, cache hits, estimated cycles). It can additionally run [`DHAT`](https://valgrind.org/docs/manual/dh-manual.html) for heap-allocation metrics, but DHAT is much slower, so we don't always run it:
+
+- On `main` (and plain local / `--dry-run` runs): all three suites run DHAT.
+- On PR benchmarks (`--pr-benchmark`, triggered by the `ci:perf` label): only the `slang_v2` suite runs DHAT (it's fast enough). The slower `slang` (v1) and `comparison` suites run callgrind only.
+- On full PR benchmarks (`--pr-benchmark=full`, triggered by the `ci:perf:full` label): the `slang` and `comparison` suites also run DHAT, matching `main`. (`slang_v2` is fast enough that its workflow always passes `--pr-benchmark=full`, so it runs DHAT on every PR regardless of the `ci:perf:full` label.)
+
+DHAT accuracy depends on its `num-callers` argument (see [`config.rs`](./cargo/src/config.rs)): `comparison` and `slang_v2` use the maximum (`500`) for accurate attribution, while `slang` (v1) is slow enough that it intentionally uses a smaller value (`12`) and accepts less accurate measurements.
+
+Whether DHAT runs on a given PR is therefore a per-suite CI decision: each workflow picks `--pr-benchmark` (standard, Callgrind only) or `--pr-benchmark=full`. `infra perf cargo` just maps the mode to DHAT on/off by setting the `SLANG_PERF_SKIP_DHAT` environment variable on the benchmark process (a CLI flag on the bench binary isn't possible, since `iai-callgrind`'s `main!` owns argument parsing).
+
 ## [`npm`](./npm/)
 
 In the `cargo` benchmarks, we use metrics that are mostly resistant from interference from outside (like other libraries running on the same process). When testing with `npm`, we can't have that, so instead, for each project we run each library in its own process, orchestrated by a main process in Rust ([`src/main.rs`](./npm/src/main.rs)). This process collects the results and sends it back to infra to ship it to bencher.

--- a/crates/solidity/testing/perf/README.md
+++ b/crates/solidity/testing/perf/README.md
@@ -24,7 +24,7 @@ Every cargo benchmark always runs [`callgrind`](https://kcachegrind.github.io/ht
 
 DHAT accuracy depends on its `num-callers` argument (see [`config.rs`](./cargo/src/config.rs)): `comparison` and `slang_v2` use the maximum (`500`) for accurate attribution, while `slang` (v1) is slow enough that it intentionally uses a smaller value (`12`) and accepts less accurate measurements.
 
-Whether DHAT runs on a given PR is therefore a per-suite CI decision: each workflow picks `--pr-benchmark` (standard, Callgrind only) or `--pr-benchmark=full`. `infra perf cargo` just maps the mode to DHAT on/off by setting the `SLANG_PERF_SKIP_DHAT` environment variable on the benchmark process (a CLI flag on the bench binary isn't possible, since `iai-callgrind`'s `main!` owns argument parsing).
+Whether DHAT runs on a given PR is therefore a per-suite CI decision: each workflow picks `--pr-benchmark` (fast, Callgrind only) or `--pr-benchmark=full`. `infra perf cargo` just maps the mode to DHAT on/off by setting the `SLANG_PERF_SKIP_DHAT` environment variable on the benchmark process (a CLI flag on the bench binary isn't possible, since `iai-callgrind`'s `main!` owns argument parsing).
 
 ## [`npm`](./npm/)
 

--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -7,7 +7,7 @@ use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use paste::paste;
 use slang_solidity::compilation::CompilationUnit;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
-use solidity_testing_perf_cargo::config::default_benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -159,7 +159,9 @@ comparison_tests!(pointer_libraries);
 comparison_tests!(merkle_proof);
 
 main!(
-    config = default_benchmark_config();
+    // We use the maximum possible value of `num-callers` to ensure DHAT values
+    // are sensible
+    config = benchmark_config(500);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -7,7 +7,7 @@ use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use paste::paste;
 use slang_solidity::compilation::CompilationUnit;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
-use solidity_testing_perf_cargo::config::benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config_with_num_callers;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -161,7 +161,7 @@ comparison_tests!(merkle_proof);
 main!(
     // We use the maximum possible value of `num-callers` to ensure DHAT values
     // are sensible
-    config = benchmark_config(500);
+    config = benchmark_config_with_num_callers(500);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use paste::paste;
 use slang_solidity::compilation::CompilationUnit;
-use solidity_testing_perf_cargo::config::benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config_with_num_callers;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 use solidity_testing_perf_cargo::tests::slang::binder_v2_run::BuiltSemanticAnalysis;
@@ -119,7 +119,7 @@ slang_define_full_tests!(merkle_proof);
 main!(
     // Slang v1 is quite slow, so we use a smaller `num-callers` value
     // and live with not so accurate DHAT measurements.
-    config = benchmark_config(12);
+    config = benchmark_config_with_num_callers(12);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use paste::paste;
 use slang_solidity::compilation::CompilationUnit;
-use solidity_testing_perf_cargo::config::default_benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 use solidity_testing_perf_cargo::tests::slang::binder_v2_run::BuiltSemanticAnalysis;
@@ -117,7 +117,9 @@ slang_define_full_tests!(weighted_pool);
 slang_define_full_tests!(merkle_proof);
 
 main!(
-    config = default_benchmark_config();
+    // Slang v1 is quite slow, so we use a smaller `num-callers` value
+    // and live with not so accurate DHAT measurements.
+    config = benchmark_config(12);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -8,7 +8,7 @@ use slang_solidity_v2_ast::abi;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use solidity_testing_perf_cargo::config::benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config_with_num_callers;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -110,7 +110,7 @@ slang_v2_define_tests!(merkle_proof);
 main!(
     // We use the maximum possible value of `num-callers` to ensure DHAT values
     // are sensible
-    config = benchmark_config(500);
+    config = benchmark_config_with_num_callers(500);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -8,7 +8,7 @@ use slang_solidity_v2_ast::abi;
 use slang_solidity_v2_cst::structured_cst::nodes::SourceUnit;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_semantic::context::SemanticContext;
-use solidity_testing_perf_cargo::config::default_benchmark_config;
+use solidity_testing_perf_cargo::config::benchmark_config;
 use solidity_testing_perf_cargo::dataset::SolidityProject;
 use solidity_testing_perf_cargo::tests;
 
@@ -108,7 +108,9 @@ slang_v2_define_tests!(pointer_libraries);
 slang_v2_define_tests!(merkle_proof);
 
 main!(
-    config = default_benchmark_config();
+    // We use the maximum possible value of `num-callers` to ensure DHAT values
+    // are sensible
+    config = benchmark_config(500);
 
     // NOTE: the trailing comma is required: without it, it won't test the last one
     // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)

--- a/crates/solidity/testing/perf/cargo/src/config.rs
+++ b/crates/solidity/testing/perf/cargo/src/config.rs
@@ -1,5 +1,13 @@
 use iai_callgrind::{Direction, FlamegraphConfig, LibraryBenchmarkConfig, Tool, ValgrindTool};
 
+/// Env var that, when set (to any value), makes [`benchmark_config`] skip the
+/// DHAT tool and run Callgrind only.
+///
+/// DHAT is expensive (especially at high `num_callers`), so in certain
+/// cases we want to skip it.
+// __SLANG_PERF_SKIP_DHAT_ENV__ (keep in sync)
+pub const SKIP_DHAT_ENV: &str = "SLANG_PERF_SKIP_DHAT";
+
 /// Shared `LibraryBenchmarkConfig` used by every perf benchmark in this crate.
 /// Centralised so the bench `main!` calls can't drift apart.
 pub fn benchmark_config(num_callers: usize) -> LibraryBenchmarkConfig {
@@ -7,8 +15,6 @@ pub fn benchmark_config(num_callers: usize) -> LibraryBenchmarkConfig {
         0 < num_callers && num_callers <= 500,
         "num_callers must be between 1 and 500"
     );
-    // We set the DHAT arguments to whatever the user provided
-    let dhat_args = [format!("--num-callers={num_callers}")];
 
     let mut config = LibraryBenchmarkConfig::default();
     config
@@ -22,23 +28,30 @@ pub fn benchmark_config(num_callers: usize) -> LibraryBenchmarkConfig {
         // Total read+write:        Total memory reads/writes during the entire execution.
         // Estimated Cycles:        Number of CPU cycles (estimated) that went by during the entire execution.
         //
-        // We also enable the 'DHAT' tool below, which reports these metrics:
-        // https://valgrind.org/docs/manual/dh-manual.html
-        //
-        // Total bytes:             How many bytes were allocated over the entire execution.
-        // Total blocks:            How many heap blocks were allocated over the entire execution.
-        // At t-gmax bytes:         How many bytes were alive when the heap size reached its global maximum (as measured in bytes).
-        // At t-gmax blocks:        How many heap blocks were alive when the heap size reached its global maximum (as measured in bytes).
-        // At t-end bytes:          How many bytes were alive at the end of execution (were not explicitly freed).
-        // At t-end blocks:         How many heap blocks were alive at the end of execution (were not explicitly freed).
-        // Reads bytes:             How many bytes within heap blocks were read during the entire execution.
-        // Writes bytes:            How many bytes within heap blocks were written during the entire execution.
-        .tool(Tool::new(ValgrindTool::DHAT).args(dhat_args))
         // This enables generating flame graphs into Cargo's 'target' directory.
         // They will be listed by 'infra perf' at the end of the run:
         .flamegraph(FlamegraphConfig::default().direction(Direction::BottomToTop))
         // 'valgrind' executes tests without any environment variables set by default.
         // Let's disable this behavior to be able to execute our infra utilities:
         .env_clear(false);
+
+    // The 'DHAT' tool is much slower than Callgrind, so it's skipped on PR
+    // benchmarks for the slower suites (see `SKIP_DHAT_ENV`). When enabled, it
+    // reports these metrics: https://valgrind.org/docs/manual/dh-manual.html
+    //
+    // Total bytes:             How many bytes were allocated over the entire execution.
+    // Total blocks:            How many heap blocks were allocated over the entire execution.
+    // At t-gmax bytes:         How many bytes were alive when the heap size reached its global maximum (as measured in bytes).
+    // At t-gmax blocks:        How many heap blocks were alive when the heap size reached its global maximum (as measured in bytes).
+    // At t-end bytes:          How many bytes were alive at the end of execution (were not explicitly freed).
+    // At t-end blocks:         How many heap blocks were alive at the end of execution (were not explicitly freed).
+    // Reads bytes:             How many bytes within heap blocks were read during the entire execution.
+    // Writes bytes:            How many bytes within heap blocks were written during the entire execution.
+    if std::env::var_os(SKIP_DHAT_ENV).is_none() {
+        // We set the DHAT arguments to whatever the user provided.
+        let dhat_args = [format!("--num-callers={num_callers}")];
+        config.tool(Tool::new(ValgrindTool::DHAT).args(dhat_args));
+    }
+
     config
 }

--- a/crates/solidity/testing/perf/cargo/src/config.rs
+++ b/crates/solidity/testing/perf/cargo/src/config.rs
@@ -2,7 +2,14 @@ use iai_callgrind::{Direction, FlamegraphConfig, LibraryBenchmarkConfig, Tool, V
 
 /// Shared `LibraryBenchmarkConfig` used by every perf benchmark in this crate.
 /// Centralised so the bench `main!` calls can't drift apart.
-pub fn default_benchmark_config() -> LibraryBenchmarkConfig {
+pub fn benchmark_config(num_callers: usize) -> LibraryBenchmarkConfig {
+    assert!(
+        0 < num_callers && num_callers <= 500,
+        "num_callers must be between 1 and 500"
+    );
+    // We set the DHAT arguments to whatever the user provided
+    let dhat_args = [format!("--num-callers={num_callers}")];
+
     let mut config = LibraryBenchmarkConfig::default();
     config
         // 'valgrind' supports many tools. By default, it runs 'callgrind', which reports these metrics:
@@ -26,7 +33,7 @@ pub fn default_benchmark_config() -> LibraryBenchmarkConfig {
         // At t-end blocks:         How many heap blocks were alive at the end of execution (were not explicitly freed).
         // Reads bytes:             How many bytes within heap blocks were read during the entire execution.
         // Writes bytes:            How many bytes within heap blocks were written during the entire execution.
-        .tool(Tool::new(ValgrindTool::DHAT))
+        .tool(Tool::new(ValgrindTool::DHAT).args(dhat_args))
         // This enables generating flame graphs into Cargo's 'target' directory.
         // They will be listed by 'infra perf' at the end of the run:
         .flamegraph(FlamegraphConfig::default().direction(Direction::BottomToTop))

--- a/crates/solidity/testing/perf/cargo/src/config.rs
+++ b/crates/solidity/testing/perf/cargo/src/config.rs
@@ -1,7 +1,8 @@
 use iai_callgrind::{Direction, FlamegraphConfig, LibraryBenchmarkConfig, Tool, ValgrindTool};
 
-/// Env var that, when set (to any value), makes [`benchmark_config`] skip the
-/// DHAT tool and run Callgrind only.
+/// Env var that, when set (to any value), makes
+/// [`benchmark_config_with_num_callers`] skip the DHAT tool and run Callgrind
+/// only.
 ///
 /// DHAT is expensive (especially at high `num_callers`), so in certain
 /// cases we want to skip it.
@@ -10,7 +11,16 @@ pub const SKIP_DHAT_ENV: &str = "SLANG_PERF_SKIP_DHAT";
 
 /// Shared `LibraryBenchmarkConfig` used by every perf benchmark in this crate.
 /// Centralised so the bench `main!` calls can't drift apart.
-pub fn benchmark_config(num_callers: usize) -> LibraryBenchmarkConfig {
+///
+/// `num_callers` sets Valgrind's `--num-callers`: the maximum depth of the call
+/// stack Valgrind records (and unwinds) at each allocation. Allocations are
+/// attributed to a stack trace truncated to this depth, so a larger value
+/// distinguishes allocation sites that share their top frames (e.g. a `malloc`
+/// reached through several layers of generic/`Vec` code) and gives more
+/// precise per-site attribution — at the cost of slower runs, since DHAT
+/// unwinds that many frames on every allocation. Smaller values are coarser
+/// but cheaper. Must be between 1 and 500 (DHAT's maximum).
+pub fn benchmark_config_with_num_callers(num_callers: usize) -> LibraryBenchmarkConfig {
     assert!(
         0 < num_callers && num_callers <= 500,
         "num_callers must be between 1 and 500"


### PR DESCRIPTION
This PR improves the usage of DHAT in our benchmarks, after a deep investigation.

1. The maximum stack trace recorded by valgrind was increased from 12 (the default) to 500 (the maximum), this makes filtering work on more cases (it's still not perfect) for V2 and comparison benchmarks, V1 is too slow and doing this caused time outs after 5hs.
2. The default run of `ci:perf` now disables DHAT from v1 and comparison, making the runs take ~12 and ~24 min, respectively. _We could do this the default on every PR, but since v1 and third parties almost never change, I don't think it's worth it_. The new behaviour is shown on the table below.
3. Thresholds of certain DHAT metrics were moved to 100%, since they are harder to interpret and are influenced by external factors.

**A draft PR using the `ci:perf:full` label is here https://github.com/NomicFoundation/slang/pull/1889**

|   |  v1  | comparison | v2 | 
|---|---|---|---|
| PR without label | ❌ | ❌  | ✔️  with DHAT | 
| PR with `ci:perf` | ✔️ withouth DHAT | ✔️ without DHAT  | ✔️  with DHAT | 
| PR with `ci:perf:full` | ✔️ with DHAT | ✔️ with DHAT  | ✔️  with DHAT | 
| main | ✔️ with DHAT | ✔️ with DHAT  | ✔️  with DHAT | 
