### PR TITLE
add `FileId::as_str()` method

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -1823,6 +1823,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_common::evm_targets::EvmTa
 pub fn slang_solidity_v2_common::evm_targets::EvmTargetSpecifier::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub mod slang_solidity_v2_common::files
 pub struct slang_solidity_v2_common::files::FileId(_)
+impl slang_solidity_v2_common::files::FileId
+pub fn slang_solidity_v2_common::files::FileId::as_str(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_common::files::FileId::clone(&self) -> slang_solidity_v2_common::files::FileId
 impl core::cmp::Eq for slang_solidity_v2_common::files::FileId

--- a/crates/solidity-v2/outputs/cargo/common/src/files/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/files/mod.rs
@@ -15,6 +15,12 @@ use serde::Serialize;
 #[serde(transparent)]
 pub struct FileId(Arc<str>);
 
+impl FileId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl From<String> for FileId {
     fn from(value: String) -> Self {
         Self(value.into())

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/entries.rs
@@ -90,7 +90,7 @@ fn test_get_contracts_abi() {
     let contracts = unit.compute_contracts_abi();
     assert_eq!(1, contracts.len());
     assert_eq!("Counter", contracts[0].name());
-    assert_eq!("main.sol", contracts[0].file_id().to_string());
+    assert_eq!("main.sol", contracts[0].file_id().as_str());
     assert_eq!(7, contracts[0].entries().len());
 
     let entries = contracts[0].entries();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/node_location.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/node_location.rs
@@ -9,7 +9,7 @@ fn test_get_file_id_and_text_range() {
         .find_contract_by_name("Ownable")
         .next()
         .expect("contract is found");
-    assert_eq!(ownable.get_file_id().to_string(), "ownable.sol");
+    assert_eq!(ownable.get_file_id().as_str(), "ownable.sol");
 
     let owner = ownable
         .members()
@@ -23,7 +23,7 @@ fn test_get_file_id_and_text_range() {
         })
         .expect("_owner state variable is found");
     assert_eq!(owner.name().name(), "_owner");
-    assert_eq!(owner.get_file_id().to_string(), "ownable.sol");
+    assert_eq!(owner.get_file_id().as_str(), "ownable.sol");
 
     // The state variable's range must sit within the enclosing contract's range.
     assert!(ownable.get_text_range().start <= owner.get_text_range().start);
@@ -33,11 +33,11 @@ fn test_get_file_id_and_text_range() {
         .find_contract_by_name("Activatable")
         .next()
         .expect("contract is found");
-    assert_eq!(activatable.get_file_id().to_string(), "activatable.sol");
+    assert_eq!(activatable.get_file_id().as_str(), "activatable.sol");
 
     let counter = unit
         .find_contract_by_name("Counter")
         .next()
         .expect("contract is found");
-    assert_eq!(counter.get_file_id().to_string(), "main.sol");
+    assert_eq!(counter.get_file_id().as_str(), "main.sol");
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/unit.rs
@@ -20,9 +20,9 @@ fn test_get_file_ast_root() {
         .expect("activatable.sol is a file in the compilation unit")
         .ast();
 
-    assert_eq!(main_ast.file_id().to_string(), "main.sol");
-    assert_eq!(ownable_ast.file_id().to_string(), "ownable.sol");
-    assert_eq!(activatable_ast.file_id().to_string(), "activatable.sol");
+    assert_eq!(main_ast.file_id().as_str(), "main.sol");
+    assert_eq!(ownable_ast.file_id().as_str(), "ownable.sol");
+    assert_eq!(activatable_ast.file_id().as_str(), "activatable.sol");
 
     assert_eq!(main_ast.contracts().len(), 1);
     assert_eq!(ownable_ast.contracts().len(), 1);

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report.rs
@@ -113,7 +113,7 @@ fn report_diagnostics(
     for diagnostic in diagnostics {
         let file_id = diagnostic.file_id();
         let source = file_contents.get(file_id).cloned().unwrap_or_default();
-        let rendered = diagnostic::render(diagnostic, &file_id.to_string(), &source, false);
+        let rendered = diagnostic::render(diagnostic, file_id.as_str(), &source, false);
         writeln!(report, "{rendered}")?;
     }
     Ok(())
@@ -127,8 +127,7 @@ fn render_bindings_for_file(
     all_references: &[CollectedReference],
     unbound_identifiers: &[CollectedIdentifier],
 ) -> Result<()> {
-    let file_id_str = file_id.to_string();
-    let file_id_str = file_id_str.as_str();
+    let file_id_str = file_id.as_str();
     let mut builder: BuilderType<'_> =
         Report::build(ReportKind::Custom("Bindings", Color::Unset), file_id_str, 0)
             .with_config(Config::default().with_color(false));

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
@@ -40,7 +40,7 @@ impl TestTarget for SlangTarget {
             let source = files.get(file_id).cloned().unwrap_or_default();
             rendered.push(diagnostic::render(
                 diagnostic,
-                &file_id.to_string(),
+                file_id.as_str(),
                 &source,
                 false,
             ));

--- a/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/utils/path_resolver.rs
@@ -6,7 +6,7 @@ use slang_solidity_v2::compilation::FileId;
 /// `CompilationBuilderConfig::resolve_import` callback.
 pub(crate) fn resolve_import(source_file_id: &FileId, import_path: &str) -> Option<FileId> {
     if is_relative_path(import_path) {
-        normalize_path(import_path, get_parent_path(&source_file_id.to_string())).map(FileId::from)
+        normalize_path(import_path, get_parent_path(source_file_id.as_str())).map(FileId::from)
     } else {
         Some(import_path.into())
     }


### PR DESCRIPTION
Missing tiny utility, to prevent users like `solx` from needlessly using `.to_string()`/cloning the underlying string.