### PR TITLE
chore(diagnostics): Diagnostic snapshots for errors handled by the grammar

### DIFF
--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1661,6 +1661,11 @@ mod syntax {
     }
 
     #[test]
+    fn library_inheritance() -> Result<()> {
+        run("syntax", "library_inheritance")
+    }
+
+    #[test]
     fn more_than_one_inheritance_list() -> Result<()> {
         run("syntax", "more_than_one_inheritance_list")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1797,6 +1797,25 @@ mod syntax {
         }
     }
 
+    mod non_address_state_mutability {
+        use super::*;
+
+        #[test]
+        fn local_variable() -> Result<()> {
+            run("syntax/non_address_state_mutability", "local_variable")
+        }
+
+        #[test]
+        fn return_parameter() -> Result<()> {
+            run("syntax/non_address_state_mutability", "return_parameter")
+        }
+
+        #[test]
+        fn state_variable() -> Result<()> {
+            run("syntax/non_address_state_mutability", "state_variable")
+        }
+    }
+
     #[test]
     fn unexpected_eof() -> Result<()> {
         run("syntax", "unexpected_eof")

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/unexpected-terminal] Error: Unexpected IsKeyword. One of OpenBrace was expected
+   ╭─[input.sol:7:11]
+   │
+ 7 │ library L is Base {}
+   │           ─┬  
+   │            ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9469] Error: Library is not allowed to inherit.
+   ╭─[input.sol:7:1]
+   │
+ 7 │ library L is Base {}
+   │ ──────────┬─────────  
+   │           ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/library_inheritance/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Base {}
+
+// A library is not allowed to declare an inheritance list.
+library L is Base {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/unexpected-terminal] Error: Unexpected PayableKeyword. One of Ampersand, AmpersandAmpersand, AmpersandEqual, Asterisk, AsteriskAsterisk, AsteriskEqual, AtKeyword, BangEqual, Bar, BarBar, BarEqual, CallDataKeyword, Caret, CaretEqual, Equal, EqualEqual, ErrorKeyword, FromKeyword, GlobalKeyword, GreaterThan, GreaterThanEqual, GreaterThanGreaterThan, GreaterThanGreaterThanEqual, GreaterThanGreaterThanGreaterThan, GreaterThanGreaterThanGreaterThanEqual, Identifier, LayoutKeyword, LessThan, LessThanEqual, LessThanLessThan, LessThanLessThanEqual, MemoryKeyword, Minus, MinusEqual, MinusMinus, OpenBrace, OpenBracket, OpenParen, Percent, PercentEqual, Period, Plus, PlusEqual, PlusPlus, QuestionMark, RevertKeyword, Semicolon, Slash, SlashEqual, StorageKeyword, TransientKeyword was expected
+   ╭─[input.sol:8:17]
+   │
+ 8 │         uint256 payable x;
+   │                 ───┬───  
+   │                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 9106] Error: State mutability can only be specified for address types.
+   ╭─[input.sol:8:17]
+   │
+ 8 │         uint256 payable x;
+   │                 ───┬───  
+   │                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/local_variable/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f() public pure {
+        // A state-mutability specifier (`payable`) may only follow `address`,
+        // not another elementary type.
+        uint256 payable x;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/unexpected-terminal] Error: Unexpected PayableKeyword. One of AtKeyword, CallDataKeyword, CloseParen, Comma, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, LayoutKeyword, MemoryKeyword, OpenBracket, RevertKeyword, StorageKeyword, TransientKeyword was expected
+   ╭─[input.sol:7:47]
+   │
+ 7 │     function f() public pure returns (uint256 payable) {}
+   │                                               ───┬───  
+   │                                                  ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 9106] Error: State mutability can only be specified for address types.
+   ╭─[input.sol:7:47]
+   │
+ 7 │     function f() public pure returns (uint256 payable) {}
+   │                                               ───┬───  
+   │                                                  ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/return_parameter/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A state-mutability specifier (`payable`) may only follow `address`, not
+    // another elementary type.
+    function f() public pure returns (uint256 payable) {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/unexpected-terminal] Error: Unexpected PayableKeyword. One of AtKeyword, ConstantKeyword, ErrorKeyword, FromKeyword, GlobalKeyword, Identifier, ImmutableKeyword, InternalKeyword, LayoutKeyword, OpenBracket, OverrideKeyword, PrivateKeyword, PublicKeyword, RevertKeyword, TransientKeyword was expected
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256 payable x;
+   │             ───┬───  
+   │                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 9106] Error: State mutability can only be specified for address types.
+   ╭─[input.sol:7:13]
+   │
+ 7 │     uint256 payable x;
+   │             ───┬───  
+   │                ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/non_address_state_mutability/state_variable/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A state-mutability specifier (`payable`) may only follow `address`, not
+    // another elementary type.
+    uint256 payable x;
+}


### PR DESCRIPTION
Closes NomicFoundation/slang-diagnostics-research#1636: State mutability can only be specified for address types
Closes NomicFoundation/slang-diagnostics-research#1674: Library is not allowed to inherit

These errors are impossible in Slang because the grammar rejects the input code.
