### PR TITLE
fix(abi): expand tuple outputs for getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
 name = "slang_solidity_v2_ast"
 version = "1.3.6"
 dependencies = [
+ "itertools 0.14.0",
  "num-bigint",
  "num-rational",
  "paste",

--- a/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ast/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+itertools = { workspace = true }
 num-bigint = { workspace = true }
 num-rational = { workspace = true }
 paste = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/mod.rs
@@ -3,6 +3,7 @@ mod node_extensions;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use itertools::Either;
 use ruint::aliases::U256;
 use sha3::{Digest, Keccak256};
 use slang_solidity_v2_common::collections::Set;
@@ -10,7 +11,7 @@ use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_semantic::binder::Definition;
 use slang_solidity_v2_semantic::context::SemanticContext;
 use slang_solidity_v2_semantic::types::{
-    ArrayType, FunctionTypeMutability, StructType, Type, TypeId,
+    ArrayType, FunctionTypeMutability, StructType, TupleType, Type, TypeId,
 };
 
 pub struct ContractAbi {
@@ -359,6 +360,11 @@ pub(crate) fn extract_function_type_parameters_abi(
     let Type::Function(function_type) = semantic.types().get_type_by_id(type_id) else {
         return None;
     };
+    // TODO: our type system doesn't track parameter names for function types,
+    // so we can't convey that information in the ABI. This is important for
+    // getters where we should transfer that information from mapping or struct
+    // types (eg. a getter that returns a struct should name its output
+    // parameters from the struct members).
     let mut inputs = Vec::new();
     for parameter_type_id in &function_type.parameter_types {
         let (type_name, components) = type_as_abi_parameter(semantic, *parameter_type_id)?;
@@ -370,14 +376,24 @@ pub(crate) fn extract_function_type_parameters_abi(
             indexed: false,
         });
     }
-    let (type_name, components) = type_as_abi_parameter(semantic, function_type.return_type)?;
-    let outputs = vec![AbiParameter {
-        node_id: None,
-        name: None,
-        type_name,
-        components,
-        indexed: false,
-    }];
+    // A tuple as a return type from a function represents multiple return
+    // values, so we need to flatten it
+    let output_types = match semantic.types().get_type_by_id(function_type.return_type) {
+        Type::Tuple(TupleType { types }) => Either::Left(types.iter()),
+        _ => Either::Right(std::iter::once(&function_type.return_type)),
+    };
+    let outputs = output_types
+        .map(|output_type_id| {
+            let (type_name, components) = type_as_abi_parameter(semantic, *output_type_id)?;
+            Some(AbiParameter {
+                node_id: None,
+                name: None,
+                type_name,
+                components,
+                indexed: false,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
     Some((inputs, outputs))
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -186,6 +186,7 @@ impl LiteralKind {
 pub struct FunctionType {
     pub definition_id: Option<NodeId>, // this may point to a FunctionDefinition
     pub parameter_types: Vec<TypeId>,
+    // Multiple return values are modeled by returning a tuple
     pub return_type: TypeId,
     pub visibility: FunctionTypeVisibility,
     pub mutability: FunctionTypeMutability,

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
@@ -39,7 +39,8 @@ macro_rules! assert_components_eq {
 
 /// Like [`assert_components_eq!`], but for top-level input/output parameters,
 /// whose names are optional. For each parameter, the name is `None` to assert
-/// it is unnamed, or `_` to skip the name check.
+/// it is unnamed, a string expression to assert its equality, or `_` to skip
+/// the name check.
 macro_rules! assert_params_eq {
     ($params:expr, [ $(($name:tt, $type_name:expr, [$($sub:tt)*])),* $(,)? ]) => {
         {
@@ -64,6 +65,7 @@ macro_rules! assert_params_eq {
     };
     (@name $param:expr, _) => {};
     (@name $param:expr, None) => { assert!($param.name().is_none()); };
+    (@name $param:expr, $name:expr) => { assert!($param.name().is_some_and(|name| name == $name)); };
 }
 
 /// Asserts that an [`AbiEntry`] is a function with the given name, inputs and
@@ -140,7 +142,7 @@ fn test_abi_entries_with_tuples() {
     let entries = contracts_abi[0].entries();
     assert_eq!(entries.len(), 5);
 
-    // f(S memory, T memory, uint) returns ()
+    // f(S memory, T memory, uint x) returns ()
     assert_function_eq!(
         &entries[0],
         "f",
@@ -151,23 +153,23 @@ fn test_abi_entries_with_tuples() {
                 ("c", "tuple[]", [("x", "uint256", []), ("y", "uint256", [])]),
             ]),
             (None, "tuple", [("x", "uint256", []), ("y", "uint256", [])]),
-            (None, "uint256", []),
+            ("x", "uint256", []),
         ],
         outputs: [],
     );
 
-    // g() returns (S memory, T memory, uint)
+    // g() returns (S memory s, T memory t, uint)
     assert_function_eq!(
         &entries[1],
         "g",
         inputs: [],
         outputs: [
-            (None, "tuple", [
+            ("s", "tuple", [
                 ("a", "uint256", []),
                 ("b", "uint256[]", []),
                 ("c", "tuple[]", [("x", "uint256", []), ("y", "uint256", [])]),
             ]),
-            (None, "tuple", [("x", "uint256", []), ("y", "uint256", [])]),
+            ("t", "tuple", [("x", "uint256", []), ("y", "uint256", [])]),
             (None, "uint256", []),
         ],
     );

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
@@ -37,6 +37,50 @@ macro_rules! assert_components_eq {
     };
 }
 
+/// Like [`assert_components_eq!`], but for top-level input/output parameters,
+/// whose names are optional. For each parameter, the name is `None` to assert
+/// it is unnamed, or `_` to skip the name check.
+macro_rules! assert_params_eq {
+    ($params:expr, [ $(($name:tt, $type_name:expr, [$($sub:tt)*])),* $(,)? ]) => {
+        {
+            let params = $params;
+            let expected: &[&str] = &[$($type_name),*];
+            assert_eq!(
+                params.len(),
+                expected.len(),
+                "expected {} parameters, got {}",
+                expected.len(),
+                params.len()
+            );
+            assert_params_eq!(@step params, 0, $(($name, $type_name, [$($sub)*]),)*);
+        }
+    };
+    (@step $params:ident, $index:expr, ) => {};
+    (@step $params:ident, $index:expr, ($name:tt, $type_name:expr, [$($sub:tt)*]), $($rest:tt)*) => {
+        assert_params_eq!(@name $params[$index], $name);
+        assert_eq!($params[$index].type_name(), $type_name);
+        assert_components_eq!($params[$index].components(), [$($sub)*]);
+        assert_params_eq!(@step $params, $index + 1, $($rest)*);
+    };
+    (@name $param:expr, _) => {};
+    (@name $param:expr, None) => { assert!($param.name().is_none()); };
+}
+
+/// Asserts that an [`AbiEntry`] is a function with the given name, inputs and
+/// outputs (each described as for [`assert_params_eq!`]).
+macro_rules! assert_function_eq {
+    ($entry:expr, $name:expr, inputs: [$($inputs:tt)*], outputs: [$($outputs:tt)*] $(,)?) => {
+        {
+            let AbiEntry::Function(function) = $entry else {
+                panic!("expected ABI for function");
+            };
+            assert_eq!(function.name(), $name);
+            assert_params_eq!(function.inputs(), [$($inputs)*]);
+            assert_params_eq!(function.outputs(), [$($outputs)*]);
+        }
+    };
+}
+
 #[test]
 fn test_get_contracts_abi() {
     let unit = fixtures::Counter::build_compilation_unit();
@@ -94,70 +138,61 @@ fn test_abi_entries_with_tuples() {
     assert_eq!(contracts_abi[0].name(), "Test");
 
     let entries = contracts_abi[0].entries();
+    assert_eq!(entries.len(), 5);
 
-    let AbiEntry::Function(function) = &entries[0] else {
-        panic!("expected ABI for function");
-    };
-    assert_eq!(function.name(), "f");
-    let inputs = function.inputs();
-    let outputs = function.outputs();
-    assert_eq!(inputs.len(), 3);
-    assert!(inputs[0].name().is_none());
-    assert_eq!(inputs[0].type_name(), "tuple");
-    assert_components_eq!(
-        inputs[0].components(),
-        [
-            ("a", "uint256", []),
-            ("b", "uint256[]", []),
-            (
-                "c",
-                "tuple[]",
-                [("x", "uint256", []), ("y", "uint256", []),]
-            ),
-        ]
+    // f(S memory, T memory, uint) returns ()
+    assert_function_eq!(
+        &entries[0],
+        "f",
+        inputs: [
+            (None, "tuple", [
+                ("a", "uint256", []),
+                ("b", "uint256[]", []),
+                ("c", "tuple[]", [("x", "uint256", []), ("y", "uint256", [])]),
+            ]),
+            (None, "tuple", [("x", "uint256", []), ("y", "uint256", [])]),
+            (None, "uint256", []),
+        ],
+        outputs: [],
     );
 
-    assert!(inputs[1].name().is_none());
-    assert_eq!(inputs[1].type_name(), "tuple");
-    assert_components_eq!(
-        inputs[1].components(),
-        [("x", "uint256", []), ("y", "uint256", []),]
+    // g() returns (S memory, T memory, uint)
+    assert_function_eq!(
+        &entries[1],
+        "g",
+        inputs: [],
+        outputs: [
+            (None, "tuple", [
+                ("a", "uint256", []),
+                ("b", "uint256[]", []),
+                ("c", "tuple[]", [("x", "uint256", []), ("y", "uint256", [])]),
+            ]),
+            (None, "tuple", [("x", "uint256", []), ("y", "uint256", [])]),
+            (None, "uint256", []),
+        ],
     );
 
-    assert!(inputs[2].name().is_none());
-    assert_eq!(inputs[2].type_name(), "uint256");
-    assert!(inputs[2].components().is_empty());
-    assert!(outputs.is_empty());
+    // T public (getter) -> t() returns (uint256 x, uint256 y)
+    assert_function_eq!(
+        &entries[2],
+        "t",
+        inputs: [],
+        outputs: [(_, "uint256", []), (_, "uint256", [])],
+    );
 
-    let AbiEntry::Function(function) = &entries[1] else {
-        panic!("expected ABI for function");
-    };
-    assert_eq!(function.name(), "g");
-    let inputs = function.inputs();
-    let outputs = function.outputs();
-    assert!(inputs.is_empty());
-    assert_eq!(outputs.len(), 3);
-    assert!(outputs[0].name().is_none());
-    assert_eq!(outputs[0].type_name(), "tuple");
-    assert_components_eq!(
-        outputs[0].components(),
-        [
-            ("a", "uint256", []),
-            ("b", "uint256[]", []),
-            (
-                "c",
-                "tuple[]",
-                [("x", "uint256", []), ("y", "uint256", []),]
-            ),
-        ]
+    // t_components() returns (uint, uint)
+    assert_function_eq!(
+        &entries[3],
+        "t_components",
+        inputs: [],
+        outputs: [(None, "uint256", []), (None, "uint256", [])],
     );
-    assert!(outputs[1].name().is_none());
-    assert_eq!(outputs[1].type_name(), "tuple");
-    assert_components_eq!(
-        outputs[1].components(),
-        [("x", "uint256", []), ("y", "uint256", []),]
+
+    // t_struct() returns (T memory)
+    assert_function_eq!(
+        &entries[4],
+        "t_struct",
+        inputs: [],
+        outputs: [(None, "tuple", [("x", "uint256", []), ("y", "uint256", [])])],
     );
-    assert!(outputs[2].name().is_none());
-    assert_eq!(outputs[2].type_name(), "uint256");
-    assert!(outputs[2].components().is_empty());
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
@@ -13,8 +13,8 @@ contract Test {
     struct S { uint a; uint[] b; T[] c; }
     struct T { uint x; uint y; }
 
-    function f(S memory, T memory, uint) public pure {}
-    function g() public pure returns (S memory, T memory, uint) {}
+    function f(S memory, T memory, uint x) public pure {}
+    function g() public pure returns (S memory s, T memory t, uint) {}
 
     T public t;  // getter returns (uint x, uint y)
     function t_components() public view returns (uint, uint) {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
@@ -12,8 +12,17 @@ define_fixture!(
 contract Test {
     struct S { uint a; uint[] b; T[] c; }
     struct T { uint x; uint y; }
+
     function f(S memory, T memory, uint) public pure {}
     function g() public pure returns (S memory, T memory, uint) {}
+
+    T public t;  // getter returns (uint x, uint y)
+    function t_components() public view returns (uint, uint) {
+        return (t.x, t.y);
+    }
+    function t_struct() public view returns (T memory) {
+        return t;
+    }
 }
 "#,
 );


### PR DESCRIPTION
We generate getter ABI entries from the generated function type in p3, which models multiple return values via a tuple. So when serializing the function type, we need to flatten the tuple into the output parameters.

This exposes a shortcoming from our type system. We don't track parameter names, so we cannot name the output elements from a public struct field as `solc` does. We may want to either extend our type system to include parameter names in `FunctionType`, or generate the getters in some other way. Filed as #1891.
