### PR TITLE
[v2] feat(binder): resolve user-defined operator functions

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -80,6 +80,7 @@ pub fn slang_solidity_v2_semantic::binder::Binder::get_linearised_bases(&self, s
 pub fn slang_solidity_v2_semantic::binder::Binder::get_references_by_definition_id(&self, slang_solidity_v2_common::nodes::NodeId) -> alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::binder::Binder::node_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Binder::references(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Reference>
+pub fn slang_solidity_v2_semantic::binder::Binder::resolved_operator_function(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl core::default::Default for slang_solidity_v2_semantic::binder::Binder
 pub fn slang_solidity_v2_semantic::binder::Binder::default() -> slang_solidity_v2_semantic::binder::Binder
 pub struct slang_solidity_v2_semantic::binder::Reference

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -21,7 +21,10 @@ pub(crate) use definitions::{
 };
 pub use references::{Reference, Resolution};
 use scopes::ContractScope;
-pub(crate) use scopes::{FileScope, ParameterDefinition, ParametersScope, Scope, UsingDirective};
+pub(crate) use scopes::{
+    FileScope, OperatorMapping, ParameterDefinition, ParametersScope, Scope, UsingDirective,
+    UsingOperator,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct ScopeId(usize);
@@ -99,6 +102,9 @@ pub struct Binder {
     definitions_by_identifier: Map<NodeId, NodeId>,
     /// `Reference` objects (identifier + `Resolution`), indexed by identifier `NodeId`
     references: Map<NodeId, Reference>,
+    /// User-defined operator functions, indexed by the `NodeId` of the
+    /// operator expression that invokes them
+    operator_functions: Map<NodeId, NodeId>,
     /// `Typing` information for each relevant `NodeId` of the AST
     node_typing: Map<NodeId, Typing>,
     /// Linearisations, as a vector of definitions, indexed by the
@@ -280,6 +286,16 @@ impl Binder {
 
     pub fn references(&self) -> &Map<NodeId, Reference> {
         &self.references
+    }
+
+    pub(crate) fn set_operator_function(&mut self, node_id: NodeId, definition_id: NodeId) {
+        self.operator_functions.insert(node_id, definition_id);
+    }
+
+    /// The user-defined operator function the operator expression with
+    /// `node_id` invokes, if it resolved to one.
+    pub fn resolved_operator_function(&self, node_id: NodeId) -> Option<NodeId> {
+        self.operator_functions.get(&node_id).copied()
     }
 
     pub(crate) fn update_definitions_to_references_index(&mut self) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -4,6 +4,7 @@ use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use smallvec::SmallVec;
 
 use super::ScopeId;
 use crate::types::TypeId;
@@ -465,7 +466,11 @@ impl YulFunctionScope {
 //////////////////////////////////////////////////////////////////////////////
 // Using directives
 
-#[allow(dead_code)]
+/// The definitions bound to each operator. One operator can carry two at
+/// most in valid code, since a `-` binds both a unary and a binary function
+/// for the same type.
+pub(crate) type OperatorMapping = Map<UsingOperator, SmallVec<[NodeId; 2]>>;
+
 pub(crate) enum UsingDirective {
     AllTypes {
         scope_id: ScopeId,
@@ -476,7 +481,7 @@ pub(crate) enum UsingDirective {
     },
     SingleTypeOperator {
         scope_id: ScopeId,
-        operator_mapping: Map<UsingOperator, String>,
+        operator_mapping: OperatorMapping,
         type_id: TypeId,
     },
 }
@@ -523,6 +528,58 @@ impl From<&ir::UsingOperator> for UsingOperator {
     }
 }
 
+impl From<&ir::AdditiveExpressionOperator> for UsingOperator {
+    fn from(value: &ir::AdditiveExpressionOperator) -> Self {
+        match value {
+            ir::AdditiveExpressionOperator::Plus(_) => Self::Plus,
+            ir::AdditiveExpressionOperator::Minus(_) => Self::Minus,
+        }
+    }
+}
+
+impl From<&ir::MultiplicativeExpressionOperator> for UsingOperator {
+    fn from(value: &ir::MultiplicativeExpressionOperator) -> Self {
+        match value {
+            ir::MultiplicativeExpressionOperator::Asterisk(_) => Self::Asterisk,
+            ir::MultiplicativeExpressionOperator::Slash(_) => Self::Slash,
+            ir::MultiplicativeExpressionOperator::Percent(_) => Self::Percent,
+        }
+    }
+}
+
+impl From<&ir::EqualityExpressionOperator> for UsingOperator {
+    fn from(value: &ir::EqualityExpressionOperator) -> Self {
+        match value {
+            ir::EqualityExpressionOperator::EqualEqual(_) => Self::EqualEqual,
+            ir::EqualityExpressionOperator::BangEqual(_) => Self::BangEqual,
+        }
+    }
+}
+
+impl From<&ir::InequalityExpressionOperator> for UsingOperator {
+    fn from(value: &ir::InequalityExpressionOperator) -> Self {
+        match value {
+            ir::InequalityExpressionOperator::LessThan(_) => Self::LessThan,
+            ir::InequalityExpressionOperator::LessThanEqual(_) => Self::LessThanEqual,
+            ir::InequalityExpressionOperator::GreaterThan(_) => Self::GreaterThan,
+            ir::InequalityExpressionOperator::GreaterThanEqual(_) => Self::GreaterThanEqual,
+        }
+    }
+}
+
+impl TryFrom<&ir::PrefixExpressionOperator> for UsingOperator {
+    type Error = ();
+
+    /// Fails for the prefix operators that cannot be user-defined.
+    fn try_from(value: &ir::PrefixExpressionOperator) -> Result<Self, Self::Error> {
+        match value {
+            ir::PrefixExpressionOperator::Minus(_) => Ok(Self::Minus),
+            ir::PrefixExpressionOperator::Tilde(_) => Ok(Self::Tilde),
+            _ => Err(()),
+        }
+    }
+}
+
 impl UsingDirective {
     pub(crate) fn new_all(scope_id: ScopeId) -> Self {
         Self::AllTypes { scope_id }
@@ -535,7 +592,7 @@ impl UsingDirective {
     pub(crate) fn new_single_type_with_operators(
         scope_id: ScopeId,
         type_id: TypeId,
-        operator_mapping: Map<UsingOperator, String>,
+        operator_mapping: OperatorMapping,
     ) -> Self {
         Self::SingleTypeOperator {
             scope_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -5,7 +5,9 @@ use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
 use super::Pass;
-use crate::binder::{Definition, Reference, Resolution, Scope, Typing, UsingDirective};
+use crate::binder::{
+    Definition, OperatorMapping, Reference, Resolution, Scope, Typing, UsingDirective,
+};
 use crate::built_ins::InternalBuiltIn;
 use crate::types::{ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type};
 
@@ -333,7 +335,7 @@ impl Visitor for Pass<'_> {
                     }
                     ir::UsingClause::UsingDeconstruction(using_deconstruction) => {
                         let mut symbols = Map::default();
-                        let mut operators = Map::default();
+                        let mut operators = OperatorMapping::default();
 
                         for symbol in using_deconstruction.symbols.iter() {
                             let symbol_name = symbol.name.last().unwrap();
@@ -350,12 +352,14 @@ impl Visitor for Pass<'_> {
                             }
 
                             let definition_ids = resolution.get_definition_ids();
-                            symbols.insert(symbol_name.unparse().to_string(), definition_ids);
-
                             if let Some(operator) = &symbol.alias {
+                                // Append since `-` can bind a unary and a binary function.
                                 operators
-                                    .insert(operator.into(), symbol_name.unparse().to_string());
+                                    .entry(operator.into())
+                                    .or_default()
+                                    .extend(definition_ids.iter().copied());
                             }
+                            symbols.insert(symbol_name.unparse().to_string(), definition_ids);
                         }
 
                         let scope = Scope::new_using(node.id(), symbols);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -13,6 +13,7 @@ use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 use super::{Pass, ScopeFrame};
 use crate::binder::{
     Definition, Reference, Resolution, ResolveOptions, ScopeId, Typing, UsingDirective,
+    UsingOperator,
 };
 use crate::built_ins::BuiltInsResolver;
 use crate::passes::common::constant_evaluator::{
@@ -234,6 +235,76 @@ impl Pass<'_> {
                 self.types
                     .implicitly_convertible_to_for_external_call(receiver_type_id, *type_id)
             })
+    }
+
+    /// Resolves the function a user-defined operator expression invokes and
+    /// records it in the binder. The operand must be a user-defined value
+    /// type with exactly one bound function taking `operand_count` operands.
+    pub(super) fn resolve_operator_function(
+        &mut self,
+        node_id: NodeId,
+        operator: UsingOperator,
+        operand: &ir::Expression,
+        operand_count: usize,
+    ) {
+        let Some(operand_type_id) =
+            self.typing_of_expression(operand)
+                .as_type_id()
+                .filter(|&type_id| {
+                    matches!(
+                        self.types.get_type_by_id(type_id),
+                        Type::UserDefinedValue(_)
+                    )
+                })
+        else {
+            return;
+        };
+
+        let mut candidates = Vec::new();
+        for directive in self.active_using_directives_for_type(operand_type_id) {
+            let UsingDirective::SingleTypeOperator {
+                operator_mapping, ..
+            } = directive
+            else {
+                continue;
+            };
+            for &definition_id in operator_mapping.get(&operator).into_iter().flatten() {
+                if !candidates.contains(&definition_id)
+                    && self.is_operator_function(definition_id, operand_type_id, operand_count)
+                {
+                    candidates.push(definition_id);
+                }
+            }
+        }
+
+        if let [definition_id] = candidates[..] {
+            self.binder.set_operator_function(node_id, definition_id);
+        }
+    }
+
+    /// Whether the definition is a function taking exactly `operand_count`
+    /// parameters of the operand's type. A `-` bound to both a unary and a
+    /// binary function disambiguates by the parameter count.
+    fn is_operator_function(
+        &self,
+        definition_id: NodeId,
+        operand_type_id: TypeId,
+        operand_count: usize,
+    ) -> bool {
+        let Some(Definition::Function(_)) = self.binder.find_definition_by_id(definition_id) else {
+            return false;
+        };
+        let Typing::Resolved(definition_type_id) = self.binder.node_typing(definition_id) else {
+            return false;
+        };
+        let Type::Function(function_type) = self.types.get_type_by_id(definition_type_id) else {
+            unreachable!("type of function definition is not a function");
+        };
+        function_type.parameter_types.len() == operand_count
+            && function_type
+                .parameter_types
+                .iter()
+                .all(|parameter_type_id| *parameter_type_id == operand_type_id)
     }
 
     fn resolve_first_modifier(&self, resolution: &Resolution) -> Resolution {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -5,7 +5,7 @@ use slang_solidity_v2_ir::ir::NodeIdentity;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
 use super::Pass;
-use crate::binder::{Reference, Resolution, Typing};
+use crate::binder::{Reference, Resolution, Typing, UsingOperator};
 use crate::built_ins::InternalBuiltIn;
 use crate::passes::common::filter_overriden_definitions;
 use crate::types::{
@@ -224,12 +224,14 @@ impl Visitor for Pass<'_> {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
+        self.resolve_operator_function(node.id(), (&node.operator).into(), &node.left_operand, 2);
     }
 
     fn leave_inequality_expression(&mut self, node: &ir::InequalityExpression) {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
+        self.resolve_operator_function(node.id(), (&node.operator).into(), &node.left_operand, 2);
     }
 
     fn leave_bitwise_or_expression(&mut self, node: &ir::BitwiseOrExpression) {
@@ -239,6 +241,7 @@ impl Visitor for Pass<'_> {
             |l, r| l.bit_or(r),
         );
         self.binder.set_node_type(node.id(), type_id);
+        self.resolve_operator_function(node.id(), UsingOperator::Bar, &node.left_operand, 2);
     }
 
     fn leave_bitwise_xor_expression(&mut self, node: &ir::BitwiseXorExpression) {
@@ -248,6 +251,7 @@ impl Visitor for Pass<'_> {
             |l, r| l.bit_xor(r),
         );
         self.binder.set_node_type(node.id(), type_id);
+        self.resolve_operator_function(node.id(), UsingOperator::Caret, &node.left_operand, 2);
     }
 
     fn leave_bitwise_and_expression(&mut self, node: &ir::BitwiseAndExpression) {
@@ -257,6 +261,7 @@ impl Visitor for Pass<'_> {
             |l, r| l.bit_and(r),
         );
         self.binder.set_node_type(node.id(), type_id);
+        self.resolve_operator_function(node.id(), UsingOperator::Ampersand, &node.left_operand, 2);
     }
 
     fn leave_shift_expression(&mut self, node: &ir::ShiftExpression) {
@@ -284,6 +289,7 @@ impl Visitor for Pass<'_> {
             },
         );
         self.binder.set_node_type(node.id(), type_id);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), &node.left_operand, 2);
     }
 
     fn leave_multiplicative_expression(&mut self, node: &ir::MultiplicativeExpression) {
@@ -297,6 +303,7 @@ impl Visitor for Pass<'_> {
             },
         );
         self.binder.set_node_type(node.id(), type_id);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), &node.left_operand, 2);
     }
 
     fn leave_exponentiation_expression(&mut self, node: &ir::ExponentiationExpression) {
@@ -317,6 +324,9 @@ impl Visitor for Pass<'_> {
     fn leave_prefix_expression(&mut self, node: &ir::PrefixExpression) {
         let type_id = self.type_of_prefix_expression(node);
         self.binder.set_node_type(node.id(), type_id);
+        if let Ok(operator) = UsingOperator::try_from(&node.operator) {
+            self.resolve_operator_function(node.id(), operator, &node.operand, 1);
+        }
     }
 
     fn leave_tuple_expression(&mut self, node: &ir::TupleExpression) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -1,6 +1,7 @@
 mod binder;
 mod getter_overrides;
 mod typing;
+mod user_defined_operator_functions;
 
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/user_defined_operator_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/user_defined_operator_functions.rs
@@ -1,0 +1,222 @@
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::ir::visitor::Visitor;
+use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
+
+use super::{TestFile, build_file};
+use crate::binder::Binder;
+use crate::context::FileNodeMapper;
+use crate::passes::{
+    p1_collect_definitions, p2_linearise_contracts, p3_type_definitions, p5_resolve_references,
+};
+use crate::types::TypeRegistry;
+
+/// Runs the semantic passes over `source`, asserting that no diagnostics
+/// were produced.
+fn analyze(source: &str) -> (TestFile, Binder) {
+    let mut id_generator = NodeIdGenerator::default();
+    let file = build_file(
+        "test.sol".into(),
+        source,
+        &mut id_generator,
+        LanguageVersion::LATEST,
+    );
+    let files = vec![file];
+
+    let mut binder = Binder::default();
+    let mut types = TypeRegistry::new(LanguageVersion::LATEST);
+    let mut diagnostics = DiagnosticCollection::default();
+    let file_node_mapper = FileNodeMapper::build_from(&files);
+    p1_collect_definitions::run(
+        &files,
+        &mut binder,
+        LanguageVersion::LATEST,
+        &mut diagnostics,
+    );
+    p2_linearise_contracts::run(&files, &mut binder, &mut diagnostics);
+    p3_type_definitions::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
+    p5_resolve_references::run(
+        &files,
+        &mut binder,
+        &mut types,
+        &file_node_mapper,
+        &mut diagnostics,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Semantic diagnostics: {diagnostics:?}"
+    );
+
+    (files.into_iter().next().unwrap(), binder)
+}
+
+/// Collects the node ids of every expression kind that can invoke a
+/// user-defined operator, in source order.
+#[derive(Default)]
+struct OperatorExpressions {
+    ids: Vec<NodeId>,
+}
+
+macro_rules! collect_operator_expression {
+    ($($hook:ident: $node:ident),* $(,)?) => {
+        $(
+            fn $hook(&mut self, node: &ir::$node) -> bool {
+                self.ids.push(node.id());
+                true
+            }
+        )*
+    };
+}
+
+impl Visitor for OperatorExpressions {
+    collect_operator_expression!(
+        enter_additive_expression: AdditiveExpression,
+        enter_bitwise_and_expression: BitwiseAndExpression,
+        enter_bitwise_or_expression: BitwiseOrExpression,
+        enter_bitwise_xor_expression: BitwiseXorExpression,
+        enter_equality_expression: EqualityExpression,
+        enter_inequality_expression: InequalityExpression,
+        enter_multiplicative_expression: MultiplicativeExpression,
+        enter_prefix_expression: PrefixExpression,
+    );
+}
+
+/// The name of the function each operator expression in `source` resolves
+/// to, in source order. `None` for expressions that resolve to no
+/// user-defined operator function.
+fn operator_resolutions(source: &str) -> Vec<Option<String>> {
+    let (file, binder) = analyze(source);
+    let mut collector = OperatorExpressions::default();
+    ir::visitor::accept_source_unit(&file.ir_root, &mut collector);
+    collector
+        .ids
+        .iter()
+        .map(|node_id| {
+            binder
+                .resolved_operator_function(*node_id)
+                .map(|definition_id| {
+                    binder
+                        .find_definition_by_id(definition_id)
+                        .unwrap()
+                        .identifier()
+                        .unparse()
+                        .to_string()
+                })
+        })
+        .collect()
+}
+
+#[test]
+fn binary_operator_resolves_to_bound_function() {
+    let resolutions = operator_resolutions(
+        "type Int is int256;
+        function add(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        using {add as +} for Int global;
+        contract C {
+            function f(Int a, Int b) internal pure returns (Int) {
+                return a + b;
+            }
+        }",
+    );
+    assert_eq!(vec![Some("add".into())], resolutions);
+}
+
+#[test]
+fn every_overloadable_operator_resolves() {
+    let resolutions = operator_resolutions(
+        "type Int is int256;
+        function add(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function sub(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function neg(Int) pure returns (Int) { return Int.wrap(0); }
+        function bitnot(Int) pure returns (Int) { return Int.wrap(0); }
+        function mul(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function div(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function rem(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function bitand(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function bitor(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function bitxor(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function eq(Int, Int) pure returns (bool) { return true; }
+        function neq(Int, Int) pure returns (bool) { return true; }
+        function lt(Int, Int) pure returns (bool) { return true; }
+        function lte(Int, Int) pure returns (bool) { return true; }
+        function gt(Int, Int) pure returns (bool) { return true; }
+        function gte(Int, Int) pure returns (bool) { return true; }
+        using {
+            add as +, sub as -, neg as -, bitnot as ~,
+            mul as *, div as /, rem as %,
+            bitand as &, bitor as |, bitxor as ^,
+            eq as ==, neq as !=, lt as <, lte as <=, gt as >, gte as >=
+        } for Int global;
+        contract C {
+            function f(Int a, Int b) internal pure {
+                a + b; a - b; -a; ~a;
+                a * b; a / b; a % b;
+                a & b; a | b; a ^ b;
+                a == b; a != b; a < b; a <= b; a > b; a >= b;
+            }
+        }",
+    );
+    let expected = [
+        "add", "sub", "neg", "bitnot", "mul", "div", "rem", "bitand", "bitor", "bitxor", "eq",
+        "neq", "lt", "lte", "gt", "gte",
+    ];
+    assert_eq!(expected.map(|name| Some(name.into())).to_vec(), resolutions);
+}
+
+#[test]
+fn unbound_operators_are_not_resolved() {
+    let resolutions = operator_resolutions(
+        "type Int is int256;
+        function add(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        using {add as +} for Int global;
+        contract C {
+            function f(Int a, Int b, uint256 x) internal pure {
+                a - b;
+                -a;
+                x + x;
+                a + b;
+            }
+        }",
+    );
+    assert_eq!(vec![None, None, None, Some("add".into())], resolutions);
+}
+
+#[test]
+fn duplicate_binding_is_ambiguous_and_not_resolved() {
+    let resolutions = operator_resolutions(
+        "type Int is int256;
+        function add1(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        function add2(Int, Int) pure returns (Int) { return Int.wrap(0); }
+        using {add1 as +} for Int global;
+        using {add2 as +} for Int global;
+        contract C {
+            function f(Int a, Int b) internal pure {
+                a + b;
+            }
+        }",
+    );
+    assert_eq!(vec![None], resolutions);
+}
+
+#[test]
+fn operator_bound_to_a_different_type_is_not_resolved() {
+    let resolutions = operator_resolutions(
+        "type Int is int256;
+        type Other is int256;
+        function add(Other, Other) pure returns (Other) { return Other.wrap(0); }
+        using {add as +} for Other global;
+        contract C {
+            function f(Int a, Int b) internal pure {
+                a + b;
+            }
+        }",
+    );
+    assert_eq!(vec![None], resolutions);
+}


### PR DESCRIPTION
Resolve operator expressions on user-defined value types to the functions bound by `using` directives, recording them in a new binder map keyed by the expression node. A `-` bound to a unary and a binary function disambiguates by operand count, and ambiguous bindings stay unresolved.