### PR TITLE
[v2] feat(diagnostics): Validate fallback functions

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -510,6 +510,7 @@ pub mod slang_solidity_v2_common::diagnostics::kinds::structure
 pub enum slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::FunctionNameMatchesContainer(slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::InvalidUsingDirectiveContainer(slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryFallbackFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -520,6 +521,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -571,6 +574,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
@@ -768,6 +790,8 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal:
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::type_system
 pub enum slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionMutability(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionSignature(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::InvalidBase(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::InvalidFunctionTypeVisibility(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
@@ -775,6 +799,10 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiag
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
@@ -790,6 +818,45 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::mutability: alloc::string::String
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
@@ -878,6 +945,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::FunctionNameMatchesContainer) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -898,6 +967,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::U
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedEof) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidFunctionTypeVisibility> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1060,6 +1133,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::message(&self) -> alloc::string::String
@@ -1100,6 +1177,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnexpectedTerminal::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::InvalidBase::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_fallback_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_fallback_function.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a library declares a fallback function.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LibraryFallbackFunction;
+
+impl DiagnosticExtensions for LibraryFallbackFunction {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/library-fallback-function"
+    }
+
+    fn message(&self) -> String {
+        "Libraries cannot have fallback functions.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -1,9 +1,11 @@
 mod function_name_matches_container;
 mod invalid_using_directive_container;
+mod library_fallback_function;
 mod multiple_constructors;
 
 pub use function_name_matches_container::FunctionNameMatchesContainer;
 pub use invalid_using_directive_container::InvalidUsingDirectiveContainer;
+pub use library_fallback_function::LibraryFallbackFunction;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
 
@@ -23,5 +25,8 @@ define_diagnostic_kind! {
         FunctionNameMatchesContainer(FunctionNameMatchesContainer),
         /// A contract defines more than one constructor.
         MultipleConstructors(MultipleConstructors),
+
+        /// A library declares a fallback function.
+        LibraryFallbackFunction(LibraryFallbackFunction),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/fallback_function_mutability.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/fallback_function_mutability.rs
@@ -1,0 +1,29 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a fallback function is declared with a state
+/// mutability other than `payable` or non-payable (ie. `pure` or `view`).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FallbackFunctionMutability {
+    /// The offending mutability, as written (eg. `"pure"` or `"view"`).
+    pub mutability: String,
+}
+
+impl DiagnosticExtensions for FallbackFunctionMutability {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/fallback-function-mutability"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Fallback function must be payable or non-payable, but is \"{mutability}\".",
+            mutability = self.mutability
+        )
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/fallback_function_signature.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/fallback_function_signature.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a fallback function declares parameters and/or
+/// return values that do not match one of the two accepted signatures:
+/// `fallback()` or `fallback(bytes calldata) returns (bytes memory)`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FallbackFunctionSignature;
+
+impl DiagnosticExtensions for FallbackFunctionSignature {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/fallback-function-signature"
+    }
+
+    fn message(&self) -> String {
+        "Fallback function either has to have the signature \"fallback()\" or \"fallback(bytes calldata) returns (bytes memory)\".".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
@@ -1,6 +1,10 @@
+mod fallback_function_mutability;
+mod fallback_function_signature;
 mod invalid_base;
 mod invalid_function_type_visibility;
 
+pub use fallback_function_mutability::FallbackFunctionMutability;
+pub use fallback_function_signature::FallbackFunctionSignature;
 pub use invalid_base::InvalidBase;
 pub use invalid_function_type_visibility::InvalidFunctionTypeVisibility;
 use serde::Serialize;
@@ -20,5 +24,10 @@ define_diagnostic_kind! {
         InvalidBase(InvalidBase),
         /// A function type has a visibility other than `internal` or `external`.
         InvalidFunctionTypeVisibility(InvalidFunctionTypeVisibility),
+
+        /// A fallback function is declared `pure` or `view`.
+        FallbackFunctionMutability(FallbackFunctionMutability),
+        /// A fallback function has a signature other than the two accepted forms.
+        FallbackFunctionSignature(FallbackFunctionSignature),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -1840,6 +1840,8 @@ pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::returns: core::option::O
 pub slang_solidity_v2_ir::ir::FunctionDefinitionStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::signature_text_range(&self) -> core::ops::range::Range<usize>
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionDefinitionStruct

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/node_extensions/function_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/node_extensions/function_definition.rs
@@ -1,0 +1,21 @@
+use std::ops::Range;
+
+use crate::ir;
+
+impl ir::FunctionDefinitionStruct {
+    /// The text range of the function's signature, ie. everything but its body.
+    ///
+    /// Falls back to the full range for bodyless declarations (eg. functions in
+    /// interfaces or abstract contracts).
+    ///
+    pub fn signature_text_range(&self) -> Range<usize> {
+        // TODO: This shouldn't use the start of the body, but right now
+        // the IR doesn't have enough information to compute the
+        // actual range.
+        let end = match &self.body {
+            Some(body) => body.range.start,
+            None => self.range.end,
+        };
+        self.range.start..end
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/node_extensions/mod.rs
@@ -1,2 +1,3 @@
+mod function_definition;
 mod function_mutability;
 mod state_variable_mutability;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -88,6 +88,7 @@ impl SemanticContext {
             language_version,
             evm_target,
             &file_node_mapper,
+            &types,
             diagnostics,
         );
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/fallback_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/fallback_functions.rs
@@ -1,9 +1,9 @@
 //! Shape checks for the special `fallback` function.
 //!
-//! A fallback's accepted state mutabilities and its accepted signatures are
-//! properties of its resolved type, and whether a library may declare one is a
-//! structural rule. The checks run here, in the code-analysis pass, over the
-//! fully resolved program.
+//! A fallback's accepted state mutability and its accepted signatures are
+//! properties of its resolved type, and a library may not declare one.
+//! The checks run here, in the code-analysis pass, over the fully
+//! resolved program.
 //!
 //! Note that the v2 grammar already rejects most malformed special functions
 //! as syntax errors (eg. `internal`/`public` visibility, or `view`/`pure`
@@ -72,7 +72,19 @@ fn check_fallback_function(
     file_node_mapper: &FileNodeMapper,
     diagnostics: &mut DiagnosticCollection,
 ) {
-    // The mutability and signature rules are properties of the function's type,
+    let file_id = file_node_mapper.file_id_from_node_id(node.id()).to_owned();
+    let signature_range = node.signature_text_range();
+
+    // Libraries cannot declare a fallback function.
+    if enclosing_is_library {
+        diagnostics.push(
+            file_id.clone(),
+            signature_range.clone(),
+            LibraryFallbackFunction,
+        );
+    }
+
+    // The mutability and signature can be extracted from the function's type,
     // computed during type definition. A function definition always types to a
     // function type.
     let Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
@@ -82,35 +94,25 @@ fn check_fallback_function(
         unreachable!("type of function definition is not a function");
     };
 
-    let invalid_mutability = match function_type.mutability {
+    // A fallback must be `payable` or non-payable, not `pure`/`view`.
+    if let Some(mutability) = match function_type.mutability {
         FunctionTypeMutability::Pure => Some("pure"),
         FunctionTypeMutability::View => Some("view"),
         FunctionTypeMutability::NonPayable | FunctionTypeMutability::Payable => None,
-    };
-    let invalid_signature = !has_valid_signature(function_type, types);
-
-    if !enclosing_is_library && invalid_mutability.is_none() && !invalid_signature {
-        return;
-    }
-
-    // At least one diagnostic will be pushed, so resolve the file id once here
-    // rather than for every fallback (the common, diagnostic-free case).
-    let file_id = file_node_mapper.file_id_from_node_id(node.id()).to_owned();
-
-    if enclosing_is_library {
-        diagnostics.push(file_id.clone(), node.range.clone(), LibraryFallbackFunction);
-    }
-    if let Some(mutability) = invalid_mutability {
+    } {
         diagnostics.push(
             file_id.clone(),
-            node.range.clone(),
+            signature_range.clone(),
             FallbackFunctionMutability {
                 mutability: mutability.to_owned(),
             },
         );
     }
-    if invalid_signature {
-        diagnostics.push(file_id, node.range.clone(), FallbackFunctionSignature);
+
+    // Its signature must be exactly `fallback()` or
+    // `fallback(bytes calldata) returns (bytes memory)`.
+    if !has_valid_signature(function_type, types) {
+        diagnostics.push(file_id, signature_range, FallbackFunctionSignature);
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/fallback_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/fallback_functions.rs
@@ -1,0 +1,131 @@
+//! Shape checks for the special `fallback` function.
+//!
+//! A fallback's accepted state mutabilities and its accepted signatures are
+//! properties of its resolved type, and whether a library may declare one is a
+//! structural rule. The checks run here, in the code-analysis pass, over the
+//! fully resolved program.
+//!
+//! Note that the v2 grammar already rejects most malformed special functions
+//! as syntax errors (eg. `internal`/`public` visibility, or `view`/`pure`
+//! mutability on a `receive`). Only the forms that parse cleanly need a
+//! semantic check here.
+
+use slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    FallbackFunctionMutability, FallbackFunctionSignature,
+};
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_ir::ir;
+
+use crate::binder::{Binder, Definition, Typing};
+use crate::context::FileNodeMapper;
+use crate::types::{FunctionType, FunctionTypeMutability, Type, TypeRegistry};
+
+/// Validates the shape of every `fallback` function in the program.
+pub(crate) fn check_fallback_functions(
+    binder: &Binder,
+    types: &TypeRegistry,
+    file_node_mapper: &FileNodeMapper,
+    diagnostics: &mut DiagnosticCollection,
+) {
+    for definition in binder.definitions().values() {
+        let (members, enclosing_is_library) = match definition {
+            Definition::Contract(contract) => (&contract.ir_node.members, false),
+            Definition::Interface(interface) => (&interface.ir_node.members, false),
+            Definition::Library(library) => (&library.ir_node.members, true),
+            _ => continue,
+        };
+
+        for member in members {
+            let ir::ContractMember::FunctionDefinition(function) = member else {
+                continue;
+            };
+
+            if matches!(function.kind, ir::FunctionKind::Fallback) {
+                check_fallback_function(
+                    function,
+                    enclosing_is_library,
+                    binder,
+                    types,
+                    file_node_mapper,
+                    diagnostics,
+                );
+            }
+        }
+    }
+}
+
+/// Emits the shape diagnostics for a single `fallback` function:
+///
+/// * libraries cannot declare a fallback function;
+/// * a fallback must be `payable` or non-payable (not `pure`/`view`); and
+/// * its signature must be exactly `fallback()` or
+///   `fallback(bytes calldata) returns (bytes memory)`.
+///
+/// The checks are independent, mirroring solc, so a single fallback can emit
+/// more than one of them.
+fn check_fallback_function(
+    node: &ir::FunctionDefinition,
+    enclosing_is_library: bool,
+    binder: &Binder,
+    types: &TypeRegistry,
+    file_node_mapper: &FileNodeMapper,
+    diagnostics: &mut DiagnosticCollection,
+) {
+    // The mutability and signature rules are properties of the function's type,
+    // computed during type definition. A function definition always types to a
+    // function type.
+    let Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
+        unreachable!("fallback function definition is not typed");
+    };
+    let Type::Function(function_type) = types.get_type_by_id(type_id) else {
+        unreachable!("type of function definition is not a function");
+    };
+
+    let invalid_mutability = match function_type.mutability {
+        FunctionTypeMutability::Pure => Some("pure"),
+        FunctionTypeMutability::View => Some("view"),
+        FunctionTypeMutability::NonPayable | FunctionTypeMutability::Payable => None,
+    };
+    let invalid_signature = !has_valid_signature(function_type, types);
+
+    if !enclosing_is_library && invalid_mutability.is_none() && !invalid_signature {
+        return;
+    }
+
+    // At least one diagnostic will be pushed, so resolve the file id once here
+    // rather than for every fallback (the common, diagnostic-free case).
+    let file_id = file_node_mapper.file_id_from_node_id(node.id()).to_owned();
+
+    if enclosing_is_library {
+        diagnostics.push(file_id.clone(), node.range.clone(), LibraryFallbackFunction);
+    }
+    if let Some(mutability) = invalid_mutability {
+        diagnostics.push(
+            file_id.clone(),
+            node.range.clone(),
+            FallbackFunctionMutability {
+                mutability: mutability.to_owned(),
+            },
+        );
+    }
+    if invalid_signature {
+        diagnostics.push(file_id, node.range.clone(), FallbackFunctionSignature);
+    }
+}
+
+/// Whether `function_type`'s parameters and returns match one of the two
+/// accepted fallback signatures: `fallback()` or
+/// `fallback(bytes calldata) returns (bytes memory)`.
+fn has_valid_signature(function_type: &FunctionType, types: &TypeRegistry) -> bool {
+    match function_type.parameter_types.as_slice() {
+        // `fallback()` — no parameters and no return values.
+        [] => function_type.return_type == types.void(),
+        // `fallback(bytes calldata) returns (bytes memory)`.
+        [parameter_type_id] => {
+            *parameter_type_id == types.bytes_calldata()
+                && function_type.return_type == types.bytes_memory()
+        }
+        _ => false,
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/mod.rs
@@ -1,5 +1,6 @@
 mod built_ins;
 mod constant_cycles;
+mod fallback_functions;
 
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
@@ -7,6 +8,7 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 
 use crate::binder::Binder;
 use crate::context::FileNodeMapper;
+use crate::types::TypeRegistry;
 
 /// This pass hosts analyses that emit diagnostics over the fully resolved
 /// program, ie. they can only run after all references have been recorded.
@@ -16,6 +18,7 @@ pub fn run(
     language_version: LanguageVersion,
     evm_target: EvmTarget,
     file_node_mapper: &FileNodeMapper,
+    types: &TypeRegistry,
     diagnostics: &mut DiagnosticCollection,
 ) {
     constant_cycles::detect_constant_value_dependency_cycles(binder, diagnostics);
@@ -27,4 +30,6 @@ pub fn run(
         file_node_mapper,
         diagnostics,
     );
+
+    fallback_functions::check_fallback_functions(binder, types, file_node_mapper, diagnostics);
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -612,6 +612,11 @@ mod structure {
     }
 
     #[test]
+    fn library_fallback_function() -> Result<()> {
+        run("structure", "library_fallback_function")
+    }
+
+    #[test]
     fn multiple_constructors() -> Result<()> {
         run("structure", "multiple_constructors")
     }
@@ -763,6 +768,16 @@ mod syntax {
 
 mod type_system {
     use super::*;
+
+    #[test]
+    fn fallback_function_mutability() -> Result<()> {
+        run("type_system", "fallback_function_mutability")
+    }
+
+    #[test]
+    fn fallback_function_signature() -> Result<()> {
+        run("type_system", "fallback_function_signature")
+    }
 
     mod invalid_base {
         use super::*;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/slang/0.8.0-failure.txt
@@ -2,10 +2,10 @@
 
 Diagnostics: 1
 
-Error: Libraries cannot have fallback functions.
+[structure/library-fallback-function] Error: Libraries cannot have fallback functions.
    ╭─[input.sol:6:5]
    │
  6 │     fallback() external {}
-   │     ───────────┬──────────  
-   │                ╰──────────── Error occurred here.
+   │     ──────────┬─────────  
+   │               ╰─────────── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+Error: Libraries cannot have fallback functions.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     fallback() external {}
+   │     ───────────┬──────────  
+   │                ╰──────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5982] Error: Libraries cannot have fallback functions.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     fallback() external {}
+   │     ───────────┬──────────  
+   │                ╰──────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_fallback_function/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A library cannot declare a fallback function.
+library L {
+    fallback() external {}
+}
+
+// A contract may declare one, and must not be flagged.
+contract C {
+    fallback() external {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [syntax/multiple-mutability-specifiers] Error: Only a single mutability specifier can be provided.
-   ╭─[input.sol:5:28]
+   ╭─[input.sol:5:31]
    │
- 5 │   fallback() external pure view {}
-   │                            ──┬─  
-   │                              ╰─── Error occurred here.
+ 5 │   fallback() external payable view {}
+   │                               ──┬─  
+   │                                 ╰─── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/generated/solc/0.8.0-failure.txt
@@ -2,10 +2,10 @@
 
 Diagnostics: 1
 
-[ParserError 9680] Error: State mutability already specified as "pure".
-   ╭─[input.sol:5:28]
+[ParserError 9680] Error: State mutability already specified as "payable".
+   ╭─[input.sol:5:31]
    │
- 5 │   fallback() external pure view {}
-   │                            ──┬─  
-   │                              ╰─── Error occurred here.
+ 5 │   fallback() external payable view {}
+   │                               ──┬─  
+   │                                 ╰─── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/multiple_mutability_specifiers/fallback_functions/input.sol
@@ -2,5 +2,5 @@
 pragma solidity *;
 
 contract Test {
-  fallback() external pure view {}
+  fallback() external payable view {}
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/fallback-function-mutability] Error: Fallback function must be payable or non-payable, but is "pure".
+   ╭─[input.sol:6:5]
+   │
+ 6 │     fallback() external pure {}
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯
+
+[type-system/fallback-function-mutability] Error: Fallback function must be payable or non-payable, but is "view".
+    ╭─[input.sol:11:5]
+    │
+ 11 │     fallback() external view {}
+    │     ─────────────┬─────────────  
+    │                  ╰─────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/slang/0.8.0-failure.txt
@@ -6,14 +6,14 @@ Diagnostics: 2
    ╭─[input.sol:6:5]
    │
  6 │     fallback() external pure {}
-   │     ─────────────┬─────────────  
-   │                  ╰─────────────── Error occurred here.
+   │     ────────────┬────────────  
+   │                 ╰────────────── Error occurred here.
 ───╯
 
 [type-system/fallback-function-mutability] Error: Fallback function must be payable or non-payable, but is "view".
     ╭─[input.sol:11:5]
     │
  11 │     fallback() external view {}
-    │     ─────────────┬─────────────  
-    │                  ╰─────────────── Error occurred here.
+    │     ────────────┬────────────  
+    │                 ╰────────────── Error occurred here.
 ────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 4575] Error: Fallback function must be payable or non-payable, but is "pure".
+   ╭─[input.sol:6:5]
+   │
+ 6 │     fallback() external pure {}
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯
+
+[TypeError 4575] Error: Fallback function must be payable or non-payable, but is "view".
+    ╭─[input.sol:11:5]
+    │
+ 11 │     fallback() external view {}
+    │     ─────────────┬─────────────  
+    │                  ╰─────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_mutability/input.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A `pure` fallback is invalid: a fallback must be payable or non-payable.
+contract A {
+    fallback() external pure {}
+}
+
+// A `view` fallback is invalid for the same reason.
+contract B {
+    fallback() external view {}
+}
+
+// Non-payable and payable fallbacks are valid and must not be flagged.
+contract C {
+    fallback() external {}
+}
+
+contract D {
+    fallback() external payable {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,43 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 5
+
+[type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+   ╭─[input.sol:6:5]
+   │
+ 6 │     fallback(uint256) external {}
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯
+
+[type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:11:5]
+    │
+ 11 │     fallback() external returns (uint256) {}
+    │     ────────────────────┬───────────────────  
+    │                         ╰───────────────────── Error occurred here.
+────╯
+
+[type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:16:5]
+    │
+ 16 │     fallback(bytes memory) external returns (bytes memory) {}
+    │     ────────────────────────────┬────────────────────────────  
+    │                                 ╰────────────────────────────── Error occurred here.
+────╯
+
+[type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:21:5]
+    │
+ 21 │     fallback(bytes calldata) external returns (bytes calldata) {}
+    │     ──────────────────────────────┬──────────────────────────────  
+    │                                   ╰──────────────────────────────── Error occurred here.
+────╯
+
+[type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:26:5]
+    │
+ 26 │     fallback() external returns (bytes memory, bytes memory) {}
+    │     ─────────────────────────────┬─────────────────────────────  
+    │                                  ╰─────────────────────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/slang/0.8.0-failure.txt
@@ -6,38 +6,38 @@ Diagnostics: 5
    ╭─[input.sol:6:5]
    │
  6 │     fallback(uint256) external {}
-   │     ──────────────┬──────────────  
-   │                   ╰──────────────── Error occurred here.
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
 ───╯
 
 [type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
     ╭─[input.sol:11:5]
     │
  11 │     fallback() external returns (uint256) {}
-    │     ────────────────────┬───────────────────  
-    │                         ╰───────────────────── Error occurred here.
+    │     ───────────────────┬──────────────────  
+    │                        ╰──────────────────── Error occurred here.
 ────╯
 
 [type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
     ╭─[input.sol:16:5]
     │
  16 │     fallback(bytes memory) external returns (bytes memory) {}
-    │     ────────────────────────────┬────────────────────────────  
-    │                                 ╰────────────────────────────── Error occurred here.
+    │     ───────────────────────────┬───────────────────────────  
+    │                                ╰───────────────────────────── Error occurred here.
 ────╯
 
 [type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
     ╭─[input.sol:21:5]
     │
  21 │     fallback(bytes calldata) external returns (bytes calldata) {}
-    │     ──────────────────────────────┬──────────────────────────────  
-    │                                   ╰──────────────────────────────── Error occurred here.
+    │     ─────────────────────────────┬─────────────────────────────  
+    │                                  ╰─────────────────────────────── Error occurred here.
 ────╯
 
 [type-system/fallback-function-signature] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
     ╭─[input.sol:26:5]
     │
  26 │     fallback() external returns (bytes memory, bytes memory) {}
-    │     ─────────────────────────────┬─────────────────────────────  
-    │                                  ╰─────────────────────────────── Error occurred here.
+    │     ────────────────────────────┬────────────────────────────  
+    │                                 ╰────────────────────────────── Error occurred here.
 ────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,43 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 5
+
+[TypeError 5570] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+   ╭─[input.sol:6:32]
+   │
+ 6 │     fallback(uint256) external {}
+   │                                │ 
+   │                                ╰─ Error occurred here.
+───╯
+
+[TypeError 5570] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:11:33]
+    │
+ 11 │     fallback() external returns (uint256) {}
+    │                                 ────┬────  
+    │                                     ╰────── Error occurred here.
+────╯
+
+[TypeError 5570] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:16:45]
+    │
+ 16 │     fallback(bytes memory) external returns (bytes memory) {}
+    │                                             ───────┬──────  
+    │                                                    ╰──────── Error occurred here.
+────╯
+
+[TypeError 5570] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:21:47]
+    │
+ 21 │     fallback(bytes calldata) external returns (bytes calldata) {}
+    │                                               ────────┬───────  
+    │                                                       ╰───────── Error occurred here.
+────╯
+
+[TypeError 5570] Error: Fallback function either has to have the signature "fallback()" or "fallback(bytes calldata) returns (bytes memory)".
+    ╭─[input.sol:26:33]
+    │
+ 26 │     fallback() external returns (bytes memory, bytes memory) {}
+    │                                 ──────────────┬─────────────  
+    │                                               ╰─────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/fallback_function_signature/input.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A parameter whose type is not `bytes calldata` is invalid.
+contract A {
+    fallback(uint256) external {}
+}
+
+// Declaring returns without the accepted signature is invalid.
+contract B {
+    fallback() external returns (uint256) {}
+}
+
+// A `bytes` parameter at the wrong data location is invalid.
+contract C {
+    fallback(bytes memory) external returns (bytes memory) {}
+}
+
+// A `bytes` return at the wrong data location is invalid.
+contract D {
+    fallback(bytes calldata) external returns (bytes calldata) {}
+}
+
+// More than one return value is invalid.
+contract E {
+    fallback() external returns (bytes memory, bytes memory) {}
+}
+
+// The two accepted forms are valid and must not be flagged:
+// `fallback()` and `fallback(bytes calldata) returns (bytes memory)`.
+contract F {
+    fallback() external {}
+}
+
+contract G {
+    fallback(bytes calldata) external returns (bytes memory) {}
+}


### PR DESCRIPTION
This PR adds three validations for `fallback` functions:
- They can't be inside a library
- They must have a specific type signature
- They can't be `pure` nor `view`

Fix https://github.com/NomicFoundation/slang-diagnostics-research/issues/1296
Fix https://github.com/NomicFoundation/slang-diagnostics-research/issues/1117
Fix https://github.com/NomicFoundation/slang-diagnostics-research/issues/1248