### PR TITLE
feat(diagnostics): Emit for constructors in libraries/interfaces

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -558,6 +558,8 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::LinearisationImpo
 pub mod slang_solidity_v2_common::diagnostics::kinds::structure
 pub enum slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::BreakOutsideLoop(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ConstructorInInterface(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ConstructorInLibrary(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContinueOutsideLoop(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyEnum(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyStruct(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct)
@@ -580,6 +582,10 @@ impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::stru
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> bool
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -640,6 +646,44 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop
@@ -1552,6 +1596,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic:
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -1796,6 +1844,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInInterface::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorInLibrary::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/constructor_in_interface.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/constructor_in_interface.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a constructor is defined in an interface.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConstructorInInterface;
+
+impl DiagnosticExtensions for ConstructorInInterface {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/constructor-in-interface"
+    }
+
+    fn message(&self) -> String {
+        "Constructor cannot be defined in interfaces.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/constructor_in_library.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/constructor_in_library.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a constructor is defined in a library.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConstructorInLibrary;
+
+impl DiagnosticExtensions for ConstructorInLibrary {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/constructor-in-library"
+    }
+
+    fn message(&self) -> String {
+        "Constructor cannot be defined in libraries.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -1,4 +1,6 @@
 mod break_outside_loop;
+mod constructor_in_interface;
+mod constructor_in_library;
 mod continue_outside_loop;
 mod empty_enum;
 mod empty_struct;
@@ -16,6 +18,8 @@ mod virtual_free_function;
 mod virtual_private_function;
 
 pub use break_outside_loop::BreakOutsideLoop;
+pub use constructor_in_interface::ConstructorInInterface;
+pub use constructor_in_library::ConstructorInLibrary;
 pub use continue_outside_loop::ContinueOutsideLoop;
 pub use empty_enum::EmptyEnum;
 pub use empty_struct::EmptyStruct;
@@ -54,6 +58,10 @@ define_diagnostic_kind! {
         FunctionNameMatchesContainer(FunctionNameMatchesContainer),
         /// A contract defines more than one constructor.
         MultipleConstructors(MultipleConstructors),
+        /// A constructor is defined in an interface.
+        ConstructorInInterface(ConstructorInInterface),
+        /// A constructor is defined in a library.
+        ConstructorInLibrary(ConstructorInLibrary),
 
         /// An enum declares more than 256 members.
         EnumWithTooManyMembers(EnumWithTooManyMembers),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration;
 use slang_solidity_v2_common::diagnostics::kinds::structure::{
-    BreakOutsideLoop, ContinueOutsideLoop, EmptyEnum, EmptyStruct, EnumWithTooManyMembers,
-    FunctionNameMatchesContainer, InvalidUsingDirectiveContainer, LibraryVirtualFunction,
-    LibraryVirtualModifier, MultipleConstructors, UnimplementedModifierMustBeVirtual,
-    VirtualFreeFunction, VirtualPrivateFunction,
+    BreakOutsideLoop, ConstructorInInterface, ConstructorInLibrary, ContinueOutsideLoop, EmptyEnum,
+    EmptyStruct, EnumWithTooManyMembers, FunctionNameMatchesContainer,
+    InvalidUsingDirectiveContainer, LibraryVirtualFunction, LibraryVirtualModifier,
+    MultipleConstructors, UnimplementedModifierMustBeVirtual, VirtualFreeFunction,
+    VirtualPrivateFunction,
 };
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::files::FileId;
@@ -237,24 +238,42 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
         constructor_parameters_scope_id: ScopeId,
     ) {
         let current_scope_node_id = self.current_scope().node_id();
-        let Definition::Contract(contract_definition) =
-            self.binder.get_definition_mut(current_scope_node_id)
-        else {
-            unreachable!("the current scope is not a contract");
-        };
-
-        if contract_definition
-            .constructor_parameters_scope_id
-            .is_some()
-        {
-            self.diagnostics.push(
-                self.current_file.id().to_owned(),
-                node.range.clone(),
-                MultipleConstructors,
-            );
-        } else {
-            contract_definition.constructor_parameters_scope_id =
-                Some(constructor_parameters_scope_id);
+        match self.binder.get_definition_mut(current_scope_node_id) {
+            Definition::Contract(contract_definition) => {
+                if contract_definition
+                    .constructor_parameters_scope_id
+                    .is_some()
+                {
+                    self.diagnostics.push(
+                        self.current_file.id().to_owned(),
+                        node.range.clone(),
+                        MultipleConstructors,
+                    );
+                } else {
+                    contract_definition.constructor_parameters_scope_id =
+                        Some(constructor_parameters_scope_id);
+                }
+            }
+            // A constructor cannot be defined in an interface or a library. We
+            // don't track its parameters scope in these containers, but still
+            // recurse into the body during resolution.
+            Definition::Interface(_) => {
+                self.diagnostics.push(
+                    self.current_file.id().to_owned(),
+                    node.range.clone(),
+                    ConstructorInInterface,
+                );
+            }
+            Definition::Library(_) => {
+                self.diagnostics.push(
+                    self.current_file.id().to_owned(),
+                    node.range.clone(),
+                    ConstructorInLibrary,
+                );
+            }
+            _ => {
+                unreachable!("a constructor is only allowed in a contract, interface, or library by the grammar");
+            }
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -744,6 +744,16 @@ mod structure {
     }
 
     #[test]
+    fn constructor_in_interface() -> Result<()> {
+        run("structure", "constructor_in_interface")
+    }
+
+    #[test]
+    fn constructor_in_library() -> Result<()> {
+        run("structure", "constructor_in_library")
+    }
+
+    #[test]
     fn continue_outside_loop() -> Result<()> {
         run("structure", "continue_outside_loop")
     }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/constructor-in-interface] Error: Constructor cannot be defined in interfaces.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     constructor() {}
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 4726] Error: Functions in interfaces cannot have an implementation.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     constructor() {}
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯
+
+[TypeError 6482] Error: Constructor cannot be defined in interfaces.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     constructor() {}
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_interface/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A constructor with a body parses fine, but is not allowed inside an
+// interface. solc reports TypeError 6482; slang emits
+// structure/constructor-in-interface. (A bodyless constructor would instead be
+// a parse error, so a body is required to reach this semantic check.)
+interface I {
+    constructor() {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/constructor-in-library] Error: Constructor cannot be defined in libraries.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     constructor() {}
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7634] Error: Constructor cannot be defined in libraries.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     constructor() {}
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/constructor_in_library/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A constructor with a body parses fine, but is not allowed inside a library.
+// solc reports TypeError 7634; slang emits structure/constructor-in-library.
+// (A bodyless constructor would instead be a parse error, so a body is
+// required to reach this semantic check.)
+library L {
+    constructor() {}
+}


### PR DESCRIPTION
This PR emits a diagnostic for constructors (with a body, otherwise it's a parser error) in libraries and interfaces. This also fixes a panic that happened because the code expected the enclosing scope to be a contract.

Closes NomicFoundation/slang-diagnostics-research#1364
Closes NomicFoundation/slang-diagnostics-research#1480

