### PR TITLE
re-export `EvmTarget` from `slang_solidity_v2`

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -1771,7 +1771,7 @@ pub fn slang_solidity_v2_common::evm_targets::EvmTarget::eq(&self, &slang_solidi
 impl core::cmp::PartialOrd for slang_solidity_v2_common::evm_targets::EvmTarget
 pub fn slang_solidity_v2_common::evm_targets::EvmTarget::partial_cmp(&self, &slang_solidity_v2_common::evm_targets::EvmTarget) -> core::option::Option<core::cmp::Ordering>
 impl core::convert::TryFrom<&str> for slang_solidity_v2_common::evm_targets::EvmTarget
-pub type slang_solidity_v2_common::evm_targets::EvmTarget::Error = slang_solidity_v2_common::evm_targets::FromStrError
+pub type slang_solidity_v2_common::evm_targets::EvmTarget::Error = slang_solidity_v2_common::evm_targets::EvmTargetConversionError
 pub fn slang_solidity_v2_common::evm_targets::EvmTarget::try_from(&str) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for slang_solidity_v2_common::evm_targets::EvmTarget
 pub fn slang_solidity_v2_common::evm_targets::EvmTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1781,6 +1781,22 @@ impl core::marker::Copy for slang_solidity_v2_common::evm_targets::EvmTarget
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::evm_targets::EvmTarget
 impl serde_core::ser::Serialize for slang_solidity_v2_common::evm_targets::EvmTarget
 pub fn slang_solidity_v2_common::evm_targets::EvmTarget::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+pub enum slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub slang_solidity_v2_common::evm_targets::EvmTargetConversionError::UnrecognizedEvmTarget
+impl core::clone::Clone for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub fn slang_solidity_v2_common::evm_targets::EvmTargetConversionError::clone(&self) -> slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+impl core::cmp::Eq for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+impl core::cmp::PartialEq for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub fn slang_solidity_v2_common::evm_targets::EvmTargetConversionError::eq(&self, &slang_solidity_v2_common::evm_targets::EvmTargetConversionError) -> bool
+impl core::error::Error for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+impl core::fmt::Debug for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub fn slang_solidity_v2_common::evm_targets::EvmTargetConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub fn slang_solidity_v2_common::evm_targets::EvmTargetConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+pub fn slang_solidity_v2_common::evm_targets::EvmTargetConversionError::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::evm_targets::EvmTargetConversionError
 pub enum slang_solidity_v2_common::evm_targets::EvmTargetSpecifier
 pub slang_solidity_v2_common::evm_targets::EvmTargetSpecifier::From
 pub slang_solidity_v2_common::evm_targets::EvmTargetSpecifier::From::from: slang_solidity_v2_common::evm_targets::EvmTarget
@@ -1805,22 +1821,6 @@ pub fn slang_solidity_v2_common::evm_targets::EvmTargetSpecifier::fmt(&self, &mu
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::evm_targets::EvmTargetSpecifier
 impl serde_core::ser::Serialize for slang_solidity_v2_common::evm_targets::EvmTargetSpecifier
 pub fn slang_solidity_v2_common::evm_targets::EvmTargetSpecifier::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
-pub enum slang_solidity_v2_common::evm_targets::FromStrError
-pub slang_solidity_v2_common::evm_targets::FromStrError::UnrecognizedEvmTarget
-impl core::clone::Clone for slang_solidity_v2_common::evm_targets::FromStrError
-pub fn slang_solidity_v2_common::evm_targets::FromStrError::clone(&self) -> slang_solidity_v2_common::evm_targets::FromStrError
-impl core::cmp::Eq for slang_solidity_v2_common::evm_targets::FromStrError
-impl core::cmp::PartialEq for slang_solidity_v2_common::evm_targets::FromStrError
-pub fn slang_solidity_v2_common::evm_targets::FromStrError::eq(&self, &slang_solidity_v2_common::evm_targets::FromStrError) -> bool
-impl core::error::Error for slang_solidity_v2_common::evm_targets::FromStrError
-impl core::fmt::Debug for slang_solidity_v2_common::evm_targets::FromStrError
-pub fn slang_solidity_v2_common::evm_targets::FromStrError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for slang_solidity_v2_common::evm_targets::FromStrError
-pub fn slang_solidity_v2_common::evm_targets::FromStrError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for slang_solidity_v2_common::evm_targets::FromStrError
-pub fn slang_solidity_v2_common::evm_targets::FromStrError::hash<__H: core::hash::Hasher>(&self, &mut __H)
-impl core::marker::Copy for slang_solidity_v2_common::evm_targets::FromStrError
-impl core::marker::StructuralPartialEq for slang_solidity_v2_common::evm_targets::FromStrError
 pub mod slang_solidity_v2_common::files
 pub struct slang_solidity_v2_common::files::FileId(_)
 impl core::clone::Clone for slang_solidity_v2_common::files::FileId
@@ -2108,23 +2108,6 @@ pub mod slang_solidity_v2_common::utils
 pub fn slang_solidity_v2_common::utils::strip_string_literal_prefix_and_quotes<'a>(&'a str, &str) -> &'a str
 pub fn slang_solidity_v2_common::utils::strip_string_literal_quotes(&str) -> &str
 pub mod slang_solidity_v2_common::versions
-pub enum slang_solidity_v2_common::versions::FromSemverError
-pub slang_solidity_v2_common::versions::FromSemverError::UnexpectedMetadata
-pub slang_solidity_v2_common::versions::FromSemverError::UnsupportedVersion
-impl core::clone::Clone for slang_solidity_v2_common::versions::FromSemverError
-pub fn slang_solidity_v2_common::versions::FromSemverError::clone(&self) -> slang_solidity_v2_common::versions::FromSemverError
-impl core::cmp::Eq for slang_solidity_v2_common::versions::FromSemverError
-impl core::cmp::PartialEq for slang_solidity_v2_common::versions::FromSemverError
-pub fn slang_solidity_v2_common::versions::FromSemverError::eq(&self, &slang_solidity_v2_common::versions::FromSemverError) -> bool
-impl core::error::Error for slang_solidity_v2_common::versions::FromSemverError
-impl core::fmt::Debug for slang_solidity_v2_common::versions::FromSemverError
-pub fn slang_solidity_v2_common::versions::FromSemverError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for slang_solidity_v2_common::versions::FromSemverError
-pub fn slang_solidity_v2_common::versions::FromSemverError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for slang_solidity_v2_common::versions::FromSemverError
-pub fn slang_solidity_v2_common::versions::FromSemverError::hash<__H: core::hash::Hasher>(&self, &mut __H)
-impl core::marker::Copy for slang_solidity_v2_common::versions::FromSemverError
-impl core::marker::StructuralPartialEq for slang_solidity_v2_common::versions::FromSemverError
 pub enum slang_solidity_v2_common::versions::LanguageVersion
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_0
 pub slang_solidity_v2_common::versions::LanguageVersion::V0_8_1
@@ -2178,7 +2161,7 @@ pub fn slang_solidity_v2_common::versions::LanguageVersion::partial_cmp(&self, &
 impl core::convert::From<slang_solidity_v2_common::versions::LanguageVersion> for semver::Version
 pub fn semver::Version::from(slang_solidity_v2_common::versions::LanguageVersion) -> Self
 impl core::convert::TryFrom<semver::Version> for slang_solidity_v2_common::versions::LanguageVersion
-pub type slang_solidity_v2_common::versions::LanguageVersion::Error = slang_solidity_v2_common::versions::FromSemverError
+pub type slang_solidity_v2_common::versions::LanguageVersion::Error = slang_solidity_v2_common::versions::LanguageVersionConversionError
 pub fn slang_solidity_v2_common::versions::LanguageVersion::try_from(semver::Version) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for slang_solidity_v2_common::versions::LanguageVersion
 pub fn slang_solidity_v2_common::versions::LanguageVersion::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -2188,6 +2171,23 @@ impl core::marker::Copy for slang_solidity_v2_common::versions::LanguageVersion
 impl core::marker::StructuralPartialEq for slang_solidity_v2_common::versions::LanguageVersion
 impl serde_core::ser::Serialize for slang_solidity_v2_common::versions::LanguageVersion
 pub fn slang_solidity_v2_common::versions::LanguageVersion::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+pub enum slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub slang_solidity_v2_common::versions::LanguageVersionConversionError::UnexpectedMetadata
+pub slang_solidity_v2_common::versions::LanguageVersionConversionError::UnsupportedVersion
+impl core::clone::Clone for slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub fn slang_solidity_v2_common::versions::LanguageVersionConversionError::clone(&self) -> slang_solidity_v2_common::versions::LanguageVersionConversionError
+impl core::cmp::Eq for slang_solidity_v2_common::versions::LanguageVersionConversionError
+impl core::cmp::PartialEq for slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub fn slang_solidity_v2_common::versions::LanguageVersionConversionError::eq(&self, &slang_solidity_v2_common::versions::LanguageVersionConversionError) -> bool
+impl core::error::Error for slang_solidity_v2_common::versions::LanguageVersionConversionError
+impl core::fmt::Debug for slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub fn slang_solidity_v2_common::versions::LanguageVersionConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub fn slang_solidity_v2_common::versions::LanguageVersionConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_common::versions::LanguageVersionConversionError
+pub fn slang_solidity_v2_common::versions::LanguageVersionConversionError::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for slang_solidity_v2_common::versions::LanguageVersionConversionError
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::versions::LanguageVersionConversionError
 pub enum slang_solidity_v2_common::versions::LanguageVersionSpecifier
 pub slang_solidity_v2_common::versions::LanguageVersionSpecifier::From
 pub slang_solidity_v2_common::versions::LanguageVersionSpecifier::From::from: slang_solidity_v2_common::versions::LanguageVersion

--- a/crates/solidity-v2/outputs/cargo/common/src/evm_targets/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/evm_targets/mod.rs
@@ -3,4 +3,4 @@ mod specifier;
 mod target;
 
 pub use specifier::EvmTargetSpecifier;
-pub use target::{EvmTarget, FromStrError};
+pub use target::{EvmTarget, EvmTargetConversionError};

--- a/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.generated.rs
@@ -75,13 +75,13 @@ impl Display for EvmTarget {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error, Hash)]
-pub enum FromStrError {
+pub enum EvmTargetConversionError {
     #[error("Provided value is not recognized as a supported EVM target.")]
     UnrecognizedEvmTarget,
 }
 
 impl TryFrom<&str> for EvmTarget {
-    type Error = FromStrError;
+    type Error = EvmTargetConversionError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
@@ -100,7 +100,7 @@ impl TryFrom<&str> for EvmTarget {
             "Cancun" => Ok(EvmTarget::Cancun),
             "Prague" => Ok(EvmTarget::Prague),
             "Osaka" => Ok(EvmTarget::Osaka),
-            _ => Err(FromStrError::UnrecognizedEvmTarget),
+            _ => Err(EvmTargetConversionError::UnrecognizedEvmTarget),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.rs.jinja2
@@ -37,20 +37,20 @@ impl Display for EvmTarget {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error, Hash)]
-pub enum FromStrError {
+pub enum EvmTargetConversionError {
     #[error("Provided value is not recognized as a supported EVM target.")]
     UnrecognizedEvmTarget,
 }
 
 impl TryFrom<&str> for EvmTarget {
-    type Error = FromStrError;
+    type Error = EvmTargetConversionError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             {%- for evm_target in model.language.evm_targets %}
                 "{{ evm_target }}" => Ok(EvmTarget::{{ evm_target }}),
             {%- endfor %}
-            _ => Err(FromStrError::UnrecognizedEvmTarget),
+            _ => Err(EvmTargetConversionError::UnrecognizedEvmTarget),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/mod.rs
@@ -3,7 +3,7 @@ mod specifier;
 mod version;
 
 pub use specifier::LanguageVersionSpecifier;
-pub use version::{FromSemverError, LanguageVersion};
+pub use version::{LanguageVersion, LanguageVersionConversionError};
 
 #[cfg(test)]
 mod tests;

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/tests.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/tests.rs
@@ -1,4 +1,4 @@
-use crate::versions::version::{FromSemverError, LanguageVersion};
+use crate::versions::version::{LanguageVersion, LanguageVersionConversionError};
 
 #[test]
 fn test_correct_version() {
@@ -10,24 +10,36 @@ fn test_correct_version() {
 fn test_older_version() {
     let unsupported_version = semver::Version::new(0, 7, 6);
     let version = LanguageVersion::try_from(unsupported_version.clone());
-    assert_eq!(version, Err(FromSemverError::UnsupportedVersion));
+    assert_eq!(
+        version,
+        Err(LanguageVersionConversionError::UnsupportedVersion)
+    );
 }
 
 #[test]
 fn test_newer_version() {
     let unsupported_version = semver::Version::new(0, 9, 0);
     let version = LanguageVersion::try_from(unsupported_version.clone());
-    assert_eq!(version, Err(FromSemverError::UnsupportedVersion));
+    assert_eq!(
+        version,
+        Err(LanguageVersionConversionError::UnsupportedVersion)
+    );
 }
 
 #[test]
 fn test_pre_release_metadata() {
     let version = LanguageVersion::try_from(semver::Version::parse("0.8.0-alpha").unwrap());
-    assert_eq!(version, Err(FromSemverError::UnexpectedMetadata));
+    assert_eq!(
+        version,
+        Err(LanguageVersionConversionError::UnexpectedMetadata)
+    );
 }
 
 #[test]
 fn test_build_metadata() {
     let version = LanguageVersion::try_from(semver::Version::parse("0.8.0+alpha").unwrap());
-    assert_eq!(version, Err(FromSemverError::UnexpectedMetadata));
+    assert_eq!(
+        version,
+        Err(LanguageVersionConversionError::UnexpectedMetadata)
+    );
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/version.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/version.generated.rs
@@ -97,7 +97,7 @@ impl LanguageVersion {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error, Hash)]
-pub enum FromSemverError {
+pub enum LanguageVersionConversionError {
     #[error("provided version is not supported")]
     UnsupportedVersion,
     #[error("versions with pre-release or build metadata are not supported")]
@@ -105,7 +105,7 @@ pub enum FromSemverError {
 }
 
 impl TryFrom<Version> for LanguageVersion {
-    type Error = FromSemverError;
+    type Error = LanguageVersionConversionError;
 
     #[allow(clippy::too_many_lines)]
     fn try_from(version: Version) -> Result<Self, Self::Error> {
@@ -118,7 +118,7 @@ impl TryFrom<Version> for LanguageVersion {
         } = &version;
 
         if !pre.is_empty() || !build.is_empty() {
-            return Err(FromSemverError::UnexpectedMetadata);
+            return Err(LanguageVersionConversionError::UnexpectedMetadata);
         }
 
         Ok(match (major, minor, patch) {
@@ -158,7 +158,7 @@ impl TryFrom<Version> for LanguageVersion {
             (0, 8, 33) => LanguageVersion::V0_8_33,
             (0, 8, 34) => LanguageVersion::V0_8_34,
             (0, 8, 35) => LanguageVersion::V0_8_35,
-            _ => return Err(FromSemverError::UnsupportedVersion),
+            _ => return Err(LanguageVersionConversionError::UnsupportedVersion),
         })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/versions/version.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/common/src/versions/version.rs.jinja2
@@ -31,7 +31,7 @@ impl LanguageVersion {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error, Hash)]
-pub enum FromSemverError {
+pub enum LanguageVersionConversionError {
     #[error("provided version is not supported")]
     UnsupportedVersion,
     #[error("versions with pre-release or build metadata are not supported")]
@@ -39,7 +39,7 @@ pub enum FromSemverError {
 }
 
 impl TryFrom<Version> for LanguageVersion {
-    type Error = FromSemverError;
+    type Error = LanguageVersionConversionError;
 
     #[allow(clippy::too_many_lines)]
     fn try_from(version: Version) -> Result<Self, Self::Error> {
@@ -52,7 +52,7 @@ impl TryFrom<Version> for LanguageVersion {
         } = &version;
 
         if !pre.is_empty() || !build.is_empty() {
-            return Err(FromSemverError::UnexpectedMetadata);
+            return Err(LanguageVersionConversionError::UnexpectedMetadata);
         }
 
         Ok(match (major, minor, patch) {
@@ -61,7 +61,7 @@ impl TryFrom<Version> for LanguageVersion {
                     {{ _versions::version(v=version) }}
                 }
             {%- endfor %}
-            _ => return Err(FromSemverError::UnsupportedVersion),
+            _ => return Err(LanguageVersionConversionError::UnsupportedVersion),
         })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/generated/public_api.txt
@@ -46,6 +46,9 @@ pub use slang_solidity_v2::diagnostics::DiagnosticKind
 pub use slang_solidity_v2::diagnostics::DiagnosticSeverity
 pub use slang_solidity_v2::diagnostics::kinds
 pub mod slang_solidity_v2::utils
-pub use slang_solidity_v2::utils::FromSemverError
+pub use slang_solidity_v2::utils::EvmTarget
+pub use slang_solidity_v2::utils::EvmTargetConversionError
+pub use slang_solidity_v2::utils::EvmTargetSpecifier
 pub use slang_solidity_v2::utils::LanguageVersion
+pub use slang_solidity_v2::utils::LanguageVersionConversionError
 pub use slang_solidity_v2::utils::LanguageVersionSpecifier

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/utils.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/utils.rs
@@ -1,3 +1,6 @@
+pub use slang_solidity_v2_common::evm_targets::{
+    EvmTarget, EvmTargetConversionError, EvmTargetSpecifier,
+};
 pub use slang_solidity_v2_common::versions::{
-    FromSemverError, LanguageVersion, LanguageVersionSpecifier,
+    LanguageVersion, LanguageVersionConversionError, LanguageVersionSpecifier,
 };


### PR DESCRIPTION
While updating `solx`, I noticed this is not exposed, which forces `solx` to depend on the "internal" `slang_solidity_v2_common`.

Also renames the error types to differentiate between `LanguageVersion` and `EvmTarget` errors.

cc @ggiraldez 