### PR TITLE
[v2] fix(typing): Fix some UDVT and Enum typings

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -28,6 +28,9 @@ pub slang_solidity_v2_semantic::binder::Definition::YulVariable(slang_solidity_v
 impl slang_solidity_v2_semantic::binder::Definition
 pub fn slang_solidity_v2_semantic::binder::Definition::identifier(&self) -> &slang_solidity_v2_ir::ir::nodes::Identifier
 pub fn slang_solidity_v2_semantic::binder::Definition::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::convert::TryFrom<&slang_solidity_v2_semantic::binder::Definition> for slang_solidity_v2_semantic::types::Type
+pub type slang_solidity_v2_semantic::types::Type::Error = ()
+pub fn slang_solidity_v2_semantic::types::Type::try_from(&slang_solidity_v2_semantic::binder::Definition) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for slang_solidity_v2_semantic::binder::Definition
 pub fn slang_solidity_v2_semantic::binder::Definition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity_v2_semantic::binder::Resolution
@@ -455,6 +458,9 @@ pub fn slang_solidity_v2_semantic::types::Type::clone(&self) -> slang_solidity_v
 impl core::cmp::Eq for slang_solidity_v2_semantic::types::Type
 impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::eq(&self, &slang_solidity_v2_semantic::types::Type) -> bool
+impl core::convert::TryFrom<&slang_solidity_v2_semantic::binder::Definition> for slang_solidity_v2_semantic::types::Type
+pub type slang_solidity_v2_semantic::types::Type::Error = ()
+pub fn slang_solidity_v2_semantic::types::Type::try_from(&slang_solidity_v2_semantic::binder::Definition) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for slang_solidity_v2_semantic::types::Type

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -6,7 +6,10 @@ use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
 use super::ScopeId;
-use crate::types::TypeId;
+use crate::types::{
+    ContractType, DataLocation, EnumType, InterfaceType, LibraryType, StructType, Type, TypeId,
+    UserDefinedValueType,
+};
 
 //////////////////////////////////////////////////////////////////////////////
 // Definitions
@@ -503,5 +506,29 @@ impl Definition {
         Self::YulVariable(YulVariableDefinition {
             ir_node: Arc::clone(ir_node),
         })
+    }
+}
+
+impl TryFrom<&Definition> for Type {
+    type Error = ();
+
+    fn try_from(definition: &Definition) -> Result<Self, Self::Error> {
+        let definition_id = definition.node_id();
+        match definition {
+            Definition::Contract(_) => Ok(Type::Contract(ContractType { definition_id })),
+            Definition::Enum(_) => Ok(Type::Enum(EnumType { definition_id })),
+            Definition::Interface(_) => Ok(Type::Interface(InterfaceType { definition_id })),
+            Definition::Library(_) => Ok(Type::Library(LibraryType { definition_id })),
+            Definition::Struct(_) => Ok(Type::Struct(StructType {
+                definition_id,
+                location: DataLocation::Memory,
+            })),
+            Definition::UserDefinedValueType(_) => {
+                Ok(Type::UserDefinedValue(UserDefinedValueType {
+                    definition_id,
+                }))
+            }
+            _ => Err(()),
+        }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -11,11 +11,11 @@ pub use internal::InternalBuiltIn;
 
 pub(crate) struct BuiltInsResolver<'a> {
     binder: &'a Binder,
-    types: &'a TypeRegistry,
+    types: &'a mut TypeRegistry,
 }
 
 impl<'a> BuiltInsResolver<'a> {
-    pub(crate) fn new(binder: &'a Binder, types: &'a TypeRegistry) -> Self {
+    pub(crate) fn new(binder: &'a Binder, types: &'a mut TypeRegistry) -> Self {
         Self { binder, types }
     }
 
@@ -434,15 +434,36 @@ impl<'a> BuiltInsResolver<'a> {
 
     #[allow(clippy::too_many_lines)]
     pub(crate) fn typing_of_function_call(
-        &self,
+        &mut self,
         built_in: &InternalBuiltIn,
         argument_typings: &[Typing],
     ) -> Typing {
         match built_in {
             InternalBuiltIn::AbiDecode => {
-                // Special case: this is handled in the resolution pass because
-                // we need to register the types given as parameters
-                Typing::Unresolved
+                if argument_typings.len() != 2 {
+                    return Typing::Unresolved;
+                }
+                match &argument_typings[1] {
+                    Typing::Resolved(type_id) => {
+                        // TODO(validation) SDR[42]: this only makes sense if type_id is a tuple
+                        Typing::Resolved(*type_id)
+                    }
+                    Typing::UserMetaType(definition_id) => {
+                        let Some(definition) = self.binder.find_definition_by_id(*definition_id)
+                        else {
+                            return Typing::Unresolved;
+                        };
+                        if let Ok(type_) = definition.try_into() {
+                            Typing::Resolved(self.types.register_type(type_))
+                        } else {
+                            Typing::Unresolved
+                        }
+                    }
+                    Typing::MetaType(type_) => {
+                        Typing::Resolved(self.types.register_type(type_.clone()))
+                    }
+                    _ => Typing::Unresolved,
+                }
             }
             InternalBuiltIn::AbiEncode => Typing::Resolved(self.types.bytes_memory()),
             InternalBuiltIn::AbiEncodeCall => Typing::Resolved(self.types.bytes_memory()),
@@ -499,13 +520,11 @@ impl<'a> BuiltInsResolver<'a> {
                 else {
                     unreachable!("definition bound to wrap built-in is not a UDVT");
                 };
-                Typing::Resolved(
-                    self.types
-                        .find_type(&Type::UserDefinedValue(UserDefinedValueType {
-                            definition_id: *definition_id,
-                        }))
-                        .unwrap(),
-                )
+                Typing::Resolved(self.types.register_type(Type::UserDefinedValue(
+                    UserDefinedValueType {
+                        definition_id: *definition_id,
+                    },
+                )))
             }
             _ => {
                 // other built-ins cannot be called

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -7,9 +7,7 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use super::Pass;
 use crate::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
 use crate::built_ins::InternalBuiltIn;
-use crate::types::{
-    ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type, UserDefinedValueType,
-};
+use crate::types::{ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -287,12 +285,6 @@ impl Visitor for Pass<'_> {
         node: &ir::UserDefinedValueTypeDefinition,
     ) {
         self.binder.mark_user_meta_type_node(node.id());
-
-        // Register the UDVT's type
-        self.types
-            .register_type(Type::UserDefinedValue(UserDefinedValueType {
-                definition_id: node.id(),
-            }));
 
         let target_type_id = self.type_of_elementary_type(&node.value_type, None);
         let Definition::UserDefinedValueType(udvt) = self.binder.get_definition_mut(node.id())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -7,7 +7,9 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 use super::Pass;
 use crate::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
 use crate::built_ins::InternalBuiltIn;
-use crate::types::{ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type};
+use crate::types::{
+    ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type, UserDefinedValueType,
+};
 
 impl Visitor for Pass<'_> {
     fn enter_source_unit(&mut self, node: &ir::SourceUnit) -> bool {
@@ -285,6 +287,12 @@ impl Visitor for Pass<'_> {
         node: &ir::UserDefinedValueTypeDefinition,
     ) {
         self.binder.mark_user_meta_type_node(node.id());
+
+        // Register the UDVT's type
+        self.types
+            .register_type(Type::UserDefinedValue(UserDefinedValueType {
+                definition_id: node.id(),
+            }));
 
         let target_type_id = self.type_of_elementary_type(&node.value_type, None);
         let Definition::UserDefinedValueType(udvt) = self.binder.get_definition_mut(node.id())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
@@ -64,7 +64,7 @@ impl<'a> Pass<'a> {
         assert!(pass.scope_stack.is_empty());
     }
 
-    fn built_ins_resolver(&self) -> BuiltInsResolver<'_> {
+    fn built_ins_resolver(&mut self) -> BuiltInsResolver<'_> {
         BuiltInsResolver::new(self.binder, self.types)
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -93,7 +93,7 @@ impl Pass<'_> {
             .filter(move |directive| directive.applies_to(type_id))
     }
 
-    pub(super) fn resolve_symbol_in_typing(&self, typing: &Typing, symbol: &str) -> Resolution {
+    pub(super) fn resolve_symbol_in_typing(&mut self, typing: &Typing, symbol: &str) -> Resolution {
         match typing {
             Typing::Unresolved => Resolution::Unresolved,
             Typing::Undetermined(type_ids) => {
@@ -178,7 +178,7 @@ impl Pass<'_> {
         }
     }
 
-    fn resolve_symbol_in_type(&self, type_id: TypeId, symbol: &str) -> Resolution {
+    fn resolve_symbol_in_type(&mut self, type_id: TypeId, symbol: &str) -> Resolution {
         let type_ = self.types.get_type_by_id(type_id);
 
         // Resolve direct members of the type first

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -424,6 +424,15 @@ impl Pass<'_> {
                         }));
                         Typing::Resolved(type_id)
                     }
+                    Some(Definition::Enum(_)) => {
+                        // explicit conversion from an integer to the enum
+                        // TODO(validation) SDR[868]: Only one argument expected
+                        // TODO(validation) SDR[1698]: Check the type of the argument is compatible
+                        let type_id = self.types.register_type(Type::Enum(EnumType {
+                            definition_id: node_id,
+                        }));
+                        Typing::Resolved(type_id)
+                    }
                     Some(Definition::Struct(_)) => {
                         // struct construction
                         let type_id = self.types.register_type(Type::Struct(StructType {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -4,12 +4,11 @@ use slang_solidity_v2_ir::ir;
 
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
-use crate::built_ins::InternalBuiltIn;
 use crate::passes::common::node_id_for_expression_typing;
 use crate::types::{
     literals, AddressType, ContractType, DataLocation, EnumType, FixedSizeArrayType, FunctionType,
     IntegerType, InterfaceType, LibraryType, LiteralKind, Number, StringType, StructType, Type,
-    TypeId, UserDefinedValueType,
+    TypeId,
 };
 
 impl Pass<'_> {
@@ -71,22 +70,7 @@ impl Pass<'_> {
 
     pub(super) fn type_of_definition(&mut self, definition_id: NodeId) -> Option<Type> {
         let definition = self.binder.find_definition_by_id(definition_id)?;
-        match definition {
-            Definition::Contract(_) => Some(Type::Contract(ContractType { definition_id })),
-            Definition::Enum(_) => Some(Type::Enum(EnumType { definition_id })),
-            Definition::Interface(_) => Some(Type::Interface(InterfaceType { definition_id })),
-            Definition::Library(_) => Some(Type::Library(LibraryType { definition_id })),
-            Definition::Struct(_) => Some(Type::Struct(StructType {
-                definition_id,
-                location: DataLocation::Memory,
-            })),
-            Definition::UserDefinedValueType(_) => {
-                Some(Type::UserDefinedValue(UserDefinedValueType {
-                    definition_id,
-                }))
-            }
-            _ => None,
-        }
+        definition.try_into().ok()
     }
 
     /// Returns the type of an binary operator expression. If both operands are
@@ -230,7 +214,7 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn typing_of_resolution(&self, resolution: &Resolution) -> Typing {
+    pub(super) fn typing_of_resolution(&mut self, resolution: &Resolution) -> Typing {
         match resolution {
             Resolution::Unresolved => Typing::Unresolved,
             Resolution::BuiltIn(built_in) => self.built_ins_resolver().typing_of(built_in),
@@ -444,36 +428,9 @@ impl Pass<'_> {
                     _ => Typing::Unresolved,
                 }
             }
-            // Special case: for `abi.decode` we need to register the types
-            // given as the second argument and we need a mutable `TypeRegistry`
-            // for that.
-            Typing::BuiltIn(InternalBuiltIn::AbiDecode) => {
-                self.typing_of_abi_decode(&argument_typings)
-            }
             Typing::BuiltIn(built_in) => self
                 .built_ins_resolver()
                 .typing_of_function_call(&built_in, &argument_typings),
-        }
-    }
-
-    fn typing_of_abi_decode(&mut self, argument_typings: &[Typing]) -> Typing {
-        if argument_typings.len() != 2 {
-            return Typing::Unresolved;
-        }
-        match &argument_typings[1] {
-            Typing::Resolved(type_id) => {
-                // TODO(validation) SDR[42]: this only makes sense if type_id is a tuple
-                Typing::Resolved(*type_id)
-            }
-            Typing::UserMetaType(definition_id) => {
-                if let Some(type_) = self.type_of_definition(*definition_id) {
-                    Typing::Resolved(self.types.register_type(type_))
-                } else {
-                    Typing::Unresolved
-                }
-            }
-            Typing::MetaType(type_) => Typing::Resolved(self.types.register_type(type_.clone())),
-            _ => Typing::Unresolved,
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1589,3 +1589,26 @@ fn test_storage_base_slot_evaluation() {
         (None, Some(StorageLayoutBaseNotConstant.into())),
     );
 }
+
+#[test]
+fn test_user_meta_type_built_in_members() {
+    // Built-in members of a *type name* resolve through its meta-type: errors
+    // expose `selector`, and UDVTs expose `wrap`/`unwrap`.
+    let (type_, _) = type_of_expression_in_context("error Err(uint x);", "Err.selector");
+    assert_eq!(type_, Type::ByteArray(ByteArrayType { width: 4 }));
+
+    let (type_, _) = type_of_expression_in_context("type T is uint256;", "T.wrap(1)");
+    assert!(
+        matches!(type_, Type::UserDefinedValue(_)),
+        "expected `T.wrap(1)` to type as the UDVT, got {type_:?}",
+    );
+
+    let (type_, _) = type_of_expression_in_context("type T is uint256;", "T.unwrap(T.wrap(1))");
+    assert_eq!(
+        type_,
+        Type::Integer(IntegerType {
+            is_signed: false,
+            bits: 256
+        })
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1612,3 +1612,19 @@ fn test_user_meta_type_built_in_members() {
         })
     );
 }
+
+#[test]
+fn test_explicit_enum_cast() {
+    // Explicit conversion from an integer to an enum is valid Solidity and
+    // types as the enum.
+    let (type_, _) = type_of_expression_in_context("enum E { A, B }", "E(1)");
+    assert!(
+        matches!(type_, Type::Enum(_)),
+        "expected `E(1)` to type as the enum, got {type_:?}",
+    );
+
+    // User defined value types are not castable by name: conversion goes
+    // through `wrap`/`unwrap`.
+    let (type_, _) = try_type_of_expression_in_context("type T is uint256;", "T(1)");
+    assert_eq!(type_, None);
+}


### PR DESCRIPTION
This PR fixes some bugs on the type system:
- UDVT types are now registered, allowing to do `T.wrap` without a `panic!`
- Enums can be casted

Also, since the BuiltInResolver now takes a mutable Registry:
- It removes a special case used with abi.decode