### PR TITLE
[v2] test(diagnostics): Add tests for already covered `receive` and `constructor` functions cases

### DIFF
--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -106,6 +106,11 @@ mod constructor_definition {
     fn virtual_attribute() -> Result<()> {
         run("ConstructorDefinition", "virtual_attribute")
     }
+
+    #[test]
+    fn with_returns() -> Result<()> {
+        run("ConstructorDefinition", "with_returns")
+    }
 }
 
 mod contract_definition {

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -1321,6 +1321,16 @@ mod receive_function_definition {
     use super::*;
 
     #[test]
+    fn inherited_return_values() -> Result<()> {
+        run("ReceiveFunctionDefinition", "inherited_return_values")
+    }
+
+    #[test]
+    fn return_values() -> Result<()> {
+        run("ReceiveFunctionDefinition", "return_values")
+    }
+
+    #[test]
     fn simple() -> Result<()> {
         run("ReceiveFunctionDefinition", "simple")
     }

--- a/crates/solidity-v2/testing/snapshots/cst_output/ConstructorDefinition/with_returns/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ConstructorDefinition/with_returns/generated/0.8.0-failure.yml
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     constructor() returns (uint x) {}                                            │ 13..50
+  3  │ }                                                                                │ 51..52
+
+Errors: # 1 total
+  - >
+    [syntax/unexpected-terminal] Error: Unexpected ReturnsKeyword. One of AtKeyword, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, InternalKeyword, LayoutKeyword, OpenBrace, PayableKeyword, PublicKeyword, RevertKeyword, TransientKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ConstructorDefinition/with_returns/input.sol:2:19]
+       │
+     2 │     constructor() returns (uint x) {}
+       │                   ───┬───  
+       │                      ╰───── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ConstructorDefinition/with_returns/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ConstructorDefinition/with_returns/input.sol
@@ -1,0 +1,3 @@
+contract C {
+    constructor() returns (uint x) {}
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/inherited_return_values/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/inherited_return_values/generated/0.8.0-failure.yml
@@ -1,0 +1,22 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     receive() external payable virtual returns (uint256) {}                      │ 13..72
+  3  │ }                                                                                │ 73..74
+  4  │ contract D is C {                                                                │ 75..92
+  5  │     receive() external payable override {}                                       │ 93..135
+  6  │ }                                                                                │ 136..137
+
+Errors: # 1 total
+  - >
+    [syntax/unexpected-terminal] Error: Unexpected ReturnsKeyword. One of AtKeyword, ErrorKeyword, ExternalKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, OpenBrace, OverrideKeyword, PayableKeyword, RevertKeyword, Semicolon, TransientKeyword, VirtualKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/inherited_return_values/input.sol:2:40]
+       │
+     2 │     receive() external payable virtual returns (uint256) {}
+       │                                        ───┬───  
+       │                                           ╰───── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/inherited_return_values/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/inherited_return_values/input.sol
@@ -1,0 +1,6 @@
+contract C {
+    receive() external payable virtual returns (uint256) {}
+}
+contract D is C {
+    receive() external payable override {}
+}

--- a/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/return_values/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/return_values/generated/0.8.0-failure.yml
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     receive() external payable returns (uint256) {}                              │ 13..64
+  3  │ }                                                                                │ 65..66
+
+Errors: # 1 total
+  - >
+    [syntax/unexpected-terminal] Error: Unexpected ReturnsKeyword. One of AtKeyword, ErrorKeyword, ExternalKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, OpenBrace, OverrideKeyword, PayableKeyword, RevertKeyword, Semicolon, TransientKeyword, VirtualKeyword was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/return_values/input.sol:2:32]
+       │
+     2 │     receive() external payable returns (uint256) {}
+       │                                ───┬───  
+       │                                   ╰───── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/return_values/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/ReceiveFunctionDefinition/return_values/input.sol
@@ -1,0 +1,3 @@
+contract C {
+    receive() external payable returns (uint256) {}
+}


### PR DESCRIPTION
This PR adds tests for cases that were already failing due to the grammar, but were untested.


Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1410
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1411
Fixes https://github.com/NomicFoundation/slang-diagnostics-research/issues/1704