### PR TITLE
feat(diagnostics): Emit for duplicate inheritance lists or storage layout specifiers

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -931,6 +931,8 @@ pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::IncompatibleSyntaxVersion(slang_solidity_v2_common::diagnostics::kinds::syntax::IncompatibleSyntaxVersion)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::InvalidMutability(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidMutability)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::InvalidVisibility(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility)
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MoreThanOneInheritanceList(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList)
+pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MoreThanOneStorageLayout(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleMutabilitySpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleOverrideSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::MultipleVirtualSpecifiers(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleVirtualSpecifiers)
@@ -950,6 +952,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::I
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
@@ -1052,6 +1058,44 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout> for slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers
@@ -1592,6 +1636,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::I
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleOverrideSpecifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1876,6 +1924,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::InvalidVisibility::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneInheritanceList::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MoreThanOneStorageLayout::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::MultipleMutabilitySpecifiers::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -569,6 +569,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualModifier(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::StorageLayoutForAbstractContract(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UninitializedConstant(slang_solidity_v2_common::diagnostics::kinds::structure::UninitializedConstant)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::VirtualFreeFunction(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction)
@@ -602,6 +603,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -849,6 +852,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
@@ -1618,6 +1640,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1888,6 +1912,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -10,6 +10,7 @@ mod library_receive_function;
 mod library_virtual_function;
 mod library_virtual_modifier;
 mod multiple_constructors;
+mod storage_layout_for_abstract_contract;
 mod unimplemented_modifier_must_be_virtual;
 mod uninitialized_constant;
 mod virtual_free_function;
@@ -28,6 +29,7 @@ pub use library_virtual_function::LibraryVirtualFunction;
 pub use library_virtual_modifier::LibraryVirtualModifier;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
+pub use storage_layout_for_abstract_contract::StorageLayoutForAbstractContract;
 pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
 pub use uninitialized_constant::UninitializedConstant;
 pub use virtual_free_function::VirtualFreeFunction;
@@ -83,5 +85,8 @@ define_diagnostic_kind! {
 
         /// A `constant` is declared without an initializer value.
         UninitializedConstant(UninitializedConstant),
+
+        /// An abstract contract declares a storage layout (`layout at`) specifier.
+        StorageLayoutForAbstractContract(StorageLayoutForAbstractContract),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/storage_layout_for_abstract_contract.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/storage_layout_for_abstract_contract.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when an abstract contract declares a storage layout
+/// (`layout at`) specifier.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StorageLayoutForAbstractContract;
+
+impl DiagnosticExtensions for StorageLayoutForAbstractContract {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/storage-layout-for-abstract-contract"
+    }
+
+    fn message(&self) -> String {
+        "Storage layout cannot be specified for abstract contracts.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/mod.rs
@@ -2,6 +2,8 @@ mod expected_array_length_expression;
 mod incompatible_syntax_version;
 mod invalid_mutability;
 mod invalid_visibility;
+mod more_than_one_inheritance_list;
+mod more_than_one_storage_layout;
 mod multiple_mutability_specifiers;
 mod multiple_override_specifiers;
 mod multiple_virtual_specifiers;
@@ -13,6 +15,8 @@ pub use expected_array_length_expression::ExpectedArrayLengthExpression;
 pub use incompatible_syntax_version::IncompatibleSyntaxVersion;
 pub use invalid_mutability::InvalidMutability;
 pub use invalid_visibility::InvalidVisibility;
+pub use more_than_one_inheritance_list::MoreThanOneInheritanceList;
+pub use more_than_one_storage_layout::MoreThanOneStorageLayout;
 pub use multiple_mutability_specifiers::MultipleMutabilitySpecifiers;
 pub use multiple_override_specifiers::MultipleOverrideSpecifiers;
 pub use multiple_virtual_specifiers::MultipleVirtualSpecifiers;
@@ -52,12 +56,16 @@ define_diagnostic_kind! {
 
         /// More than one `virtual` specifier was provided on a definition.
         MultipleVirtualSpecifiers(MultipleVirtualSpecifiers),
-
         /// More than one `override` specifier was provided on a definition.
         MultipleOverrideSpecifiers(MultipleOverrideSpecifiers),
 
         /// A range/slice index access was used where an array length
         /// expression is expected
         ExpectedArrayLengthExpression(ExpectedArrayLengthExpression),
+
+        /// A contract declared more than one inheritance (`is`) list.
+        MoreThanOneInheritanceList(MoreThanOneInheritanceList),
+        /// A contract declared more than one storage layout (`layout at`) specifier.
+        MoreThanOneStorageLayout(MoreThanOneStorageLayout),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/more_than_one_inheritance_list.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/more_than_one_inheritance_list.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a contract declares more than one inheritance
+/// (`is`) list.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MoreThanOneInheritanceList;
+
+impl DiagnosticExtensions for MoreThanOneInheritanceList {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "syntax/more-than-one-inheritance-list"
+    }
+
+    fn message(&self) -> String {
+        "More than one inheritance list.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/more_than_one_storage_layout.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/syntax/more_than_one_storage_layout.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a contract declares more than one storage layout
+/// (`layout at`) specifier.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MoreThanOneStorageLayout;
+
+impl DiagnosticExtensions for MoreThanOneStorageLayout {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "syntax/more-than-one-storage-layout"
+    }
+
+    fn message(&self) -> String {
+        "More than one storage layout definition.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -6,6 +6,9 @@ pub(crate) mod node_id_generator;
 use std::sync::Arc;
 
 use slang_solidity_v2_common::diagnostics::kinds::structure::UninitializedConstant;
+use slang_solidity_v2_common::diagnostics::kinds::syntax::{
+    MoreThanOneInheritanceList, MoreThanOneStorageLayout,
+};
 use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -102,25 +105,51 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         let is_abstract = source.abstract_keyword.is_some();
         let name = self.build_identifier(&source.name);
         let members = self.build_contract_members(&source.members);
-        let inheritance_types = source
-            .specifiers
-            .elements
-            .iter()
-            .find_map(|specifier| {
+        let mut inheritance_specifiers =
+            source.specifiers.elements.iter().filter_map(|specifier| {
                 if let input::ContractSpecifier::InheritanceSpecifier(inheritance) = specifier {
-                    Some(self.build_inheritance_specifier(inheritance))
+                    Some(inheritance)
                 } else {
                     None
                 }
-            })
+            });
+        let inheritance_types = inheritance_specifiers
+            .next()
+            .map(|inheritance| self.build_inheritance_specifier(inheritance))
             .unwrap_or_default();
-        let storage_layout = source.specifiers.elements.iter().find_map(|specifier| {
-            if let input::ContractSpecifier::StorageLayoutSpecifier(storage_layout) = specifier {
-                Some(self.build_storage_layout_specifier(storage_layout))
-            } else {
-                None
-            }
-        });
+        // The grammar allows more than one inheritance list; solc only accepts
+        // the first and rejects any subsequent ones.
+        for inheritance in inheritance_specifiers {
+            self.diagnostics.push(
+                self.file_id.to_owned(),
+                inheritance.is_keyword.calculate_text_range().unwrap(),
+                MoreThanOneInheritanceList,
+            );
+        }
+        let mut storage_layout_specifiers =
+            source.specifiers.elements.iter().filter_map(|specifier| {
+                if let input::ContractSpecifier::StorageLayoutSpecifier(storage_layout) = specifier
+                {
+                    Some(storage_layout)
+                } else {
+                    None
+                }
+            });
+        let storage_layout = storage_layout_specifiers
+            .next()
+            .map(|storage_layout| self.build_storage_layout_specifier(storage_layout));
+        // The grammar allows more than one storage layout specifier; solc only
+        // accepts the first and rejects any subsequent ones.
+        for storage_layout in storage_layout_specifiers {
+            self.diagnostics.push(
+                self.file_id.to_owned(),
+                storage_layout
+                    .layout_keyword
+                    .calculate_text_range()
+                    .unwrap(),
+                MoreThanOneStorageLayout,
+            );
+        }
 
         Arc::new(output::ContractDefinitionStruct {
             id,

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -5,7 +5,9 @@ pub(crate) mod node_id_generator;
 
 use std::sync::Arc;
 
-use slang_solidity_v2_common::diagnostics::kinds::structure::UninitializedConstant;
+use slang_solidity_v2_common::diagnostics::kinds::structure::{
+    StorageLayoutForAbstractContract, UninitializedConstant,
+};
 use slang_solidity_v2_common::diagnostics::kinds::syntax::{
     MoreThanOneInheritanceList, MoreThanOneStorageLayout,
 };
@@ -135,8 +137,21 @@ impl<S: Source> CstToIrBuilder<'_, S> {
                     None
                 }
             });
-        let storage_layout = storage_layout_specifiers
-            .next()
+        let first_storage_layout_specifier = storage_layout_specifiers.next();
+        // Abstract contracts cannot specify a storage layout.
+        if is_abstract {
+            if let Some(storage_layout) = first_storage_layout_specifier {
+                self.diagnostics.push(
+                    self.file_id.to_owned(),
+                    storage_layout
+                        .layout_keyword
+                        .calculate_text_range()
+                        .unwrap(),
+                    StorageLayoutForAbstractContract,
+                );
+            }
+        }
+        let storage_layout = first_storage_layout_specifier
             .map(|storage_layout| self.build_storage_layout_specifier(storage_layout));
         // The grammar allows more than one storage layout specifier; solc only
         // accepts the first and rejects any subsequent ones.

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -953,6 +953,16 @@ mod syntax {
         }
     }
 
+    #[test]
+    fn more_than_one_inheritance_list() -> Result<()> {
+        run("syntax", "more_than_one_inheritance_list")
+    }
+
+    #[test]
+    fn more_than_one_storage_layout() -> Result<()> {
+        run("syntax", "more_than_one_storage_layout")
+    }
+
     mod multiple_mutability_specifiers {
         use super::*;
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -832,6 +832,11 @@ mod structure {
     }
 
     #[test]
+    fn storage_layout_for_abstract_contract() -> Result<()> {
+        run("structure", "storage_layout_for_abstract_contract")
+    }
+
+    #[test]
     fn unimplemented_modifier_must_be_virtual() -> Result<()> {
         run("structure", "unimplemented_modifier_must_be_virtual")
     }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:19]
+   │
+ 5 │ contract Concrete layout at 0x1234 {}
+   │                   ────────┬───────  
+   │                           ╰───────── Error occurred here.
+───╯
+
+[structure/storage-layout-for-abstract-contract] Error: Storage layout cannot be specified for abstract contracts.
+   ╭─[input.sol:8:28]
+   │
+ 8 │ abstract contract Abstract layout at 0x1234 {}
+   │                            ───┬──  
+   │                               ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:8:28]
+   │
+ 8 │ abstract contract Abstract layout at 0x1234 {}
+   │                            ────────┬───────  
+   │                                    ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/storage-layout-for-abstract-contract] Error: Storage layout cannot be specified for abstract contracts.
+   ╭─[input.sol:8:28]
+   │
+ 8 │ abstract contract Abstract layout at 0x1234 {}
+   │                            ───┬──  
+   │                               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:19]
+   │
+ 5 │ contract Concrete layout at 0x1234 {}
+   │                   ───┬──  
+   │                      ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7587] Error: Storage layout cannot be specified for abstract contracts.
+   ╭─[input.sol:8:28]
+   │
+ 8 │ abstract contract Abstract layout at 0x1234 {}
+   │                            ────────┬───────  
+   │                                    ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/storage_layout_for_abstract_contract/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Valid: a non-abstract contract may specify a storage layout.
+contract Concrete layout at 0x1234 {}
+
+// Invalid: an abstract contract cannot specify a storage layout.
+abstract contract Abstract layout at 0x1234 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/more-than-one-inheritance-list] Error: More than one inheritance list.
+    ╭─[input.sol:11:29]
+    │
+ 11 │ contract Duplicated is A, B is B {}
+    │                             ─┬  
+    │                              ╰── Error occurred here.
+────╯
+
+[syntax/more-than-one-inheritance-list] Error: More than one inheritance list.
+    ╭─[input.sol:14:24]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                        ─┬  
+    │                         ╰── Error occurred here.
+────╯
+
+[syntax/more-than-one-inheritance-list] Error: More than one inheritance list.
+    ╭─[input.sol:14:29]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                             ─┬  
+    │                              ╰── Error occurred here.
+────╯
+
+[syntax/more-than-one-inheritance-list] Error: More than one inheritance list.
+    ╭─[input.sol:14:34]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                                  ─┬  
+    │                                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got 'is'
+    ╭─[input.sol:11:29]
+    │
+ 11 │ contract Duplicated is A, B is B {}
+    │                             ─┬  
+    │                              ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[ParserError 6668] Error: More than one inheritance list.
+    ╭─[input.sol:11:29]
+    │
+ 11 │ contract Duplicated is A, B is B {}
+    │                             ─┬  
+    │                              ╰── Error occurred here.
+────╯
+
+[ParserError 6668] Error: More than one inheritance list.
+    ╭─[input.sol:14:24]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                        ─┬  
+    │                         ╰── Error occurred here.
+────╯
+
+[ParserError 6668] Error: More than one inheritance list.
+    ╭─[input.sol:14:29]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                             ─┬  
+    │                              ╰── Error occurred here.
+────╯
+
+[ParserError 6668] Error: More than one inheritance list.
+    ╭─[input.sol:14:34]
+    │
+ 14 │ contract Repeated is A is B is B is A {}
+    │                                  ─┬  
+    │                                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_inheritance_list/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {}
+contract B {}
+
+// Valid: a single inheritance list is not flagged.
+contract Valid is A, B {}
+
+// Two inheritance lists: the second `is` is flagged.
+contract Duplicated is A, B is B {}
+
+// Several repeated inheritance lists: every `is` after the first is flagged.
+contract Repeated is A is B is B is A {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,91 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 11
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:5:16]
+   │
+ 5 │ contract Valid layout at 0x1234 {}
+   │                ────────┬───────  
+   │                        ╰───────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:8:21]
+   │
+ 8 │ contract Duplicated layout at 0x1234 layout at 0xABC {}
+   │                     ────────┬───────  
+   │                             ╰───────── Error occurred here.
+───╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+   ╭─[input.sol:8:38]
+   │
+ 8 │ contract Duplicated layout at 0x1234 layout at 0xABC {}
+   │                                      ───┬──  
+   │                                         ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+   ╭─[input.sol:8:38]
+   │
+ 8 │ contract Duplicated layout at 0x1234 layout at 0xABC {}
+   │                                      ───────┬───────  
+   │                                             ╰───────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+    ╭─[input.sol:11:19]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                   ────────┬───────  
+    │                           ╰───────── Error occurred here.
+────╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:36]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                    ───┬──  
+    │                                       ╰──── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+    ╭─[input.sol:11:36]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                    ───────┬───────  
+    │                                           ╰───────── Error occurred here.
+────╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:52]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                    ───┬──  
+    │                                                       ╰──── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+    ╭─[input.sol:11:52]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                    ────────┬───────  
+    │                                                            ╰───────── Error occurred here.
+────╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:69]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                                     ───┬──  
+    │                                                                        ╰──── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.
+    ╭─[input.sol:11:69]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                                     ───────┬───────  
+    │                                                                            ╰───────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/slang/0.8.29-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+   ╭─[input.sol:8:38]
+   │
+ 8 │ contract Duplicated layout at 0x1234 layout at 0xABC {}
+   │                                      ───┬──  
+   │                                         ╰──── Error occurred here.
+───╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:36]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                    ───┬──  
+    │                                       ╰──── Error occurred here.
+────╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:52]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                    ───┬──  
+    │                                                       ╰──── Error occurred here.
+────╯
+
+[syntax/more-than-one-storage-layout] Error: More than one storage layout definition.
+    ╭─[input.sol:11:69]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                                     ───┬──  
+    │                                                                        ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '{' but got identifier
+   ╭─[input.sol:5:16]
+   │
+ 5 │ contract Valid layout at 0x1234 {}
+   │                ───┬──  
+   │                   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/solc/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/generated/solc/0.8.29-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[ParserError 8714] Error: More than one storage layout definition.
+   ╭─[input.sol:8:38]
+   │
+ 8 │ contract Duplicated layout at 0x1234 layout at 0xABC {}
+   │                                      ───┬──  
+   │                                         ╰──── Error occurred here.
+───╯
+
+[ParserError 8714] Error: More than one storage layout definition.
+    ╭─[input.sol:11:36]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                    ───┬──  
+    │                                       ╰──── Error occurred here.
+────╯
+
+[ParserError 8714] Error: More than one storage layout definition.
+    ╭─[input.sol:11:52]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                    ───┬──  
+    │                                                       ╰──── Error occurred here.
+────╯
+
+[ParserError 8714] Error: More than one storage layout definition.
+    ╭─[input.sol:11:69]
+    │
+ 11 │ contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}
+    │                                                                     ───┬──  
+    │                                                                        ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/more_than_one_storage_layout/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Valid: a single storage layout specifier is not flagged.
+contract Valid layout at 0x1234 {}
+
+// Two storage layout specifiers: the second `layout` is flagged.
+contract Duplicated layout at 0x1234 layout at 0xABC {}
+
+// Several repeated storage layout specifiers: every `layout` after the first is flagged.
+contract Repeated layout at 0x1234 layout at 0xABC layout at 0x4321 layout at 0xCBA {}


### PR DESCRIPTION
Closes NomicFoundation/slang-diagnostics-research#1384
Closes NomicFoundation/slang-diagnostics-research#1599
Closes NomicFoundation/slang-diagnostics-research#1474

Also emit diagnostic when an `abstract` contract has a storage layout specifier

