### PR TITLE
fix(typing): Model reference-typed constants as memory values

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -269,7 +269,10 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_constant_definition(&mut self, node: &ir::ConstantDefinition) {
-        let type_id = self.resolve_type_name(&node.type_name, None);
+        // TODO: the data location is not strictly correct, but a constant has no
+        // storage slot and reference types (strings, bytes) won't type if we pass
+        // None here.
+        let type_id = self.resolve_type_name(&node.type_name, Some(DataLocation::Memory));
         self.binder.set_node_type(node.id(), type_id);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1311,3 +1311,10 @@ fn test_partially_applied_function_is_not_convertible() {
         "partially applied function pointers should not be convertible",
     );
 }
+
+#[test]
+fn reference_type_constant_is_indexable() {
+    let (element_type, _types) =
+        type_of_expression_in_context(r#"bytes constant B = hex"1234";"#, "B[0]");
+    assert_eq!(element_type, Type::ByteArray(ByteArrayType { width: 1 }));
+}


### PR DESCRIPTION
This was reported and fixed by @hedgar2017.

Constants have no storage slot, and strictly speaking they are not in memory either since they should be inlined by the compiler. Nevertheless, we need to provide _some_ data location in order for them to type correctly. There's a similar `TODO` comment in `leave_error_definition` and `leave_event_definition` for theirs parameters which have the same problem (although one could argue those do always live in memory).
