### PR TITLE
feat(diagnostics): Emit for various misuses of the `virtual` keyword

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -570,6 +570,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualModifier(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::VirtualFreeFunction(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::VirtualPrivateFunction(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -604,6 +605,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -862,6 +865,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
@@ -1534,6 +1556,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1800,6 +1824,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualFreeFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -566,6 +566,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::InvalidUsingDirectiveContainer(slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryFallbackFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryReceiveFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualModifier(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
@@ -592,6 +593,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -780,6 +783,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
@@ -1480,6 +1502,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1732,6 +1756,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -570,6 +570,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualModifier(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::VirtualPrivateFunction(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -603,6 +604,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -859,6 +862,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::syntax
 pub enum slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExpectedArrayLengthExpression(slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression)
@@ -1512,6 +1534,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::IncompatibleSyntaxVersion> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1776,6 +1800,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::VirtualPrivateFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -567,6 +567,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryFallbackFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryReceiveFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -594,6 +595,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -793,6 +796,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::syntax
 pub enum slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::syntax::SyntaxDiagnosticKind::ExpectedArrayLengthExpression(slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression)
@@ -1440,6 +1462,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::syntax::IncompatibleSyntaxVersion> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1692,6 +1716,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -566,6 +566,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::InvalidUsingDirectiveContainer(slang_solidity_v2_common::diagnostics::kinds::structure::InvalidUsingDirectiveContainer)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryFallbackFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryReceiveFunction(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::LibraryVirtualModifier(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -591,6 +592,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -777,6 +780,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
@@ -1458,6 +1480,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryFallbackFunction) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1708,6 +1732,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryReceiveFunction::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::LibraryVirtualModifier::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_function.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a function declared in a library is marked `virtual`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LibraryVirtualFunction;
+
+impl DiagnosticExtensions for LibraryVirtualFunction {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/library-virtual-function"
+    }
+
+    fn message(&self) -> String {
+        "Library functions cannot be \"virtual\".".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_function.rs
@@ -17,6 +17,6 @@ impl DiagnosticExtensions for LibraryVirtualFunction {
     }
 
     fn message(&self) -> String {
-        "Library functions cannot be \"virtual\".".to_string()
+        "Library functions cannot be 'virtual'.".to_string()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_modifier.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_modifier.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a modifier declared in a library is marked `virtual`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LibraryVirtualModifier;
+
+impl DiagnosticExtensions for LibraryVirtualModifier {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/library-virtual-modifier"
+    }
+
+    fn message(&self) -> String {
+        "Modifiers in a library cannot be virtual.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_modifier.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/library_virtual_modifier.rs
@@ -17,6 +17,6 @@ impl DiagnosticExtensions for LibraryVirtualModifier {
     }
 
     fn message(&self) -> String {
-        "Modifiers in a library cannot be virtual.".to_string()
+        "Modifiers in a library cannot be 'virtual'.".to_string()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -7,6 +7,7 @@ mod function_name_matches_container;
 mod invalid_using_directive_container;
 mod library_fallback_function;
 mod library_receive_function;
+mod library_virtual_function;
 mod library_virtual_modifier;
 mod multiple_constructors;
 mod unimplemented_modifier_must_be_virtual;
@@ -20,6 +21,7 @@ pub use function_name_matches_container::FunctionNameMatchesContainer;
 pub use invalid_using_directive_container::InvalidUsingDirectiveContainer;
 pub use library_fallback_function::LibraryFallbackFunction;
 pub use library_receive_function::LibraryReceiveFunction;
+pub use library_virtual_function::LibraryVirtualFunction;
 pub use library_virtual_modifier::LibraryVirtualModifier;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
@@ -59,6 +61,8 @@ define_diagnostic_kind! {
         LibraryFallbackFunction(LibraryFallbackFunction),
         /// A library declares a receive function.
         LibraryReceiveFunction(LibraryReceiveFunction),
+        /// A function declared in a library is marked `virtual`.
+        LibraryVirtualFunction(LibraryVirtualFunction),
         /// A modifier declared in a library is marked `virtual`.
         LibraryVirtualModifier(LibraryVirtualModifier),
 

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -11,6 +11,7 @@ mod library_virtual_function;
 mod library_virtual_modifier;
 mod multiple_constructors;
 mod unimplemented_modifier_must_be_virtual;
+mod virtual_free_function;
 mod virtual_private_function;
 
 pub use break_outside_loop::BreakOutsideLoop;
@@ -27,6 +28,7 @@ pub use library_virtual_modifier::LibraryVirtualModifier;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
 pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
+pub use virtual_free_function::VirtualFreeFunction;
 pub use virtual_private_function::VirtualPrivateFunction;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
@@ -71,6 +73,8 @@ define_diagnostic_kind! {
         /// A modifier without an implementation body is not marked `virtual`.
         UnimplementedModifierMustBeVirtual(UnimplementedModifierMustBeVirtual),
 
+        /// A free function is marked `virtual`.
+        VirtualFreeFunction(VirtualFreeFunction),
         /// A function is marked both `virtual` and `private`.
         VirtualPrivateFunction(VirtualPrivateFunction),
     }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -8,6 +8,7 @@ mod invalid_using_directive_container;
 mod library_fallback_function;
 mod library_receive_function;
 mod multiple_constructors;
+mod unimplemented_modifier_must_be_virtual;
 
 pub use break_outside_loop::BreakOutsideLoop;
 pub use continue_outside_loop::ContinueOutsideLoop;
@@ -20,6 +21,7 @@ pub use library_fallback_function::LibraryFallbackFunction;
 pub use library_receive_function::LibraryReceiveFunction;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
+pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
 use crate::diagnostics::kinds::DiagnosticKind;
@@ -55,5 +57,8 @@ define_diagnostic_kind! {
         LibraryFallbackFunction(LibraryFallbackFunction),
         /// A library declares a receive function.
         LibraryReceiveFunction(LibraryReceiveFunction),
+
+        /// A modifier without an implementation body is not marked `virtual`.
+        UnimplementedModifierMustBeVirtual(UnimplementedModifierMustBeVirtual),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -7,6 +7,7 @@ mod function_name_matches_container;
 mod invalid_using_directive_container;
 mod library_fallback_function;
 mod library_receive_function;
+mod library_virtual_modifier;
 mod multiple_constructors;
 mod unimplemented_modifier_must_be_virtual;
 
@@ -19,6 +20,7 @@ pub use function_name_matches_container::FunctionNameMatchesContainer;
 pub use invalid_using_directive_container::InvalidUsingDirectiveContainer;
 pub use library_fallback_function::LibraryFallbackFunction;
 pub use library_receive_function::LibraryReceiveFunction;
+pub use library_virtual_modifier::LibraryVirtualModifier;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
 pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
@@ -57,6 +59,8 @@ define_diagnostic_kind! {
         LibraryFallbackFunction(LibraryFallbackFunction),
         /// A library declares a receive function.
         LibraryReceiveFunction(LibraryReceiveFunction),
+        /// A modifier declared in a library is marked `virtual`.
+        LibraryVirtualModifier(LibraryVirtualModifier),
 
         /// A modifier without an implementation body is not marked `virtual`.
         UnimplementedModifierMustBeVirtual(UnimplementedModifierMustBeVirtual),

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -11,6 +11,7 @@ mod library_virtual_function;
 mod library_virtual_modifier;
 mod multiple_constructors;
 mod unimplemented_modifier_must_be_virtual;
+mod virtual_private_function;
 
 pub use break_outside_loop::BreakOutsideLoop;
 pub use continue_outside_loop::ContinueOutsideLoop;
@@ -26,6 +27,7 @@ pub use library_virtual_modifier::LibraryVirtualModifier;
 pub use multiple_constructors::MultipleConstructors;
 use serde::Serialize;
 pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
+pub use virtual_private_function::VirtualPrivateFunction;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
 use crate::diagnostics::kinds::DiagnosticKind;
@@ -68,5 +70,8 @@ define_diagnostic_kind! {
 
         /// A modifier without an implementation body is not marked `virtual`.
         UnimplementedModifierMustBeVirtual(UnimplementedModifierMustBeVirtual),
+
+        /// A function is marked both `virtual` and `private`.
+        VirtualPrivateFunction(VirtualPrivateFunction),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/unimplemented_modifier_must_be_virtual.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/unimplemented_modifier_must_be_virtual.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a modifier has no implementation body and is not
+/// marked `virtual`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UnimplementedModifierMustBeVirtual;
+
+impl DiagnosticExtensions for UnimplementedModifierMustBeVirtual {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/unimplemented-modifier-must-be-virtual"
+    }
+
+    fn message(&self) -> String {
+        "Modifiers without implementation must be marked virtual.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/unimplemented_modifier_must_be_virtual.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/unimplemented_modifier_must_be_virtual.rs
@@ -18,6 +18,6 @@ impl DiagnosticExtensions for UnimplementedModifierMustBeVirtual {
     }
 
     fn message(&self) -> String {
-        "Modifiers without implementation must be marked virtual.".to_string()
+        "Modifiers without implementation must be 'virtual'.".to_string()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_free_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_free_function.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a free function is marked `virtual`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct VirtualFreeFunction;
+
+impl DiagnosticExtensions for VirtualFreeFunction {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/virtual-free-function"
+    }
+
+    fn message(&self) -> String {
+        "Free functions cannot be virtual.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_free_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_free_function.rs
@@ -17,6 +17,6 @@ impl DiagnosticExtensions for VirtualFreeFunction {
     }
 
     fn message(&self) -> String {
-        "Free functions cannot be virtual.".to_string()
+        "Free functions cannot be 'virtual'.".to_string()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_private_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_private_function.rs
@@ -17,6 +17,6 @@ impl DiagnosticExtensions for VirtualPrivateFunction {
     }
 
     fn message(&self) -> String {
-        "\"virtual\" and \"private\" cannot be used together.".to_string()
+        "Attributes 'virtual' and 'private' cannot be used together.".to_string()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_private_function.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/virtual_private_function.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a function is marked both `virtual` and `private`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct VirtualPrivateFunction;
+
+impl DiagnosticExtensions for VirtualPrivateFunction {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/virtual-private-function"
+    }
+
+    fn message(&self) -> String {
+        "\"virtual\" and \"private\" cannot be used together.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclar
 use slang_solidity_v2_common::diagnostics::kinds::structure::{
     BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
     FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, MultipleConstructors,
+    UnimplementedModifierMustBeVirtual,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -408,6 +409,15 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
             }
 
             ir::FunctionKind::Modifier => {
+                // A modifier without an implementation body must be marked `virtual`.
+                if node.body.is_none() && !node.attributes.is_virtual {
+                    self.diagnostics.push(
+                        self.current_file.id().to_owned(),
+                        node.range.clone(),
+                        UnimplementedModifierMustBeVirtual,
+                    );
+                }
+
                 let definition = Definition::new_modifier(node);
                 self.insert_definition_in_current_scope(definition);
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration;
 use slang_solidity_v2_common::diagnostics::kinds::structure::{
     BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
-    FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, MultipleConstructors,
-    UnimplementedModifierMustBeVirtual,
+    FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualModifier,
+    MultipleConstructors, UnimplementedModifierMustBeVirtual,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -130,6 +130,15 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
     fn current_scope(&mut self) -> &mut Scope {
         let scope_id = self.current_scope_id();
         self.binder.get_scope_mut(scope_id)
+    }
+
+    /// Whether the current (enclosing) scope belongs to a library definition.
+    fn enclosing_container_is_library(&mut self) -> bool {
+        let node_id = self.current_scope().node_id();
+        matches!(
+            self.binder.find_definition_by_id(node_id),
+            Some(Definition::Library(_))
+        )
     }
 
     fn current_file_scope(&mut self) -> &mut FileScope {
@@ -415,6 +424,15 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                         self.current_file.id().to_owned(),
                         node.range.clone(),
                         UnimplementedModifierMustBeVirtual,
+                    );
+                }
+
+                // A modifier declared in a library cannot be marked `virtual`.
+                if node.attributes.is_virtual && self.enclosing_container_is_library() {
+                    self.diagnostics.push(
+                        self.current_file.id().to_owned(),
+                        node.range.clone(),
+                        LibraryVirtualModifier,
                     );
                 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -5,7 +5,7 @@ use slang_solidity_v2_common::diagnostics::kinds::structure::{
     BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
     FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualFunction,
     LibraryVirtualModifier, MultipleConstructors, UnimplementedModifierMustBeVirtual,
-    VirtualPrivateFunction,
+    VirtualFreeFunction, VirtualPrivateFunction,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -134,12 +134,18 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
     }
 
     /// Whether the current (enclosing) scope belongs to a library definition.
-    fn enclosing_container_is_library(&mut self) -> bool {
+    fn current_scope_is_library(&mut self) -> bool {
         let node_id = self.current_scope().node_id();
         matches!(
             self.binder.find_definition_by_id(node_id),
             Some(Definition::Library(_))
         )
+    }
+
+    /// Whether the current (enclosing) scope is the file scope, i.e. the
+    /// definition is a free (file-level) one.
+    fn current_scope_is_file(&mut self) -> bool {
+        matches!(self.current_scope(), Scope::File(_))
     }
 
     fn current_file_scope(&mut self) -> &mut FileScope {
@@ -364,24 +370,32 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
             | ir::FunctionKind::Constructor
             | ir::FunctionKind::Fallback
             | ir::FunctionKind::Receive => {
-                // A function declared in a library cannot be marked `virtual`.
-                if node.attributes.is_virtual && self.enclosing_container_is_library() {
-                    self.diagnostics.push(
-                        self.current_file.id().to_owned(),
-                        node.range.clone(),
-                        LibraryVirtualFunction,
-                    );
-                }
+                if node.attributes.is_virtual {
+                    // A function declared in a library cannot be marked `virtual`.
+                    if self.current_scope_is_library() {
+                        self.diagnostics.push(
+                            self.current_file.id().to_owned(),
+                            node.range.clone(),
+                            LibraryVirtualFunction,
+                        );
 
-                // A `private` function cannot also be marked `virtual`.
-                if node.attributes.is_virtual
-                    && node.attributes.visibility == ir::FunctionVisibility::Private
-                {
-                    self.diagnostics.push(
-                        self.current_file.id().to_owned(),
-                        node.range.clone(),
-                        VirtualPrivateFunction,
-                    );
+                    // A free (file-level) function cannot be marked `virtual`.
+                    } else if self.current_scope_is_file() {
+                        self.diagnostics.push(
+                            self.current_file.id().to_owned(),
+                            node.range.clone(),
+                            VirtualFreeFunction,
+                        );
+                    }
+
+                    // A `virtual` function cannot also be marked `private`.
+                    if node.attributes.visibility == ir::FunctionVisibility::Private {
+                        self.diagnostics.push(
+                            self.current_file.id().to_owned(),
+                            node.range.clone(),
+                            VirtualPrivateFunction,
+                        );
+                    }
                 }
 
                 let parameters_scope_id = self.collect_parameters(&node.parameters);
@@ -449,7 +463,7 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                 }
 
                 // A modifier declared in a library cannot be marked `virtual`.
-                if node.attributes.is_virtual && self.enclosing_container_is_library() {
+                if node.attributes.is_virtual && self.current_scope_is_library() {
                     self.diagnostics.push(
                         self.current_file.id().to_owned(),
                         node.range.clone(),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration;
 use slang_solidity_v2_common::diagnostics::kinds::structure::{
     BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
-    FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualModifier,
-    MultipleConstructors, UnimplementedModifierMustBeVirtual,
+    FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualFunction,
+    LibraryVirtualModifier, MultipleConstructors, UnimplementedModifierMustBeVirtual,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -363,6 +363,15 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
             | ir::FunctionKind::Constructor
             | ir::FunctionKind::Fallback
             | ir::FunctionKind::Receive => {
+                // A function declared in a library cannot be marked `virtual`.
+                if node.attributes.is_virtual && self.enclosing_container_is_library() {
+                    self.diagnostics.push(
+                        self.current_file.id().to_owned(),
+                        node.range.clone(),
+                        LibraryVirtualFunction,
+                    );
+                }
+
                 let parameters_scope_id = self.collect_parameters(&node.parameters);
 
                 if let Some(name) = &node.name {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -5,6 +5,7 @@ use slang_solidity_v2_common::diagnostics::kinds::structure::{
     BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
     FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualFunction,
     LibraryVirtualModifier, MultipleConstructors, UnimplementedModifierMustBeVirtual,
+    VirtualPrivateFunction,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -369,6 +370,17 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                         self.current_file.id().to_owned(),
                         node.range.clone(),
                         LibraryVirtualFunction,
+                    );
+                }
+
+                // A `private` function cannot also be marked `virtual`.
+                if node.attributes.is_virtual
+                    && node.attributes.visibility == ir::FunctionVisibility::Private
+                {
+                    self.diagnostics.push(
+                        self.current_file.id().to_owned(),
+                        node.range.clone(),
+                        VirtualPrivateFunction,
                     );
                 }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -820,6 +820,11 @@ mod structure {
     fn multiple_constructors() -> Result<()> {
         run("structure", "multiple_constructors")
     }
+
+    #[test]
+    fn unimplemented_modifier_must_be_virtual() -> Result<()> {
+        run("structure", "unimplemented_modifier_must_be_virtual")
+    }
 }
 
 mod syntax {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -835,6 +835,11 @@ mod structure {
     fn unimplemented_modifier_must_be_virtual() -> Result<()> {
         run("structure", "unimplemented_modifier_must_be_virtual")
     }
+
+    #[test]
+    fn virtual_private_function() -> Result<()> {
+        run("structure", "virtual_private_function")
+    }
 }
 
 mod syntax {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -817,6 +817,11 @@ mod structure {
     }
 
     #[test]
+    fn library_virtual_function() -> Result<()> {
+        run("structure", "library_virtual_function")
+    }
+
+    #[test]
     fn library_virtual_modifier() -> Result<()> {
         run("structure", "library_virtual_modifier")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -817,6 +817,11 @@ mod structure {
     }
 
     #[test]
+    fn library_virtual_modifier() -> Result<()> {
+        run("structure", "library_virtual_modifier")
+    }
+
+    #[test]
     fn multiple_constructors() -> Result<()> {
         run("structure", "multiple_constructors")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -837,6 +837,11 @@ mod structure {
     }
 
     #[test]
+    fn virtual_free_function() -> Result<()> {
+        run("structure", "virtual_free_function")
+    }
+
+    #[test]
     fn virtual_private_function() -> Result<()> {
         run("structure", "virtual_private_function")
     }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/library-virtual-function] Error: Library functions cannot be "virtual".
+   ╭─[input.sol:6:5]
+   │
+ 6 │     function f1() internal virtual {}
+   │     ────────────────┬────────────────  
+   │                     ╰────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-[structure/library-virtual-function] Error: Library functions cannot be "virtual".
+[structure/library-virtual-function] Error: Library functions cannot be 'virtual'.
    ╭─[input.sol:6:5]
    │
  6 │     function f1() internal virtual {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7801] Error: Library functions cannot be "virtual".
+   ╭─[input.sol:6:5]
+   │
+ 6 │     function f1() internal virtual {}
+   │     ────────────────┬────────────────  
+   │                     ╰────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_function/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+library L {
+    // A function in a library cannot be marked `virtual`.
+    function f1() internal virtual {}
+
+    // A non-virtual library function is allowed.
+    function f2() internal {}
+}
+
+contract C {
+    // A `virtual` function is allowed outside a library.
+    function f3() internal virtual {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/library-virtual-modifier] Error: Modifiers in a library cannot be virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │ ╭─▶     modifier m1() virtual {
+   ┆ ┆   
+ 8 │ ├─▶     }
+   │ │           
+   │ ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-[structure/library-virtual-modifier] Error: Modifiers in a library cannot be virtual.
+[structure/library-virtual-modifier] Error: Modifiers in a library cannot be 'virtual'.
    ╭─[input.sol:6:5]
    │
  6 │ ╭─▶     modifier m1() virtual {

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3275] Error: Modifiers in a library cannot be virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │ ╭─▶     modifier m1() virtual {
+   ┆ ┆   
+ 8 │ ├─▶     }
+   │ │           
+   │ ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,33 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
+   ╭─[input.sol:6:5]
+   │
+ 6 │ ╭─▶     modifier m1() virtual {
+   ┆ ┆   
+ 8 │ ├─▶     }
+   │ │           
+   │ ╰─────────── Error occurred here.
+───╯
+
+[Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
+    ╭─[input.sol:18:5]
+    │
+ 18 │ ╭─▶     modifier m3() virtual {
+    ┆ ┆   
+ 20 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+
+[TypeError 3275] Error: Modifiers in a library cannot be virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │ ╭─▶     modifier m1() virtual {
+   ┆ ┆   
+ 8 │ ├─▶     }
+   │ │           
+   │ ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/library_virtual_modifier/input.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+library L {
+    // A modifier in a library cannot be marked `virtual`.
+    modifier m1() virtual {
+        _;
+    }
+
+    // A non-virtual modifier in a library is allowed.
+    modifier m2() {
+        _;
+    }
+}
+
+contract C {
+    // A `virtual` modifier is allowed outside a library.
+    modifier m3() virtual {
+        _;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-[structure/unimplemented-modifier-must-be-virtual] Error: Modifiers without implementation must be marked virtual.
+[structure/unimplemented-modifier-must-be-virtual] Error: Modifiers without implementation must be 'virtual'.
    ╭─[input.sol:6:5]
    │
  6 │     modifier m1;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/unimplemented-modifier-must-be-virtual] Error: Modifiers without implementation must be marked virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     modifier m1;
+   │     ──────┬─────  
+   │           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.0-failure.txt
@@ -1,16 +1,6 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 2
-
-[TypeError 3656] Error: Contract "C" should be marked as abstract.
-    ╭─[input.sol:4:1]
-    │
-  4 │ ╭─▶ contract C {
-    ┆ ┆   
- 15 │ ├─▶ }
-    │ │       
-    │ ╰─────── Error occurred here.
-────╯
+Diagnostics: 1
 
 [TypeError 8063] Error: Modifiers without implementation must be marked virtual.
    ╭─[input.sol:6:5]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 3656] Error: Contract "C" should be marked as abstract.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ contract C {
+    ┆ ┆   
+ 15 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+
+[TypeError 8063] Error: Modifiers without implementation must be marked virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     modifier m1;
+   │     ──────┬─────  
+   │           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.31-failure.txt
@@ -1,6 +1,6 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 3
+Diagnostics: 2
 
 [Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
    ╭─[input.sol:9:5]
@@ -9,16 +9,6 @@ Diagnostics: 3
    │     ──────────┬─────────  
    │               ╰─────────── Error occurred here.
 ───╯
-
-[TypeError 3656] Error: Contract "C" should be marked as abstract.
-    ╭─[input.sol:4:1]
-    │
-  4 │ ╭─▶ contract C {
-    ┆ ┆   
- 15 │ ├─▶ }
-    │ │       
-    │ ╰─────── Error occurred here.
-────╯
 
 [TypeError 8063] Error: Modifiers without implementation must be marked virtual.
    ╭─[input.sol:6:5]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,29 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     modifier m2 virtual;
+   │     ──────────┬─────────  
+   │               ╰─────────── Error occurred here.
+───╯
+
+[TypeError 3656] Error: Contract "C" should be marked as abstract.
+    ╭─[input.sol:4:1]
+    │
+  4 │ ╭─▶ contract C {
+    ┆ ┆   
+ 15 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯
+
+[TypeError 8063] Error: Modifiers without implementation must be marked virtual.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     modifier m1;
+   │     ──────┬─────  
+   │           ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/input.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity *;
 
-contract C {
+abstract contract C {
     // An unimplemented modifier must be marked `virtual`.
     modifier m1;
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/unimplemented_modifier_must_be_virtual/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // An unimplemented modifier must be marked `virtual`.
+    modifier m1;
+
+    // Marked `virtual`, so this is allowed.
+    modifier m2 virtual;
+
+    // Has an implementation body, so this is allowed.
+    modifier m3() {
+        _;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/virtual-free-function] Error: Free functions cannot be virtual.
+   ╭─[input.sol:5:1]
+   │
+ 5 │ function f1() virtual {}
+   │ ────────────┬───────────  
+   │             ╰───────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-[structure/virtual-free-function] Error: Free functions cannot be virtual.
+[structure/virtual-free-function] Error: Free functions cannot be 'virtual'.
    ╭─[input.sol:5:1]
    │
  5 │ function f1() virtual {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[SyntaxError 4493] Error: Free functions cannot be virtual.
+   ╭─[input.sol:5:1]
+   │
+ 5 │ function f1() virtual {}
+   │ ────────────┬───────────  
+   │             ╰───────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_free_function/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A free (file-level) function cannot be marked `virtual`.
+function f1() virtual {}
+
+// A free function that is not `virtual` is allowed.
+function f2() {}
+
+contract C {
+    // A `virtual` function inside a contract is allowed.
+    function f3() internal virtual {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 1
 
-[structure/virtual-private-function] Error: "virtual" and "private" cannot be used together.
+[structure/virtual-private-function] Error: Attributes 'virtual' and 'private' cannot be used together.
    ╭─[input.sol:6:5]
    │
  6 │     function f1() private virtual {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/virtual-private-function] Error: "virtual" and "private" cannot be used together.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     function f1() private virtual {}
+   │     ────────────────┬───────────────  
+   │                     ╰───────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3942] Error: "virtual" and "private" cannot be used together.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     function f1() private virtual {}
+   │     ────────────────┬───────────────  
+   │                     ╰───────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/virtual_private_function/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A function cannot be both `private` and `virtual`.
+    function f1() private virtual {}
+
+    // A `private` function that is not `virtual` is allowed.
+    function f2() private {}
+
+    // A `virtual` function with another visibility is allowed.
+    function f3() internal virtual {}
+}


### PR DESCRIPTION
Closes NomicFoundation/slang-diagnostics-research#1037 (`virtual` and `private` cannot be used together)
Closes NomicFoundation/slang-diagnostics-research#959 (modifiers in library cannot be virtual)
Closes NomicFoundation/slang-diagnostics-research#1515 (functions in library cannot be virtual)
Closes NomicFoundation/slang-diagnostics-research#1538 (modifiers without body must be `virtual`)
Closes NomicFoundation/slang-diagnostics-research#1109 (free functions cannot be `virtual`)
