### PR TITLE
fix(bindings): Yul built-ins are reserved keywords

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/mod.rs
@@ -120,6 +120,16 @@ impl<'a> Pass<'a> {
         *scope_id
     }
 
+    // This is always the bottom of the stack (ie. the initial scope) by
+    // construction, since it's the enclosing scope of the assembly block being
+    // processed
+    fn current_solidity_scope_id(&self) -> ScopeId {
+        self.scope_stack
+            .first()
+            .copied()
+            .expect("empty scope stack")
+    }
+
     fn insert_definition_in_current_scope(&mut self, definition: Definition) {
         self.insert_definition_in_scope(definition, self.current_scope_id());
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/resolution.rs
@@ -39,6 +39,15 @@ impl Pass<'_> {
         })
     }
 
+    pub(super) fn resolve_symbol_in_enclosing_solidity_scope(&self, symbol: &str) -> Resolution {
+        filter_overriden_definitions(
+            self.binder,
+            self.types,
+            self.binder
+                .resolve_in_scope(self.current_solidity_scope_id(), symbol),
+        )
+    }
+
     pub(super) fn resolve_yul_suffix(
         &self,
         symbol: &str,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/resolution.rs
@@ -27,16 +27,16 @@ impl Pass<'_> {
         scope_id: ScopeId,
         symbol: &str,
     ) -> Resolution {
-        let resolution = filter_overriden_definitions(
-            self.binder,
-            self.types,
-            self.binder.resolve_in_scope(scope_id, symbol),
-        );
-        if resolution == Resolution::Unresolved {
-            BuiltInsResolver::lookup_yul_global(symbol).into()
-        } else {
-            resolution
-        }
+        // Resolve Yul built-ins first, since strictly speaking they are
+        // reserved keywords. If that fails, lookup the symbol in the scope.
+        let resolution: Resolution = BuiltInsResolver::lookup_yul_global(symbol).into();
+        resolution.or_else(|| {
+            filter_overriden_definitions(
+                self.binder,
+                self.types,
+                self.binder.resolve_in_scope(scope_id, symbol),
+            )
+        })
     }
 
     pub(super) fn resolve_yul_suffix(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p6_resolve_yul/visitor.rs
@@ -105,14 +105,25 @@ impl Visitor for Pass<'_> {
 
         let mut item_iter = items.iter();
 
-        let scope_id = self.current_scope_id();
         let identifier = item_iter.next().expect("items is not empty");
-        let resolution = self.resolve_symbol_in_yul_scope(scope_id, identifier.unparse());
+        let suffix = item_iter.next();
+
+        let resolution = if suffix.is_none() {
+            let scope_id = self.current_scope_id();
+            self.resolve_symbol_in_yul_scope(scope_id, identifier.unparse())
+        } else {
+            // If there is a suffix, we're looking for Solidity definitions
+            // (state variables or functions) and we can skip the Yul scopes
+            // entirely.
+            // NOTE: this is the only case where we can reference a Solidity
+            // identifier named after a Yul built-in.
+            self.resolve_symbol_in_enclosing_solidity_scope(identifier.unparse())
+        };
         self.record_solidity_reference(&resolution);
         let reference = Reference::new(Arc::clone(identifier), resolution.clone());
         self.binder.insert_reference(reference);
 
-        if let Some(suffix) = item_iter.next() {
+        if let Some(suffix) = suffix {
             let resolution = self.resolve_yul_suffix(suffix.unparse(), &resolution);
             self.record_solidity_reference(&resolution);
             let reference = Reference::new(Arc::clone(suffix), resolution);

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -1337,6 +1337,11 @@ mod yul {
     }
 
     #[test]
+    fn calldata_access_resolves_to_solidity() -> Result<()> {
+        run("yul", "calldata_access_resolves_to_solidity")
+    }
+
+    #[test]
     fn catch_params() -> Result<()> {
         run("yul", "catch_params")
     }
@@ -1419,6 +1424,11 @@ mod yul {
     #[test]
     fn non_functional_notation() -> Result<()> {
         run("yul", "non_functional_notation")
+    }
+
+    #[test]
+    fn slot_access_resolves_to_solidity() -> Result<()> {
+        run("yul", "slot_access_resolves_to_solidity")
     }
 
     #[test]

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -1322,6 +1322,16 @@ mod yul {
     }
 
     #[test]
+    fn built_in_shadows_function() -> Result<()> {
+        run("yul", "built_in_shadows_function")
+    }
+
+    #[test]
+    fn built_in_shadows_variable() -> Result<()> {
+        run("yul", "built_in_shadows_variable")
+    }
+
+    #[test]
     fn built_ins() -> Result<()> {
         run("yul", "built_ins")
     }

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_function/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_function/generated/0.8.0-success.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (6):
+- Def: #1 ["add" @ input.sol:1:10] (function, type: function (uint256, uint256) returns uint256)
+- Def: #2 ["a" @ input.sol:1:22] (parameter, type: uint256)
+- Def: #3 ["b" @ input.sol:1:33] (parameter, type: uint256)
+- Def: #4 ["Test" @ input.sol:5:10] (contract)
+- Def: #5 ["test" @ input.sol:6:14] (function, type: function () returns void)
+- Def: #6 ["result" @ input.sol:10:17] (yul variable)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["a" @ input.sol:2:12] -> #2
+- Ref: ["b" @ input.sol:2:16] -> #3
+- Ref: ["add" @ input.sol:10:27] -> built-in
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ function add(uint256 a, uint256 b) pure returns (uint256) {
+    │          ─┬─         ┬          ┬  
+    │           ╰──────────────────────── name: 1
+    │                      │          │  
+    │                      ╰───────────── name: 2
+    │                                 │  
+    │                                 ╰── name: 3
+  2 │     return a + b;
+    │            ┬   ┬  
+    │            ╰────── ref: 2
+    │                │  
+    │                ╰── ref: 3
+    │ 
+  5 │ contract Test {
+    │          ──┬─  
+    │            ╰─── name: 4
+  6 │     function test() public pure {
+    │              ──┬─  
+    │                ╰─── name: 5
+    │ 
+ 10 │             let result := add(1, 2)
+    │                 ───┬──    ─┬─  
+    │                    ╰─────────── name: 6
+    │                            │   
+    │                            ╰─── built-in
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_function/input.sol
@@ -1,0 +1,13 @@
+function add(uint256 a, uint256 b) pure returns (uint256) {
+    return a + b;
+}
+
+contract Test {
+    function test() public pure {
+        assembly {
+            // `add` is a Yul built-in, so it shadows the Solidity free
+            // function `add` even though that function is in scope.
+            let result := add(1, 2)
+        }
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_variable/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_variable/generated/0.8.0-success.txt
@@ -1,0 +1,43 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (4):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["test" @ input.sol:2:14] (function, type: function (uint256) returns uint256)
+- Def: #3 ["add" @ input.sol:2:27] (parameter, type: uint256)
+- Def: #4 ["result" @ input.sol:2:61] (parameter, type: uint256)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["result" @ input.sol:7:13] -> #4
+- Ref: ["add" @ input.sol:7:23] -> built-in
+- Ref: ["add" @ input.sol:7:30] -> built-in
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     function test(uint256 add) public pure returns (uint256 result) {
+   │              ──┬─         ─┬─                               ───┬──  
+   │                ╰──────────────────────────────────────────────────── name: 2
+   │                            │                                   │    
+   │                            ╰──────────────────────────────────────── name: 3
+   │                                                                │    
+   │                                                                ╰──── name: 4
+   │ 
+ 7 │             result := add(1, add)
+   │             ───┬──    ─┬─    ─┬─  
+   │                ╰────────────────── ref: 4
+   │                        │      │   
+   │                        ╰────────── built-in
+   │                               │   
+   │                               ╰─── built-in
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_variable/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/built_in_shadows_variable/input.sol
@@ -1,0 +1,10 @@
+contract Test {
+    function test(uint256 add) public pure returns (uint256 result) {
+        assembly {
+            // `add` is a Yul built-in, so it shadows the Solidity parameter
+            // `add` in both call position (the outer `add`) and value position
+            // (the inner `add`). The parameter is never referenced.
+            result := add(1, add)
+        }
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/calldata_access_resolves_to_solidity/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/calldata_access_resolves_to_solidity/generated/0.8.0-success.txt
@@ -1,0 +1,56 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (5):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["test" @ input.sol:2:14] (function, type: function (bytes calldata) returns (uint256, uint256))
+- Def: #3 ["add" @ input.sol:2:34] (parameter, type: bytes calldata)
+- Def: #4 ["len" @ input.sol:2:68] (parameter, type: uint256)
+- Def: #5 ["off" @ input.sol:2:81] (parameter, type: uint256)
+
+------------------------------------------------------------------------
+
+References (6):
+- Ref: ["len" @ input.sol:5:13] -> #4
+- Ref: ["add" @ input.sol:5:20] -> #3
+- Ref: ["length" @ input.sol:5:24] -> built-in
+- Ref: ["off" @ input.sol:6:13] -> #5
+- Ref: ["add" @ input.sol:6:20] -> #3
+- Ref: ["offset" @ input.sol:6:24] -> built-in
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     function test(bytes calldata add) public pure returns (uint256 len, uint256 off) {
+   │              ──┬─                ─┬─                               ─┬─          ─┬─  
+   │                ╰───────────────────────────────────────────────────────────────────── name: 2
+   │                                   │                                 │            │   
+   │                                   ╰────────────────────────────────────────────────── name: 3
+   │                                                                     │            │   
+   │                                                                     ╰──────────────── name: 4
+   │                                                                                  │   
+   │                                                                                  ╰─── name: 5
+   │ 
+ 5 │             len := add.length
+   │             ─┬─    ─┬─ ───┬──  
+   │              ╰───────────────── ref: 4
+   │                     │     │    
+   │                     ╰────────── ref: 3
+   │                           │    
+   │                           ╰──── built-in
+ 6 │             off := add.offset
+   │             ─┬─    ─┬─ ───┬──  
+   │              ╰───────────────── ref: 5
+   │                     │     │    
+   │                     ╰────────── ref: 3
+   │                           │    
+   │                           ╰──── built-in
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/calldata_access_resolves_to_solidity/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/calldata_access_resolves_to_solidity/input.sol
@@ -1,0 +1,9 @@
+contract Test {
+    function test(bytes calldata add) public pure returns (uint256 len, uint256 off) {
+        assembly {
+            // `add` below resolves to the calldata parameter, not the built-in
+            len := add.length
+            off := add.offset
+        }
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/slot_access_resolves_to_solidity/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/slot_access_resolves_to_solidity/generated/0.8.0-success.txt
@@ -1,0 +1,48 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (4):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["add" @ input.sol:2:13] (state var, type: uint256)
+- Def: #3 ["test" @ input.sol:4:14] (function, type: function () returns uint256)
+- Def: #4 ["result" @ input.sol:4:50] (parameter, type: uint256)
+
+------------------------------------------------------------------------
+
+References (4):
+- Ref: ["result" @ input.sol:7:13] -> #4
+- Ref: ["sload" @ input.sol:7:23] -> built-in
+- Ref: ["add" @ input.sol:7:29] -> #2
+- Ref: ["slot" @ input.sol:7:33] -> built-in
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     uint256 add;
+   │             ─┬─  
+   │              ╰─── name: 2
+   │ 
+ 4 │     function test() public view returns (uint256 result) {
+   │              ──┬─                                ───┬──  
+   │                ╰───────────────────────────────────────── name: 3
+   │                                                     │    
+   │                                                     ╰──── name: 4
+   │ 
+ 7 │             result := sload(add.slot)
+   │             ───┬──    ──┬── ─┬─ ──┬─  
+   │                ╰────────────────────── ref: 4
+   │                         │    │    │   
+   │                         ╰───────────── built-in
+   │                              │    │   
+   │                              ╰──────── ref: 2
+   │                                   │   
+   │                                   ╰─── built-in
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/slot_access_resolves_to_solidity/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/slot_access_resolves_to_solidity/input.sol
@@ -1,0 +1,10 @@
+contract Test {
+    uint256 add;
+
+    function test() public view returns (uint256 result) {
+        assembly {
+            // `add` here resolves to the state variable, not the built-in
+            result := sload(add.slot)
+        }
+    }
+}


### PR DESCRIPTION
This was raised by @hedgar2017 

Identifiers named after Yul built-ins inside Yul scopes should *always* resolve to the built-in. The only exception is when using the suffix notation (eg. `.slot`, `.offset`, etc) in which case the symbol should _always_ resolve to a Solidity definition. This PR addresses both of these cases.
