### PR TITLE
memoize file-scope import resolution

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -483,16 +483,16 @@ impl Binder {
         // Fast path: with no default imports the file's own scope is the whole
         // search set, so resolve with a single map lookup and no traversal:
         if file_scope.default_imports.is_empty() {
-            return match file_scope.definitions.get(symbol).map(Vec::as_slice) {
-                None => Resolution::Unresolved,
-                Some([/* empty */]) => Resolution::Unresolved,
-                Some([single_def]) => Resolution::Definition(*single_def),
-                Some(multiple_defs) => Resolution::Ambiguous(multiple_defs.to_vec()),
-            };
+            return file_scope.lookup_symbol(symbol).collect::<Vec<_>>().into();
         }
 
         // Otherwise scan the precomputed transitive default-import closure
         // (which starts with this file's own scope), collecting every match.
+        assert!(
+            !file_scope.default_import_closure.is_empty(),
+            "FileScope::default_import_closure should be precomputed"
+        );
+
         let mut found_definitions = Vec::new();
         for scope_id in &file_scope.default_import_closure {
             let Scope::File(imported_scope) = self.get_scope_by_id(*scope_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -422,30 +422,84 @@ impl Binder {
             .unwrap()
     }
 
-    // Resolving a symbol in a file scope is special because of default imports.
-    // We want to find *all* definitions with the given symbol reachable from
-    // the file.
-    fn resolve_in_file_scope(&self, file_id: &FileId, symbol: &str) -> Resolution {
-        let mut found_definitions = Vec::new();
-        let mut visited_files = Set::default();
-        let mut files_to_search = VecDeque::new();
-        files_to_search.push_back(file_id);
+    /// Precompute each [`FileScope::default_import_closure`]: the set of file
+    /// scopes a file-scope symbol lookup must search (the file itself plus
+    /// every file transitively reachable through its default imports).
+    /// This lets [`Self::resolve_in_file_scope`] do a flat scan instead
+    /// of a fresh breadth-first walk on every lookup.
+    pub(crate) fn precompute_default_import_closures(&mut self) {
+        let file_scope_ids: Vec<ScopeId> = self
+            .scopes
+            .iter()
+            .filter_map(|scope| match scope {
+                Scope::File(file_scope) if !file_scope.default_imports.is_empty() => {
+                    self.scope_id_for_file_id(&file_scope.file_id)
+                }
+                _ => None,
+            })
+            .collect();
 
-        while let Some(file_id) = files_to_search.pop_front() {
-            let file_scope = self.get_file_scope(file_id);
-            if !visited_files.insert(file_id) {
+        for file_scope_id in file_scope_ids {
+            let closure = self.compute_file_import_closure(file_scope_id);
+            let Scope::File(file_scope) = self.get_scope_mut(file_scope_id) else {
+                unreachable!("scope id should be a file scope");
+            };
+            file_scope.default_import_closure = closure;
+        }
+    }
+
+    /// Walks the default-import graph breadth-first from `file_scope_id` (a file
+    /// scope), returning the reachable file scope ids in first-visit order and
+    /// starting with `file_scope_id` itself.
+    fn compute_file_import_closure(&self, file_scope_id: ScopeId) -> Vec<ScopeId> {
+        let mut closure = Vec::new();
+        let mut visited = Set::default();
+        let mut queue = VecDeque::from_iter([file_scope_id]);
+
+        while let Some(file_scope_id) = queue.pop_front() {
+            if !visited.insert(file_scope_id) {
                 continue;
             }
 
-            found_definitions.extend(file_scope.lookup_symbol(symbol));
-            files_to_search.extend(
-                file_scope
-                    .default_imports
-                    .iter()
-                    .map(|import| &import.file_id),
-            );
+            let Scope::File(file_scope) = self.get_scope_by_id(file_scope_id) else {
+                unreachable!("default import closure should only reach file scopes");
+            };
+            closure.push(file_scope_id);
+
+            for import in &file_scope.default_imports {
+                if let Some(imported_scope_id) = self.scope_id_for_file_id(&import.file_id) {
+                    queue.push_back(imported_scope_id);
+                }
+            }
         }
 
+        closure
+    }
+
+    // Resolving a symbol in a file scope is special because of default imports.
+    // We want to find *all* definitions with the given symbol reachable from
+    // the file.
+    fn resolve_in_file_scope(&self, file_scope: &FileScope, symbol: &str) -> Resolution {
+        // Fast path: with no default imports the file's own scope is the whole
+        // search set, so resolve with a single map lookup and no traversal:
+        if file_scope.default_imports.is_empty() {
+            return match file_scope.definitions.get(symbol).map(Vec::as_slice) {
+                None => Resolution::Unresolved,
+                Some([/* empty */]) => Resolution::Unresolved,
+                Some([single_def]) => Resolution::Definition(*single_def),
+                Some(multiple_defs) => Resolution::Ambiguous(multiple_defs.to_vec()),
+            };
+        }
+
+        // Otherwise scan the precomputed transitive default-import closure
+        // (which starts with this file's own scope), collecting every match.
+        let mut found_definitions = Vec::new();
+        for scope_id in &file_scope.default_import_closure {
+            let Scope::File(imported_scope) = self.get_scope_by_id(*scope_id) else {
+                unreachable!("default import closure should only contain file scopes");
+            };
+            found_definitions.extend(imported_scope.lookup_symbol(symbol));
+        }
         Resolution::from(found_definitions)
     }
 
@@ -549,7 +603,7 @@ impl Binder {
                 })
             }
             Scope::Enum(enum_scope) => enum_scope.definitions.get(symbol).into(),
-            Scope::File(file_scope) => self.resolve_in_file_scope(&file_scope.file_id, symbol),
+            Scope::File(file_scope) => self.resolve_in_file_scope(file_scope, symbol),
             Scope::Function(function_scope) => function_scope
                 .definitions
                 .get(symbol)
@@ -677,7 +731,7 @@ impl Binder {
             Scope::Enum(enum_scope) => enum_scope.definitions.get(symbol).into(),
             Scope::File(file_scope) => {
                 // We can get here by a file named file import
-                self.resolve_in_file_scope(&file_scope.file_id, symbol)
+                self.resolve_in_file_scope(file_scope, symbol)
             }
             Scope::Struct(struct_scope) => struct_scope.definitions.get(symbol).into(),
             Scope::Using(using_scope) => using_scope

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -64,6 +64,12 @@ pub(crate) struct FileScope {
     /// source order. The same file may appear more than once if imported by
     /// several directives.
     pub(crate) default_imports: Vec<DefaultImport>,
+    /// Reflexive-transitive closure of file scopes a file-scope lookup must
+    /// search: this file's own scope followed by every scope reachable through
+    /// [`Self::default_imports`], in breadth-first (first-visit) order.
+    /// This way, [`super::Binder::resolve_in_file_scope`] becomes a flat scan
+    /// rather than a fresh graph walk on every lookup.
+    pub(crate) default_import_closure: Vec<ScopeId>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
@@ -321,6 +327,7 @@ impl FileScope {
             file_id: file_id.clone(),
             definitions: Map::default(),
             default_imports: Vec::new(),
+            default_import_closure: Vec::new(),
             using_directives: Vec::new(),
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -48,6 +48,11 @@ pub fn run(
     for (file_id, range) in conflicts::find_default_import_conflicts(binder, file_ids) {
         diagnostics.push(file_id, range, IdentifierRedeclaration);
     }
+
+    // The default-import graph is now final. Precompute each file's transitive
+    // import closure once, so later passes resolve file-scope symbols with a
+    // flat scan instead of re-walking the graph on every lookup.
+    binder.precompute_default_import_closures();
 }
 
 struct ScopeFrame {


### PR DESCRIPTION
Optimize file-scope symbol resolution by precomputing the transitive closure of default imports once after the first pass, rather than re-walking the import graph on every symbol lookup:

- This dramatically improves most benchmarks for contracts that use default imports (old `import "..."` syntax).
- `resolve_in_file_scope` no longer allocates a `Vec`/`Set`/`VecDeque` on every call.
- Files with no default imports (using the more modern `import {x} from "..."` syntax) now resolve with a single map lookup and no allocation.

## Results

Here is the highest impactful subset:

Benchmark | Estimated Cycles | Instructions | Total blocks | Total read+write
-- | -- | -- | -- | --
semantic ensregistrarcontroller | -14.47% | -16.34% | -11.86% | -15.34%
semantic uniswap | -10.31% | -11.34% | -21.71% | -11.29%
semantic pointerlibraries | -9.59% | -10.2% | -22.97% | -10.02%
semantic uipooldataproviderv3 | -7.73% | -8.22% | -16.61% | -8.11%
