### PR TITLE
[v2] fix(linearisation): drop functions overridden by public getters

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -169,7 +169,9 @@ impl SemanticContext {
 
     /// Returns the pre-computed list of functions visible in the given
     /// contract's hierarchy (per C3 linearisation), with overrides resolved and
-    /// sorted by name. `contract_id` must be a registered contract definition.
+    /// sorted by name. A function overridden by a public state variable's getter
+    /// is dropped from the list. `contract_id` must be a registered contract
+    /// definition.
     pub fn linearised_functions(&self, contract_id: NodeId) -> &[ir::FunctionDefinition] {
         self.contract_data.linearised_functions(contract_id)
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_compute_linearisations/linearisations.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p4_compute_linearisations/linearisations.rs
@@ -10,7 +10,7 @@ use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition};
 use crate::context::ContractLinearisations;
-use crate::types::TypeRegistry;
+use crate::types::{TypeId, TypeRegistry};
 
 /// Walks the contract's linearised bases in reverse (most-base-first) and
 /// gathers the members visible in its hierarchy.
@@ -69,33 +69,48 @@ pub(super) fn compute_linearisations(
 
 /// Flattens the contract bases' members (gathered most-base-first) into the
 /// hierarchy's function list: most-derived-first, dropping a function once a
-/// more-derived one overrides it, then sorted by name. Functions are cloned
-/// out only once they're known to survive override resolution.
+/// more-derived function or a public state variable's getter overrides it, then
+/// sorted by name. Functions are cloned out only once they're known to survive
+/// override resolution.
 fn linearise_functions(
     binder: &Binder,
     types: &TypeRegistry,
     contract_base_members: &[&[ir::ContractMember]],
 ) -> Vec<ir::FunctionDefinition> {
     let mut functions: Vec<&ir::FunctionDefinition> = Vec::new();
+    let mut getters: Vec<GetterSlot<'_>> = Vec::new();
     for members in contract_base_members.iter().rev() {
         for member in *members {
-            let ir::ContractMember::FunctionDefinition(function) = member else {
-                continue;
-            };
-            if !matches!(
-                function.kind,
-                ir::FunctionKind::Regular | ir::FunctionKind::Fallback | ir::FunctionKind::Receive
-            ) {
-                continue;
+            match member {
+                ir::ContractMember::FunctionDefinition(function)
+                    if matches!(
+                        function.kind,
+                        ir::FunctionKind::Regular
+                            | ir::FunctionKind::Fallback
+                            | ir::FunctionKind::Receive
+                    ) =>
+                {
+                    let already_overridden = functions
+                        .iter()
+                        .any(|kept| function_overrides(binder, types, kept, function))
+                        || getters
+                            .iter()
+                            .any(|getter| getter_overrides(binder, types, getter, function));
+                    if !already_overridden {
+                        functions.push(function);
+                    }
+                    // TODO(validation): if overriding, function must have the `override` specifier
+                    // and the overriden functions must be marked `virtual`
+                    // TODO(validation): if overriding multiple ancestors, the function needs to
+                    // specify the bases in a specifier
+                }
+                ir::ContractMember::StateVariableDefinition(state_variable) => {
+                    // Record its getter, if it has one, so it can shadow a
+                    // matching function inherited from a base contract.
+                    getters.extend(getter_slot(binder, state_variable));
+                }
+                _ => {}
             }
-            let already_overridden = functions
-                .iter()
-                .any(|kept| function_overrides(binder, types, kept, function));
-            if !already_overridden {
-                functions.push(function);
-            }
-            // TODO(validation): if overriding, function must have the `override` specifier and the overriden functions must be marked `virtual`
-            // TODO(validation): if overriding multiple ancestors, the function needs to specify the bases in a specifier
         }
     }
     functions.sort_by(|a, b| match (&a.name, &b.name) {
@@ -105,6 +120,50 @@ fn linearise_functions(
         (Some(a), Some(b)) => a.unparse().cmp(b.unparse()),
     });
     functions.into_iter().map(Arc::clone).collect()
+}
+
+/// A public state variable's generated getter, reduced to what we need to tell
+/// whether it overrides a function. Just its name and its function type.
+struct GetterSlot<'a> {
+    name: &'a str,
+    type_id: TypeId,
+}
+
+/// The [`GetterSlot`] for `state_variable`, or `None` when it has no getter.
+/// Only public state variables have a getter, and `getter_type_id` is set only
+/// for those, so unwrapping it below is what filters the non-public ones out.
+fn getter_slot<'a>(
+    binder: &Binder,
+    state_variable: &'a ir::StateVariableDefinition,
+) -> Option<GetterSlot<'a>> {
+    match binder.find_definition_by_id(state_variable.id()) {
+        Some(Definition::StateVariable(definition)) => Some(GetterSlot {
+            name: state_variable.name.unparse(),
+            type_id: definition.getter_type_id?,
+        }),
+        _ => None,
+    }
+}
+
+/// Whether `getter` overrides `function`. True when they share a name and the
+/// getter's type can override the function's. The getter version of
+/// [`function_overrides`].
+fn getter_overrides(
+    binder: &Binder,
+    types: &TypeRegistry,
+    getter: &GetterSlot<'_>,
+    function: &ir::FunctionDefinition,
+) -> bool {
+    function
+        .name
+        .as_ref()
+        .is_some_and(|name| name.unparse() == getter.name)
+        && binder
+            .node_typing(function.id())
+            .as_type_id()
+            .is_some_and(|function_type_id| {
+                types.type_id_is_function_and_overrides(getter.type_id, function_type_id)
+            })
 }
 
 /// Whether `overriding` overrides `overridden`: they share a name (or are the

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/getter_overrides.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/getter_overrides.rs
@@ -1,0 +1,122 @@
+//! Tests that a public state variable's getter overrides a same-named function
+//! inherited from a base contract, so `linearised_functions` drops it.
+
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::evm_targets::EvmTarget;
+use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::ir::NodeIdGenerator;
+
+use super::build_file;
+use crate::context::SemanticContext;
+
+/// Builds a `SemanticContext` over `source`, asserting no diagnostics.
+fn build_context(source: &str) -> SemanticContext {
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file(
+        "test.sol".into(),
+        source,
+        &mut id_generator,
+        LanguageVersion::LATEST,
+    );
+    let files = vec![file];
+    let mut diagnostics = DiagnosticCollection::default();
+    let context = SemanticContext::build_from(
+        LanguageVersion::LATEST,
+        EvmTarget::LATEST,
+        &files,
+        None,
+        &mut diagnostics,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Semantic diagnostics: {diagnostics:?}"
+    );
+    context
+}
+
+/// The names of the named functions in `contract`'s linearised function list.
+/// The list is already sorted by name.
+fn linearised_function_names(context: &SemanticContext, contract: &str) -> Vec<String> {
+    let definition = context
+        .find_contract_by_name(contract)
+        .next()
+        .unwrap_or_else(|| panic!("contract `{contract}` not found"));
+    context
+        .linearised_functions(definition.id())
+        .iter()
+        .filter_map(|function| function.name.as_ref().map(|name| name.unparse().to_owned()))
+        .collect()
+}
+
+#[test]
+fn getter_shadows_overridden_function() {
+    let context = build_context(
+        r#"
+        contract Base {
+            function x() external virtual returns (uint256) { return 0; }
+        }
+        contract D is Base {
+            uint256 public override x;
+        }
+        "#,
+    );
+
+    // The getter serves D's dispatch slot, so `Base.x` is dropped from D.
+    assert!(!linearised_function_names(&context, "D").contains(&"x".to_owned()));
+    // Base's own list still has the function.
+    assert!(linearised_function_names(&context, "Base").contains(&"x".to_owned()));
+}
+
+#[test]
+fn getter_shadows_from_middle_of_hierarchy() {
+    let context = build_context(
+        r#"
+        abstract contract A {
+            function x() external virtual returns (uint256);
+        }
+        contract B is A {
+            uint256 public override x;
+        }
+        contract D is B {}
+        "#,
+    );
+
+    // The getter overriding in B shadows `A.x` for both B and its descendant D.
+    assert!(!linearised_function_names(&context, "B").contains(&"x".to_owned()));
+    assert!(!linearised_function_names(&context, "D").contains(&"x".to_owned()));
+}
+
+#[test]
+fn parameterized_getter_shadows_overridden_function() {
+    let context = build_context(
+        r#"
+        abstract contract Base {
+            function m(uint256) external virtual returns (uint256);
+        }
+        contract D is Base {
+            mapping(uint256 => uint256) public override m;
+        }
+        "#,
+    );
+
+    // The mapping's getter has the function type `function(uint256) returns
+    // (uint256)`, matching `Base.m`, so the function is dropped.
+    assert!(!linearised_function_names(&context, "D").contains(&"m".to_owned()));
+}
+
+#[test]
+fn differently_named_variable_does_not_shadow() {
+    let context = build_context(
+        r#"
+        contract Base {
+            function x() external virtual returns (uint256) { return 0; }
+        }
+        contract D is Base {
+            uint256 public y;
+        }
+        "#,
+    );
+
+    // `y`'s getter has a different name, so `Base.x` stays in D's list.
+    assert!(linearised_function_names(&context, "D").contains(&"x".to_owned()));
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -1,4 +1,5 @@
 mod binder;
+mod getter_overrides;
 mod typing;
 
 use slang_solidity_v2_common::files::FileId;


### PR DESCRIPTION
A public state variable's getter can override an inherited external function, taking over its dispatch slot. The linearised function list only resolved function-vs-function overrides, so it wrongly kept the overridden base function. Getters now take part in the flattening, so such a function is dropped.