### PR TITLE
switch to bencher API project keys

### DIFF
--- a/.github/workflows/benchmark_archive.yml
+++ b/.github/workflows/benchmark_archive.yml
@@ -30,9 +30,30 @@ jobs:
           setup-tools: "cargo"
           sfw-optional: "true"
 
-      - name: "infra perf archive"
+      - name: "infra perf archive slang-dashboard-cargo-cmp"
         continue-on-error: true
         env:
-          BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_CMP }}"
           HEAD_REF: "${{ github.head_ref }}"
-        run: './scripts/bin/infra perf archive --branch "${HEAD_REF}"'
+        run: './scripts/bin/infra perf archive --project "slang-dashboard-cargo-cmp" --branch "${HEAD_REF}"'
+
+      - name: "infra perf archive slang-dashboard-cargo-slang-v2"
+        continue-on-error: true
+        env:
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_SLANG_V2 }}"
+          HEAD_REF: "${{ github.head_ref }}"
+        run: './scripts/bin/infra perf archive --project "slang-dashboard-cargo-slang-v2" --branch "${HEAD_REF}"'
+
+      - name: "infra perf archive slang-dashboard-cargo-slang"
+        continue-on-error: true
+        env:
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_SLANG }}"
+          HEAD_REF: "${{ github.head_ref }}"
+        run: './scripts/bin/infra perf archive --project "slang-dashboard-cargo-slang" --branch "${HEAD_REF}"'
+
+      - name: "infra perf archive slang-dashboard-npm"
+        continue-on-error: true
+        env:
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__NPM }}"
+          HEAD_REF: "${{ github.head_ref }}"
+        run: './scripts/bin/infra perf archive --project "slang-dashboard-npm" --branch "${HEAD_REF}"'

--- a/.github/workflows/benchmark_cargo_cmp.yml
+++ b/.github/workflows/benchmark_cargo_cmp.yml
@@ -11,10 +11,6 @@ on:
         required: true
         default: true
 
-      bencherProject:
-        description: "Bencher project:"
-        type: "string"
-
   # Run on pushes to 'main' branch:
   push:
     branches:
@@ -44,7 +40,7 @@ jobs:
       pull-requests: "write"
       checks: "write"
 
-    # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
+    # Skip fork PRs (can't access GitHub Actions secrets). For non-PR events, only run on the main repo.
     if: >-
       ${{
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -72,8 +68,7 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:perf:full') && '--pr-benchmark=full' || '--pr-benchmark') || (inputs.dryRun == true && '--dry-run' || '') }} comparison"
         env:
-          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-          BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_CMP }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/benchmark_cargo_slang.yml
+++ b/.github/workflows/benchmark_cargo_slang.yml
@@ -11,10 +11,6 @@ on:
         required: true
         default: true
 
-      bencherProject:
-        description: "Bencher project:"
-        type: "string"
-
   # Run on pushes to 'main' branch:
   push:
     branches:
@@ -44,7 +40,7 @@ jobs:
       pull-requests: "write"
       checks: "write"
 
-    # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
+    # Skip fork PRs (can't access GitHub Actions secrets). For non-PR events, only run on the main repo.
     if: >-
       ${{
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -72,8 +68,7 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') || contains(github.event.pull_request.labels.*.name, 'ci:perf:full') }}"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:perf:full') && '--pr-benchmark=full' || '--pr-benchmark') || (inputs.dryRun == true && '--dry-run' || '') }} slang"
         env:
-          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-          BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_SLANG }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/benchmark_cargo_slang_v2.yml
+++ b/.github/workflows/benchmark_cargo_slang_v2.yml
@@ -11,10 +11,6 @@ on:
         required: true
         default: true
 
-      bencherProject:
-        description: "Bencher project:"
-        type: "string"
-
   # Run on pushes to 'main' branch:
   push:
     branches:
@@ -43,7 +39,7 @@ jobs:
       pull-requests: "write"
       checks: "write"
 
-    # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
+    # Skip fork PRs (can't access GitHub Actions secrets). For non-PR events, only run on the main repo.
     if: >-
       ${{
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -70,8 +66,7 @@ jobs:
       - name: "Benchmark > infra perf cargo slang-v2"
         run: "./scripts/bin/infra perf cargo ${{ github.event_name == 'pull_request' && '--pr-benchmark=full' || (inputs.dryRun == true && '--dry-run' || '') }} slang-v2"
         env:
-          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-          BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__CARGO_SLANG_V2 }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/benchmark_npm.yml
+++ b/.github/workflows/benchmark_npm.yml
@@ -11,10 +11,6 @@ on:
         required: true
         default: true
 
-      bencherProject:
-        description: "Bencher project:"
-        type: "string"
-
   # Run on pushes to 'main' branch:
   push:
     branches:
@@ -44,7 +40,7 @@ jobs:
       pull-requests: "write"
       checks: "write"
 
-    # Skip fork PRs (can't access BENCHER_API_TOKEN). For non-PR events, only run on the main repo.
+    # Skip fork PRs (can't access GitHub Actions secrets). For non-PR events, only run on the main repo.
     if: >-
       ${{
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -75,7 +71,6 @@ jobs:
         if: "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:perf') }}"
         run: "./scripts/bin/infra perf npm ${{ github.event_name == 'pull_request' && '--pr-benchmark' || (inputs.dryRun == true && '--dry-run' || '') }}"
         env:
-          SLANG_BENCHER_PROJECT: "${{ inputs.bencherProject }}"
-          BENCHER_API_TOKEN: "${{ secrets.BENCHER_API_TOKEN }}"
+          BENCHER_API_KEY: "${{ secrets.BENCHER_API_KEY__NPM }}"
           BENCHER_PR_HEAD_HASH: "${{ github.event.pull_request.head.sha }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/crates/infra/cli/src/commands/perf/archive.rs
+++ b/crates/infra/cli/src/commands/perf/archive.rs
@@ -3,17 +3,14 @@ use clap::Parser;
 use infra_utils::commands::Command;
 
 use crate::commands::perf::binaries;
-use crate::toolchains::bencher;
-
-const BENCHER_PROJECTS: &[&str] = &[
-    "slang-dashboard-cargo-slang",
-    "slang-dashboard-cargo-slang-v2",
-    "slang-dashboard-cargo-cmp",
-    "slang-dashboard-npm",
-];
+use crate::toolchains::bencher::{BencherProject, archive_branch, unarchive_branch};
 
 #[derive(Clone, Debug, Parser)]
 pub struct ArchiveController {
+    /// Bencher project to archive.
+    #[arg(long)]
+    project: BencherProject,
+
     /// Branch name to archive. If omitted, uses the current git branch.
     #[arg(long)]
     branch: Option<String>,
@@ -21,6 +18,10 @@ pub struct ArchiveController {
 
 #[derive(Clone, Debug, Parser)]
 pub struct UnarchiveController {
+    /// Bencher project to unarchive.
+    #[arg(long)]
+    project: BencherProject,
+
     /// Branch name to unarchive. If omitted, uses the current git branch.
     #[arg(long)]
     branch: Option<String>,
@@ -50,11 +51,7 @@ impl ArchiveController {
     pub fn execute(&self) -> Result<()> {
         let branch = resolve_branch(self.branch.as_deref())?;
         binaries::install_bencher_cli()?;
-
-        for project in BENCHER_PROJECTS {
-            bencher::archive_branch(project, &branch);
-        }
-
+        archive_branch(self.project, &branch);
         Ok(())
     }
 }
@@ -63,11 +60,7 @@ impl UnarchiveController {
     pub fn execute(&self) -> Result<()> {
         let branch = resolve_branch(self.branch.as_deref())?;
         binaries::install_bencher_cli()?;
-
-        for project in BENCHER_PROJECTS {
-            bencher::unarchive_branch(project, &branch);
-        }
-
+        unarchive_branch(self.project, &branch);
         Ok(())
     }
 }

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -73,9 +73,9 @@ impl CargoController {
         let package = "solidity_testing_perf_cargo";
 
         let (bench_name, bencher_project) = match self.bench {
-            Benches::Comparison => ("comparison", BencherProject::SlangDashboardCargoCmp),
-            Benches::Slang => ("slang", BencherProject::SlangDashboardCargoSlang),
-            Benches::SlangV2 => ("slang_v2", BencherProject::SlangDashboardCargoSlangV2),
+            Benches::Comparison => ("comparison", BencherProject::CargoCmp),
+            Benches::Slang => ("slang", BencherProject::CargoSlang),
+            Benches::SlangV2 => ("slang_v2", BencherProject::CargoSlangV2),
         };
 
         if self.smoke {

--- a/crates/infra/cli/src/commands/perf/cargo/mod.rs
+++ b/crates/infra/cli/src/commands/perf/cargo/mod.rs
@@ -6,13 +6,9 @@ use infra_utils::commands::Command;
 use infra_utils::paths::{FileWalker, PathExtensions};
 
 use crate::commands::perf::binaries;
-use crate::toolchains::bencher::{BencherThreshold, run_bench};
+use crate::toolchains::bencher::{BencherProject, BencherThreshold, run_bench};
 use crate::toolchains::pipenv::PipEnv;
 use crate::utils::DryRun;
-
-const DEFAULT_BENCHER_PROJECT_CMP: &str = "slang-dashboard-cargo-cmp";
-const DEFAULT_BENCHER_PROJECT_SLANG: &str = "slang-dashboard-cargo-slang";
-const DEFAULT_BENCHER_PROJECT_SLANG_V2: &str = "slang-dashboard-cargo-slang-v2";
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Parser)]
@@ -74,22 +70,12 @@ impl CargoController {
             binaries::install_bencher_cli()?;
         }
 
-        let (package, bench_name, bencher_project) = match self.bench {
-            Benches::Slang => (
-                "solidity_testing_perf_cargo",
-                "slang",
-                DEFAULT_BENCHER_PROJECT_SLANG,
-            ),
-            Benches::Comparison => (
-                "solidity_testing_perf_cargo",
-                "comparison",
-                DEFAULT_BENCHER_PROJECT_CMP,
-            ),
-            Benches::SlangV2 => (
-                "solidity_testing_perf_cargo",
-                "slang_v2",
-                DEFAULT_BENCHER_PROJECT_SLANG_V2,
-            ),
+        let package = "solidity_testing_perf_cargo";
+
+        let (bench_name, bencher_project) = match self.bench {
+            Benches::Comparison => ("comparison", BencherProject::SlangDashboardCargoCmp),
+            Benches::Slang => ("slang", BencherProject::SlangDashboardCargoSlang),
+            Benches::SlangV2 => ("slang_v2", BencherProject::SlangDashboardCargoSlangV2),
         };
 
         if self.smoke {
@@ -107,7 +93,12 @@ impl CargoController {
         Ok(())
     }
 
-    fn run_gungraun_bench(&self, package_name: &str, bench_name: &str, bencher_project: &str) {
+    fn run_gungraun_bench(
+        &self,
+        package_name: &str,
+        bench_name: &str,
+        bencher_project: BencherProject,
+    ) {
         let test_runner = format!("cargo bench --package {package_name} --bench {bench_name}");
 
         // gungraun's metrics come from valgrind's simulation, so they're deterministic: any change reflects a

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -46,7 +46,7 @@ impl NpmController {
         run_bench(
             self.dry_run.get(),
             self.pr_benchmark,
-            BencherProject::SlangDashboardNpm,
+            BencherProject::Npm,
             "json",
             &[BencherThreshold::new("duration", "0.15")],
             &[],

--- a/crates/infra/cli/src/commands/perf/npm/mod.rs
+++ b/crates/infra/cli/src/commands/perf/npm/mod.rs
@@ -3,10 +3,8 @@ use clap::Parser;
 use infra_utils::commands::Command;
 
 use crate::commands::perf::binaries;
-use crate::toolchains::bencher::{BencherThreshold, run_bench};
+use crate::toolchains::bencher::{BencherProject, BencherThreshold, run_bench};
 use crate::utils::DryRun;
-
-const DEFAULT_BENCHER_PROJECT: &str = "slang-dashboard-npm";
 
 #[derive(Clone, Debug, Parser)]
 pub struct NpmController {
@@ -48,7 +46,7 @@ impl NpmController {
         run_bench(
             self.dry_run.get(),
             self.pr_benchmark,
-            DEFAULT_BENCHER_PROJECT,
+            BencherProject::SlangDashboardNpm,
             "json",
             &[BencherThreshold::new("duration", "0.15")],
             &[],

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -1,7 +1,8 @@
+use std::fmt::Display;
+
 use clap::ValueEnum;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
-use strum::Display;
 
 // Three modes:
 // 1. dry-run: runs benchmarks locally, uploads to bencher with a dummy key (no dashboard update).
@@ -14,13 +15,26 @@ use strum::Display;
 // Source: https://github.com/bencherdev/bencher/blob/d2895af8c867c83b8fe766a6b84d8ccd4df5c315/tasks/test_api/src/task/test/smoke_test.rs#L27
 const BENCHER_TEST_API_KEY: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhcGlfa2V5IiwiZXhwIjo1OTkzNjQyMTU2LCJpYXQiOjE2OTg2NzQ4NjEsImlzcyI6Imh0dHBzOi8vZGV2ZWwtLWJlbmNoZXIubmV0bGlmeS5hcHAvIiwic3ViIjoibXVyaWVsLmJhZ2dlQG5vd2hlcmUuY29tIiwib3JnIjpudWxsfQ.9z7jmM53TcVzc1inDxTeX9_OR0PQPpZAsKsCE7lWHfo";
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Display)]
-#[strum(serialize_all = "kebab-case")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum BencherProject {
-    SlangDashboardCargoCmp,
-    SlangDashboardCargoSlangV2,
-    SlangDashboardCargoSlang,
-    SlangDashboardNpm,
+    // https://bencher.dev/console/projects/slang-dashboard-cargo-cmp/
+    #[value(name = "slang-dashboard-cargo-cmp")]
+    CargoCmp,
+    // https://bencher.dev/console/projects/slang-dashboard-cargo-slang-v2/
+    #[value(name = "slang-dashboard-cargo-slang-v2")]
+    CargoSlangV2,
+    // https://bencher.dev/console/projects/slang-dashboard-cargo-slang/
+    #[value(name = "slang-dashboard-cargo-slang")]
+    CargoSlang,
+    // https://bencher.dev/console/projects/slang-dashboard-npm/
+    #[value(name = "slang-dashboard-npm")]
+    Npm,
+}
+
+impl Display for BencherProject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value().unwrap().get_name().fmt(f)
+    }
 }
 
 /// Represents a performance threshold for a Bencher benchmark comparison, used in PR benchmarking mode.
@@ -66,7 +80,7 @@ pub(crate) fn run_bench(
         BENCHER_TEST_API_KEY.to_string()
     } else {
         std::env::var("BENCHER_API_KEY").unwrap_or_else(|_| {
-            panic!("BENCHER_API_KEY is not set. Either perform a '--dry-run', or set it to your Bencher API key: https://bencher.dev/console/projects/{project}/keys");
+            panic!("BENCHER_API_KEY is not set. Either perform a '--dry-run', or set it to the project's Bencher API key: https://bencher.dev/console/projects/{project}/keys");
         })
     };
 
@@ -155,7 +169,7 @@ pub(crate) fn unarchive_branch(project: BencherProject, branch: &str) {
 
 fn bencher_archive_command(action: &str, project: BencherProject, branch: &str) {
     let api_key = std::env::var("BENCHER_API_KEY").unwrap_or_else(|_| {
-        panic!("BENCHER_API_KEY is not set. Either perform a '--dry-run', or set it to your Bencher API key: https://bencher.dev/console/projects/{project}/keys");
+        panic!("BENCHER_API_KEY is not set. Set it to the project's Bencher API key: https://bencher.dev/console/projects/{project}/keys");
     });
 
     Command::new("bencher")

--- a/crates/infra/cli/src/toolchains/bencher/mod.rs
+++ b/crates/infra/cli/src/toolchains/bencher/mod.rs
@@ -1,16 +1,27 @@
+use clap::ValueEnum;
 use infra_utils::commands::Command;
 use infra_utils::github::GitHub;
+use strum::Display;
 
 // Three modes:
-// 1. dry-run: runs benchmarks locally, uploads to bencher with a dummy token (no dashboard update).
+// 1. dry-run: runs benchmarks locally, uploads to bencher with a dummy key (no dashboard update).
 // 2. pr-benchmark: uploads to a temporary PR branch in bencher, compares against the base branch
 //    with inline thresholds (percentage), and posts results as a PR comment. Mutually exclusive with dry-run.
 // 3. normal (neither flag): uploads results to the main branch on the bencher dashboard.
 //
-// Use a dummy test token for dry runs:
+// Use a dummy test key for dry runs:
 // https://github.com/bencherdev/bencher/issues/468
-// Source: https://github.com/bencherdev/bencher/blob/aa31a002842cfb0da9d6c60569396fc5261f5111/tasks/test_api/src/task/test/smoke_test.rs#L20
-const BENCHER_TEST_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhcGlfa2V5IiwiZXhwIjo1OTkzNjQyMTU2LCJpYXQiOjE2OTg2NzQ4NjEsImlzcyI6Imh0dHBzOi8vZGV2ZWwtLWJlbmNoZXIubmV0bGlmeS5hcHAvIiwic3ViIjoibXVyaWVsLmJhZ2dlQG5vd2hlcmUuY29tIiwib3JnIjpudWxsfQ.9z7jmM53TcVzc1inDxTeX9_OR0PQPpZAsKsCE7lWHfo";
+// Source: https://github.com/bencherdev/bencher/blob/d2895af8c867c83b8fe766a6b84d8ccd4df5c315/tasks/test_api/src/task/test/smoke_test.rs#L27
+const BENCHER_TEST_API_KEY: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhcGlfa2V5IiwiZXhwIjo1OTkzNjQyMTU2LCJpYXQiOjE2OTg2NzQ4NjEsImlzcyI6Imh0dHBzOi8vZGV2ZWwtLWJlbmNoZXIubmV0bGlmeS5hcHAvIiwic3ViIjoibXVyaWVsLmJhZ2dlQG5vd2hlcmUuY29tIiwib3JnIjpudWxsfQ.9z7jmM53TcVzc1inDxTeX9_OR0PQPpZAsKsCE7lWHfo";
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Display)]
+#[strum(serialize_all = "kebab-case")]
+pub(crate) enum BencherProject {
+    SlangDashboardCargoCmp,
+    SlangDashboardCargoSlangV2,
+    SlangDashboardCargoSlang,
+    SlangDashboardNpm,
+}
 
 /// Represents a performance threshold for a Bencher benchmark comparison, used in PR benchmarking mode.
 #[derive(Clone)]
@@ -37,7 +48,7 @@ impl BencherThreshold {
 pub(crate) fn run_bench(
     dry_run: bool,
     pr_benchmark: bool,
-    project: &str,
+    project: BencherProject,
     adapter: &str,
     thresholds: &[BencherThreshold],
     // Extra environment variables to set on the benchmark command. These
@@ -51,12 +62,12 @@ pub(crate) fn run_bench(
          PR benchmarks must upload to bencher for comparison."
     );
 
-    let token = if dry_run {
-        BENCHER_TEST_TOKEN.to_string()
+    let api_key = if dry_run {
+        BENCHER_TEST_API_KEY.to_string()
     } else {
-        std::env::var("BENCHER_API_TOKEN").expect(
-            "BENCHER_API_TOKEN is not set. Either perform a '--dry-run', or set it to your Bencher API token: https://bencher.dev/console"
-        )
+        std::env::var("BENCHER_API_KEY").unwrap_or_else(|_| {
+            panic!("BENCHER_API_KEY is not set. Either perform a '--dry-run', or set it to your Bencher API key: https://bencher.dev/console/projects/{project}/keys");
+        })
     };
 
     let testbed = if GitHub::is_running_in_ci() {
@@ -65,17 +76,12 @@ pub(crate) fn run_bench(
         "dev"
     };
 
-    let project = std::env::var("SLANG_BENCHER_PROJECT")
-        .ok()
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| project.to_owned());
-
     let mut command = Command::new("bencher")
         .arg("run")
-        .property("--project", &project)
+        .property("--project", project.to_string())
         .property("--adapter", adapter)
         .property("--testbed", testbed)
-        .secret("BENCHER_API_TOKEN", token);
+        .secret("BENCHER_API_KEY", api_key);
 
     for (key, value) in bench_env {
         command = command.env(*key, *value);
@@ -139,23 +145,23 @@ Test Results: [https://bencher.dev/console/projects/{project}/reports]
     );
 }
 
-pub(crate) fn archive_branch(project: &str, branch: &str) {
+pub(crate) fn archive_branch(project: BencherProject, branch: &str) {
     bencher_archive_command("archive", project, branch);
 }
 
-pub(crate) fn unarchive_branch(project: &str, branch: &str) {
+pub(crate) fn unarchive_branch(project: BencherProject, branch: &str) {
     bencher_archive_command("unarchive", project, branch);
 }
 
-fn bencher_archive_command(action: &str, project: &str, branch: &str) {
-    let token = std::env::var("BENCHER_API_TOKEN").expect(
-        "BENCHER_API_TOKEN is not set. Set it to your Bencher API token: https://bencher.dev/console",
-    );
+fn bencher_archive_command(action: &str, project: BencherProject, branch: &str) {
+    let api_key = std::env::var("BENCHER_API_KEY").unwrap_or_else(|_| {
+        panic!("BENCHER_API_KEY is not set. Either perform a '--dry-run', or set it to your Bencher API key: https://bencher.dev/console/projects/{project}/keys");
+    });
 
     Command::new("bencher")
         .arg(action)
-        .property("--project", project)
+        .property("--project", project.to_string())
         .property("--branch", branch)
-        .secret("BENCHER_API_TOKEN", token)
+        .secret("BENCHER_API_KEY", api_key)
         .run();
 }


### PR DESCRIPTION
The new API uses per-project keys, instead of user tokens:

> 🐰 DEPRECATED: API tokens are deprecated in favor of API keys. New API tokens can no longer be created; existing API tokens continue to work. Use [the `--key` option](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.

- https://bencher.dev/docs/explanation/bencher-run/#--token-token
- https://bencher.dev/docs/explanation/bencher-run/#--key-key

New four secrets are now added to the repository. Will remove the old one once:

- The PR is merged ✅
- A full benchmark run on `main` succeeds ✅ ([[1](https://github.com/NomicFoundation/slang/actions/runs/30386413065)] [[2](https://github.com/NomicFoundation/slang/actions/runs/30386413201)] [[3](https://github.com/NomicFoundation/slang/actions/runs/30386412633)] [[4](https://github.com/NomicFoundation/slang/actions/runs/30386413131)])
- A PR queue `unarchive` run succeeds ✅ ([run](https://github.com/NomicFoundation/slang/actions/runs/30375347996))