### PR TITLE
[v2] feat(semantic): expose the common operand type of binary operators

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1241,6 +1241,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::AddressType
 impl slang_solidity_v2_ast::ast::AddressType
 pub fn slang_solidity_v2_ast::ast::AddressType::is_payable(&self) -> bool
@@ -1291,6 +1293,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::AndExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::AndExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AndExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::AndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::ArrayExpressionStruct
 impl slang_solidity_v2_ast::ast::ArrayExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1435,6 +1439,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::BitwiseAndExpressionStru
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1447,6 +1453,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruc
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1459,6 +1467,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::BitwiseXorExpressionStru
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::BlockStruct
 impl slang_solidity_v2_ast::ast::BlockStruct
 pub fn slang_solidity_v2_ast::ast::BlockStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1831,6 +1841,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::EqualityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::EqualityExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::EqualityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::ErrorDefinitionStruct
 impl slang_solidity_v2_ast::ast::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
@@ -1910,6 +1922,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ExponentiationExpression
 pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
+pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::ExpressionStatementStruct
 impl slang_solidity_v2_ast::ast::ExpressionStatementStruct
 pub fn slang_solidity_v2_ast::ast::ExpressionStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::Expression
@@ -2311,6 +2325,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::InequalityExpressionStru
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::InequalityExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::InequalityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::InequalityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::InheritanceTypeStruct
 impl slang_solidity_v2_ast::ast::InheritanceTypeStruct
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::arguments(&self) -> core::option::Option<slang_solidity_v2_ast::ast::ArgumentsDeclaration>
@@ -2609,6 +2625,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::MultiplicativeExpression
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::NamedArgumentStruct
 impl slang_solidity_v2_ast::ast::NamedArgumentStruct
 pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -2653,6 +2671,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::OrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::OrExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::OrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::OrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::OverridePathsStruct
 impl slang_solidity_v2_ast::ast::OverridePathsStruct
 pub fn slang_solidity_v2_ast::ast::OverridePathsStruct::is_empty(&self) -> bool
@@ -2968,6 +2988,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ShiftExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::ShiftExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ShiftExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::ShiftExpressionStruct
+pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub struct slang_solidity_v2_ast::ast::SimpleVersionLiteralStruct
 impl slang_solidity_v2_ast::ast::SimpleVersionLiteralStruct
 pub fn slang_solidity_v2_ast::ast::SimpleVersionLiteralStruct::is_empty(&self) -> bool
@@ -3778,6 +3800,30 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::YulVariableNamesStruct
 pub fn slang_solidity_v2_ast::ast::YulVariableNamesStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulVariableNamesStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulVariableNamesStruct
 pub fn slang_solidity_v2_ast::ast::YulVariableNamesStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub trait slang_solidity_v2_ast::ast::BinaryOperatorExpression
+pub fn slang_solidity_v2_ast::ast::BinaryOperatorExpression::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::AndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AndExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::EqualityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::ExponentiationExpressionStruct
+pub fn slang_solidity_v2_ast::ast::ExponentiationExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::InequalityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::OrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::ShiftExpressionStruct
+pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::create_abicoder_pragma(&slang_solidity_v2_ir::ir::nodes::AbicoderPragma, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AbicoderPragma
 pub fn slang_solidity_v2_ast::ast::create_additive_expression(&slang_solidity_v2_ir::ir::nodes::AdditiveExpression, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AdditiveExpression
 pub fn slang_solidity_v2_ast::ast::create_address_type(&slang_solidity_v2_ir::ir::nodes::AddressType, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AddressTypeStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/binary_operators.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/binary_operators.rs
@@ -1,0 +1,63 @@
+use super::super::Type;
+use crate::ast::{
+    AdditiveExpressionStruct, AndExpressionStruct, BitwiseAndExpressionStruct,
+    BitwiseOrExpressionStruct, BitwiseXorExpressionStruct, EqualityExpressionStruct,
+    ExponentiationExpressionStruct, InequalityExpressionStruct, MultiplicativeExpressionStruct,
+    OrExpressionStruct, ShiftExpressionStruct,
+};
+
+/// A binary operator expression, whose two operands are reconciled to a common
+/// type before the operator applies.
+pub trait BinaryOperatorExpression {
+    /// The common type both operands reconcile to before the operator applies;
+    /// `None` when they have no common type.
+    fn common_operand_type(&self) -> Option<Type>;
+}
+
+/// The comparison operators are the only binary operators whose common operand
+/// type differs from their (boolean) result, so the typing pass records it and
+/// the AST reads it back from the binder.
+macro_rules! impl_recorded_common_operand_type {
+    ($($node:ident),* $(,)?) => {
+        $(
+            impl BinaryOperatorExpression for $node {
+                fn common_operand_type(&self) -> Option<Type> {
+                    let type_id = self
+                        .semantic
+                        .binder()
+                        .common_operand_typing(self.ir_node.id())
+                        .as_type_id()?;
+                    Some(Type::create(type_id, &self.semantic))
+                }
+            }
+        )*
+    };
+}
+
+/// Every other binary operator reconciles its operands to its own result type,
+/// so the common operand type is just the node's type — no separate record.
+macro_rules! impl_result_common_operand_type {
+    ($($node:ident),* $(,)?) => {
+        $(
+            impl BinaryOperatorExpression for $node {
+                fn common_operand_type(&self) -> Option<Type> {
+                    self.get_type()
+                }
+            }
+        )*
+    };
+}
+
+impl_recorded_common_operand_type!(EqualityExpressionStruct, InequalityExpressionStruct);
+
+impl_result_common_operand_type!(
+    AdditiveExpressionStruct,
+    AndExpressionStruct,
+    BitwiseAndExpressionStruct,
+    BitwiseOrExpressionStruct,
+    BitwiseXorExpressionStruct,
+    ExponentiationExpressionStruct,
+    MultiplicativeExpressionStruct,
+    OrExpressionStruct,
+    ShiftExpressionStruct,
+);

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -1,6 +1,9 @@
 mod common;
 
 mod assembly_statement;
+mod binary_operators;
+pub use binary_operators::BinaryOperatorExpression;
+
 mod contract_base;
 mod contract_definition;
 mod contract_members;

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -71,6 +71,7 @@ pub fn slang_solidity_v2_semantic::binder::Typing::fmt(&self, &mut core::fmt::Fo
 pub struct slang_solidity_v2_semantic::binder::Binder
 impl slang_solidity_v2_semantic::binder::Binder
 pub fn slang_solidity_v2_semantic::binder::Binder::assembly_block_referenced_definitions(&self, slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_common::nodes::NodeId]
+pub fn slang_solidity_v2_semantic::binder::Binder::common_operand_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Binder::definitions(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Definition>
 pub fn slang_solidity_v2_semantic::binder::Binder::enclosing_definition_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::binder::Binder::find_definition_by_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Definition>

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/capacities.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/capacities.rs
@@ -166,6 +166,13 @@ const PARAMETER_SCOPE_NODE_KINDS: &[NodeKind] = &[
 const LINEARISATION_KINDS: &[NodeKind] =
     &[NodeKind::ContractDefinition, NodeKind::InterfaceDefinition];
 
+/// Comparison operators (one `common_operand_typing` entry each). Their
+/// operands reconcile to a common type that is recorded apart from the
+/// operator's boolean result — the only binary operators where the two differ,
+/// so the only ones needing an entry (see `BinaryOperatorExpression`).
+const COMPARISON_KINDS: &[NodeKind] =
+    &[NodeKind::EqualityExpression, NodeKind::InequalityExpression];
+
 /// Up-front sizes for the binder's dominant per-node collections, derived from
 /// the IR node-kind histogram (see `Binder::with_capacity`). These are keyed
 /// by (or indexed alongside) `NodeId` and end up roughly as large as the source,
@@ -178,6 +185,9 @@ pub(crate) struct BinderCapacities {
     /// names. Tends to **under**-shoot slightly (a few non-expression nodes are
     /// also typed, and the subtraction is conservative) → at worst one rehash.
     pub node_typing: usize,
+    /// Reconciled comparison operand types (`common_operand_typing`). One entry
+    /// per comparison expression. **Exact.**
+    pub common_operand_typing: usize,
     /// Reference identifiers (`references`). Estimate: identifiers minus
     /// definition names. Tends to **under**-shoot slightly → at worst one
     /// rehash.
@@ -212,6 +222,7 @@ impl From<&NodeKindHistogram> for BinderCapacities {
             // Expression nodes, minus the definition-name identifiers counted
             // under `Identifier` that are never typed.
             node_typing: count_kinds(EXPRESSION_KINDS, histogram).saturating_sub(definitions),
+            common_operand_typing: count_kinds(COMPARISON_KINDS, histogram),
             // Identifiers that aren't definition names ≈ resolved references.
             references: identifiers.saturating_sub(definitions),
             definitions,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -101,6 +101,11 @@ pub struct Binder {
     references: Map<NodeId, Reference>,
     /// `Typing` information for each relevant `NodeId` of the AST
     node_typing: Map<NodeId, Typing>,
+    /// Common type both operands of a comparison reconcile to before the
+    /// comparison runs, indexed by the comparison expression's `NodeId`. Only
+    /// comparisons are stored, other binary operators have the common operand
+    /// types match the result.
+    common_operand_typing: Map<NodeId, Typing>,
     /// Linearisations, as a vector of definitions, indexed by the
     /// contract/interface definition's `NodeId`
     linearisations: Map<NodeId, Vec<NodeId>>,
@@ -142,6 +147,7 @@ impl Binder {
             scopes: Vec::with_capacity(capacities.scopes),
             scopes_by_node_id: Map::default_with_capacity(capacities.scopes_by_node_id),
             node_typing: Map::default_with_capacity(capacities.node_typing),
+            common_operand_typing: Map::default_with_capacity(capacities.common_operand_typing),
             references: Map::default_with_capacity(capacities.references),
             definitions: Map::default_with_capacity(capacities.definitions),
             definitions_by_identifier: Map::default_with_capacity(capacities.definitions),
@@ -378,6 +384,13 @@ impl Binder {
             .unwrap_or(Typing::Unresolved)
     }
 
+    pub fn common_operand_typing(&self, node_id: NodeId) -> Typing {
+        self.common_operand_typing
+            .get(&node_id)
+            .cloned()
+            .unwrap_or(Typing::Unresolved)
+    }
+
     pub(crate) fn set_node_type(&mut self, node_id: NodeId, type_id: Option<TypeId>) {
         let typing = if let Some(type_id) = type_id {
             Typing::Resolved(type_id)
@@ -404,6 +417,18 @@ impl Binder {
             previous_typing.is_some(),
             "update_node_typing called on node {node_id:?} with no existing typing"
         );
+    }
+
+    pub(crate) fn set_common_operand_type(&mut self, node_id: NodeId, type_id: Option<TypeId>) {
+        let typing = if let Some(type_id) = type_id {
+            Typing::Resolved(type_id)
+        } else {
+            Typing::Unresolved
+        };
+        let previous_typing = self.common_operand_typing.insert(node_id, typing);
+        if previous_typing.is_some() {
+            unreachable!("common operand typing for node {node_id:?} already set");
+        }
     }
 
     // File scope resolution context

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -103,8 +103,9 @@ pub struct Binder {
     node_typing: Map<NodeId, Typing>,
     /// Common type both operands of a comparison reconcile to before the
     /// comparison runs, indexed by the comparison expression's `NodeId`. Only
-    /// comparisons are stored, other binary operators have the common operand
-    /// types match the result.
+    /// comparison expressions are stored as other binary operators have
+    /// the type matching the result type, and hence stored in the typing of
+    /// the expression (ie. `node_typing` above).
     common_operand_typing: Map<NodeId, Typing>,
     /// Linearisations, as a vector of definitions, indexed by the
     /// contract/interface definition's `NodeId`

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -63,6 +63,22 @@ impl Pass<'_> {
         definition.try_into().ok()
     }
 
+    /// Records the common type both operands of a comparison reconcile to
+    /// before the comparison runs.
+    pub(super) fn record_comparison_common_operand_type(
+        &mut self,
+        node_id: NodeId,
+        left_operand: &ir::Expression,
+        right_operand: &ir::Expression,
+    ) {
+        let common = self
+            .typing_of_expression(left_operand)
+            .as_type_id()
+            .zip(self.typing_of_expression(right_operand).as_type_id())
+            .and_then(|(left, right)| self.types.common_operand_type(left, right));
+        self.binder.set_common_operand_type(node_id, common);
+    }
+
     /// Returns the type of an binary operator expression. If both operands are
     /// number literals, applies `op` to fold them into a narrowed literal type;
     /// otherwise falls back to the implicit-convertibility rule between the

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -222,12 +222,22 @@ impl Visitor for Pass<'_> {
 
     fn leave_equality_expression(&mut self, node: &ir::EqualityExpression) {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
+        self.record_comparison_common_operand_type(
+            node.id(),
+            &node.left_operand,
+            &node.right_operand,
+        );
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
     fn leave_inequality_expression(&mut self, node: &ir::InequalityExpression) {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
+        self.record_comparison_common_operand_type(
+            node.id(),
+            &node.left_operand,
+            &node.right_operand,
+        );
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/operator_typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/operator_typing.rs
@@ -83,6 +83,43 @@ impl UnaryOperator {
 }
 
 impl TypeRegistry {
+    /// The type both operands of a binary operator reconcile to.
+    ///
+    /// `Self::common_type` mobilises *one* side and tests the other operand's
+    /// *raw* type against it (solc's `Type::commonType` rule), so a raw literal
+    /// is measured against a concrete operand as-is — eg. `int8 x; x == 5`
+    /// keeps `5` raw and reconciles to `int8`, not to `5`'s own mobile type
+    /// `uint8`. When neither raw type fits the other's mobile type, both sides
+    /// are mobilised and retried, recovering eg. two address literals whose raw
+    /// literal types don't inter-convert but whose mobile `address` types do.
+    pub(crate) fn common_operand_type(&mut self, left: TypeId, right: TypeId) -> Option<TypeId> {
+        // Fast path: operands that already share a type reconcile to its mobile
+        // type. The `common_type`/mobilise dance below would only rediscover
+        // that, at the cost of extra `Type` clones and convertibility checks.
+        if left == right {
+            return self.compute_mobile_type(left);
+        }
+        if let Some(common) = self.common_type(left, right) {
+            return Some(common);
+        }
+        let left_mobile = self.compute_mobile_type(left)?;
+        let right_mobile = self.compute_mobile_type(right)?;
+        if left_mobile == left && right_mobile == right {
+            // Nothing mobilised, so `common_type` already failed on these.
+            return None;
+        }
+        // Equivalent to `common_type(left_mobile, right_mobile)`, but mobile
+        // types are idempotent (`mobile(mobile(t)) == mobile(t)`), so skip
+        // re-mobilising both sides — just apply the convertibility rule.
+        if self.implicitly_convertible_to(right_mobile, left_mobile) {
+            return Some(left_mobile);
+        }
+        if self.implicitly_convertible_to(left_mobile, right_mobile) {
+            return Some(right_mobile);
+        }
+        None
+    }
+
     /// Result type of a binary operator, dispatched on the left operand. For
     /// shifts and exponentiation the result follows the left operand, and the
     /// right operand must be a nonnegative unsigned integer amount or

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/common_operand.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/common_operand.rs
@@ -1,0 +1,198 @@
+//! Exercises `common_operand_type` on the binary operator AST nodes: the type
+//! both operands of a binary operator reconcile to before the operator runs,
+//! as recorded by the typing pass (solc's `commonType` annotation).
+
+use crate::ast::BinaryOperatorExpression;
+use crate::{ast, define_fixture};
+
+define_fixture!(
+    CommonOperands,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.29;
+
+type Wrapped is int128;
+using {add as +, eq as ==, lt as <} for Wrapped global;
+
+function add(Wrapped a, Wrapped b) pure returns (Wrapped) { return a; }
+function eq(Wrapped a, Wrapped b) pure returns (bool) { return true; }
+function lt(Wrapped a, Wrapped b) pure returns (bool) { return false; }
+
+contract CommonOperands {
+    enum Color { Red, Green }
+
+    function f() internal pure {}
+    function g() internal pure {}
+
+    function run(
+        uint8 small,
+        uint256 big,
+        address first,
+        address second,
+        bytes2 two,
+        bytes4 four,
+        bool yes,
+        bool no,
+        Color c1,
+        Color c2,
+        Wrapped w1,
+        Wrapped w2
+    ) public pure {
+        // Arithmetic and bitwise operands reconcile through their common type,
+        // which is also the operator's own type.
+        small + big;
+        1 + 2;
+        small * small;
+        big & 0xff;
+        two | four;
+
+        // Shifts and exponentiation follow their left operand.
+        big << small;
+        two << 2;
+        big ** small;
+        2 ** small;
+
+        // `&&` and `||` reconcile both operands to `bool`.
+        yes && no;
+        yes || no;
+
+        // Comparison operands reconcile through their common type, while the
+        // comparison itself types as `bool`.
+        small < big;
+        big == 5;
+        1 < 2;
+        first == second;
+        0x1111111111111111111111111111111111111111 ==
+            0x2222222222222222222222222222222222222222;
+        two < four;
+        yes == no;
+        c1 == c2;
+        c1 < c2;
+        f == g;
+
+        // Operators defined through `using {..} for T` reconcile both
+        // operands to `T`.
+        w1 + w2;
+        w1 == w2;
+        w1 < w2;
+    }
+}
+"#,
+);
+
+#[derive(Default)]
+struct CommonOperandCollector {
+    common_types: Vec<Option<ast::Type>>,
+}
+
+macro_rules! collect_common_operand_type {
+    ($($hook:ident: $node:ident),* $(,)?) => {
+        $(
+            fn $hook(&mut self, node: &ast::$node) -> bool {
+                self.common_types.push(node.common_operand_type());
+                true
+            }
+        )*
+    };
+}
+
+impl ast::visitor::Visitor for CommonOperandCollector {
+    collect_common_operand_type!(
+        enter_additive_expression: AdditiveExpression,
+        enter_and_expression: AndExpression,
+        enter_bitwise_and_expression: BitwiseAndExpression,
+        enter_bitwise_or_expression: BitwiseOrExpression,
+        enter_bitwise_xor_expression: BitwiseXorExpression,
+        enter_equality_expression: EqualityExpression,
+        enter_exponentiation_expression: ExponentiationExpression,
+        enter_inequality_expression: InequalityExpression,
+        enter_multiplicative_expression: MultiplicativeExpression,
+        enter_or_expression: OrExpression,
+        enter_shift_expression: ShiftExpression,
+    );
+}
+
+#[test]
+fn binary_operators_record_their_common_operand_type() {
+    let unit = CommonOperands::build_compilation_unit();
+    let ast = unit.file(&"main.sol".into()).unwrap().ast();
+
+    let mut collector = CommonOperandCollector::default();
+    ast::visitor::accept_source_unit(&ast, &mut collector);
+
+    // The collector visits the binary operators in source order; `next` pops
+    // the one matching the given source text (the text is just for readable
+    // failures).
+    let mut common_types = collector.common_types.into_iter();
+    let mut next = |source: &str| {
+        common_types
+            .next()
+            .unwrap_or_else(|| panic!("`{source}` is visited"))
+    };
+
+    // Arithmetic: the smaller side widens into the common type, two literals
+    // fold into a literal.
+    let common = next("small + big").expect("uint8 and uint256 reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    let common = next("1 + 2").expect("two literals fold");
+    assert!(matches!(common, ast::Type::Literal(_)));
+    let common = next("small * small").expect("uint8 operands reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 8));
+    let common = next("big & 0xff").expect("uint256 and a literal reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    let common = next("two | four").expect("fixed bytes reconcile");
+    assert!(matches!(common, ast::Type::ByteArray(t) if t.width() == 4));
+
+    // Shifts and exponentiation follow their left operand.
+    let common = next("big << small").expect("shifts follow the left operand");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    let common = next("two << 2").expect("fixed bytes support shifts");
+    assert!(matches!(common, ast::Type::ByteArray(t) if t.width() == 2));
+    let common = next("big ** small").expect("exponentiation follows the left operand");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    let common = next("2 ** small").expect("a literal base widens to uint256");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+
+    // `&&` and `||` reconcile both operands to `bool`.
+    let common = next("yes && no").expect("boolean conjunction reconciles");
+    assert!(matches!(common, ast::Type::Boolean(_)));
+    let common = next("yes || no").expect("boolean disjunction reconciles");
+    assert!(matches!(common, ast::Type::Boolean(_)));
+
+    // Comparisons record the type the operands are compared at.
+    let common = next("small < big").expect("uint8 and uint256 reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    let common = next("big == 5").expect("uint256 and a literal reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 256));
+    // Two number literals are mobilised before reconciling.
+    let common = next("1 < 2").expect("two small literals reconcile");
+    assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 8));
+    let common = next("first == second").expect("addresses reconcile");
+    assert!(matches!(common, ast::Type::Address(t) if !t.is_payable()));
+    let common = next("0x11..11 == 0x22..22").expect("two address literals reconcile");
+    assert!(matches!(common, ast::Type::Address(t) if !t.is_payable()));
+    let common = next("two < four").expect("fixed bytes reconcile");
+    assert!(matches!(common, ast::Type::ByteArray(t) if t.width() == 4));
+    let common = next("yes == no").expect("booleans support equality");
+    assert!(matches!(common, ast::Type::Boolean(_)));
+    let common = next("c1 == c2").expect("identical enums reconcile");
+    assert!(matches!(common, ast::Type::Enum(_)));
+    let common = next("c1 < c2").expect("enums support ordering");
+    assert!(matches!(common, ast::Type::Enum(_)));
+    let common = next("f == g").expect("matching function values reconcile");
+    assert!(matches!(common, ast::Type::Function(_)));
+
+    // Operators defined through `using {..} for T` reconcile both operands to
+    // `T`.
+    let common = next("w1 + w2").expect("user-defined addition reconciles");
+    assert!(matches!(common, ast::Type::UserDefinedValue(_)));
+    let common = next("w1 == w2").expect("user-defined equality reconciles");
+    assert!(matches!(common, ast::Type::UserDefinedValue(_)));
+    let common = next("w1 < w2").expect("user-defined ordering reconciles");
+    assert!(matches!(common, ast::Type::UserDefinedValue(_)));
+
+    assert!(
+        common_types.next().is_none(),
+        "all binary operators are asserted on"
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/common_operand.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/common_operand.rs
@@ -2,12 +2,12 @@
 //! both operands of a binary operator reconcile to before the operator runs,
 //! as recorded by the typing pass (solc's `commonType` annotation).
 
+use std::ops::Range;
+
 use crate::ast::BinaryOperatorExpression;
 use crate::{ast, define_fixture};
 
-define_fixture!(
-    CommonOperands,
-    file: "main.sol", r#"
+const SOURCE: &str = r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.29;
 
@@ -77,19 +77,28 @@ contract CommonOperands {
         w1 < w2;
     }
 }
-"#,
-);
+"#;
+
+define_fixture!(CommonOperands, file: "main.sol", SOURCE);
+
+struct VisitedOperator {
+    range: Range<usize>,
+    common_type: Option<ast::Type>,
+}
 
 #[derive(Default)]
 struct CommonOperandCollector {
-    common_types: Vec<Option<ast::Type>>,
+    operators: Vec<VisitedOperator>,
 }
 
 macro_rules! collect_common_operand_type {
     ($($hook:ident: $node:ident),* $(,)?) => {
         $(
             fn $hook(&mut self, node: &ast::$node) -> bool {
-                self.common_types.push(node.common_operand_type());
+                self.operators.push(VisitedOperator {
+                    range: node.get_text_range().clone(),
+                    common_type: node.common_operand_type(),
+                });
                 true
             }
         )*
@@ -121,13 +130,21 @@ fn binary_operators_record_their_common_operand_type() {
     ast::visitor::accept_source_unit(&ast, &mut collector);
 
     // The collector visits the binary operators in source order; `next` pops
-    // the one matching the given source text (the text is just for readable
-    // failures).
-    let mut common_types = collector.common_types.into_iter();
+    // the next one and asserts its source text matches `source`, so an
+    // inserted/removed expression fails on the offending assertion rather than
+    // silently shifting every one that follows.
+    let mut operators = collector.operators.into_iter();
     let mut next = |source: &str| {
-        common_types
+        let operator = operators
             .next()
-            .unwrap_or_else(|| panic!("`{source}` is visited"))
+            .unwrap_or_else(|| panic!("`{source}` is visited"));
+        // Collapse whitespace so multi-line expressions match their snippet.
+        let visited = SOURCE[operator.range.clone()]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(visited, source, "walk landed on the expected expression");
+        operator.common_type
     };
 
     // Arithmetic: the smaller side widens into the common type, two literals
@@ -169,7 +186,10 @@ fn binary_operators_record_their_common_operand_type() {
     assert!(matches!(common, ast::Type::Integer(t) if !t.is_signed() && t.bits() == 8));
     let common = next("first == second").expect("addresses reconcile");
     assert!(matches!(common, ast::Type::Address(t) if !t.is_payable()));
-    let common = next("0x11..11 == 0x22..22").expect("two address literals reconcile");
+    let common = next(
+        "0x1111111111111111111111111111111111111111 == 0x2222222222222222222222222222222222222222",
+    )
+    .expect("two address literals reconcile");
     assert!(matches!(common, ast::Type::Address(t) if !t.is_payable()));
     let common = next("two < four").expect("fixed bytes reconcile");
     assert!(matches!(common, ast::Type::ByteArray(t) if t.width() == 4));
@@ -192,7 +212,7 @@ fn binary_operators_record_their_common_operand_type() {
     assert!(matches!(common, ast::Type::UserDefinedValue(_)));
 
     assert!(
-        common_types.next().is_none(),
+        operators.next().is_none(),
         "all binary operators are asserted on"
     );
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/mod.rs
@@ -2,6 +2,7 @@ use super::fixtures;
 
 mod assembly_references;
 mod built_in_resolution;
+mod common_operand;
 mod definition_references;
 mod enclosing_definition;
 mod identifier_path_resolution;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -17,8 +17,8 @@ pub(super) struct FixtureFile {
 
 #[macro_export]
 macro_rules! define_fixture {
-    // Recursive case: consume one file definition
-    (@accum [$($acc:expr),*] ; $name:ident ; file : $k:literal, $v:literal $(, $($rest:tt)*)?) => {
+    // Recursive case: consume one file definition.
+    (@accum [$($acc:expr),*] ; $name:ident ; file : $k:literal, $v:expr $(, $($rest:tt)*)?) => {
         define_fixture!(
             @accum [$($acc,)* $crate::tests::fixtures::FixtureFile { id: $k.into(), contents: $v }] ;
             $name ;


### PR DESCRIPTION
Adds `BinaryOperatorExpression::common_operand_type`, the type both operands reconcile to before the operator applies (solc's `commonType`).

For comparisons (`==`, `!=`, `<`, ...) this differs from the expression's own `bool` type, so the typing pass records it in the binder. For every other binary operator the common operand type *is* the expression's type, so the trait returns `get_type()` and nothing extra is stored — matching solc, which sets commonType equal to the result for those operators.

The recorded comparison type reconciles the operands through their common (mobile) type, so any comparison that compiles on solc — including user-defined `==`/`<` from `using ... for` directives — records a type.

**Note:** This PR doesn't implement diagnostics, that will come later 

__Based on this commit by @hedgar2017__