### PR TITLE
add AST benchmarks

### DIFF
--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -7,6 +7,8 @@ use solidity_testing_perf_cargo::config::benchmark_config_with_num_callers;
 use solidity_testing_perf_cargo::tests;
 // Local aliases for the setup functions, so the generated benchmark ID reads
 // `parser_setup("uniswap")` instead of `tests :: slang_v2 :: parser :: setup("uniswap")`.
+use tests::slang_v2::ast_analysis::setup as ast_analysis_setup;
+use tests::slang_v2::ast_visitor::setup as ast_visitor_setup;
 use tests::slang_v2::compute_contracts_abi::setup as compute_contracts_abi_setup;
 use tests::slang_v2::ir_builder::setup as ir_builder_setup;
 use tests::slang_v2::parser::setup as parser_setup;
@@ -109,10 +111,32 @@ bench_projects! {
     }
 }
 
+bench_projects! {
+    #[library_benchmark(setup = ast_visitor_setup)]
+    fn ast_visitor(
+        input: tests::slang_v2::ast_visitor::Input,
+    ) -> tests::slang_v2::ast_visitor::Output {
+        black_box(tests::slang_v2::ast_visitor::run(
+            black_box(input),
+        ))
+    }
+}
+
+bench_projects! {
+    #[library_benchmark(setup = ast_analysis_setup)]
+    fn ast_analysis(
+        input: tests::slang_v2::ast_analysis::Input,
+    ) -> tests::slang_v2::ast_analysis::Output {
+        black_box(tests::slang_v2::ast_analysis::run(
+            black_box(input),
+        ))
+    }
+}
+
 library_benchmark_group!(
     name = pipeline;
     // __SLANG_V2_INFRA_BENCHMARKS_LIST__ (keep in sync)
-    benchmarks = parser, ir_builder, semantic, compute_contracts_abi,
+    benchmarks = parser, ir_builder, semantic, compute_contracts_abi, ast_visitor, ast_analysis,
 );
 
 main!(

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -24,7 +24,7 @@ mod unit_tests {
     // Sum of the references resolved by the binder.
     const RESOLVED_REFERENCES_COUNT: usize = 1443;
     // Sum of all of expressions that the AST provides a type for.
-    const TYPED_EXPRESSIONS_COUNT: usize = 1815;
+    const TYPED_EXPRESSIONS_COUNT: usize = 1910;
 
     mod slang {
         macro_rules! define_payload_test {

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -23,6 +23,8 @@ mod unit_tests {
     const IDENTIFIER_COUNT: usize = 2829;
     // Sum of the references resolved by the binder.
     const RESOLVED_REFERENCES_COUNT: usize = 1443;
+    // Sum of all of expressions that the AST provides a type for.
+    const TYPED_EXPRESSIONS_COUNT: usize = 1815;
 
     mod slang {
         macro_rules! define_payload_test {
@@ -103,6 +105,23 @@ mod unit_tests {
             compute_contracts_abi,
             count_concrete_contracts,
             super::CONCRETE_CONTRACT_COUNT
+        );
+
+        define_payload_test_and_assert_count_eq!(
+            ast_visitor,
+            count_identifiers,
+            super::IDENTIFIER_COUNT
+        );
+
+        define_payload_test_and_assert_count_eq!(
+            ast_analysis,
+            count_resolved_references,
+            super::RESOLVED_REFERENCES_COUNT
+        );
+        define_payload_test_and_assert_count_eq!(
+            ast_analysis,
+            count_typed_expressions,
+            super::TYPED_EXPRESSIONS_COUNT
         );
     }
 

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_analysis.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_analysis.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::sync::Arc;
 
 use slang_solidity_v2_ast::ast::visitor::{accept_source_unit, Visitor};
@@ -60,13 +61,15 @@ struct AnalysisWalk {
 
 impl Visitor for AnalysisWalk {
     fn visit_identifier(&mut self, node: &Identifier) {
-        if node.resolve_to_definition().is_some() || node.resolve_to_built_in().is_some() {
+        if black_box(node.resolve_to_definition()).is_some()
+            || black_box(node.resolve_to_built_in()).is_some()
+        {
             self.resolved_references_count += 1;
         }
     }
 
     fn enter_expression(&mut self, node: &Expression) -> bool {
-        if node.get_type().is_some() {
+        if black_box(node.get_type()).is_some() {
             self.typed_expressions_count += 1;
         }
         true

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_analysis.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_analysis.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use slang_solidity_v2_ast::ast::visitor::{accept_source_unit, Visitor};
+use slang_solidity_v2_ast::ast::{self, Expression, Identifier};
+use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
+
+use super::semantic::File;
+
+pub struct Input {
+    pub(crate) files: Vec<File>,
+    pub(crate) semantic: Arc<SemanticContext>,
+}
+
+#[allow(unused)]
+pub struct Output {
+    pub(crate) files: Vec<File>,
+    pub(crate) semantic: Arc<SemanticContext>,
+
+    pub(crate) resolved_references_count: usize,
+    pub(crate) typed_expressions_count: usize,
+}
+
+pub fn setup(project: &str) -> Input {
+    let semantic_input = super::semantic::setup(project);
+    let files = semantic_input.files.clone();
+    let semantic_output = super::semantic::test(semantic_input);
+
+    Input {
+        files,
+        semantic: Arc::new(semantic_output),
+    }
+}
+
+pub fn run(input: Input) -> Output {
+    test(input)
+}
+
+pub fn test(input: Input) -> Output {
+    let mut walk = AnalysisWalk::default();
+
+    for file in &input.files {
+        let source_unit = ast::create_source_unit(file.ir_root(), &input.semantic);
+        accept_source_unit(&source_unit, &mut walk);
+    }
+
+    Output {
+        files: input.files,
+        semantic: input.semantic,
+
+        resolved_references_count: walk.resolved_references_count,
+        typed_expressions_count: walk.typed_expressions_count,
+    }
+}
+
+#[derive(Default)]
+struct AnalysisWalk {
+    resolved_references_count: usize,
+    typed_expressions_count: usize,
+}
+
+impl Visitor for AnalysisWalk {
+    fn visit_identifier(&mut self, node: &Identifier) {
+        if node.resolve_to_definition().is_some() || node.resolve_to_built_in().is_some() {
+            self.resolved_references_count += 1;
+        }
+    }
+
+    fn enter_expression(&mut self, node: &Expression) -> bool {
+        if node.get_type().is_some() {
+            self.typed_expressions_count += 1;
+        }
+        true
+    }
+}
+
+pub fn count_resolved_references(output: &Output) -> usize {
+    output.resolved_references_count
+}
+
+pub fn count_typed_expressions(output: &Output) -> usize {
+    output.typed_expressions_count
+}

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_visitor.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/ast_visitor.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use slang_solidity_v2_ast::ast::visitor::{accept_source_unit, Visitor};
+use slang_solidity_v2_ast::ast::{self, Identifier};
+use slang_solidity_v2_semantic::context::{SemanticContext, SemanticFile};
+
+use super::semantic::File;
+
+pub struct Input {
+    pub(crate) files: Vec<File>,
+    pub(crate) semantic: Arc<SemanticContext>,
+}
+
+#[allow(unused)]
+pub struct Output {
+    pub(crate) files: Vec<File>,
+    pub(crate) semantic: Arc<SemanticContext>,
+    pub(crate) identifier_count: usize,
+}
+
+pub fn setup(project: &str) -> Input {
+    let semantic_input = super::semantic::setup(project);
+    let files = semantic_input.files.clone();
+    let semantic_output = super::semantic::test(semantic_input);
+
+    Input {
+        files,
+        semantic: Arc::new(semantic_output),
+    }
+}
+
+pub fn run(input: Input) -> Output {
+    test(input)
+}
+
+pub fn test(input: Input) -> Output {
+    let mut walk = NodeWalk::default();
+
+    for file in &input.files {
+        let source_unit = ast::create_source_unit(file.ir_root(), &input.semantic);
+        accept_source_unit(&source_unit, &mut walk);
+    }
+
+    Output {
+        files: input.files,
+        semantic: input.semantic,
+        identifier_count: walk.identifier_count,
+    }
+}
+
+#[derive(Default)]
+struct NodeWalk {
+    identifier_count: usize,
+}
+
+impl Visitor for NodeWalk {
+    fn visit_identifier(&mut self, _node: &Identifier) {
+        self.identifier_count += 1;
+    }
+}
+
+pub fn count_identifiers(output: &Output) -> usize {
+    output.identifier_count
+}

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/mod.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/mod.rs
@@ -1,5 +1,7 @@
 mod common;
 
+pub mod ast_analysis;
+pub mod ast_visitor;
 pub mod compute_contracts_abi;
 pub mod ir_builder;
 pub mod parser;


### PR DESCRIPTION
Add two new performance benchmarks for Slang v2 that measure the cost of traversing and analyzing the public AST wrapper layer:

1. `ast_visitor`: Measures the overhead of the AST wrapper layer itself by walking the entire public AST with a trivial visitor that only counts identifiers.
2. `ast_analysis`: Measures semantic query performance by walking the AST while resolving identifier references and querying expression types.

These benchmarks isolate the performance characteristics of the public AST API surface.