### PR TITLE
[v2] feat(typing): Use NodeIdentity for expression typing

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/mod.rs
@@ -6,17 +6,15 @@
 //!   `p3_type_definitions` for array lengths and `p5_resolve_references` for
 //!   storage base slots).
 //! - [`resolution`]: shared reference-resolution helpers.
-//! - [`node_extensions`]: small helpers over IR nodes (eg. picking the `NodeId`
-//!   used to register an expression's typing).
+//! - [`node_extensions`]: small helpers over IR nodes (eg. computing a node's
+//!   source location).
 
 pub(crate) mod conflicts;
 pub(crate) mod constant_evaluator;
 mod node_extensions;
 mod resolution;
 
-pub(crate) use node_extensions::{
-    node_id_for_expression_typing, node_id_for_string_expression_typing, node_location,
-};
+pub(crate) use node_extensions::node_location;
 pub(crate) use resolution::{
     filter_overriden_definitions, find_definition_namespace_scope_id,
     resolve_identifier_path_in_scope,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/node_extensions.rs
@@ -1,8 +1,6 @@
 use std::ops::Range;
 
 use slang_solidity_v2_common::files::FileId;
-use slang_solidity_v2_common::nodes::NodeId;
-use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 
 use crate::context::FileNodeMapper;
@@ -18,60 +16,4 @@ pub(crate) fn node_location(
         .to_owned();
     let range = node.calculate_text_range().expect("node has a text range");
     (file_id, range)
-}
-
-/// Since `StringExpression` nodes are plain enums and each variant is in
-/// turn a collection of terminals, they don't have a `NodeId`. So we pick
-/// the `NodeId` of the first terminal of the collection.
-pub(crate) fn node_id_for_string_expression_typing(node: &ir::StringExpression) -> NodeId {
-    match node {
-        ir::StringExpression::StringLiterals(strings) => strings[0].id(),
-        ir::StringExpression::HexStringLiterals(hex_strings) => hex_strings[0].id(),
-        ir::StringExpression::UnicodeStringLiterals(unicode_strings) => unicode_strings[0].id(),
-    }
-}
-
-/// Returns the `NodeId` of an `ir::Expression`, dispatching across the variants
-/// sub-expression types. This is `NodeId` is what the typing pass uses to
-/// register the typing of the `Expression`.
-pub(crate) fn node_id_for_expression_typing(node: &ir::Expression) -> Option<NodeId> {
-    match node {
-        ir::Expression::AssignmentExpression(e) => Some(e.id()),
-        ir::Expression::ConditionalExpression(e) => Some(e.id()),
-        ir::Expression::OrExpression(e) => Some(e.id()),
-        ir::Expression::AndExpression(e) => Some(e.id()),
-        ir::Expression::EqualityExpression(e) => Some(e.id()),
-        ir::Expression::InequalityExpression(e) => Some(e.id()),
-        ir::Expression::BitwiseOrExpression(e) => Some(e.id()),
-        ir::Expression::BitwiseXorExpression(e) => Some(e.id()),
-        ir::Expression::BitwiseAndExpression(e) => Some(e.id()),
-        ir::Expression::ShiftExpression(e) => Some(e.id()),
-        ir::Expression::AdditiveExpression(e) => Some(e.id()),
-        ir::Expression::MultiplicativeExpression(e) => Some(e.id()),
-        ir::Expression::ExponentiationExpression(e) => Some(e.id()),
-        ir::Expression::PostfixExpression(e) => Some(e.id()),
-        ir::Expression::PrefixExpression(e) => Some(e.id()),
-        ir::Expression::FunctionCallExpression(e) => Some(e.id()),
-        ir::Expression::CallOptionsExpression(e) => Some(e.id()),
-        ir::Expression::MemberAccessExpression(e) => Some(e.id()),
-        ir::Expression::IndexAccessExpression(e) => Some(e.id()),
-        ir::Expression::NewExpression(e) => Some(e.id()),
-        ir::Expression::TupleExpression(e) => Some(e.id()),
-        ir::Expression::TypeExpression(e) => Some(e.id()),
-        ir::Expression::ArrayExpression(e) => Some(e.id()),
-        ir::Expression::HexNumberExpression(e) => Some(e.id()),
-        ir::Expression::DecimalNumberExpression(e) => Some(e.id()),
-        ir::Expression::StringExpression(s) => Some(node_id_for_string_expression_typing(s)),
-        ir::Expression::Identifier(ident) => Some(ident.id()),
-        ir::Expression::ThisKeyword(e) => Some(e.id()),
-        ir::Expression::ElementaryType(e) => {
-            Some(e.node_id().expect("ElementaryType should have a node id"))
-        }
-        ir::Expression::PayableKeyword(e) => Some(e.id()),
-
-        // Other expression variants don't register typing by `NodeId`
-        ir::Expression::SuperKeyword(_)
-        | ir::Expression::TrueKeyword(_)
-        | ir::Expression::FalseKeyword(_) => None,
-    }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -1,10 +1,10 @@
 use ruint::aliases::{U160, U256};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use slang_solidity_v2_ir::ir::NodeIdentity;
 
 use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
-use crate::passes::common::node_id_for_expression_typing;
 use crate::types::{
     literals, AddressType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
     IntegerType, LiteralKind, MetaType, Number, StringType, Type, TypeId, UserMetaType,
@@ -22,26 +22,12 @@ impl Pass<'_> {
     }
 
     pub(super) fn typing_of_expression(&self, node: &ir::Expression) -> Typing {
-        match node {
-            // These are always typed as boolean
-            ir::Expression::OrExpression(_)
-            | ir::Expression::AndExpression(_)
-            | ir::Expression::EqualityExpression(_)
-            | ir::Expression::InequalityExpression(_)
-            | ir::Expression::TrueKeyword(_)
-            | ir::Expression::FalseKeyword(_) => Typing::Resolved(self.types.boolean()),
-
-            // Other special cases
-            ir::Expression::SuperKeyword(_) => Typing::Super,
-
-            // By default, query the binder for registered typing information
-            _ => {
-                let node_id = node_id_for_expression_typing(node).expect(
-                    "typing of expression variant not handled and it doesn't have a NodeId",
-                );
-                self.binder.node_typing(node_id)
-            }
-        }
+        // Every expression variant registers its typing in the binder during
+        // the pass, so we simply look it up by `NodeId`.
+        let node_id = node
+            .node_id()
+            .expect("expression should have a NodeId to look up its typing");
+        self.binder.node_typing(node_id)
     }
 
     pub(super) fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -7,7 +7,7 @@ use slang_solidity_v2_ir::ir::NodeIdentity;
 use super::Pass;
 use crate::binder::{Reference, Resolution, Typing};
 use crate::built_ins::InternalBuiltIn;
-use crate::passes::common::{filter_overriden_definitions, node_id_for_string_expression_typing};
+use crate::passes::common::filter_overriden_definitions;
 use crate::types::{
     AddressType, ArrayType, DataLocation, FixedSizeArrayType, MappingType, MetaType, Number,
     TupleType, Type, UserMetaType,
@@ -169,7 +169,9 @@ impl Visitor for Pass<'_> {
         let type_id = self
             .types
             .register_type(Self::type_of_string_expression(node));
-        let node_id = node_id_for_string_expression_typing(node);
+        let node_id = node
+            .node_id()
+            .expect("StringExpression should have a NodeId");
         self.binder.set_node_type(node_id, Some(type_id));
     }
 
@@ -537,6 +539,20 @@ impl Visitor for Pass<'_> {
             None => operand_typing,
         };
         self.binder.set_node_typing(node.id(), typing);
+    }
+
+    fn visit_true_keyword(&mut self, node: &ir::TrueKeyword) {
+        self.binder
+            .set_node_typing(node.id(), Typing::Resolved(self.types.boolean()));
+    }
+
+    fn visit_false_keyword(&mut self, node: &ir::FalseKeyword) {
+        self.binder
+            .set_node_typing(node.id(), Typing::Resolved(self.types.boolean()));
+    }
+
+    fn visit_super_keyword(&mut self, node: &ir::SuperKeyword) {
+        self.binder.set_node_typing(node.id(), Typing::Super);
     }
 
     fn visit_this_keyword(&mut self, node: &ir::ThisKeyword) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -9,12 +9,11 @@ use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator, NodeIdentity};
 
 use super::{build_file, TestFile};
-use crate::binder::{Binder, Definition};
+use crate::binder::{Binder, Definition, Typing};
 use crate::context::{FileNodeMapper, SemanticContext, SemanticFile};
-use crate::passes::common::node_id_for_expression_typing;
 use crate::passes::{
     p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
 };
@@ -91,7 +90,7 @@ fn recover_expression_type(
     binder: &Binder,
     types: &TypeRegistry,
 ) -> Option<Type> {
-    let node_id = node_id_for_expression_typing(node)?;
+    let node_id = node.node_id()?;
     binder
         .node_typing(node_id)
         .as_type_id()
@@ -1032,6 +1031,45 @@ fn test_conditional_expression_unifies_booleans() {
 }
 
 #[test]
+fn test_super_keyword_types_as_super() {
+    let source = r#"
+        contract A {
+            function f() public virtual {}
+        }
+        contract B is A {
+            function g() public {
+                super.f();
+            }
+        }
+        "#;
+
+    let TypeAnalysis { file, binder, .. } = analyze(LanguageVersion::LATEST, source);
+
+    let contract = find_contract(&file, "B");
+    let function = find_function(&contract.members, "g").expect("g function");
+    let body = function.body.as_ref().expect("g has a body");
+
+    let statement = body.statements.first().expect("g has a statement");
+    let ir::Statement::ExpressionStatement(expression_statement) = statement else {
+        panic!("expected an expression statement");
+    };
+    let ir::Expression::FunctionCallExpression(call) = &expression_statement.expression else {
+        panic!("expected a function call expression");
+    };
+    let ir::Expression::MemberAccessExpression(member_access) = &call.operand else {
+        panic!("expected a member access expression");
+    };
+    let ir::Expression::SuperKeyword(super_keyword) = &member_access.operand else {
+        panic!("expected a super keyword");
+    };
+
+    assert!(
+        matches!(binder.node_typing(super_keyword.id()), Typing::Super),
+        "`super` should be typed as `Typing::Super`"
+    );
+}
+
+#[test]
 fn test_string_literal_byte_count_with_escapes() {
     // Plain ASCII: one byte per char.
     let (type_, _) = type_of_expression(r#""abc""#);
@@ -1809,8 +1847,7 @@ fn test_meta_type_internal_names() {
     let ir::Expression::FunctionCallExpression(call) = cast else {
         panic!("expected a function call expression");
     };
-    let operand_node_id =
-        node_id_for_expression_typing(&call.operand).expect("operand has a typing node");
+    let operand_node_id = call.operand.node_id().expect("operand has a node id");
     let uint_meta_id = context
         .binder()
         .node_typing(operand_node_id)
@@ -1820,8 +1857,7 @@ fn test_meta_type_internal_names() {
 
     // `E`: the bare enum name carries the user meta-type.
     let enum_expression = expressions.next().expect("enum statement");
-    let enum_node_id =
-        node_id_for_expression_typing(enum_expression).expect("expression has a typing node");
+    let enum_node_id = enum_expression.node_id().expect("expression has a node id");
     let enum_meta_id = context
         .binder()
         .node_typing(enum_node_id)


### PR DESCRIPTION
As discussed here https://github.com/NomicFoundation/slang/pull/1952#discussion_r3616836159 we can now use `NodeIdentity` as the general case of node identification.

This particular change requires registering types for `true`, `false`, and `super` keywords, making the whole system a lot more uniform.