### PR TITLE
[v2] feat(diagnostics): validate using directive symbols

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -277,9 +277,12 @@ pub enum slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDia
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::BuiltInRedeclaration(slang_solidity_v2_common::diagnostics::kinds::resolution::BuiltInRedeclaration)
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::ExternalDeclarationShadowing(slang_solidity_v2_common::diagnostics::kinds::resolution::ExternalDeclarationShadowing)
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IdentifierNotFound(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound)
+pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IdentifierNotFunctionOrNotUnique(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique)
+pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IdentifierNotLibraryName(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName)
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IdentifierRedeclaration(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration)
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IncompatibleBuiltInTarget(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInTarget)
 pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::IncompatibleBuiltInVersion(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion)
+pub slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::NonFreeOrLibraryFunctionInUsingDirective(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective)
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
@@ -291,12 +294,18 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolutio
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::ExternalDeclarationShadowing) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInTarget> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInTarget) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
@@ -366,6 +375,44 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration
@@ -425,6 +472,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective> for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::semantic
 pub enum slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicConstantDefinition(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition)
@@ -1883,12 +1949,18 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolutio
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::ExternalDeclarationShadowing) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInTarget> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInTarget) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2137,6 +2209,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFound::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotFunctionOrNotUnique::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierNotLibraryName::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IdentifierRedeclaration::message(&self) -> alloc::string::String
@@ -2149,6 +2229,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::IncompatibleBuiltInVersion::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_function_or_not_unique.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_function_or_not_unique.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// A symbol in a `using {...} for` directive did not resolve to a unique
+/// declaration (it is either undeclared or ambiguous).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IdentifierNotFunctionOrNotUnique;
+
+impl DiagnosticExtensions for IdentifierNotFunctionOrNotUnique {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "resolution/identifier-not-function-or-not-unique"
+    }
+
+    fn message(&self) -> String {
+        "Identifier is not a function name or not unique.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_library_name.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/identifier_not_library_name.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// The library name in a `using ... for` directive did not resolve to a unique
+/// declaration.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IdentifierNotLibraryName;
+
+impl DiagnosticExtensions for IdentifierNotLibraryName {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "resolution/identifier-not-library-name"
+    }
+
+    fn message(&self) -> String {
+        "Identifier not found or not a library name.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/mod.rs
@@ -1,16 +1,22 @@
 mod built_in_redeclaration;
 mod external_declaration_shadowing;
 mod identifier_not_found;
+mod identifier_not_function_or_not_unique;
+mod identifier_not_library_name;
 mod identifier_redeclaration;
 mod incompatible_built_in_target;
 mod incompatible_built_in_version;
+mod non_free_or_library_function_in_using_directive;
 
 pub use built_in_redeclaration::BuiltInRedeclaration;
 pub use external_declaration_shadowing::ExternalDeclarationShadowing;
 pub use identifier_not_found::IdentifierNotFound;
+pub use identifier_not_function_or_not_unique::IdentifierNotFunctionOrNotUnique;
+pub use identifier_not_library_name::IdentifierNotLibraryName;
 pub use identifier_redeclaration::IdentifierRedeclaration;
 pub use incompatible_built_in_target::IncompatibleBuiltInTarget;
 pub use incompatible_built_in_version::IncompatibleBuiltInVersion;
+pub use non_free_or_library_function_in_using_directive::NonFreeOrLibraryFunctionInUsingDirective;
 use serde::Serialize;
 
 use crate::diagnostics::kinds::utils::define_diagnostic_kind;
@@ -33,6 +39,16 @@ define_diagnostic_kind! {
         /// A Yul variable declaration shadows a declaration (Solidity or
         /// built-in) visible from outside the assembly block.
         ExternalDeclarationShadowing(ExternalDeclarationShadowing),
+
+        /// A symbol in a `using {...} for` directive did not resolve to a
+        /// unique function.
+        IdentifierNotFunctionOrNotUnique(IdentifierNotFunctionOrNotUnique),
+        /// A `using {...} for` directive attached a function that is neither
+        /// file-level nor a library function.
+        NonFreeOrLibraryFunctionInUsingDirective(NonFreeOrLibraryFunctionInUsingDirective),
+        /// The library name in a `using ... for` directive did not resolve to
+        /// a unique library.
+        IdentifierNotLibraryName(IdentifierNotLibraryName),
 
         /// A built-in is not compatible with the currently selected language version.
         IncompatibleBuiltInVersion(IncompatibleBuiltInVersion),

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/non_free_or_library_function_in_using_directive.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/resolution/non_free_or_library_function_in_using_directive.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// A `using {...} for` directive attached a function that is neither a
+/// file-level function nor a library function.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NonFreeOrLibraryFunctionInUsingDirective;
+
+impl DiagnosticExtensions for NonFreeOrLibraryFunctionInUsingDirective {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "resolution/non-free-or-library-function-in-using-directive"
+    }
+
+    fn message(&self) -> String {
+        "Only file-level functions and library functions can be attached to a type in a \"using\" directive.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -1,5 +1,9 @@
 use num_traits::Signed;
 use ruint::aliases::U256;
+use slang_solidity_v2_common::diagnostics::kinds::resolution::{
+    IdentifierNotFunctionOrNotUnique, IdentifierNotLibraryName,
+    NonFreeOrLibraryFunctionInUsingDirective,
+};
 use slang_solidity_v2_common::diagnostics::kinds::type_system::{
     ArrayLengthFractional, ArrayLengthNegative, ArrayLengthNotConstant, ArrayLengthTooLarge,
     ArrayLengthZero,
@@ -92,7 +96,7 @@ impl Pass<'_> {
     }
 
     /// Emits `kind` located at `node`.
-    fn push_diagnostic(
+    pub(super) fn push_diagnostic(
         &mut self,
         node: &(impl NodeIdentity + TextRange),
         kind: impl Into<DiagnosticKind>,
@@ -173,28 +177,70 @@ impl Pass<'_> {
         }
     }
 
+    /// Resolves the library named in a `using L for ...` directive to its
+    /// scope, or returns the diagnostic to report when it is not a valid
+    /// library.
     pub(super) fn find_library_scope_id_for_identifier_path(
         &self,
         identifier_path: &ir::IdentifierPath,
-    ) -> Option<ScopeId> {
-        let definition_id = identifier_path
+    ) -> Result<ScopeId, DiagnosticKind> {
+        let resolution = identifier_path
             .last()
             .and_then(|identifier| {
                 self.binder
                     .find_reference_by_identifier_node_id(identifier.id())
             })
-            .and_then(|reference| {
+            .map_or(Resolution::Unresolved, |reference| {
                 // reference may resolve to an imported library, so we need to
                 // follow aliases
                 self.binder
                     .follow_symbol_aliases(reference.resolution.clone())
-                    .as_definition_id()
-            })?;
+            });
 
-        let Some(Definition::Library(_)) = self.binder.find_definition_by_id(definition_id) else {
-            // the referenced definition is not a library
-            return None;
-        };
-        self.binder.scope_id_for_node_id(definition_id)
+        // Must resolve to a unique library.
+        match resolution.as_definition_id() {
+            Some(definition_id)
+                if matches!(
+                    self.binder.find_definition_by_id(definition_id),
+                    Some(Definition::Library(_))
+                ) =>
+            {
+                Ok(self.binder.scope_id_for_node_id(definition_id).unwrap())
+            }
+            _ => Err(IdentifierNotLibraryName.into()),
+        }
+    }
+
+    /// Validates a `using {...} for` symbol. Returns the diagnostic for why it is
+    /// rejected, or `None` if it resolves to a single free or library function.
+    pub(super) fn validate_using_directive_symbol(
+        &self,
+        resolution: &Resolution,
+    ) -> Option<DiagnosticKind> {
+        match resolution {
+            Resolution::Definition(id) => match self.binder.find_definition_by_id(*id) {
+                Some(Definition::Function(_)) => {
+                    // A free function has no enclosing definition. A library
+                    // function is enclosed by its library.
+                    let is_free_or_library = self
+                        .binder
+                        .enclosing_definition_node_id(*id)
+                        .is_none_or(|enclosing_id| {
+                            matches!(
+                                self.binder.find_definition_by_id(enclosing_id),
+                                Some(Definition::Library(_))
+                            )
+                        });
+                    (!is_free_or_library).then(|| NonFreeOrLibraryFunctionInUsingDirective.into())
+                }
+                _ => Some(IdentifierNotFunctionOrNotUnique.into()),
+            },
+            // Global built-ins are not visible in the scope where using
+            // directives resolve, so a built-in never reaches here.
+            Resolution::BuiltIn(_) => unreachable!("built-ins do not resolve in a using directive"),
+            Resolution::Unresolved | Resolution::Ambiguous(_) => {
+                Some(IdentifierNotFunctionOrNotUnique.into())
+            }
+        }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -322,11 +322,14 @@ impl Visitor for Pass<'_> {
                 };
                 match &node.clause {
                     ir::UsingClause::IdentifierPath(identifier_path) => {
-                        let Some(scope_id) =
-                            self.find_library_scope_id_for_identifier_path(identifier_path)
-                        else {
-                            return;
-                        };
+                        let scope_id =
+                            match self.find_library_scope_id_for_identifier_path(identifier_path) {
+                                Ok(scope_id) => scope_id,
+                                Err(kind) => {
+                                    self.push_diagnostic(identifier_path.last().unwrap(), kind);
+                                    return;
+                                }
+                            };
                         UsingDirective::new_single_type(scope_id, type_id)
                     }
                     ir::UsingClause::UsingDeconstruction(using_deconstruction) => {
@@ -335,14 +338,19 @@ impl Visitor for Pass<'_> {
 
                         for symbol in &using_deconstruction.symbols {
                             let symbol_name = symbol.name.last().unwrap();
-                            let definition_ids = self
+                            let resolution = self
                                 .binder
                                 .find_reference_by_identifier_node_id(symbol_name.id())
-                                .map_or(Vec::new(), |reference| {
-                                    reference.resolution.get_definition_ids()
+                                .map_or(Resolution::Unresolved, |reference| {
+                                    self.binder
+                                        .follow_symbol_aliases(reference.resolution.clone())
                                 });
-                            // TODO(validation) SDR[29]: *all* definitions should point to functions
 
+                            if let Some(kind) = self.validate_using_directive_symbol(&resolution) {
+                                self.push_diagnostic(symbol_name, kind);
+                            }
+
+                            let definition_ids = resolution.get_definition_ids();
                             symbols.insert(symbol_name.unparse().to_string(), definition_ids);
 
                             if let Some(operator) = &symbol.alias {
@@ -369,11 +377,13 @@ impl Visitor for Pass<'_> {
                     // only libraries can be attached to all types
                     return;
                 };
-                let Some(scope_id) =
-                    self.find_library_scope_id_for_identifier_path(identifier_path)
-                else {
-                    // the identifier path does not point to a valid library
-                    return;
+                let scope_id = match self.find_library_scope_id_for_identifier_path(identifier_path)
+                {
+                    Ok(scope_id) => scope_id,
+                    Err(kind) => {
+                        self.push_diagnostic(identifier_path.last().unwrap(), kind);
+                        return;
+                    }
                 };
                 UsingDirective::new_all(scope_id)
             }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -60,6 +60,148 @@ mod resolution {
         }
     }
 
+    mod expected_function_in_using_directive {
+        use super::*;
+
+        #[test]
+        fn ambiguous_with_non_function() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "ambiguous_with_non_function",
+            )
+        }
+
+        #[test]
+        fn asterisk_not_a_library() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "asterisk_not_a_library",
+            )
+        }
+
+        #[test]
+        fn builtin_keccak256() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "builtin_keccak256",
+            )
+        }
+
+        #[test]
+        fn builtin_name_in_member_path() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "builtin_name_in_member_path",
+            )
+        }
+
+        #[test]
+        fn contract_member_function() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "contract_member_function",
+            )
+        }
+
+        #[test]
+        fn error() -> Result<()> {
+            run("resolution/expected_function_in_using_directive", "error")
+        }
+
+        #[test]
+        fn event() -> Result<()> {
+            run("resolution/expected_function_in_using_directive", "event")
+        }
+
+        #[test]
+        fn free_and_library_function() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "free_and_library_function",
+            )
+        }
+
+        #[test]
+        fn function_without_braces() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "function_without_braces",
+            )
+        }
+
+        #[test]
+        fn imported_alias() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "imported_alias",
+            )
+        }
+
+        #[test]
+        fn library_form() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "library_form",
+            )
+        }
+
+        #[test]
+        fn library_forward_reference() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "library_forward_reference",
+            )
+        }
+
+        #[test]
+        fn library_not_found() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "library_not_found",
+            )
+        }
+
+        #[test]
+        fn not_a_library() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "not_a_library",
+            )
+        }
+
+        #[test]
+        fn not_found() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "not_found",
+            )
+        }
+
+        #[test]
+        fn operator_non_function() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "operator_non_function",
+            )
+        }
+
+        #[test]
+        fn overloaded_functions() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "overloaded_functions",
+            )
+        }
+
+        #[test]
+        fn state_variable() -> Result<()> {
+            run(
+                "resolution/expected_function_in_using_directive",
+                "state_variable",
+            )
+        }
+    }
+
     mod external_declaration_shadowing {
         use super::*;
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[resolution/identifier-redeclaration] Error: Identifier already declared.
+   ╭─[input.sol:8:18]
+   │
+ 8 │ uint256 constant foo = 1;
+   │                  ─┬─  
+   │                   ╰─── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+    ╭─[input.sol:11:11]
+    │
+ 11 │     using {foo} for uint256;
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+    ╭─[input.sol:11:12]
+    │
+ 11 │     using {foo} for uint256;
+    │            ─┬─  
+    │             ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[resolution/identifier-redeclaration] Error: Identifier already declared.
+   ╭─[input.sol:8:18]
+   │
+ 8 │ uint256 constant foo = 1;
+   │                  ─┬─  
+   │                   ╰─── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+    ╭─[input.sol:11:12]
+    │
+ 11 │     using {foo} for uint256;
+    │            ─┬─  
+    │             ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+    ╭─[input.sol:11:11]
+    │
+ 11 │     using {foo} for uint256;
+    │           ┬  
+    │           ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 2333] Error: Identifier already declared.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ uint256 constant foo = 1;
+   │ ────────────┬───────────  
+   │             ╰───────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/ambiguous_with_non_function/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function foo(uint256 self) pure returns (uint256) {
+    return self;
+}
+
+uint256 constant foo = 1;
+
+contract C {
+    using {foo} for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-library-name] Error: Identifier not found or not a library name.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for *;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4357] Error: Library name expected.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for *;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4357] Error: Library name expected. If you want to attach a function, use '{...}'.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for *;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/asterisk_not_a_library/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Other {}
+
+contract C {
+    using Other for *;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ using {keccak256} for bytes;
+   │ ──────────────┬─────────────  
+   │               ╰─────────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:4:8]
+   │
+ 4 │ using {keccak256} for bytes;
+   │        ────┬────  
+   │            ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:4:8]
+   │
+ 4 │ using {keccak256} for bytes;
+   │        ────┬────  
+   │            ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ using {keccak256} for bytes;
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8187] Error: Expected function name.
+   ╭─[input.sol:4:8]
+   │
+ 4 │ using {keccak256} for bytes;
+   │        ────┬────  
+   │            ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_keccak256/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+using {keccak256} for bytes;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │           ───────┬───────  
+   │                  ╰───────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:16]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │                ────┬────  
+   │                    ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:16]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │                ────┬────  
+   │                    ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 7920] Error: Identifier not found or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │            ──────┬──────  
+   │                  ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/generated/solc/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 9589] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {Foo.keccak256} for uint256;
+   │            ──────┬──────  
+   │                  ╰──────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/builtin_name_in_member_path/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    using {Foo.keccak256} for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {f} for uint256;
+   │           ─┬─  
+   │            ╰─── Error occurred here.
+───╯
+
+[resolution/non-free-or-library-function-in-using-directive] Error: Only file-level functions and library functions can be attached to a type in a "using" directive.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {f} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/non-free-or-library-function-in-using-directive] Error: Only file-level functions and library functions can be attached to a type in a "using" directive.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {f} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {f} for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4167] Error: Only file-level functions and library functions can be bound to a type in a "using" statement
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {f} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4167] Error: Only file-level functions and library functions can be attached to a type in a "using" statement
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {f} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/contract_member_function/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    using {f} for uint256;
+
+    function f(uint256 self) internal pure returns (uint256) {
+        return self;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.4'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ error Err();
+   │ ──────┬─────  
+   │       ╰─────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ type T is uint256;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {Err} for T;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {Err} for T;
+   │        ─┬─  
+   │         ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {Err} for T;
+   │        ─┬─  
+   │         ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ type T is uint256;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {Err} for T;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {Err} for T;
+   │        ─┬─  
+   │         ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/slang/0.8.8-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {Err} for T;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {Err} for T;
+   │        ─┬─  
+   │         ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected ';' but got '('
+   ╭─[input.sol:4:10]
+   │
+ 4 │ error Err();
+   │          ┬  
+   │          ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8187] Error: Expected function name.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {Err} for T;
+   │        ─┬─  
+   │         ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ type T is uint256;
+   │ ──┬─  
+   │   ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/generated/solc/0.8.8-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {Err} for T;
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/error/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+error Err();
+
+type T is uint256;
+
+using {Err} for T;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ type T is uint256;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {E} for T;
+   │ ────────┬───────  
+   │         ╰───────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.22-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.22-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/slang/0.8.8-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {E} for T;
+   │ ────────┬───────  
+   │         ╰───────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.14-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.14-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.22-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/generated/solc/0.8.22-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8187] Error: Expected function name.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/event/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+event E();
+
+type T is uint256;
+
+using {E} for T;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+    ╭─[input.sol:15:11]
+    │
+ 15 │     using {f, L.g} for uint256;
+    │           ────┬───  
+    │               ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/slang/0.8.13-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/slang/0.8.13-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+    ╭─[input.sol:15:11]
+    │
+ 15 │     using {f, L.g} for uint256;
+    │           ┬  
+    │           ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/solc/0.8.13-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/generated/solc/0.8.13-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/free_and_library_function/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function f(uint256 self) pure returns (uint256) {
+    return self;
+}
+
+library L {
+    function g(uint256 self) internal pure returns (uint256) {
+        return self;
+    }
+}
+
+contract C {
+    using {f, L.g} for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using f for uint256;
+   │ ──────────┬─────────  
+   │           ╰─────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-library-name] Error: Identifier not found or not a library name.
+   ╭─[input.sol:8:7]
+   │
+ 8 │ using f for uint256;
+   │       ┬  
+   │       ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-library-name] Error: Identifier not found or not a library name.
+   ╭─[input.sol:8:7]
+   │
+ 8 │ using f for uint256;
+   │       ┬  
+   │       ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using f for uint256;
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4357] Error: Library name expected. If you want to attach a function, use '{...}'.
+   ╭─[input.sol:8:7]
+   │
+ 8 │ using f for uint256;
+   │       ┬  
+   │       ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/function_without_braces/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function f(uint256 self) pure returns (uint256) {
+    return self;
+}
+
+using f for uint256;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[main.sol:7:11]
+   │
+ 7 │     using {aliased} for uint256;
+   │           ────┬────  
+   │               ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/slang/0.8.13-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/slang/0.8.13-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+   ╭─[main.sol:7:11]
+   │
+ 7 │     using {aliased} for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/solc/0.8.13-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/generated/solc/0.8.13-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/imported_alias/input.sol
@@ -1,0 +1,17 @@
+// --- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import {original as aliased} from "./lib.sol";
+
+contract C {
+    using {aliased} for uint256;
+}
+
+// --- path: lib.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function original(uint256 self) pure returns (uint256) {
+    return self;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_form/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+library L {
+    function f(uint256 self) internal pure returns (uint256) {
+        return self;
+    }
+}
+
+contract C {
+    using L for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_forward_reference/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    using L for uint256;
+}
+
+library L {
+    function f(uint256 self) internal pure returns (uint256) {
+        return self;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-library-name] Error: Identifier not found or not a library name.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using L for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 7920] Error: Identifier not found or not unique.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using L for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/solc/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/generated/solc/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 9589] Error: Identifier is not a library name.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using L for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/library_not_found/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    using L for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-library-name] Error: Identifier not found or not a library name.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for uint256;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4357] Error: Library name expected.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for uint256;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4357] Error: Library name expected. If you want to attach a function, use '{...}'.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using Other for uint256;
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_a_library/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Other {}
+
+contract C {
+    using Other for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │           ───────┬──────  
+   │                  ╰──────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │            ──────┬─────  
+   │                  ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │            ──────┬─────  
+   │                  ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+   ╭─[input.sol:5:11]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 7920] Error: Identifier not found or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │            ──────┬─────  
+   │                  ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/generated/solc/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 9589] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:5:12]
+   │
+ 5 │     using {doesNotExist} for uint256;
+   │            ──────┬─────  
+   │                  ╰─────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/not_found/input.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    using {doesNotExist} for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ type T is uint256;
+   │ ─────────┬────────  
+   │          ╰────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {E as +} for T;
+   │ ──────────┬──────────  
+   │           ╰──────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.19'.
+   ╭─[input.sol:8:10]
+   │
+ 8 │ using {E as +} for T;
+   │          ──┬─  
+   │            ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.19-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.22-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.22-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/slang/0.8.8-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.22'.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ─────┬────  
+   │      ╰────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ using {E as +} for T;
+   │ ──────────┬──────────  
+   │           ╰──────────── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.14-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.14-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+   ╭─[input.sol:4:1]
+   │
+ 4 │ event E();
+   │ ──┬──  
+   │   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.22-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/generated/solc/0.8.22-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8187] Error: Expected function name.
+   ╭─[input.sol:8:8]
+   │
+ 8 │ using {E as +} for T;
+   │        ┬  
+   │        ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/operator_non_function/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+event E();
+
+type T is uint256;
+
+using {E as +} for T;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+    ╭─[input.sol:13:11]
+    │
+ 13 │     using {f} for uint256;
+    │           ─┬─  
+    │            ╰─── Error occurred here.
+────╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+    ╭─[input.sol:13:12]
+    │
+ 13 │     using {f} for uint256;
+    │            ┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+    ╭─[input.sol:13:12]
+    │
+ 13 │     using {f} for uint256;
+    │            ┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+    ╭─[input.sol:13:11]
+    │
+ 13 │     using {f} for uint256;
+    │           ┬  
+    │           ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 7920] Error: Identifier not found or not unique.
+    ╭─[input.sol:13:12]
+    │
+ 13 │     using {f} for uint256;
+    │            ┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/generated/solc/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 9589] Error: Identifier is not a function name or not unique.
+    ╭─[input.sol:13:12]
+    │
+ 13 │     using {f} for uint256;
+    │            ┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/overloaded_functions/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+function f(uint256 self) pure returns (uint256) {
+    return self;
+}
+
+function f(uint256 self, uint256 other) pure returns (uint256) {
+    return self + other;
+}
+
+contract C {
+    using {f} for uint256;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using {x} for uint256;
+   │           ─┬─  
+   │            ╰─── Error occurred here.
+───╯
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:7:12]
+   │
+ 7 │     using {x} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/identifier-not-function-or-not-unique] Error: Identifier is not a function name or not unique.
+   ╭─[input.sol:7:12]
+   │
+ 7 │     using {x} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got '{'
+   ╭─[input.sol:7:11]
+   │
+ 7 │     using {x} for uint256;
+   │           ┬  
+   │           ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 8187] Error: Expected function name.
+   ╭─[input.sol:7:12]
+   │
+ 7 │     using {x} for uint256;
+   │            ┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/expected_function_in_using_directive/state_variable/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function() internal pure x;
+
+    using {x} for uint256;
+}


### PR DESCRIPTION
Reject `using` directives whose symbols don't resolve to a valid function or library, reporting expected-function, not-a-function-or-not-unique, non-free-or-library-function, not-a-library-name, and library-name-expected.