### PR TITLE
[v2] feat(typing): Modeling Meta types as regular types

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1047,10 +1047,12 @@ pub slang_solidity_v2_ast::ast::Type::Interface(slang_solidity_v2_ast::ast::Inte
 pub slang_solidity_v2_ast::ast::Type::Library(slang_solidity_v2_ast::ast::types::LibraryType)
 pub slang_solidity_v2_ast::ast::Type::Literal(slang_solidity_v2_ast::ast::LiteralType)
 pub slang_solidity_v2_ast::ast::Type::Mapping(slang_solidity_v2_ast::ast::MappingType)
+pub slang_solidity_v2_ast::ast::Type::MetaType(slang_solidity_v2_ast::ast::MetaType)
 pub slang_solidity_v2_ast::ast::Type::String(slang_solidity_v2_ast::ast::StringType)
 pub slang_solidity_v2_ast::ast::Type::Struct(slang_solidity_v2_ast::ast::StructType)
 pub slang_solidity_v2_ast::ast::Type::Tuple(slang_solidity_v2_ast::ast::TupleType)
 pub slang_solidity_v2_ast::ast::Type::UserDefinedValue(slang_solidity_v2_ast::ast::UserDefinedValueType)
+pub slang_solidity_v2_ast::ast::Type::UserMetaType(slang_solidity_v2_ast::ast::UserMetaType)
 pub slang_solidity_v2_ast::ast::Type::Void(slang_solidity_v2_ast::ast::VoidType)
 impl slang_solidity_v2_ast::ast::Type
 pub fn slang_solidity_v2_ast::ast::Type::data_location(&self) -> core::option::Option<slang_solidity_v2_semantic::types::DataLocation>
@@ -2294,6 +2296,11 @@ pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::node_id(&self) -> slang_
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::unparse(&self) -> &str
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MemoryKeywordStruct
 pub fn slang_solidity_v2_ast::ast::MemoryKeywordStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub struct slang_solidity_v2_ast::ast::MetaType
+impl slang_solidity_v2_ast::ast::MetaType
+pub fn slang_solidity_v2_ast::ast::MetaType::meta_type(&self) -> slang_solidity_v2_ast::ast::Type
+impl core::clone::Clone for slang_solidity_v2_ast::ast::MetaType
+pub fn slang_solidity_v2_ast::ast::MetaType::clone(&self) -> slang_solidity_v2_ast::ast::MetaType
 pub struct slang_solidity_v2_ast::ast::MinusEqualStruct
 impl slang_solidity_v2_ast::ast::MinusEqualStruct
 pub fn slang_solidity_v2_ast::ast::MinusEqualStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -3013,6 +3020,11 @@ pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::node_id
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::value_type(&self) -> slang_solidity_v2_ast::ast::ElementaryType
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::UserDefinedValueTypeDefinitionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub struct slang_solidity_v2_ast::ast::UserMetaType
+impl slang_solidity_v2_ast::ast::UserMetaType
+pub fn slang_solidity_v2_ast::ast::UserMetaType::definition(&self) -> slang_solidity_v2_ast::ast::Definition
+impl core::clone::Clone for slang_solidity_v2_ast::ast::UserMetaType
+pub fn slang_solidity_v2_ast::ast::UserMetaType::clone(&self) -> slang_solidity_v2_ast::ast::UserMetaType
 pub struct slang_solidity_v2_ast::ast::UsingDeconstructionStruct
 impl slang_solidity_v2_ast::ast::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ast::ast::UsingDeconstructionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/types.rs
@@ -214,7 +214,9 @@ fn abi_type_from_ast_type(value: &AstType, visited_structs: &mut Set<NodeId>) ->
         AstType::Library(_)
         | AstType::Literal(_)
         | AstType::Mapping(_)
+        | AstType::MetaType(_)
         | AstType::Tuple(_)
+        | AstType::UserMetaType(_)
         | AstType::Void(_) => None,
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
@@ -18,8 +18,8 @@ mod types;
 pub use types::{
     AddressType, ArrayType, BooleanType, ByteArrayType, BytesType, ContractType, EnumType,
     FixedPointNumberType, FixedSizeArrayType, FunctionType, IntegerType, InterfaceType,
-    LiteralKind, LiteralType, MappingType, Number, StringType, StructType, TupleType, Type,
-    UserDefinedValueType, VoidType,
+    LiteralKind, LiteralType, MappingType, MetaType, Number, StringType, StructType, TupleType,
+    Type, UserDefinedValueType, UserMetaType, VoidType,
 };
 
 #[path = "visitor.generated.rs"]

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/function_call_expression.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/function_call_expression.rs
@@ -1,23 +1,12 @@
-use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_semantic::binder::Typing;
-
-use super::super::FunctionCallExpressionStruct;
+use super::super::{FunctionCallExpressionStruct, Type};
 
 impl FunctionCallExpressionStruct {
     /// Returns `true` if this call is a type conversion (e.g. `uint256(x)`,
-    /// `address(y)`) rather than a function call.
+    /// `address(y)`) rather than a function call: ie. its operand names a
+    /// type — types as a meta-type — rather than a value.
     pub fn is_type_conversion(&self) -> bool {
-        match &self.ir_node.operand {
-            ir::Expression::ElementaryType(_) | ir::Expression::PayableKeyword(_) => true,
-            ir::Expression::Identifier(terminal) => matches!(
-                self.semantic.binder().node_typing(terminal.id()),
-                Typing::MetaType(_) | Typing::UserMetaType(_)
-            ),
-            ir::Expression::MemberAccessExpression(mae) => matches!(
-                self.semantic.binder().node_typing(mae.id()),
-                Typing::MetaType(_) | Typing::UserMetaType(_)
-            ),
-            _ => false,
-        }
+        self.operand().get_type().is_some_and(|operand_type| {
+            matches!(operand_type, Type::MetaType(_) | Type::UserMetaType(_))
+        })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -30,10 +30,12 @@ pub enum Type {
     Library(LibraryType),
     Literal(LiteralType),
     Mapping(MappingType),
+    MetaType(MetaType),
     String(StringType),
     Struct(StructType),
     Tuple(TupleType),
     UserDefinedValue(UserDefinedValueType),
+    UserMetaType(UserMetaType),
     Void(VoidType),
 }
 
@@ -78,9 +80,11 @@ define_type_variant!(Function);
 define_type_variant!(Interface);
 define_type_variant!(Library);
 define_type_variant!(Mapping);
+define_type_variant!(Meta);
 define_type_variant!(Struct);
 define_type_variant!(Tuple);
 define_type_variant!(UserDefinedValue);
+define_type_variant!(UserMeta);
 
 #[derive(Clone)]
 pub struct LiteralType {
@@ -125,11 +129,15 @@ impl Type {
             types::Type::Library(inner) => Self::Library(LibraryType { inner, semantic }),
             types::Type::Literal(inner) => Self::Literal(LiteralType { inner }),
             types::Type::Mapping(inner) => Self::Mapping(MappingType { inner, semantic }),
+            types::Type::MetaType(inner) => Self::MetaType(MetaType { inner, semantic }),
             types::Type::String(inner) => Self::String(StringType { inner }),
             types::Type::Struct(inner) => Self::Struct(StructType { inner, semantic }),
             types::Type::Tuple(inner) => Self::Tuple(TupleType { inner, semantic }),
             types::Type::UserDefinedValue(inner) => {
                 Self::UserDefinedValue(UserDefinedValueType { inner, semantic })
+            }
+            types::Type::UserMetaType(inner) => {
+                Self::UserMetaType(UserMetaType { inner, semantic })
             }
             types::Type::Void => Self::Void(VoidType),
         }
@@ -319,6 +327,23 @@ impl LiteralType {
             types::Type::Address(inner) => Some(Type::Address(AddressType { inner })),
             _ => None,
         })
+    }
+}
+
+impl MetaType {
+    /// Returns the type this is a meta-type of, eg. `uint` for the meta-type of
+    /// the `uint` in `uint(x)`.
+    pub fn meta_type(&self) -> Type {
+        Type::create(self.inner.type_id, &self.semantic)
+    }
+}
+
+impl UserMetaType {
+    /// Returns the user-defined type definition this meta-type refers to, eg.
+    /// the contract, struct or enum named by the expression.
+    pub fn definition(&self) -> Definition {
+        Definition::try_create(self.inner.definition_id, &self.semantic)
+            .expect("invalid user meta-type definition")
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -56,14 +56,12 @@ pub fn slang_solidity_v2_semantic::binder::Resolution::fmt(&self, &mut core::fmt
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::binder::Resolution
 pub enum slang_solidity_v2_semantic::binder::Typing
 pub slang_solidity_v2_semantic::binder::Typing::BuiltIn(slang_solidity_v2_semantic::built_ins::InternalBuiltIn)
-pub slang_solidity_v2_semantic::binder::Typing::MetaType(slang_solidity_v2_semantic::types::Type)
 pub slang_solidity_v2_semantic::binder::Typing::NewExpression(slang_solidity_v2_semantic::types::TypeId)
 pub slang_solidity_v2_semantic::binder::Typing::Resolved(slang_solidity_v2_semantic::types::TypeId)
 pub slang_solidity_v2_semantic::binder::Typing::Super
 pub slang_solidity_v2_semantic::binder::Typing::This(slang_solidity_v2_semantic::types::TypeId)
 pub slang_solidity_v2_semantic::binder::Typing::Undetermined(alloc::vec::Vec<slang_solidity_v2_semantic::types::TypeId>)
 pub slang_solidity_v2_semantic::binder::Typing::Unresolved
-pub slang_solidity_v2_semantic::binder::Typing::UserMetaType(slang_solidity_v2_common::nodes::NodeId)
 impl slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Typing::as_type_id(&self) -> core::option::Option<slang_solidity_v2_semantic::types::TypeId>
 impl core::clone::Clone for slang_solidity_v2_semantic::binder::Typing
@@ -435,10 +433,12 @@ pub slang_solidity_v2_semantic::types::Type::Interface(slang_solidity_v2_semanti
 pub slang_solidity_v2_semantic::types::Type::Library(slang_solidity_v2_semantic::types::LibraryType)
 pub slang_solidity_v2_semantic::types::Type::Literal(slang_solidity_v2_semantic::types::LiteralKind)
 pub slang_solidity_v2_semantic::types::Type::Mapping(slang_solidity_v2_semantic::types::MappingType)
+pub slang_solidity_v2_semantic::types::Type::MetaType(slang_solidity_v2_semantic::types::MetaType)
 pub slang_solidity_v2_semantic::types::Type::String(slang_solidity_v2_semantic::types::StringType)
 pub slang_solidity_v2_semantic::types::Type::Struct(slang_solidity_v2_semantic::types::StructType)
 pub slang_solidity_v2_semantic::types::Type::Tuple(slang_solidity_v2_semantic::types::TupleType)
 pub slang_solidity_v2_semantic::types::Type::UserDefinedValue(slang_solidity_v2_semantic::types::UserDefinedValueType)
+pub slang_solidity_v2_semantic::types::Type::UserMetaType(slang_solidity_v2_semantic::types::UserMetaType)
 pub slang_solidity_v2_semantic::types::Type::Void
 impl slang_solidity_v2_semantic::types::Type
 pub fn slang_solidity_v2_semantic::types::Type::can_return_from_getter_directly(&self) -> bool
@@ -637,6 +637,18 @@ pub fn slang_solidity_v2_semantic::types::MappingType::fmt(&self, &mut core::fmt
 impl core::hash::Hash for slang_solidity_v2_semantic::types::MappingType
 pub fn slang_solidity_v2_semantic::types::MappingType::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::MappingType
+pub struct slang_solidity_v2_semantic::types::MetaType
+pub slang_solidity_v2_semantic::types::MetaType::type_id: slang_solidity_v2_semantic::types::TypeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::MetaType
+pub fn slang_solidity_v2_semantic::types::MetaType::clone(&self) -> slang_solidity_v2_semantic::types::MetaType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::MetaType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::MetaType
+pub fn slang_solidity_v2_semantic::types::MetaType::eq(&self, &slang_solidity_v2_semantic::types::MetaType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::MetaType
+pub fn slang_solidity_v2_semantic::types::MetaType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::MetaType
+pub fn slang_solidity_v2_semantic::types::MetaType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::MetaType
 pub struct slang_solidity_v2_semantic::types::StringType
 pub slang_solidity_v2_semantic::types::StringType::location: slang_solidity_v2_semantic::types::DataLocation
 impl core::clone::Clone for slang_solidity_v2_semantic::types::StringType
@@ -703,3 +715,15 @@ pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::fmt(&self, &mut 
 impl core::hash::Hash for slang_solidity_v2_semantic::types::UserDefinedValueType
 pub fn slang_solidity_v2_semantic::types::UserDefinedValueType::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::UserDefinedValueType
+pub struct slang_solidity_v2_semantic::types::UserMetaType
+pub slang_solidity_v2_semantic::types::UserMetaType::definition_id: slang_solidity_v2_common::nodes::NodeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::UserMetaType
+pub fn slang_solidity_v2_semantic::types::UserMetaType::clone(&self) -> slang_solidity_v2_semantic::types::UserMetaType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::UserMetaType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::UserMetaType
+pub fn slang_solidity_v2_semantic::types::UserMetaType::eq(&self, &slang_solidity_v2_semantic::types::UserMetaType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::UserMetaType
+pub fn slang_solidity_v2_semantic::types::UserMetaType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::UserMetaType
+pub fn slang_solidity_v2_semantic::types::UserMetaType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::UserMetaType

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -5,7 +5,7 @@ use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::built_ins::InternalBuiltIn;
-use super::types::{Type, TypeId};
+use super::types::TypeId;
 
 mod assembly;
 mod capacities;
@@ -50,17 +50,6 @@ pub enum Typing {
     /// the appropriate type by matching the types of the arguments and work
     /// backwards to the reference (if any) and fixup the selected definition.
     Undetermined(Vec<TypeId>),
-    /// A node which refers to a user defined type by name, eg. the identifier
-    /// of a contract. This is not a type that can be translated to the EVM, and
-    /// as such is a way to suspend the typing until more information on how
-    /// it's used is gathered. Eg. to create a new contract via the new
-    /// operator, or construct a struct by using the struct's name in a function
-    /// call.
-    UserMetaType(NodeId),
-    /// Similar to `UserMetaType` above, but refers to the meta type of an
-    /// elementary type. A typical use case is explicit casting, which parses as
-    /// a function call.
-    MetaType(Type),
     /// Used to type the `BuiltIn` resolution when the result is not yet an
     /// actual type representable in the EVM. Eg. the built-in function `addmod`
     /// resolves to `Resolution::BuiltIn(Addmod)` and will type to
@@ -80,6 +69,7 @@ pub enum Typing {
 }
 
 impl Typing {
+    /// Returns the resolved `TypeId`, if any.
     pub fn as_type_id(&self) -> Option<TypeId> {
         match self {
             Self::Resolved(type_id) => Some(*type_id),
@@ -386,11 +376,6 @@ impl Binder {
             .get(&node_id)
             .cloned()
             .unwrap_or(Typing::Unresolved)
-    }
-
-    pub(crate) fn mark_user_meta_type_node(&mut self, node_id: NodeId) {
-        self.node_typing
-            .insert(node_id, Typing::UserMetaType(node_id));
     }
 
     pub(crate) fn set_node_type(&mut self, node_id: NodeId, type_id: Option<TypeId>) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,7 +1,7 @@
 use super::binder::{Binder, Definition, Typing};
 use super::types::{
-    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, Type, TypeId, TypeRegistry,
-    UserDefinedValueType,
+    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType, TupleType, Type,
+    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 #[path = "internal.generated.rs"]
@@ -200,7 +200,7 @@ impl<'a> BuiltInsResolver<'a> {
         }
     }
 
-    pub(crate) fn lookup_member_of_user_definition(
+    fn lookup_member_of_user_definition(
         definition: &Definition,
         symbol: &str,
     ) -> Option<InternalBuiltIn> {
@@ -216,23 +216,6 @@ impl<'a> BuiltInsResolver<'a> {
             Definition::UserDefinedValueType(_) => match symbol {
                 "wrap" => Some(InternalBuiltIn::Wrap(definition.node_id())),
                 "unwrap" => Some(InternalBuiltIn::Unwrap(definition.node_id())),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    pub(crate) fn lookup_member_of_meta_type(
-        parent_type: &Type,
-        symbol: &str,
-    ) -> Option<InternalBuiltIn> {
-        match parent_type {
-            Type::Bytes(_) => match symbol {
-                "concat" => Some(InternalBuiltIn::BytesConcat),
-                _ => None,
-            },
-            Type::String(_) => match symbol {
-                "concat" => Some(InternalBuiltIn::StringConcat),
                 _ => None,
             },
             _ => None,
@@ -307,6 +290,27 @@ impl<'a> BuiltInsResolver<'a> {
             }
             Type::Literal(_) => None,
             Type::Mapping(_) => None,
+            // The meta-type of `bytes`/`string` exposes the `concat` built-in.
+            Type::MetaType(MetaType { type_id }) => match self.types.get_type_by_id(*type_id) {
+                Type::Bytes(_) => match symbol {
+                    "concat" => Some(InternalBuiltIn::BytesConcat),
+                    _ => None,
+                },
+                Type::String(_) => match symbol {
+                    "concat" => Some(InternalBuiltIn::StringConcat),
+                    _ => None,
+                },
+                _ => None,
+            },
+            // The meta-type of a named user definition exposes the built-in
+            // members of that definition (eg. `MyError.selector`,
+            // `MyUDVT.wrap`). Its *namespace* members (eg. enum variants,
+            // library functions) are resolved in `resolve_symbol_in_type`,
+            // which has the scope-resolution machinery this resolver lacks.
+            Type::UserMetaType(UserMetaType { definition_id }) => self
+                .binder
+                .find_definition_by_id(*definition_id)
+                .and_then(|definition| Self::lookup_member_of_user_definition(definition, symbol)),
             Type::String(_) => match symbol {
                 "length" => Some(InternalBuiltIn::Length),
                 _ => None,
@@ -443,27 +447,40 @@ impl<'a> BuiltInsResolver<'a> {
                 if argument_typings.len() != 2 {
                     return Typing::Unresolved;
                 }
-                match &argument_typings[1] {
-                    Typing::Resolved(type_id) => {
-                        // TODO(validation) SDR[42]: this only makes sense if type_id is a tuple
-                        Typing::Resolved(*type_id)
-                    }
-                    Typing::UserMetaType(definition_id) => {
-                        let Some(definition) = self.binder.find_definition_by_id(*definition_id)
-                        else {
+                let Typing::Resolved(type_id) = &argument_typings[1] else {
+                    return Typing::Unresolved;
+                };
+
+                // `abi.decode(data, (T))`: a single-element tuple collapses to the
+                // meta-type of `T`, which decodes to `T` itself.
+                if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
+                    return Typing::Resolved(decoded);
+                }
+
+                // `abi.decode(data, (T1, T2, ...))`: a tuple of meta-types decodes to
+                // the tuple of the types they denote. Note a *nested* tuple element is
+                // not a type name and does not decode (matching solc, which rejects
+                // eg. `abi.decode(data, (uint, (bool, bool)))`).
+                if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(*type_id) {
+                    let element_ids = types.clone();
+                    let mut decoded = Vec::with_capacity(element_ids.len());
+                    for element_id in element_ids {
+                        let Some(element) = self.type_denoted_by_meta_type(element_id) else {
+                            // TODO(validation) SDR[42]: report an error when a tuple
+                            // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
                             return Typing::Unresolved;
                         };
-                        if let Ok(type_) = definition.try_into() {
-                            Typing::Resolved(self.types.register_type(type_))
-                        } else {
-                            Typing::Unresolved
-                        }
+                        decoded.push(element);
                     }
-                    Typing::MetaType(type_) => {
-                        Typing::Resolved(self.types.register_type(type_.clone()))
-                    }
-                    _ => Typing::Unresolved,
+                    return Typing::Resolved(
+                        self.types
+                            .register_type(Type::Tuple(TupleType { types: decoded })),
+                    );
                 }
+
+                // TODO(validation) SDR[42]: report an error when the second argument
+                // is not a type or a tuple of types.
+                Typing::Unresolved
             }
             InternalBuiltIn::AbiEncode => Typing::Resolved(self.types.bytes_memory()),
             InternalBuiltIn::AbiEncodeCall => Typing::Resolved(self.types.bytes_memory()),
@@ -530,6 +547,22 @@ impl<'a> BuiltInsResolver<'a> {
                 // other built-ins cannot be called
                 Typing::Unresolved
             }
+        }
+    }
+
+    /// Returns the value type a meta-type denotes: `type(T)` unwraps to `T`,
+    /// and the meta-type of a named definition to the definition's type.
+    /// Returns `None` when `type_id` is not a meta-type.
+    fn type_denoted_by_meta_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        match self.types.get_type_by_id(type_id) {
+            Type::MetaType(MetaType { type_id }) => Some(*type_id),
+            Type::UserMetaType(UserMetaType { definition_id }) => {
+                let definition_id = *definition_id;
+                let definition = self.binder.find_definition_by_id(definition_id)?;
+                let type_ = definition.try_into().ok()?;
+                Some(self.types.register_type(type_))
+            }
+            _ => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -18,8 +18,8 @@ use crate::passes::{
 };
 use crate::types::{
     ArrayType, ByteArrayType, ContractType, EnumType, FixedPointNumberType, FixedSizeArrayType,
-    IntegerType, InterfaceType, LibraryType, MappingType, StructType, TupleType, Type, TypeId,
-    TypeRegistry, UserDefinedValueType,
+    IntegerType, InterfaceType, LibraryType, MappingType, MetaType, StructType, TupleType, Type,
+    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 mod contract_data;
@@ -287,6 +287,13 @@ impl SemanticContext {
             | Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
                 self.definition_canonical_name(*definition_id)
             }
+            // Meta-types print in solc's `type(T)` notation.
+            Type::MetaType(MetaType { type_id }) => {
+                format!("type({})", self.type_internal_name(*type_id))
+            }
+            Type::UserMetaType(UserMetaType { definition_id }) => {
+                format!("type({})", self.definition_canonical_name(*definition_id))
+            }
             Type::Void => "void".to_string(),
         }
     }
@@ -374,7 +381,12 @@ impl SemanticContext {
                 )
             }
 
-            Type::Library(_) | Type::Literal(_) | Type::Tuple(_) | Type::Void => None,
+            Type::Library(_)
+            | Type::Literal(_)
+            | Type::MetaType(_)
+            | Type::Tuple(_)
+            | Type::UserMetaType(_)
+            | Type::Void => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
@@ -64,11 +64,13 @@ pub(crate) fn node_id_for_expression_typing(node: &ir::Expression) -> Option<Nod
         ir::Expression::StringExpression(s) => Some(node_id_for_string_expression_typing(s)),
         ir::Expression::Identifier(ident) => Some(ident.id()),
         ir::Expression::ThisKeyword(e) => Some(e.id()),
+        ir::Expression::ElementaryType(e) => {
+            Some(e.node_id().expect("ElementaryType should have a node id"))
+        }
+        ir::Expression::PayableKeyword(e) => Some(e.id()),
 
         // Other expression variants don't register typing by `NodeId`
-        ir::Expression::ElementaryType(_)
-        | ir::Expression::PayableKeyword(_)
-        | ir::Expression::SuperKeyword(_)
+        ir::Expression::SuperKeyword(_)
         | ir::Expression::TrueKeyword(_)
         | ir::Expression::FalseKeyword(_) => None,
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
 use crate::context::{FileNodeMapper, SemanticFile};
-use crate::types::{ContractType, Type, TypeId, TypeRegistry};
+use crate::types::{ContractType, Type, TypeId, TypeRegistry, UserMetaType};
 
 mod resolution;
 mod typing;
@@ -44,6 +44,15 @@ struct Pass<'a> {
 }
 
 impl<'a> Pass<'a> {
+    /// Registers a [`Type::UserMetaType`] for the given definition node and
+    /// records it as the node's typing.
+    fn mark_user_meta_type_node(&mut self, node_id: NodeId) {
+        let type_id = self.types.register_type(Type::UserMetaType(UserMetaType {
+            definition_id: node_id,
+        }));
+        self.binder.set_node_type(node_id, Some(type_id));
+    }
+
     fn visit_file(
         file: &'a impl SemanticFile,
         binder: &'a mut Binder,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -263,7 +263,12 @@ impl Pass<'_> {
                 }
 
                 // invalid types
-                Type::Library(_) | Type::Literal(_) | Type::Tuple(_) | Type::Void => {
+                Type::Library(_)
+                | Type::Literal(_)
+                | Type::MetaType(_)
+                | Type::Tuple(_)
+                | Type::UserMetaType(_)
+                | Type::Void => {
                     unreachable!("cannot compute the getter type for {type_id:?}")
                 }
             }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -40,7 +40,7 @@ impl Visitor for Pass<'_> {
         self.leave_scope_for_node_id(node.id());
 
         self.current_receiver_type = None;
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
     }
 
     fn enter_interface_definition(&mut self, node: &ir::InterfaceDefinition) -> bool {
@@ -64,7 +64,7 @@ impl Visitor for Pass<'_> {
         self.leave_scope_for_node_id(node.id());
 
         self.current_receiver_type = None;
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
     }
 
     fn enter_library_definition(&mut self, node: &ir::LibraryDefinition) -> bool {
@@ -80,12 +80,12 @@ impl Visitor for Pass<'_> {
     fn leave_library_definition(&mut self, node: &ir::LibraryDefinition) {
         self.leave_scope_for_node_id(node.id());
 
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
     }
 
     fn leave_path_import(&mut self, node: &ir::PathImport) {
         if node.alias.is_some() {
-            self.binder.mark_user_meta_type_node(node.id());
+            self.mark_user_meta_type_node(node.id());
         }
     }
 
@@ -182,7 +182,7 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_event_definition(&mut self, node: &ir::EventDefinition) {
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
 
         // Resolve and collect the types of the parameters, saving them in the
         // scope to use in overload disambiguation when invoking an event as a
@@ -210,7 +210,7 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_error_definition(&mut self, node: &ir::ErrorDefinition) {
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
 
         // Resolve the types of the parameters
         for parameter in &node.parameters {
@@ -261,7 +261,7 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_struct_definition(&mut self, node: &ir::StructDefinition) {
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
     }
 
     fn leave_struct_member(&mut self, node: &ir::StructMember) {
@@ -277,14 +277,14 @@ impl Visitor for Pass<'_> {
             self.binder.set_node_type(member.id(), Some(type_id));
         }
 
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
     }
 
     fn leave_user_defined_value_type_definition(
         &mut self,
         node: &ir::UserDefinedValueTypeDefinition,
     ) {
-        self.binder.mark_user_meta_type_node(node.id());
+        self.mark_user_meta_type_node(node.id());
 
         let target_type_id = self.type_of_elementary_type(&node.value_type, None);
         let Definition::UserDefinedValueType(udvt) = self.binder.get_definition_mut(node.id())

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
@@ -124,20 +124,15 @@ impl Pass<'_> {
         argument_typing: &Typing,
         external_call: bool,
     ) -> bool {
-        match argument_typing {
-            Typing::Resolved(type_id) => {
-                if external_call {
-                    self.types
-                        .implicitly_convertible_to_for_external_call(*type_id, parameter_type)
-                } else {
-                    self.types
-                        .implicitly_convertible_to(*type_id, parameter_type)
-                }
-            }
-            Typing::This(type_id) => self
-                .types
-                .implicitly_convertible_to(*type_id, parameter_type),
-            _ => false,
+        let Some(type_id) = argument_typing.as_type_id() else {
+            return false;
+        };
+        if external_call {
+            self.types
+                .implicitly_convertible_to_for_external_call(type_id, parameter_type)
+        } else {
+            self.types
+                .implicitly_convertible_to(type_id, parameter_type)
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -19,7 +19,7 @@ use crate::passes::common::constant_evaluator::{
     evaluate_compile_time_constant, ConstantResolver, EvaluationError,
 };
 use crate::passes::common::{find_definition_namespace_scope_id, node_location};
-use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId};
+use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId, UserMetaType};
 
 /// Lexical style resolution of symbols
 impl Pass<'_> {
@@ -151,26 +151,6 @@ impl Pass<'_> {
                 // No legacy constructor call options in >= 0.8.0
                 Resolution::Unresolved
             }
-            Typing::MetaType(type_) => {
-                if let Some(built_in) = BuiltInsResolver::lookup_member_of_meta_type(type_, symbol)
-                {
-                    Resolution::BuiltIn(built_in)
-                } else {
-                    Resolution::Unresolved
-                }
-            }
-            Typing::UserMetaType(node_id) => {
-                // We're trying to resolve a member access expression into a
-                // type name, ie. this is a meta-type member access
-                let Some(definition) = self.binder.find_definition_by_id(*node_id) else {
-                    return Resolution::Unresolved;
-                };
-                if let Some(scope_id) = find_definition_namespace_scope_id(self.binder, *node_id) {
-                    self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
-                } else {
-                    BuiltInsResolver::lookup_member_of_user_definition(definition, symbol).into()
-                }
-            }
             Typing::BuiltIn(built_in) => self
                 .built_ins_resolver()
                 .lookup_member_of(built_in, symbol)
@@ -199,6 +179,12 @@ impl Pass<'_> {
             Type::Struct(StructType { definition_id, .. }) => {
                 let scope_id = self.binder.scope_id_for_node_id(*definition_id).unwrap();
                 self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
+            }
+            Type::UserMetaType(UserMetaType { definition_id }) => {
+                find_definition_namespace_scope_id(self.binder, *definition_id)
+                    .map_or(Resolution::Unresolved, |scope_id| {
+                        self.binder.resolve_in_scope_as_namespace(scope_id, symbol)
+                    })
             }
             _ => Resolution::Unresolved,
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -6,12 +6,21 @@ use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::passes::common::node_id_for_expression_typing;
 use crate::types::{
-    literals, AddressType, ContractType, DataLocation, EnumType, FixedSizeArrayType, FunctionType,
-    IntegerType, InterfaceType, LibraryType, LiteralKind, Number, StringType, StructType, Type,
-    TypeId,
+    literals, AddressType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
+    IntegerType, LiteralKind, MetaType, Number, StringType, Type, TypeId, UserMetaType,
 };
 
 impl Pass<'_> {
+    /// Registers `inner` and the [`Type::MetaType`] wrapping it, returning the
+    /// meta-type as a `Typing::Resolved`.
+    pub(super) fn meta_typing_of(&mut self, inner: Type) -> Typing {
+        let type_id = self.types.register_type(inner);
+        Typing::Resolved(
+            self.types
+                .register_type(Type::MetaType(MetaType { type_id })),
+        )
+    }
+
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
         match node {
             // These are always typed as boolean
@@ -22,15 +31,7 @@ impl Pass<'_> {
             | ir::Expression::TrueKeyword(_)
             | ir::Expression::FalseKeyword(_) => Typing::Resolved(self.types.boolean()),
 
-            // Special case for elementary types: it's always a meta-type
-            ir::Expression::ElementaryType(elementary_type) => {
-                Typing::MetaType(Self::type_of_elementary_type(elementary_type))
-            }
-
             // Other special cases
-            ir::Expression::PayableKeyword(_) => {
-                Typing::MetaType(Type::Address(AddressType { is_payable: true }))
-            }
             ir::Expression::SuperKeyword(_) => Typing::Super,
 
             // By default, query the binder for registered typing information
@@ -43,7 +44,7 @@ impl Pass<'_> {
         }
     }
 
-    fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
+    pub(super) fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
         match elementary_type {
             ir::ElementaryType::AddressType(address_type) => Type::Address(AddressType {
                 is_payable: address_type.is_payable,
@@ -68,7 +69,7 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn type_of_definition(&mut self, definition_id: NodeId) -> Option<Type> {
+    pub(super) fn type_of_definition(&self, definition_id: NodeId) -> Option<Type> {
         let definition = self.binder.find_definition_by_id(definition_id)?;
         definition.try_into().ok()
     }
@@ -280,31 +281,40 @@ impl Pass<'_> {
         typing
     }
 
-    fn type_id_of_receiver(&self, operand: &ir::Expression) -> Option<TypeId> {
+    fn type_id_of_value_receiver(&self, operand: &ir::Expression) -> Option<TypeId> {
         if let ir::Expression::MemberAccessExpression(member_access_expression) = operand {
-            self.typing_of_expression(&member_access_expression.operand)
-                .as_type_id()
+            let type_id = self
+                .typing_of_expression(&member_access_expression.operand)
+                .as_type_id()?;
+            // A meta-type operand is a namespace qualifier, not
+            // a runtime value, so there is no receiver to bind as an implicit
+            // first argument during overload resolution.
+            if self.types.get_type_by_id(type_id).is_meta_type() {
+                return None;
+            }
+            Some(type_id)
         } else {
             None
         }
     }
 
-    fn typing_of_cast(&mut self, argument_typing: &Typing, target_type: Type) -> Typing {
+    fn typing_of_cast(&mut self, argument_typing: &Typing, target_type_id: TypeId) -> Typing {
         // TODO(validation) SDR[40]: this is a cast to the given type, but we
         // need to verify that the (single) argument is convertible
-        match argument_typing {
-            Typing::Resolved(argument_type_id) | Typing::This(argument_type_id) => {
+        match argument_typing.as_type_id() {
+            Some(argument_type_id) => {
                 // the resulting cast type inherits the data location of the argument
-                let argument_type = self.types.get_type_by_id(*argument_type_id);
+                let argument_type = self.types.get_type_by_id(argument_type_id);
                 let type_id = if let Some(data_location) = argument_type.data_location() {
+                    let target_type = self.types.get_type_by_id(target_type_id).clone();
                     self.types
                         .register_type_with_data_location(target_type, data_location)
                 } else {
-                    self.types.register_type(target_type)
+                    target_type_id
                 };
                 Typing::Resolved(type_id)
             }
-            _ => Typing::Unresolved,
+            None => Typing::Unresolved,
         }
     }
 
@@ -331,18 +341,53 @@ impl Pass<'_> {
                 // `this` and `super` are not callable
                 Typing::Unresolved
             }
-            Typing::Resolved(type_id) => {
-                if let Type::Function(FunctionType { return_type, .. }) =
-                    self.types.get_type_by_id(type_id)
-                {
-                    Typing::Resolved(*return_type)
-                } else {
+            Typing::Resolved(type_id) => match self.types.get_type_by_id(type_id) {
+                Type::Function(FunctionType { return_type, .. }) => Typing::Resolved(*return_type),
+                Type::MetaType(MetaType {
+                    type_id: target_type_id,
+                }) => {
+                    // This is an explicit cast to the (meta-)type, eg. `uint(x)`.
+                    let target_type_id = *target_type_id;
+                    if argument_typings.len() == 1 {
+                        self.typing_of_cast(&argument_typings[0], target_type_id)
+                    } else {
+                        Typing::Unresolved
+                    }
+                }
+                Type::UserMetaType(UserMetaType { definition_id }) => {
+                    // A cast to the underlying type of the definition (eg.
+                    // `MyEnum(1)`), or a struct construction. UDVTs are not
+                    // castable by name (they convert via `wrap`/`unwrap`).
+                    let definition_id = *definition_id;
+                    match self.binder.find_definition_by_id(definition_id) {
+                        Some(
+                            Definition::Contract(_)
+                            | Definition::Interface(_)
+                            | Definition::Library(_)
+                            | Definition::Enum(_)
+                            | Definition::Struct(_),
+                        ) => {
+                            // TODO(validation) SDR[39]: for contract, interface
+                            // and library targets the type of the (single)
+                            // argument should be an address
+                            // TODO(validation) SDR[868]: For enums, only one argument expected
+                            // TODO(validation) SDR[1698]: For enums, check the type of the argument is compatible
+
+                            let type_ = self
+                                .type_of_definition(definition_id)
+                                .expect("definition kind is handled by type_of_definition");
+                            Typing::Resolved(self.types.register_type(type_))
+                        }
+                        _ => Typing::Unresolved,
+                    }
+                }
+                _ => {
                     // TODO(validation) SDR[41]: the operand did not resolve to a function
                     Typing::Unresolved
                 }
-            }
+            },
             Typing::Undetermined(type_ids) => {
-                let receiver_type_id = self.type_id_of_receiver(&node.operand);
+                let receiver_type_id = self.type_id_of_value_receiver(&node.operand);
                 let candidate = self.lookup_function_matching_positional_arguments(
                     &type_ids,
                     &argument_typings,
@@ -366,13 +411,6 @@ impl Pass<'_> {
                     Typing::Unresolved
                 }
             }
-            Typing::MetaType(type_) => {
-                if argument_typings.len() == 1 {
-                    self.typing_of_cast(&argument_typings[0], type_)
-                } else {
-                    Typing::Unresolved
-                }
-            }
             Typing::NewExpression(type_id) => {
                 match self.types.get_type_by_id(type_id) {
                     Type::Array(_) | Type::Contract(_) => Typing::Resolved(type_id),
@@ -380,52 +418,6 @@ impl Pass<'_> {
                         // only contracts can be created with `new`
                         Typing::Unresolved
                     }
-                }
-            }
-            Typing::UserMetaType(node_id) => {
-                // Generally this is a cast to the underlying type of the given
-                // definition, except for structs for which we need to construct
-                // the value in memory
-                match self.binder.find_definition_by_id(node_id) {
-                    Some(Definition::Contract(_)) => {
-                        // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Contract(ContractType {
-                            definition_id: node_id,
-                        }));
-                        Typing::Resolved(type_id)
-                    }
-                    Some(Definition::Interface(_)) => {
-                        // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Interface(InterfaceType {
-                            definition_id: node_id,
-                        }));
-                        Typing::Resolved(type_id)
-                    }
-                    Some(Definition::Library(_)) => {
-                        // TODO(validation) SDR[39]: the type of the first argument should be an address
-                        let type_id = self.types.register_type(Type::Library(LibraryType {
-                            definition_id: node_id,
-                        }));
-                        Typing::Resolved(type_id)
-                    }
-                    Some(Definition::Enum(_)) => {
-                        // explicit conversion from an integer to the enum
-                        // TODO(validation) SDR[868]: Only one argument expected
-                        // TODO(validation) SDR[1698]: Check the type of the argument is compatible
-                        let type_id = self.types.register_type(Type::Enum(EnumType {
-                            definition_id: node_id,
-                        }));
-                        Typing::Resolved(type_id)
-                    }
-                    Some(Definition::Struct(_)) => {
-                        // struct construction
-                        let type_id = self.types.register_type(Type::Struct(StructType {
-                            definition_id: node_id,
-                            location: DataLocation::Memory,
-                        }));
-                        Typing::Resolved(type_id)
-                    }
-                    _ => Typing::Unresolved,
                 }
             }
             Typing::BuiltIn(built_in) => self
@@ -461,21 +453,44 @@ impl Pass<'_> {
                 // `this` and `super` are not callable
                 (Typing::Unresolved, None)
             }
-            Typing::Resolved(type_id) => {
-                if let Type::Function(FunctionType {
+            Typing::Resolved(type_id) => match self.types.get_type_by_id(type_id) {
+                Type::Function(FunctionType {
                     definition_id,
                     return_type,
                     ..
-                }) = self.types.get_type_by_id(type_id)
-                {
-                    (Typing::Resolved(*return_type), *definition_id)
-                } else {
+                }) => (Typing::Resolved(*return_type), *definition_id),
+                Type::MetaType(_) => {
+                    // This is a cast to the given type and is not valid with named arguments
+                    (Typing::Unresolved, None)
+                }
+                Type::UserMetaType(UserMetaType { definition_id }) => {
+                    // Function call with named arguments are only valid in user
+                    // types of the struct kind, which results in the construction
+                    // of such struct in memory
+                    let definition_id = *definition_id;
+                    match self.binder.find_definition_by_id(definition_id) {
+                        Some(Definition::Struct(_)) => {
+                            // struct construction
+                            let type_ = self
+                                .type_of_definition(definition_id)
+                                .expect("struct definitions are handled by type_of_definition");
+                            let type_id = self.types.register_type(type_);
+                            (Typing::Resolved(type_id), Some(definition_id))
+                        }
+                        Some(Definition::Event(_)) => {
+                            // this is an event called as a function, which is valid in <0.5.0
+                            (Typing::Resolved(self.types.void()), Some(definition_id))
+                        }
+                        _ => (Typing::Unresolved, None),
+                    }
+                }
+                _ => {
                     // TODO(validation) SDR[41]: the operand did not resolve to a function
                     (Typing::Unresolved, None)
                 }
-            }
+            },
             Typing::Undetermined(type_ids) => {
-                let receiver_type_id = self.type_id_of_receiver(&node.operand);
+                let receiver_type_id = self.type_id_of_value_receiver(&node.operand);
                 let argument_typings = self.collect_named_argument_typings(arguments);
                 let candidate = self.lookup_function_matching_named_arguments(
                     &type_ids,
@@ -500,10 +515,6 @@ impl Pass<'_> {
                     (Typing::Unresolved, None)
                 }
             }
-            Typing::MetaType(_) => {
-                // This is a cast to the given type and is not valid with named arguments
-                (Typing::Unresolved, None)
-            }
             Typing::NewExpression(type_id) => {
                 if let Type::Contract(ContractType { definition_id }) =
                     self.types.get_type_by_id(type_id)
@@ -512,26 +523,6 @@ impl Pass<'_> {
                 } else {
                     // only contracts can be created with `new`
                     (Typing::Unresolved, None)
-                }
-            }
-            Typing::UserMetaType(node_id) => {
-                // Function call with named arguments are only valid in user
-                // types of the struct kind, which results in the construction
-                // of such struct in memory
-                match self.binder.find_definition_by_id(node_id) {
-                    Some(Definition::Struct(_)) => {
-                        // struct construction
-                        let type_id = self.types.register_type(Type::Struct(StructType {
-                            definition_id: node_id,
-                            location: DataLocation::Memory,
-                        }));
-                        (Typing::Resolved(type_id), Some(node_id))
-                    }
-                    Some(Definition::Event(_)) => {
-                        // this is an event called as a function, which is valid in <0.5.0
-                        (Typing::Resolved(self.types.void()), Some(node_id))
-                    }
-                    _ => (Typing::Unresolved, None),
                 }
             }
             Typing::BuiltIn(_) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -2,13 +2,15 @@ use std::sync::Arc;
 
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
+use slang_solidity_v2_ir::ir::NodeIdentity;
 
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::InternalBuiltIn;
 use crate::passes::common::{filter_overriden_definitions, node_id_for_string_expression_typing};
 use crate::types::{
-    ArrayType, DataLocation, FixedSizeArrayType, MappingType, Number, TupleType, Type,
+    AddressType, ArrayType, DataLocation, FixedSizeArrayType, MappingType, MetaType, Number,
+    TupleType, Type, UserMetaType,
 };
 
 impl Visitor for Pass<'_> {
@@ -102,26 +104,49 @@ impl Visitor for Pass<'_> {
     }
 
     fn enter_expression(&mut self, node: &ir::Expression) -> bool {
-        if let ir::Expression::Identifier(identifier) = node {
-            let symbol = identifier.unparse();
-            let resolution = if symbol == "_" && self.is_in_modifier_scope() {
-                Resolution::BuiltIn(InternalBuiltIn::ModifierUnderscore)
-            } else {
-                let scope_id = self.current_scope_id();
-                let resolution = self.resolve_symbol_in_scope(scope_id, symbol);
-                filter_overriden_definitions(self.binder, self.types, resolution)
-            };
+        match node {
+            ir::Expression::Identifier(identifier) => {
+                let symbol = identifier.unparse();
+                let resolution = if symbol == "_" && self.is_in_modifier_scope() {
+                    Resolution::BuiltIn(InternalBuiltIn::ModifierUnderscore)
+                } else {
+                    let scope_id = self.current_scope_id();
+                    let resolution = self.resolve_symbol_in_scope(scope_id, symbol);
+                    filter_overriden_definitions(self.binder, self.types, resolution)
+                };
 
-            // Set the typing for the `Identifier` node.
-            // The resolution may point to an imported symbol, so we need to
-            // follow through in order to get to the actual typing.
-            let followed_resolution = self.binder.follow_symbol_aliases(resolution.clone());
-            let typing = self.typing_of_resolution(&followed_resolution);
-            self.binder.set_node_typing(identifier.id(), typing);
+                // Set the typing for the `Identifier` node.
+                // The resolution may point to an imported symbol, so we need to
+                // follow through in order to get to the actual typing.
+                let followed_resolution = self.binder.follow_symbol_aliases(resolution.clone());
+                let typing = self.typing_of_resolution(&followed_resolution);
+                self.binder.set_node_typing(identifier.id(), typing);
 
-            // Finally, create the reference for the identifier.
-            let reference = Reference::new(Arc::clone(identifier), resolution);
-            self.binder.insert_reference(reference);
+                // Finally, create the reference for the identifier.
+                let reference = Reference::new(Arc::clone(identifier), resolution);
+                self.binder.insert_reference(reference);
+            }
+            // An elementary type keyword in expression position denotes a
+            // type, so it types as the meta-type of that type (eg. `uint`
+            // types as `type(uint256)`). This is handled here rather than in
+            // `leave_elementary_type` because elementary types in type
+            // positions (which vastly outnumber expression uses) don't need a
+            // typing registered.
+            ir::Expression::ElementaryType(elementary_type) => {
+                let typing = self.meta_typing_of(Self::type_of_elementary_type(elementary_type));
+                let node_id = elementary_type
+                    .node_id()
+                    .expect("ElementaryType should have a node id");
+                self.binder.set_node_typing(node_id, typing);
+            }
+            // A standalone `payable` (the operand of a `payable(x)` cast)
+            // denotes the `address payable` type, so it types as its
+            // meta-type.
+            ir::Expression::PayableKeyword(payable_keyword) => {
+                let typing = self.meta_typing_of(Type::Address(AddressType { is_payable: true }));
+                self.binder.set_node_typing(payable_keyword.id(), typing);
+            }
+            _ => {}
         }
         true
     }
@@ -388,8 +413,7 @@ impl Visitor for Pass<'_> {
         let typing = match self.typing_of_expression(&node.operand) {
             Typing::Resolved(operand_type_id) => {
                 let range_access = node.end.is_some();
-                let operand_type = self.types.get_type_by_id(operand_type_id);
-                match operand_type {
+                match self.types.get_type_by_id(operand_type_id) {
                     Type::Array(ArrayType { element_type, .. })
                     | Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) => {
                         // TODO(validation) SDR[58]: for fixed-size arrays, if the range
@@ -426,30 +450,33 @@ impl Visitor for Pass<'_> {
                             Typing::Resolved(*value_type_id)
                         }
                     }
+                    // Indexing a meta-type creates the meta-type of an array,
+                    // eg. the `uint[]` in `abi.decode(data, (uint[]))` or the
+                    // fixed-size `uint[3]`.
+                    Type::MetaType(MetaType {
+                        type_id: element_type,
+                    }) => self.meta_typing_of(Type::Array(ArrayType {
+                        element_type: *element_type,
+                        location: DataLocation::Memory,
+                    })),
+                    // Indexing a user meta-type likewise creates the meta-type
+                    // of an array (eg. `MyStruct[]`).
+                    Type::UserMetaType(UserMetaType { definition_id }) => {
+                        let definition_id = *definition_id;
+                        if let Some(operand_type) = self.type_of_definition(definition_id) {
+                            let element_type = self.types.register_type(operand_type);
+                            self.meta_typing_of(Type::Array(ArrayType {
+                                element_type,
+                                location: DataLocation::Memory,
+                            }))
+                        } else {
+                            Typing::Unresolved
+                        }
+                    }
                     _ => {
                         // TODO(validation) SDR[45]: the operand is not indexable
                         Typing::Unresolved
                     }
-                }
-            }
-            Typing::MetaType(operand_type) => {
-                // indexing a meta-type creates a new meta-type of the array
-                let operand_type_id = self.types.register_type(operand_type);
-                Typing::MetaType(Type::Array(ArrayType {
-                    element_type: operand_type_id,
-                    location: DataLocation::Memory,
-                }))
-            }
-            Typing::UserMetaType(definition_id) => {
-                // indexing a user meta-type creates a new meta-type of the array
-                if let Some(operand_type) = self.type_of_definition(definition_id) {
-                    let operand_type_id = self.types.register_type(operand_type);
-                    Typing::MetaType(Type::Array(ArrayType {
-                        element_type: operand_type_id,
-                        location: DataLocation::Memory,
-                    }))
-                } else {
-                    Typing::Unresolved
                 }
             }
             _ => Typing::Unresolved,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -276,9 +276,10 @@ contract Test is Base {
     let types_after = types.iter_types().count();
 
     // The pass registers new types for: contracts, mappings, structs, enums,
-    // function types, getter types, etc.
+    // function types, getter types, and a `Type::UserMetaType` for each
+    // type-naming definition (the two contracts, the struct, and the enum).
     let registered_types = types_after - types_before;
-    assert_eq!(registered_types, 7);
+    assert_eq!(registered_types, 11);
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -7,19 +7,21 @@ use slang_solidity_v2_common::diagnostics::kinds::type_system::{
 };
 use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 
 use super::{build_file, TestFile};
 use crate::binder::{Binder, Definition};
-use crate::context::{FileNodeMapper, SemanticFile};
+use crate::context::{FileNodeMapper, SemanticContext, SemanticFile};
 use crate::passes::common::node_id_for_expression_typing;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
 };
 use crate::types::{
-    ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType, IntegerType,
-    LibraryType, LiteralKind, MappingType, StringType, TupleType, Type, TypeId, TypeRegistry,
+    ArrayType, ByteArrayType, BytesType, ContractType, DataLocation, FixedSizeArrayType,
+    IntegerType, LibraryType, LiteralKind, MappingType, MetaType, StringType, StructType,
+    TupleType, Type, TypeId, TypeRegistry,
 };
 
 struct TypeAnalysis {
@@ -1432,6 +1434,61 @@ fn test_partially_applied_function_is_not_convertible() {
 }
 
 #[test]
+fn test_index_access_on_elementary_meta_type_yields_array_meta_type() {
+    // Control: indexing the meta-type of an elementary type (`uint[]`) yields
+    // the meta-type of an array of that elementary type.
+    let (meta, types) = type_of_expression("uint[]");
+
+    let Type::MetaType(MetaType { type_id: array_id }) = meta else {
+        panic!("expected the `uint[]` expression to be a MetaType, got {meta:?}");
+    };
+    let Type::Array(ArrayType {
+        element_type,
+        location,
+    }) = types.get_type_by_id(array_id).clone()
+    else {
+        panic!(
+            "expected the meta-type to wrap an Array, got {:?}",
+            types.get_type_by_id(array_id)
+        );
+    };
+    assert_eq!(location, DataLocation::Memory);
+    assert_eq!(element_type, types.uint256());
+}
+
+#[test]
+fn test_index_access_on_user_meta_type_yields_array_meta_type() {
+    // `MyStruct[]` is a *type expression*: indexing the user meta-type of a
+    // struct produces the meta-type of an array whose element is that struct.
+    let (meta, types) = type_of_expression_in_context("struct MyStruct { uint a; }", "MyStruct[]");
+
+    let Type::MetaType(MetaType { type_id: array_id }) = meta else {
+        panic!("expected the `MyStruct[]` expression to be a MetaType, got {meta:?}");
+    };
+    let Type::Array(ArrayType {
+        element_type,
+        location,
+    }) = types.get_type_by_id(array_id).clone()
+    else {
+        panic!(
+            "expected the meta-type to wrap an Array, got {:?}",
+            types.get_type_by_id(array_id)
+        );
+    };
+    assert_eq!(location, DataLocation::Memory);
+
+    // The array element is the struct's own value type.
+    assert!(
+        matches!(
+            types.get_type_by_id(element_type),
+            Type::Struct(StructType { .. })
+        ),
+        "expected the array element to be the struct type, got {:?}",
+        types.get_type_by_id(element_type),
+    );
+}
+
+#[test]
 fn reference_type_constant_is_indexable() {
     let (element_type, _types) =
         type_of_expression_in_context(r#"bytes constant B = hex"1234";"#, "B[0]");
@@ -1591,6 +1648,85 @@ fn test_storage_base_slot_evaluation() {
 }
 
 #[test]
+fn test_event_selector() {
+    // `.selector` on an event name types as `bytes4`.
+    let (type_, _) = type_of_expression_in_context("event E(uint a);", "E.selector");
+    assert_eq!(type_, Type::ByteArray(ByteArrayType { width: 4 }));
+
+    // With *overloaded* events the name is ambiguous; we currently resolve the
+    // member against the first candidate (both candidates expose `selector`,
+    // so the typing is still `bytes4`). solc reports an ambiguity error here —
+    // that diagnostic is part of the SDR[37] validation backlog.
+    let (type_, _) =
+        type_of_expression_in_context("event E(uint a); event E(bool b);", "E.selector");
+    assert_eq!(type_, Type::ByteArray(ByteArrayType { width: 4 }));
+}
+
+#[test]
+fn test_bytes_and_string_concat_typing() {
+    // `concat` resolves as a member of the *meta-type* of `bytes`/`string`,
+    // and the two built-ins stay distinct: `bytes.concat` yields
+    // `bytes memory` while `string.concat` yields `string memory`.
+    let (type_, _) = type_of_expression(r#"bytes.concat(hex"01", hex"02")"#);
+    assert_eq!(
+        type_,
+        Type::Bytes(BytesType {
+            location: DataLocation::Memory
+        })
+    );
+
+    let (type_, _) = type_of_expression(r#"string.concat("a", "b")"#);
+    assert_eq!(
+        type_,
+        Type::String(StringType {
+            location: DataLocation::Memory
+        })
+    );
+}
+
+#[test]
+fn test_static_library_call_is_not_partially_applied() {
+    // With a matching `using` directive in scope, a *static* call through the
+    // library name must still resolve to the full function: the type name `L`
+    // is not a value receiver, so it must not bind the first parameter as a
+    // partial application.
+    let source = r#"
+        library L {
+            function f(uint x) internal pure returns (bool) { return x > 0; }
+        }
+        contract Test {
+            using L for uint;
+            function __test() internal pure {
+                L.f(1);
+            }
+        }
+        "#;
+    let TypeAnalysis {
+        file,
+        binder,
+        types,
+        ..
+    } = analyze(LanguageVersion::LATEST, source);
+    let contract = find_contract(&file, "Test");
+    let function = find_function(&contract.members, "__test").expect("__test function");
+    let body = function.body.as_ref().expect("__test has a body");
+    let typings = expression_statement_types(body, &binder, &types);
+    assert_eq!(typings, vec![Some(Type::Boolean)]);
+}
+
+#[test]
+fn test_meta_type_argument_does_not_match_overloads() {
+    // Passing a type name as an argument must not match any overload
+    // candidate during disambiguation.
+    let context = r#"
+        function f(uint x) internal pure returns (bool) { return x > 0; }
+        function f(bool x) internal pure returns (uint) { return x ? 1 : 0; }
+    "#;
+    let (type_, _) = try_type_of_expression_in_context(context, "f(uint)");
+    assert_eq!(type_, None);
+}
+
+#[test]
 fn test_user_meta_type_built_in_members() {
     // Built-in members of a *type name* resolve through its meta-type: errors
     // expose `selector`, and UDVTs expose `wrap`/`unwrap`.
@@ -1627,4 +1763,120 @@ fn test_explicit_enum_cast() {
     // through `wrap`/`unwrap`.
     let (type_, _) = try_type_of_expression_in_context("type T is uint256;", "T(1)");
     assert_eq!(type_, None);
+}
+
+#[test]
+fn test_meta_type_internal_names() {
+    // Meta-types print in solc's `type(T)` notation: `type(uint256)` for an
+    // elementary type, `type(E)` for a named definition.
+    let mut id_generator = NodeIdGenerator::default();
+    let source = r#"
+        contract C {
+            enum E { A }
+            function g() internal pure {
+                uint(1);
+                E;
+            }
+        }
+    "#;
+    let file = build_file(
+        "test.sol".into(),
+        source,
+        &mut id_generator,
+        LanguageVersion::LATEST,
+    );
+    let files = vec![file];
+    let mut diagnostics = DiagnosticCollection::default();
+    let context = SemanticContext::build_from(
+        LanguageVersion::LATEST,
+        EvmTarget::LATEST,
+        &files,
+        None,
+        &mut diagnostics,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    let contract = find_contract(&files[0], "C");
+    let function = find_function(&contract.members, "g").expect("g function");
+    let body = function.body.as_ref().expect("g has a body");
+    let mut expressions = body.statements.iter().filter_map(|stmt| match stmt {
+        ir::Statement::ExpressionStatement(s) => Some(&s.expression),
+        _ => None,
+    });
+
+    // `uint(1)`: the call operand `uint` carries the elementary meta-type.
+    let cast = expressions.next().expect("cast statement");
+    let ir::Expression::FunctionCallExpression(call) = cast else {
+        panic!("expected a function call expression");
+    };
+    let operand_node_id =
+        node_id_for_expression_typing(&call.operand).expect("operand has a typing node");
+    let uint_meta_id = context
+        .binder()
+        .node_typing(operand_node_id)
+        .as_type_id()
+        .expect("cast operand is typed");
+    assert_eq!(context.type_internal_name(uint_meta_id), "type(uint256)");
+
+    // `E`: the bare enum name carries the user meta-type.
+    let enum_expression = expressions.next().expect("enum statement");
+    let enum_node_id =
+        node_id_for_expression_typing(enum_expression).expect("expression has a typing node");
+    let enum_meta_id = context
+        .binder()
+        .node_typing(enum_node_id)
+        .as_type_id()
+        .expect("enum name is typed");
+    assert_eq!(context.type_internal_name(enum_meta_id), "type(E)");
+}
+
+#[test]
+fn test_abi_decode_tuple_of_types() {
+    // Multi-element `abi.decode` types as the tuple of the *decoded* value
+    // types, unwrapping each element's meta-type.
+    let (decoded, types) =
+        type_of_expression_in_context("bytes b; struct S { uint a; }", "abi.decode(b, (uint, S))");
+    let Type::Tuple(TupleType { types: element_ids }) = decoded else {
+        panic!("expected a tuple type, got {decoded:?}");
+    };
+    assert_eq!(element_ids.len(), 2);
+    assert_eq!(element_ids[0], types.uint256());
+    assert!(
+        matches!(types.get_type_by_id(element_ids[1]), Type::Struct(_)),
+        "expected the second element to decode to the struct",
+    );
+
+    // A tuple element that is not a type name doesn't decode.
+    let (decoded, _) = try_type_of_expression_in_context("bytes b;", "abi.decode(b, (uint, 5))");
+    assert_eq!(decoded, None);
+
+    // A nested tuple element is not a type name, so it doesn't decode either
+    // (matching solc, which rejects `abi.decode(b, (uint, (bool, bool)))`).
+    let (decoded, _) =
+        try_type_of_expression_in_context("bytes b;", "abi.decode(b, (uint, (bool, bool)))");
+    assert_eq!(decoded, None);
+
+    // Neither does a second argument that is not a type or tuple of types.
+    let (decoded, _) = try_type_of_expression_in_context("bytes b; uint x;", "abi.decode(b, x)");
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_tuple_of_type_names_is_a_tuple_of_meta_types() {
+    // A tuple of type names is a *tuple of meta-types* (not a meta-type
+    // itself): `(uint, bool)` types as `Tuple(type(uint256), type(bool))`.
+    // This matches solc, which rejects a nested tuple element (it is not a
+    // type name) — see `test_abi_decode_tuple_of_types`.
+    let (type_, registry) = type_of_expression("(uint, bool)");
+    let Type::Tuple(TupleType { types: element_ids }) = type_ else {
+        panic!("expected `(uint, bool)` to type as a tuple, got {type_:?}");
+    };
+    assert!(matches!(
+        registry.get_type_by_id(element_ids[0]),
+        Type::MetaType(_)
+    ));
+    assert!(matches!(
+        registry.get_type_by_id(element_ids[1]),
+        Type::MetaType(_)
+    ));
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -35,10 +35,17 @@ pub enum Type {
     Library(LibraryType),
     Literal(LiteralKind),
     Mapping(MappingType),
+    /// The meta-type of an (already known) type. This is the type of an
+    /// expression that refers to a type itself rather than to a value, eg. the
+    /// `uint` in `uint(x)` (an explicit cast) or `bytes` in `bytes.concat(...)`.
+    MetaType(MetaType),
     String(StringType),
     Struct(StructType),
     Tuple(TupleType),
     UserDefinedValue(UserDefinedValueType),
+    /// The meta-type of a user defined type referred to by name, eg. the
+    /// identifier of a contract, struct or enum.
+    UserMetaType(UserMetaType),
     Void,
 }
 
@@ -127,6 +134,18 @@ pub struct TupleType {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserDefinedValueType {
+    pub definition_id: NodeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MetaType {
+    /// The `TypeId` of the type this is a meta-type of.
+    pub type_id: TypeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UserMetaType {
+    /// The `NodeId` of the definition this meta-type refers to.
     pub definition_id: NodeId,
 }
 
@@ -397,6 +416,9 @@ impl Type {
             | Type::Literal(_)
             | Type::Library(_)
             | Type::Tuple(_)
+            // Meta-types are not real values and can never be returned.
+            | Type::MetaType(_)
+            | Type::UserMetaType(_)
             | Type::Void => false,
         }
     }
@@ -424,6 +446,13 @@ impl Type {
         matches!(self, Type::Contract(_) | Type::Interface(_))
     }
 
+    /// Whether this is a meta-type, ie. the type of an expression that refers
+    /// to a type rather than a value (see [`Type::MetaType`] and
+    /// [`Type::UserMetaType`]).
+    pub(crate) fn is_meta_type(&self) -> bool {
+        matches!(self, Type::MetaType(_) | Type::UserMetaType(_))
+    }
+
     pub(crate) fn get_definition_id(&self) -> Option<NodeId> {
         match self {
             Type::Contract(ContractType { definition_id })
@@ -442,6 +471,13 @@ impl Type {
     ///
     /// TODO: This probably has a better way to resolve it, looking at the storage location
     pub(crate) fn can_be_array_element(&self) -> bool {
-        !matches!(self, Type::Mapping(_) | Type::Tuple(_) | Type::Void)
+        !matches!(
+            self,
+            Type::Mapping(_)
+                | Type::Tuple(_)
+                | Type::MetaType(_)
+                | Type::UserMetaType(_)
+                | Type::Void
+        )
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -509,8 +509,10 @@ impl TypeRegistry {
             | Type::Library(_)
             | Type::Literal(_)
             | Type::Mapping(_)
+            | Type::MetaType(_)
             | Type::Tuple(_)
             | Type::UserDefinedValue(_)
+            | Type::UserMetaType(_)
             | Type::Void => return Some(type_id),
         };
         self.find_type(&canonical_type)
@@ -569,7 +571,9 @@ impl TypeRegistry {
             | Type::Library(_)
             | Type::Literal(_)
             | Type::Mapping(_)
+            | Type::MetaType(_)
             | Type::UserDefinedValue(_)
+            | Type::UserMetaType(_)
             | Type::Void => type_,
         };
         self.register_type(type_with_location)

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/meta_type.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/meta_type.rs
@@ -1,0 +1,132 @@
+//! Exercises the public AST wrappers for meta-types (`Type::MetaType` and
+//! `Type::UserMetaType`) and their accessors, reached through
+//! `Expression::get_type()`.
+
+use crate::abi::AbiType;
+use crate::{ast, define_fixture};
+
+define_fixture!(
+    MetaTypes,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.29;
+
+contract C {
+    struct S { uint a; }
+
+    function f(uint x, bytes memory b) internal pure {
+        S(x);
+        abi.decode(b, (uint[]));
+        uint(x);
+        (uint)(x);
+    }
+}
+"#,
+);
+
+/// Returns the function call expressions of the statements in `C.f`, in source
+/// order.
+fn function_calls() -> Vec<ast::FunctionCallExpression> {
+    let unit = MetaTypes::build_compilation_unit();
+
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("can find C contract");
+    let function = contract
+        .members()
+        .iter()
+        .find_map(|member| {
+            if let ast::ContractMember::FunctionDefinition(function_definition) = member {
+                if function_definition
+                    .name()
+                    .is_some_and(|name| name.name() == "f")
+                {
+                    return Some(function_definition);
+                }
+            }
+            None
+        })
+        .expect("f function is found");
+    let body = function.body().expect("f has a body");
+
+    body.statements()
+        .iter()
+        .map(|statement| {
+            let ast::Statement::ExpressionStatement(statement) = statement else {
+                panic!("expected an expression statement");
+            };
+            let ast::Expression::FunctionCallExpression(call) = statement.expression() else {
+                panic!("expected a function call expression");
+            };
+            call
+        })
+        .collect()
+}
+
+#[test]
+fn meta_type_ast_wrappers_are_reachable_via_get_type() {
+    let calls = function_calls();
+    assert_eq!(calls.len(), 4);
+
+    // `S(x)`: a construction through a type name is a type conversion, and the
+    // operand `S` carries a `Type::UserMetaType` that resolves back to the
+    // struct definition. Meta-types have no ABI representation.
+    let construction = &calls[0];
+    assert!(construction.is_type_conversion());
+    let operand_type = construction
+        .operand()
+        .get_type()
+        .expect("`S` operand is typed");
+    let ast::Type::UserMetaType(user_meta) = &operand_type else {
+        panic!("expected the `S` operand to carry a `Type::UserMetaType`");
+    };
+    assert_eq!(user_meta.definition().identifier().name(), "S");
+    assert!(AbiType::try_from(&operand_type).is_err());
+
+    // `abi.decode(b, (uint[]))`: a plain call, not a type conversion. The
+    // `uint[]` type expression carries a `Type::MetaType` wrapping the array
+    // type it denotes.
+    let decode = &calls[1];
+    assert!(!decode.is_type_conversion());
+    let ast::ArgumentsDeclaration::PositionalArguments(arguments) = decode.arguments() else {
+        panic!("expected positional arguments");
+    };
+    let ast::Expression::TupleExpression(tuple) = arguments
+        .iter()
+        .nth(1)
+        .expect("abi.decode has a second argument")
+    else {
+        panic!("expected the type argument to be a tuple expression");
+    };
+    let type_expression = tuple
+        .items()
+        .iter()
+        .next()
+        .and_then(|item| item.expression())
+        .expect("the type tuple has an expression item");
+    let type_expression_type = type_expression
+        .get_type()
+        .expect("`uint[]` type expression is typed");
+    let ast::Type::MetaType(meta) = &type_expression_type else {
+        panic!("expected the `uint[]` type expression to carry a `Type::MetaType`");
+    };
+    assert!(matches!(meta.meta_type(), ast::Type::Array(_)));
+    assert!(AbiType::try_from(&type_expression_type).is_err());
+
+    // `uint(x)`: an elementary cast; the `uint` operand carries a stored
+    // `Type::MetaType` typing of its own, wrapping the integer type.
+    let cast = &calls[2];
+    assert!(cast.is_type_conversion());
+    let operand_type = cast.operand().get_type().expect("`uint` operand is typed");
+    let ast::Type::MetaType(meta) = &operand_type else {
+        panic!("expected the `uint` operand to carry a `Type::MetaType`");
+    };
+    assert!(matches!(meta.meta_type(), ast::Type::Integer(_)));
+    assert!(AbiType::try_from(&operand_type).is_err());
+
+    // `(uint)(x)`: a parenthesized cast; the tuple operand's typing passes the
+    // meta-type through, so it is still a type conversion.
+    let parenthesized_cast = &calls[3];
+    assert!(parenthesized_cast.is_type_conversion());
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/mod.rs
@@ -9,6 +9,7 @@ mod is_payable;
 mod json;
 mod linearisations;
 mod members;
+mod meta_type;
 mod node_location;
 mod number_literals;
 mod typing;

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -454,6 +454,13 @@ fn type_display(type_: &Type) -> String {
                 value = type_display(&mapping.value_type()),
             )
         }
+        // Meta-types are expression-only typings (the type of an expression
+        // that refers to a type rather than a value). This report only renders
+        // the types of value-bearing definitions, so a meta-type never reaches
+        // here.
+        Type::MetaType(_) | Type::UserMetaType(_) => {
+            unreachable!("meta-types are not rendered as definition types")
+        }
         Type::String(string) => {
             format!(
                 "string {location}",


### PR DESCRIPTION
This PR is pushed by https://github.com/NomicFoundation/slang/pull/1872, in particular #1872 allows to have overloads of mixtures of both meta types and function types.

Summarizing:
- Make `MetaType` and `UserMetaType` part of the regular types, rather than a Typing
- Exporting MetaType and UserMetaType as part of the AST
- Resolving abi.decode type only when second argument is a meta type or a tuple of meta types, unresolved in any other case (validation not done yet)
- Added tests for meta Array type and some other cases