### PR TITLE
Upgrade Rust to 1.97.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
   "rust-analyzer.imports.granularity.group": "module",
   "rust-analyzer.imports.prefix": "crate",
   "rust-analyzer.rustfmt.extraArgs": [
-    "+nightly-2026-03-17" // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
+    "+nightly-2026-07-14" // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
   ],
   "rust-analyzer.server.path": "${workspaceFolder}/scripts/bin/rust-analyzer",
   "search.exclude": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -40,7 +40,7 @@
         },
         "rustfmt": {
           "extraArgs": [
-            "+nightly-2026-03-17" // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
+            "+nightly-2026-07-14" // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
           ]
         }
       }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "1.3.7"
-rust-version = "1.94.0" # __RUST_STABLE_VERSION_MARKER__ (keep in sync)
+rust-version = "1.97.1" # __RUST_STABLE_VERSION_MARKER__ (keep in sync)
 edition = "2021"
 publish = false
 

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -7,8 +7,8 @@ env = {
 
   // Rust:
   "RUST_BACKTRACE": "full",
-  "RUST_STABLE_VERSION": "1.94.0", // __RUST_STABLE_VERSION_MARKER__ (keep in sync)
-  "RUST_NIGHTLY_VERSION": "nightly-2026-03-17", // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
+  "RUST_STABLE_VERSION": "1.97.1", // __RUST_STABLE_VERSION_MARKER__ (keep in sync)
+  "RUST_NIGHTLY_VERSION": "nightly-2026-07-14", // __RUST_NIGHTLY_VERSION_MARKER__ (keep in sync)
 
   // TypeScript:
   "TS_NODE_PROJECT": "${HERMIT_ENV}/tsconfig.json",

--- a/crates/codegen/generator/src/parser/codegen/scanner_definition.rs
+++ b/crates/codegen/generator/src/parser/codegen/scanner_definition.rs
@@ -179,9 +179,9 @@ impl ScannerCodegen for model::Scanner {
                     accum.insert(atom.clone());
                     true
                 }
-                model::Scanner::Choice { scanners } => scanners
-                    .iter()
-                    .fold(true, |result, node| accumulate(node, accum) && result),
+                model::Scanner::Choice { scanners } => {
+                    scanners.iter().all(|node| accumulate(node, accum))
+                }
                 _ => false,
             }
         }

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -38,9 +38,9 @@ impl NpmController {
         let test_runner = format!(
             "cargo run --package {package} -- --pattern=\"{pattern}\" --cold={cold} --hot={hot}",
             package = "solidity_testing_perf_npm",
-            pattern = &self.pattern,
-            cold = &self.cold,
-            hot = &self.hot,
+            pattern = self.pattern,
+            cold = self.cold,
+            hot = self.hot,
         );
 
         // 15% threshold: npm benchmarks use wall-clock duration which has natural variance,

--- a/crates/infra/utils/src/solc/binaries.rs
+++ b/crates/infra/utils/src/solc/binaries.rs
@@ -78,7 +78,7 @@ fn fetch_binaries_list(mirror_url: &Url) -> Result<HashMap<Version, String>> {
         releases: HashMap<Version, String>,
     }
 
-    const LIST_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24);
+    const LIST_MAX_AGE: Duration = Duration::from_hours(24);
 
     let list_path = solc_dir().join("list.json");
 

--- a/crates/language-v2/definition/src/compiler/utils/version_set.rs
+++ b/crates/language-v2/definition/src/compiler/utils/version_set.rs
@@ -94,11 +94,7 @@ impl VersionSet {
         let mut first_iter = self.ranges.iter().cloned().peekable();
         let mut second_iter = other.ranges.iter().peekable();
 
-        loop {
-            let (Some(first), Some(second)) = (first_iter.peek_mut(), second_iter.peek()) else {
-                break;
-            };
-
+        while let (Some(first), Some(second)) = (first_iter.peek_mut(), second_iter.peek()) {
             if first.end <= second.start {
                 // first fully exists before second: take it, and advance first:
                 ranges.push(first_iter.next().unwrap());

--- a/crates/language/definition/src/compiler/analysis/references.rs
+++ b/crates/language/definition/src/compiler/analysis/references.rs
@@ -246,19 +246,19 @@ fn check_fields(
 
                 if let Some(target) = analysis.metadata.get_mut(&**reference) {
                     match &target.item {
-                        SpannedItem::Repeated { item: child } => {
-                            if child.allow_empty.as_ref().is_some_and(|b| **b) {
-                                analysis
-                                    .errors
-                                    .add(reference, &Errors::OptionalFieldAllowsEmpty);
-                            }
+                        SpannedItem::Repeated { item: child }
+                            if child.allow_empty.as_ref().is_some_and(|b| **b) =>
+                        {
+                            analysis
+                                .errors
+                                .add(reference, &Errors::OptionalFieldAllowsEmpty);
                         }
-                        SpannedItem::Separated { item: child } => {
-                            if child.allow_empty.as_ref().is_some_and(|b| **b) {
-                                analysis
-                                    .errors
-                                    .add(reference, &Errors::OptionalFieldAllowsEmpty);
-                            }
+                        SpannedItem::Separated { item: child }
+                            if child.allow_empty.as_ref().is_some_and(|b| **b) =>
+                        {
+                            analysis
+                                .errors
+                                .add(reference, &Errors::OptionalFieldAllowsEmpty);
                         }
                         _ => {}
                     }

--- a/crates/language/definition/src/compiler/version_set.rs
+++ b/crates/language/definition/src/compiler/version_set.rs
@@ -68,11 +68,7 @@ impl VersionSet {
         let mut first_iter = self.ranges.iter().cloned().peekable();
         let mut second_iter = other.ranges.iter().peekable();
 
-        loop {
-            let (Some(first), Some(second)) = (first_iter.peek_mut(), second_iter.peek()) else {
-                break;
-            };
-
+        while let (Some(first), Some(second)) = (first_iter.peek_mut(), second_iter.peek()) {
             if first.end <= second.start {
                 // first fully exists before second: take it, and advance first:
                 ranges.push(first_iter.next().unwrap());

--- a/crates/metaslang/cst/generated/public_api.txt
+++ b/crates/metaslang/cst/generated/public_api.txt
@@ -43,9 +43,9 @@ pub fn metaslang_cst::cursor::Cursor<T>::clone(&self) -> metaslang_cst::cursor::
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::cursor::Cursor<T>
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::eq(&self, &metaslang_cst::cursor::Cursor<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::cursor::Cursor<T>
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::cursor::Cursor<T>
 pub fn metaslang_cst::cursor::Cursor<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::cursor::Cursor<T>
 pub struct metaslang_cst::cursor::CursorIterator<T: metaslang_cst::kinds::KindTypes>
 impl<T: metaslang_cst::kinds::KindTypes> core::iter::traits::iterator::Iterator for metaslang_cst::cursor::CursorIterator<T>
 pub type metaslang_cst::cursor::CursorIterator<T>::Item = metaslang_cst::nodes::Edge<T>
@@ -59,6 +59,7 @@ pub fn metaslang_cst::kinds::NodeKind<T>::clone(&self) -> metaslang_cst::kinds::
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::kinds::NodeKind<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::Eq, <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::Eq
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::kinds::NodeKind<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::PartialEq, <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::PartialEq
 pub fn metaslang_cst::kinds::NodeKind<T>::eq(&self, &metaslang_cst::kinds::NodeKind<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::kinds::NodeKind<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::PartialEq, <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::PartialEq
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::kinds::NodeKind<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::fmt::Debug, <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::fmt::Debug
 pub fn metaslang_cst::kinds::NodeKind<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T: core::marker::Copy + metaslang_cst::kinds::KindTypes> core::marker::Copy for metaslang_cst::kinds::NodeKind<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::marker::Copy, <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::marker::Copy
@@ -66,7 +67,6 @@ impl<T: metaslang_cst::kinds::KindTypes> core::convert::From<metaslang_cst::kind
 pub fn &'static str::from(metaslang_cst::kinds::NodeKind<T>) -> Self
 impl<T: metaslang_cst::kinds::KindTypes> core::fmt::Display for metaslang_cst::kinds::NodeKind<T>
 pub fn metaslang_cst::kinds::NodeKind<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::kinds::NodeKind<T>
 pub trait metaslang_cst::kinds::BaseKind: core::marker::Sized + core::fmt::Debug + core::marker::Copy + core::cmp::PartialEq + core::cmp::Eq + serde_core::ser::Serialize
 pub fn metaslang_cst::kinds::BaseKind::as_static_str(&self) -> &'static str
 pub fn metaslang_cst::kinds::BaseKind::try_from_str(&str) -> core::result::Result<Self, alloc::string::String>
@@ -118,13 +118,13 @@ pub fn metaslang_cst::nodes::Node<T>::clone(&self) -> metaslang_cst::nodes::Node
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::nodes::Node<T>
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::nodes::Node<T>
 pub fn metaslang_cst::nodes::Node<T>::eq(&self, &metaslang_cst::nodes::Node<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::Node<T>
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::nodes::Node<T>
 pub fn metaslang_cst::nodes::Node<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T: metaslang_cst::kinds::KindTypes> core::convert::From<alloc::rc::Rc<metaslang_cst::nodes::NonterminalNode<T>>> for metaslang_cst::nodes::Node<T>
 pub fn metaslang_cst::nodes::Node<T>::from(alloc::rc::Rc<metaslang_cst::nodes::NonterminalNode<T>>) -> Self
 impl<T: metaslang_cst::kinds::KindTypes> core::convert::From<alloc::rc::Rc<metaslang_cst::nodes::TerminalNode<T>>> for metaslang_cst::nodes::Node<T>
 pub fn metaslang_cst::nodes::Node<T>::from(alloc::rc::Rc<metaslang_cst::nodes::TerminalNode<T>>) -> Self
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::Node<T>
 impl<T> serde_core::ser::Serialize for metaslang_cst::nodes::Node<T> where T: serde_core::ser::Serialize + metaslang_cst::kinds::KindTypes
 pub fn metaslang_cst::nodes::Node<T>::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub struct metaslang_cst::nodes::Edge<T: metaslang_cst::kinds::KindTypes>
@@ -138,9 +138,9 @@ pub fn metaslang_cst::nodes::Edge<T>::clone(&self) -> metaslang_cst::nodes::Edge
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::nodes::Edge<T> where <T as metaslang_cst::kinds::KindTypes>::EdgeLabel: core::cmp::Eq
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::nodes::Edge<T> where <T as metaslang_cst::kinds::KindTypes>::EdgeLabel: core::cmp::PartialEq
 pub fn metaslang_cst::nodes::Edge<T>::eq(&self, &metaslang_cst::nodes::Edge<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::Edge<T> where <T as metaslang_cst::kinds::KindTypes>::EdgeLabel: core::cmp::PartialEq
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::nodes::Edge<T> where <T as metaslang_cst::kinds::KindTypes>::EdgeLabel: core::fmt::Debug
 pub fn metaslang_cst::nodes::Edge<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::Edge<T>
 impl<T: metaslang_cst::kinds::KindTypes> core::ops::deref::Deref for metaslang_cst::nodes::Edge<T>
 pub type metaslang_cst::nodes::Edge<T>::Target = metaslang_cst::nodes::Node<T>
 pub fn metaslang_cst::nodes::Edge<T>::deref(&self) -> &Self::Target
@@ -183,9 +183,9 @@ pub fn metaslang_cst::nodes::NonterminalNode<T>::clone(&self) -> metaslang_cst::
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::nodes::NonterminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::Eq
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::nodes::NonterminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::PartialEq
 pub fn metaslang_cst::nodes::NonterminalNode<T>::eq(&self, &metaslang_cst::nodes::NonterminalNode<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::NonterminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::cmp::PartialEq
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::nodes::NonterminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: core::fmt::Debug
 pub fn metaslang_cst::nodes::NonterminalNode<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::NonterminalNode<T>
 impl<T> serde_core::ser::Serialize for metaslang_cst::nodes::NonterminalNode<T> where T: serde_core::ser::Serialize + metaslang_cst::kinds::KindTypes, <T as metaslang_cst::kinds::KindTypes>::NonterminalKind: serde_core::ser::Serialize
 pub fn metaslang_cst::nodes::NonterminalNode<T>::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub struct metaslang_cst::nodes::TerminalNode<T: metaslang_cst::kinds::KindTypes>
@@ -203,9 +203,9 @@ pub fn metaslang_cst::nodes::TerminalNode<T>::clone(&self) -> metaslang_cst::nod
 impl<T: core::cmp::Eq + metaslang_cst::kinds::KindTypes> core::cmp::Eq for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::Eq
 impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::cmp::PartialEq for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::PartialEq
 pub fn metaslang_cst::nodes::TerminalNode<T>::eq(&self, &metaslang_cst::nodes::TerminalNode<T>) -> bool
+impl<T: core::cmp::PartialEq + metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::cmp::PartialEq
 impl<T: core::fmt::Debug + metaslang_cst::kinds::KindTypes> core::fmt::Debug for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: core::fmt::Debug
 pub fn metaslang_cst::nodes::TerminalNode<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: metaslang_cst::kinds::KindTypes> core::marker::StructuralPartialEq for metaslang_cst::nodes::TerminalNode<T>
 impl<T: metaslang_cst::kinds::KindTypes> serde_core::ser::Serialize for metaslang_cst::nodes::TerminalNode<T> where <T as metaslang_cst::kinds::KindTypes>::TerminalKind: serde_core::ser::Serialize
 pub fn metaslang_cst::nodes::TerminalNode<T>::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub mod metaslang_cst::query

--- a/crates/metaslang/cst/src/query/engine.rs
+++ b/crates/metaslang/cst/src/query/engine.rs
@@ -576,15 +576,11 @@ impl<T: KindTypes + 'static> Matcher<T> for AlternativesMatcher<T> {
             if self.child.is_none() {
                 // Create the next available child matcher forwarding the
                 // `require_explicit_match` flag, or give up if we have no more
-                match self.matcher.children.get(self.next_child_number) {
-                    Some(child) => {
-                        let child =
-                            child.create_matcher(self.cursor.clone(), self.require_explicit_match);
-                        self.child = Some(child);
-                        self.next_child_number += 1;
-                    }
-                    None => return None,
-                }
+                let child = self.matcher.children.get(self.next_child_number)?;
+                let child =
+                    child.create_matcher(self.cursor.clone(), self.require_explicit_match);
+                self.child = Some(child);
+                self.next_child_number += 1;
             }
 
             match self.child.as_mut().unwrap().next() {

--- a/crates/metaslang/cst/src/query/engine.rs
+++ b/crates/metaslang/cst/src/query/engine.rs
@@ -577,8 +577,7 @@ impl<T: KindTypes + 'static> Matcher<T> for AlternativesMatcher<T> {
                 // Create the next available child matcher forwarding the
                 // `require_explicit_match` flag, or give up if we have no more
                 let child = self.matcher.children.get(self.next_child_number)?;
-                let child =
-                    child.create_matcher(self.cursor.clone(), self.require_explicit_match);
+                let child = child.create_matcher(self.cursor.clone(), self.require_explicit_match);
                 self.child = Some(child);
                 self.next_child_number += 1;
             }

--- a/crates/metaslang/graph_builder/generated/public_api.txt
+++ b/crates/metaslang/graph_builder/generated/public_api.txt
@@ -736,7 +736,7 @@ pub struct metaslang_graph_builder::graph::Graph<KT: metaslang_cst::kinds::KindT
 impl<KT: metaslang_cst::kinds::KindTypes> metaslang_graph_builder::graph::Graph<KT>
 pub fn metaslang_graph_builder::graph::Graph<KT>::add_graph_node(&mut self) -> metaslang_graph_builder::graph::GraphNodeRef
 pub fn metaslang_graph_builder::graph::Graph<KT>::add_syntax_node(&mut self, metaslang_cst::cursor::Cursor<KT>) -> metaslang_graph_builder::graph::SyntaxNodeRef
-pub fn metaslang_graph_builder::graph::Graph<KT>::display_json(&self, core::option::Option<&std::path::Path>) -> std::io::error::Result<()>
+pub fn metaslang_graph_builder::graph::Graph<KT>::display_json(&self, core::option::Option<&std::path::Path>) -> core::io::error::Result<()>
 pub fn metaslang_graph_builder::graph::Graph<KT>::iter_nodes(&self) -> impl core::iter::traits::iterator::Iterator<Item = metaslang_graph_builder::graph::GraphNodeRef>
 pub fn metaslang_graph_builder::graph::Graph<KT>::new() -> metaslang_graph_builder::graph::Graph<KT>
 pub fn metaslang_graph_builder::graph::Graph<KT>::node_count(&self) -> usize

--- a/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/identifiers.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/ir/ast/node_extensions/identifiers.rs
@@ -13,7 +13,7 @@ pub(crate) fn create_identifier(
     ir_node: &Rc<TerminalNode>,
     semantic: &Rc<SemanticAnalysis>,
 ) -> Identifier {
-    assert!(ir_node.kind == TerminalKind::Identifier);
+    assert_eq!(ir_node.kind, TerminalKind::Identifier);
     Rc::new(IdentifierStruct {
         ir_node: Rc::clone(ir_node),
         semantic: Rc::clone(semantic),
@@ -121,7 +121,7 @@ pub(crate) fn create_yul_identifier(
     ir_node: &Rc<TerminalNode>,
     semantic: &Rc<SemanticAnalysis>,
 ) -> YulIdentifier {
-    assert!(ir_node.kind == TerminalKind::YulIdentifier);
+    assert_eq!(ir_node.kind, TerminalKind::YulIdentifier);
     Rc::new(YulIdentifierStruct {
         ir_node: Rc::clone(ir_node),
         semantic: Rc::clone(semantic),

--- a/crates/solidity/outputs/cargo/crate/src/backend/semantic/mod.rs
+++ b/crates/solidity/outputs/cargo/crate/src/backend/semantic/mod.rs
@@ -312,12 +312,12 @@ impl SemanticAnalysis {
 
             Type::Array { element_type, .. } => self
                 .type_canonical_name(*element_type)
-                .map(|element| format!("{element}[]",)),
+                .map(|element| format!("{element}[]")),
             Type::FixedSizeArray {
                 element_type, size, ..
             } => self
                 .type_canonical_name(*element_type)
-                .map(|element| format!("{element}[{size}]",)),
+                .map(|element| format!("{element}[{size}]")),
 
             Type::Contract { .. } | Type::Interface { .. } => Some("address".to_string()),
 

--- a/crates/solidity/outputs/cargo/crate/src/parser/parser_support/parser_function.rs
+++ b/crates/solidity/outputs/cargo/crate/src/parser/parser_support/parser_function.rs
@@ -176,8 +176,8 @@ where
                             .remaining_nodes()
                             .all(|edge| edge
                                 .as_terminal()
-                                .filter(|tok| !tok.kind.is_valid())
-                                .is_none())
+                                .as_ref()
+                                .is_none_or(|tok| tok.kind.is_valid()))
                     );
 
                     ParseOutput { tree, errors }

--- a/crates/solidity/outputs/cargo/crate/src/parser/parser_support/parser_result.rs
+++ b/crates/solidity/outputs/cargo/crate/src/parser/parser_support/parser_result.rs
@@ -185,8 +185,8 @@ impl Match {
             })
             .all(|edge| {
                 edge.as_terminal()
-                    .filter(|tok| !tok.kind.is_valid())
-                    .is_none()
+                    .as_ref()
+                    .is_none_or(|tok| tok.kind.is_valid())
             })
     }
 }

--- a/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/v1/graph/graphviz.rs
+++ b/crates/solidity/outputs/cargo/tests/src/bindings/bindings_output/v1/graph/graphviz.rs
@@ -61,7 +61,7 @@ impl DotSubGraph<'_> {
             // special case: JUMP_TO_SCOPE_NODE
             "JUMP_TO_SCOPE_NODE".to_string()
         } else {
-            format!("{graph_id}N{index}", graph_id = self.graph_id,)
+            format!("{graph_id}N{index}", graph_id = self.graph_id)
         }
     }
 

--- a/crates/solidity/testing/sourcify/src/main.rs
+++ b/crates/solidity/testing/sourcify/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
 // but for whatever reason clippy can't figure that out
 #[allow(clippy::needless_pass_by_value)]
 fn run_test_command(cmd: command::TestCommand) -> Result<()> {
-    Terminal::step(format!("Initialize chain {chain}", chain = cmd.chain_id,));
+    Terminal::step(format!("Initialize chain {chain}", chain = cmd.chain_id));
 
     let manifest = Manifest::new(cmd.chain_id, &cmd.sharding_options, &cmd.archive_options)
         .inspect_err(|e| eprintln!("Error fetching chain manifest: {e}"))?;

--- a/crates/solidity/testing/sourcify/src/sourcify.rs
+++ b/crates/solidity/testing/sourcify/src/sourcify.rs
@@ -41,7 +41,7 @@ impl Manifest {
             })
             .unwrap_or_default();
 
-        archive_descriptors.sort_by(|a, b| a.prefix.cmp(&b.prefix));
+        archive_descriptors.sort_by_key(|a| a.prefix);
 
         if archive_descriptors.is_empty() {
             return Err(Error::msg(format!(
@@ -265,9 +265,7 @@ impl ContractArchive {
     }
 
     pub fn contract_count(&self) -> usize {
-        fs::read_dir(&self.contracts_path)
-            .map(|i| i.count())
-            .unwrap_or(0)
+        fs::read_dir(&self.contracts_path).map_or(0, |i| i.count())
     }
 
     pub fn display_path(&self) -> String {

--- a/crates/solidity/testing/utils/src/import_resolver.rs
+++ b/crates/solidity/testing/utils/src/import_resolver.rs
@@ -234,9 +234,7 @@ fn resolve_relative_url_import(source_path: &str, import_path: &str) -> Result<S
 }
 
 fn path_is_url(path: &str) -> bool {
-    Url::parse(path)
-        .map(|url| url.is_special())
-        .unwrap_or(false)
+    Url::parse(path).is_ok_and(|url| url.is_special())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Bumps the pinned Rust toolchain to pick up the 1.97.1 miscompilation fix.

I also bumped fmt nightly and had to fix a bunch of 1.97 clippy lints. 


# Claude summary

## Changes

- **Stable `1.94.0` → `1.97.1`** (`Cargo.toml` `rust-version` + `RUST_STABLE_VERSION`, both `__RUST_STABLE_VERSION_MARKER__` sites). This is the toolchain that builds and tests all slang code, so the fix applies everywhere.
- **Nightly → `nightly-2026-07-14`** (1.99.0-nightly), all three `__RUST_NIGHTLY_VERSION_MARKER__` sites (`bin/hermit.hcl`, `.vscode/settings.json`, `.zed/settings.json`). Required by the bump: the public-api tooling builds rustdoc JSON with the nightly, and cargo rejects it if the nightly is older than the workspace MSRV. Pinned to a post-1.97.1 build so the whole toolchain is on the fix.
- **Fixed 13 new clippy lints introduced in 1.97** (fatal under CI's `-Dwarnings`): `question_mark`, `while_let_loop` (×2), `collapsible_match`, `manual_is_variant_and` (×2), `manual_assert_eq` (×2), `map_unwrap_or` (×2), `unnecessary_fold`, `unnecessary_sort_by`, `duration_suboptimal_units`, `useless_borrows_in_formatting`, `unnecessary_trailing_comma`.

## Note for reviewers

- The two `public_api.txt` diffs (`metaslang/cst`, `metaslang/graph_builder`) are **rustdoc-rendering artifacts of the newer nightly, not real API changes**: `StructuralPartialEq` impl-bound rendering, and `std::io::error::Result` → `core::io::error::Result` (the `io`-in-`core` move). CI regenerates them identically.
- `unnecessary_fold` (`scanner_definition.rs`): `.fold(true, |acc, n| accumulate(n, accum) && acc)` → `.all(|n| accumulate(n, accum))`. Observably equivalent — when it returns `false`, `literals()` discards the accumulated set via `.then_some`, so `.all()`'s short-circuit changes nothing. Verified: `parser.generated.rs` is unchanged.

## Validation

- CI-equivalent clippy (`--release -- -Dwarnings`): clean
- `infra check`: all generated files up to date
- `infra test cargo`: 2197/2197 pass
