### PR TITLE
fix(v2): exclude private base constants from inherited resolution

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -285,6 +285,12 @@ impl Definition {
                 variable_definition.ir_node.attributes.visibility,
                 ir::StateVariableVisibility::Private
             ),
+            // A `private` constant is not inherited into derived contracts,
+            // mirroring private state variables above.
+            Self::Constant(constant_definition) => !matches!(
+                constant_definition.ir_node.visibility,
+                Some(ir::StateVariableVisibility::Private)
+            ),
             _ => true,
         }
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -53,6 +53,16 @@ mod arrays {
     }
 
     #[test]
+    fn fixed_size_with_inherited_constant() -> Result<()> {
+        run("arrays", "fixed_size_with_inherited_constant")
+    }
+
+    #[test]
+    fn fixed_size_with_private_base_constant() -> Result<()> {
+        run("arrays", "fixed_size_with_private_base_constant")
+    }
+
+    #[test]
     fn fixed_size_with_shadowed_constants() -> Result<()> {
         run("arrays", "fixed_size_with_shadowed_constants")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -173,6 +173,14 @@ mod resolution {
         }
 
         #[test]
+        fn constant_shadows_private_base() -> Result<()> {
+            run(
+                "resolution/identifier_redeclaration",
+                "constant_shadows_private_base",
+            )
+        }
+
+        #[test]
         fn constant_vs_function() -> Result<()> {
             run(
                 "resolution/identifier_redeclaration",

--- a/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_inherited_constant/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_inherited_constant/generated/0.8.0-success.txt
@@ -1,0 +1,41 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (4):
+- Def: #1 ["Base" @ input.sol:4:10] (contract)
+- Def: #2 ["N" @ input.sol:5:31] (constant, type: uint256)
+- Def: #3 ["Derived" @ input.sol:7:10] (contract)
+- Def: #4 ["a" @ input.sol:8:16] (state var, type: uint256[1] storage)
+
+------------------------------------------------------------------------
+
+References (2):
+- Ref: ["Base" @ input.sol:7:21] -> #1
+- Ref: ["N" @ input.sol:8:13] -> #2
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 4 │ contract Base {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 5 │     uint256 internal constant N = 1;
+   │                               ┬  
+   │                               ╰── name: 2
+   │ 
+ 7 │ contract Derived is Base {
+   │          ───┬───    ──┬─  
+   │             ╰───────────── name: 3
+   │                       │   
+   │                       ╰─── ref: 1
+ 8 │     uint256[N] a;
+   │             ┬  ┬  
+   │             ╰───── ref: 2
+   │                │  
+   │                ╰── name: 4
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_inherited_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_inherited_constant/input.sol
@@ -1,0 +1,9 @@
+// A non-`private` base constant IS inherited, so the derived contract may use
+// it as an array length. `N` resolves to the base value and the array is
+// `uint256[1]`.
+contract Base {
+    uint256 internal constant N = 1;
+}
+contract Derived is Base {
+    uint256[N] a;
+}

--- a/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_private_base_constant/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_private_base_constant/generated/0.8.0-success.txt
@@ -1,0 +1,45 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (5):
+- Def: #1 ["Base" @ input.sol:5:10] (contract)
+- Def: #2 ["N" @ input.sol:6:30] (constant, type: uint256)
+- Def: #3 ["Derived" @ input.sol:8:10] (contract)
+- Def: #4 ["N" @ input.sol:9:22] (constant, type: uint256)
+- Def: #5 ["a" @ input.sol:10:16] (state var, type: uint256[2] storage)
+
+------------------------------------------------------------------------
+
+References (2):
+- Ref: ["Base" @ input.sol:8:21] -> #1
+- Ref: ["N" @ input.sol:10:13] -> #4
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  5 │ contract Base {
+    │          ──┬─  
+    │            ╰─── name: 1
+  6 │     uint256 private constant N = 1;
+    │                              ┬  
+    │                              ╰── name: 2
+    │ 
+  8 │ contract Derived is Base {
+    │          ───┬───    ──┬─  
+    │             ╰───────────── name: 3
+    │                       │   
+    │                       ╰─── ref: 1
+  9 │     uint256 constant N = 2;
+    │                      ┬  
+    │                      ╰── name: 4
+ 10 │     uint256[N] a;
+    │             ┬  ┬  
+    │             ╰───── ref: 4
+    │                │  
+    │                ╰── name: 5
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_private_base_constant/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/arrays/fixed_size_with_private_base_constant/input.sol
@@ -1,0 +1,11 @@
+// A `private` base constant is not inherited, so the same-named constant in the
+// derived contract is independent. `N` resolves to the derived value and the
+// array is `uint256[2]`. The array length is what exercises this. A plain
+// reference would be masked by first-match disambiguation.
+contract Base {
+    uint256 private constant N = 1;
+}
+contract Derived is Base {
+    uint256 constant N = 2;
+    uint256[N] a;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/identifier_redeclaration/constant_shadows_private_base/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A `private` base constant is not inherited, so reusing the name in the
+// derived contract is legal (the array is `uint256[2]`).
+contract Base {
+    uint256 private constant N = 1;
+}
+contract Derived is Base {
+    uint256 constant N = 2;
+    uint256[N] a;
+}


### PR DESCRIPTION
`is_internally_visible` returned true for every constant, so a `private` base constant leaked into derived contracts and made a same-named derived constant resolve as ambiguous, wrongly rejecting legal code.