### PR TITLE
add a perf benchmarks for default imports

### DIFF
--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -61,6 +61,7 @@ mod __dependencies_used_in_lib__ {
 #[bench::one_step_leverage_f("one_step_leverage_f")]
 #[bench::pointer_libraries("pointer_libraries")]
 #[bench::merkle_proof("merkle_proof")]
+#[bench::ens_registrar_controller("ens_registrar_controller")]
 fn slang(project: &SolidityProject) -> Rc<CompilationUnit> {
     black_box(tests::slang::parser::run(black_box(project)))
 }
@@ -75,6 +76,7 @@ fn slang(project: &SolidityProject) -> Rc<CompilationUnit> {
 #[bench::one_step_leverage_f("one_step_leverage_f")]
 #[bench::pointer_libraries("pointer_libraries")]
 #[bench::merkle_proof("merkle_proof")]
+#[bench::ens_registrar_controller("ens_registrar_controller")]
 fn slang_v2(input: tests::slang_v2::parser::Input) -> tests::slang_v2::parser::Output {
     black_box(tests::slang_v2::parser::run(black_box(input)))
 }
@@ -90,6 +92,7 @@ fn slang_v2(input: tests::slang_v2::parser::Input) -> tests::slang_v2::parser::O
 #[bench::one_step_leverage_f("one_step_leverage_f")]
 #[bench::pointer_libraries("pointer_libraries")]
 #[bench::merkle_proof("merkle_proof")]
+#[bench::ens_registrar_controller("ens_registrar_controller")]
 fn solar(project: &SolidityProject) -> usize {
     black_box(tests::solar::parser::run(black_box(project)))
 }
@@ -103,6 +106,7 @@ fn solar(project: &SolidityProject) -> usize {
 #[bench::cooldogs("cooldogs")]
 #[bench::one_step_leverage_f("one_step_leverage_f")]
 #[bench::merkle_proof("merkle_proof")]
+#[bench::ens_registrar_controller("ens_registrar_controller")]
 fn tree_sitter(project: &SolidityProject) -> Vec<TreeSitterTree> {
     black_box(tests::tree_sitter::parser::run(black_box(project)))
 }

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -62,6 +62,7 @@ macro_rules! bench_projects {
         #[bench::one_step_leverage_f("one_step_leverage_f")]
         #[bench::pointer_libraries("pointer_libraries")]
         #[bench::merkle_proof("merkle_proof")]
+        #[bench::ens_registrar_controller("ens_registrar_controller")]
         $($rest)*
     };
 }

--- a/crates/solidity/testing/perf/projects.json
+++ b/crates/solidity/testing/perf/projects.json
@@ -35,6 +35,11 @@
       "hash": "0x56681458E00CafE1206313D2D033946f458FDEfD",
       "name": "cooldogs",
       "comment": "Deep CST structure"
+    },
+    {
+      "hash": "0x253553366Da8546fC250F225fe3d25d0C782303b",
+      "name": "ens_registrar_controller",
+      "comment": "Deep tree of default (unqualified) imports"
     }
   ],
   "files": [


### PR DESCRIPTION
Existing benchmarks don't cover the case of a deep tree of default (unqualified) imports, which is a common pattern in solidity projects. This adds a new [ens_registrar_controller](https://etherscan.io/address/0x253553366Da8546fC250F225fe3d25d0C782303b#code) benchmark for this case.