### PR TITLE
fix `nextest` config failure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,10 +9,6 @@ build-override = { debug = true }
 debug = true
 incremental = true
 strip = false
-# Bake the toolchain libdir into binaries 'RUNPATH' so that 'proc-macro' crate test
-# harnesses (which dynamically links 'libstd') can load it under 'cargo nextest',
-# which (unlike 'cargo test') does not add the target 'libdir' to 'LD_LIBRARY_PATH'.
-rpath = true
 
 [profile.release]
 lto = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         uses: "./.github/actions/common-setup"
         with:
           sfw-optional: "true"
-          restore-deps-cache: "false"
-          restore-target-cache: "false"
+          restore-deps-cache: "${{ github.ref_name != 'main' }}"
+          restore-target-cache: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
 
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         uses: "./.github/actions/common-setup"
         with:
           sfw-optional: "true"
-          restore-deps-cache: "${{ github.ref_name != 'main' }}"
-          restore-target-cache: "${{ github.ref_name != 'main' && github.event_name != 'merge_group' }}"
+          restore-deps-cache: "false"
+          restore-target-cache: "false"
 
       #
       # Run all CI steps in order: _SLANG_INFRA_CI_STEPS_ORDERED_ (keep in sync)

--- a/crates/language-v2/internal_macros/build.rs
+++ b/crates/language-v2/internal_macros/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+/// Workaround for `cargo-nextest` older than v0.9.72:
+///
+/// `nextest` (unlike `cargo test`) does not add the toolchain `libdir` to the dynamic
+/// linker search path when launching test binaries. Proc-macro crates link `libstd`
+/// dynamically (`-C prefer-dynamic`), so this crate's unit-test harness fails to start
+/// under `nextest` with:
+///
+/// ```log
+/// error while loading shared libraries: libstd-*.so: cannot open shared object file
+/// ```
+///
+/// `nextest` v0.9.72 fixes this natively by detecting the host/target libdirs itself.
+/// For now, we bake the `libdir` into the test binary's RUNPATH instead.
+///
+/// TODO: Remove this build script once `nextest` is upgraded to `0.9.72` or later.
+///
+/// `__NEXTEST_RPATH_WORKAROUND__` (keep in sync with other proc-macro crates in the workspace)
+fn main() {
+    let rustc_binary = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+
+    let output = Command::new(rustc_binary)
+        .args(["--print", "target-libdir"])
+        .output()
+        .expect("failed to invoke `rustc --print target-libdir`");
+
+    assert!(output.status.success());
+
+    let libdir = String::from_utf8(output.stdout).unwrap();
+
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libdir.trim());
+}

--- a/crates/language-v2/macros/build.rs
+++ b/crates/language-v2/macros/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+/// Workaround for `cargo-nextest` older than v0.9.72:
+///
+/// `nextest` (unlike `cargo test`) does not add the toolchain `libdir` to the dynamic
+/// linker search path when launching test binaries. Proc-macro crates link `libstd`
+/// dynamically (`-C prefer-dynamic`), so this crate's unit-test harness fails to start
+/// under `nextest` with:
+///
+/// ```log
+/// error while loading shared libraries: libstd-*.so: cannot open shared object file
+/// ```
+///
+/// `nextest` v0.9.72 fixes this natively by detecting the host/target libdirs itself.
+/// For now, we bake the `libdir` into the test binary's RUNPATH instead.
+///
+/// TODO: Remove this build script once `nextest` is upgraded to `0.9.72` or later.
+///
+/// `__NEXTEST_RPATH_WORKAROUND__` (keep in sync with other proc-macro crates in the workspace)
+fn main() {
+    let rustc_binary = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+
+    let output = Command::new(rustc_binary)
+        .args(["--print", "target-libdir"])
+        .output()
+        .expect("failed to invoke `rustc --print target-libdir`");
+
+    assert!(output.status.success());
+
+    let libdir = String::from_utf8(output.stdout).unwrap();
+
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libdir.trim());
+}

--- a/crates/language/internal_macros/build.rs
+++ b/crates/language/internal_macros/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+/// Workaround for `cargo-nextest` older than v0.9.72:
+///
+/// `nextest` (unlike `cargo test`) does not add the toolchain `libdir` to the dynamic
+/// linker search path when launching test binaries. Proc-macro crates link `libstd`
+/// dynamically (`-C prefer-dynamic`), so this crate's unit-test harness fails to start
+/// under `nextest` with:
+///
+/// ```log
+/// error while loading shared libraries: libstd-*.so: cannot open shared object file
+/// ```
+///
+/// `nextest` v0.9.72 fixes this natively by detecting the host/target libdirs itself.
+/// For now, we bake the `libdir` into the test binary's RUNPATH instead.
+///
+/// TODO: Remove this build script once `nextest` is upgraded to `0.9.72` or later.
+///
+/// `__NEXTEST_RPATH_WORKAROUND__` (keep in sync with other proc-macro crates in the workspace)
+fn main() {
+    let rustc_binary = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+
+    let output = Command::new(rustc_binary)
+        .args(["--print", "target-libdir"])
+        .output()
+        .expect("failed to invoke `rustc --print target-libdir`");
+
+    assert!(output.status.success());
+
+    let libdir = String::from_utf8(output.stdout).unwrap();
+
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libdir.trim());
+}

--- a/crates/language/macros/build.rs
+++ b/crates/language/macros/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+/// Workaround for `cargo-nextest` older than v0.9.72:
+///
+/// `nextest` (unlike `cargo test`) does not add the toolchain `libdir` to the dynamic
+/// linker search path when launching test binaries. Proc-macro crates link `libstd`
+/// dynamically (`-C prefer-dynamic`), so this crate's unit-test harness fails to start
+/// under `nextest` with:
+///
+/// ```log
+/// error while loading shared libraries: libstd-*.so: cannot open shared object file
+/// ```
+///
+/// `nextest` v0.9.72 fixes this natively by detecting the host/target libdirs itself.
+/// For now, we bake the `libdir` into the test binary's RUNPATH instead.
+///
+/// TODO: Remove this build script once `nextest` is upgraded to `0.9.72` or later.
+///
+/// `__NEXTEST_RPATH_WORKAROUND__` (keep in sync with other proc-macro crates in the workspace)
+fn main() {
+    let rustc_binary = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+
+    let output = Command::new(rustc_binary)
+        .args(["--print", "target-libdir"])
+        .output()
+        .expect("failed to invoke `rustc --print target-libdir`");
+
+    assert!(output.status.success());
+
+    let libdir = String::from_utf8(output.stdout).unwrap();
+
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libdir.trim());
+}


### PR DESCRIPTION
CI [has been failing](https://github.com/NomicFoundation/slang/actions/runs/29451062005/job/87502448869) on `main`:

```log
/home/runner/work/slang/slang/target/release/deps/language_internal_macros-d446b4c5c9c56dd5: error while loading shared libraries: libstd-267b04dbd87607fb.so: cannot open shared object file: No such file or directory
```

It was broken by #1932. It adds `rpath = true` for `profile.dev`, but the CI runs with `profile.release`. This didn't reproduce on PRs because I suspect the cache still had the old binary from `cargo install`.

This PR fixes the issue by moving `rpath = true` from `profile.dev` to run unconditionally for all profiles in the specific crates that need it. To confirm the fix, this PR has three commits:

- the first disables the cache, and [reproduced the same error](https://github.com/NomicFoundation/slang/actions/runs/29461423127/job/87505538815?pr=1950) from `main`.
- the second adds the fix, and [confirmed it now passes](https://github.com/NomicFoundation/slang/actions/runs/29463333658/job/87511238969).
- the third reverts the first (cache re-enabled).

Note that the underlying issue has already been fixed in `nextest`, and we shouldn't need this override once hermit/renovate pick up a new `nextest` version.