### PR TITLE
feat(diagnostics): Miscellaneous structural checks on types

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -671,6 +671,7 @@ pub mod slang_solidity_v2_common::diagnostics::kinds::structure
 pub enum slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::AbstractContractPublicConstructor(slang_solidity_v2_common::diagnostics::kinds::structure::AbstractContractPublicConstructor)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::BreakOutsideLoop(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ConflictingMappingParameterName(slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ConstructorNotInContract(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContinueOutsideLoop(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContractShouldBeAbstract(slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract)
@@ -724,6 +725,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::AbstractContractPublicConstructor) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -861,6 +864,26 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::name: alloc::string::String
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract
@@ -2405,6 +2428,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::AbstractContractPublicConstructor) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2737,6 +2762,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::BreakOutsideLoop::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConflictingMappingParameterName::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -176,6 +176,8 @@ pub trait slang_solidity_v2_common::collections::DefaultWithCapacity
 pub fn slang_solidity_v2_common::collections::DefaultWithCapacity::default_with_capacity(usize) -> Self
 impl<K, V> slang_solidity_v2_common::collections::DefaultWithCapacity for slang_solidity_v2_common::collections::Map<K, V>
 pub fn slang_solidity_v2_common::collections::Map<K, V>::default_with_capacity(usize) -> Self
+impl<T> slang_solidity_v2_common::collections::DefaultWithCapacity for slang_solidity_v2_common::collections::Set<T>
+pub fn slang_solidity_v2_common::collections::Set<T>::default_with_capacity(usize) -> Self
 pub type slang_solidity_v2_common::collections::DeterministicState = core::hash::BuildHasherDefault<fxhash::FxHasher>
 pub type slang_solidity_v2_common::collections::Map<K, V> = std::collections::hash::map::HashMap<K, V, slang_solidity_v2_common::collections::DeterministicState>
 pub type slang_solidity_v2_common::collections::OrderedMap<K, V> = indexmap::map::IndexMap<K, V, slang_solidity_v2_common::collections::DeterministicState>
@@ -672,6 +674,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ConstructorNotInContract(slang_solidity_v2_common::diagnostics::kinds::structure::ConstructorNotInContract)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContinueOutsideLoop(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContractShouldBeAbstract(slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::DuplicateNamedArgument(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyEnum(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyStruct(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EnumWithTooManyMembers(slang_solidity_v2_common::diagnostics::kinds::structure::EnumWithTooManyMembers)
@@ -726,6 +729,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -911,6 +916,26 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::name: alloc::string::String
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
@@ -2364,6 +2389,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContinueOutsideLoop) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2698,6 +2725,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -701,6 +701,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleConstructors(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleConstructors)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleFallbackFunctions(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleFallbackFunctions)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::MultipleReceiveFunctions(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::NamedFunctionTypeReturnParameter(slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::NestedUncheckedBlock(slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::NonAbstractContractInternalConstructor(slang_solidity_v2_common::diagnostics::kinds::structure::NonAbstractContractInternalConstructor)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::PayableInternalOrPrivateFunction(slang_solidity_v2_common::diagnostics::kinds::structure::PayableInternalOrPrivateFunction)
@@ -783,6 +784,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleFallbackFunctions) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NonAbstractContractInternalConstructor> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -1431,6 +1434,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock
@@ -2443,6 +2465,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleFallbackFunctions) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::NonAbstractContractInternalConstructor> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2833,6 +2857,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::MultipleReceiveFunctions::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::NestedUncheckedBlock::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/collections.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/collections.rs
@@ -74,3 +74,10 @@ impl<K, V> DefaultWithCapacity for Map<K, V> {
         Map::with_capacity_and_hasher(capacity, DeterministicState::default())
     }
 }
+
+#[allow(clippy::implicit_hasher)]
+impl<T> DefaultWithCapacity for Set<T> {
+    fn default_with_capacity(capacity: usize) -> Self {
+        Set::with_capacity_and_hasher(capacity, DeterministicState::default())
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/conflicting_mapping_parameter_name.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/conflicting_mapping_parameter_name.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a named parameter of a mapping type reuses a name
+/// already used by another parameter in the same or a nested mapping type
+/// (e.g. `mapping(uint k => mapping(uint k => uint))`).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConflictingMappingParameterName {
+    /// The name that is used by more than one mapping parameter.
+    pub name: String,
+}
+
+impl DiagnosticExtensions for ConflictingMappingParameterName {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/conflicting-mapping-parameter-name"
+    }
+
+    fn message(&self) -> String {
+        format!("Conflicting parameter name '{}' in mapping.", self.name)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/duplicate_named_argument.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/duplicate_named_argument.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a function call's named-argument list contains two
+/// arguments with the same name.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DuplicateNamedArgument {
+    /// The name that appears more than once in the argument list.
+    pub name: String,
+}
+
+impl DiagnosticExtensions for DuplicateNamedArgument {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/duplicate-named-argument"
+    }
+
+    fn message(&self) -> String {
+        format!("Duplicate named argument '{}'.", self.name)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -30,6 +30,7 @@ mod modifier_in_interface;
 mod multiple_constructors;
 mod multiple_fallback_functions;
 mod multiple_receive_functions;
+mod named_function_type_return_parameter;
 mod nested_unchecked_block;
 mod non_abstract_contract_internal_constructor;
 mod payable_internal_or_private_function;
@@ -76,6 +77,7 @@ pub use modifier_in_interface::ModifierInInterface;
 pub use multiple_constructors::MultipleConstructors;
 pub use multiple_fallback_functions::MultipleFallbackFunctions;
 pub use multiple_receive_functions::MultipleReceiveFunctions;
+pub use named_function_type_return_parameter::NamedFunctionTypeReturnParameter;
 pub use nested_unchecked_block::NestedUncheckedBlock;
 pub use non_abstract_contract_internal_constructor::NonAbstractContractInternalConstructor;
 pub use payable_internal_or_private_function::PayableInternalOrPrivateFunction;
@@ -212,6 +214,9 @@ define_diagnostic_kind! {
 
         /// A variable is declared in an interface.
         VariableInInterface(VariableInInterface),
+
+        /// A return parameter of a function type is given a name.
+        NamedFunctionTypeReturnParameter(NamedFunctionTypeReturnParameter),
 
         /// An abstract contract declares a storage layout (`layout at`) specifier.
         StorageLayoutForAbstractContract(StorageLayoutForAbstractContract),

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -1,5 +1,6 @@
 mod abstract_contract_public_constructor;
 mod break_outside_loop;
+mod conflicting_mapping_parameter_name;
 mod constructor_not_in_contract;
 mod continue_outside_loop;
 mod contract_should_be_abstract;
@@ -47,6 +48,7 @@ mod virtual_private_function;
 
 pub use abstract_contract_public_constructor::AbstractContractPublicConstructor;
 pub use break_outside_loop::BreakOutsideLoop;
+pub use conflicting_mapping_parameter_name::ConflictingMappingParameterName;
 pub use constructor_not_in_contract::ConstructorNotInContract;
 pub use continue_outside_loop::ContinueOutsideLoop;
 pub use contract_should_be_abstract::ContractShouldBeAbstract;
@@ -152,6 +154,10 @@ define_diagnostic_kind! {
 
         /// A function call's named-argument list contains two arguments with the same name.
         DuplicateNamedArgument(DuplicateNamedArgument),
+
+        /// A named parameter of a mapping type reuses a name already used by
+        /// another parameter in the same or a nested mapping type.
+        ConflictingMappingParameterName(ConflictingMappingParameterName),
 
         /// A constructor in an abstract contract is declared `public`.
         AbstractContractPublicConstructor(AbstractContractPublicConstructor),

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -3,6 +3,7 @@ mod break_outside_loop;
 mod constructor_not_in_contract;
 mod continue_outside_loop;
 mod contract_should_be_abstract;
+mod duplicate_named_argument;
 mod empty_enum;
 mod empty_struct;
 mod enum_with_too_many_members;
@@ -48,6 +49,7 @@ pub use break_outside_loop::BreakOutsideLoop;
 pub use constructor_not_in_contract::ConstructorNotInContract;
 pub use continue_outside_loop::ContinueOutsideLoop;
 pub use contract_should_be_abstract::ContractShouldBeAbstract;
+pub use duplicate_named_argument::DuplicateNamedArgument;
 pub use empty_enum::EmptyEnum;
 pub use empty_struct::EmptyStruct;
 pub use enum_with_too_many_members::EnumWithTooManyMembers;
@@ -145,6 +147,9 @@ define_diagnostic_kind! {
         MultipleConstructors(MultipleConstructors),
         /// A constructor is declared outside of a contract (i.e. in an interface or library).
         ConstructorNotInContract(ConstructorNotInContract),
+
+        /// A function call's named-argument list contains two arguments with the same name.
+        DuplicateNamedArgument(DuplicateNamedArgument),
 
         /// A constructor in an abstract contract is declared `public`.
         AbstractContractPublicConstructor(AbstractContractPublicConstructor),

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/named_function_type_return_parameter.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/named_function_type_return_parameter.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a return parameter of a function type is given a
+/// name (e.g. `function () returns (uint x)`), which is not allowed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NamedFunctionTypeReturnParameter;
+
+impl DiagnosticExtensions for NamedFunctionTypeReturnParameter {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/named-function-type-return-parameter"
+    }
+
+    fn message(&self) -> String {
+        "Return parameters in function types may not be named.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -91,6 +91,7 @@ impl SemanticContext {
         p3_type_definitions::run(
             files,
             &mut binder,
+            language_version,
             &mut types,
             &file_node_mapper,
             diagnostics,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -1,5 +1,6 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
 
 use crate::binder::{Binder, Definition, Scope, ScopeId};
@@ -22,25 +23,45 @@ mod visitor;
 pub fn run(
     files: &[impl SemanticFile],
     binder: &mut Binder,
+    language_version: LanguageVersion,
     types: &mut TypeRegistry,
     file_node_mapper: &FileNodeMapper,
     diagnostics: &mut DiagnosticCollection,
 ) {
     for file in files {
-        Pass::visit_file(file, binder, types, file_node_mapper, diagnostics);
+        Pass::visit_file(
+            file,
+            binder,
+            language_version,
+            types,
+            file_node_mapper,
+            diagnostics,
+        );
     }
     for file in files {
-        Pass::visit_file_type_getters(file, binder, types, file_node_mapper, diagnostics);
+        Pass::visit_file_type_getters(
+            file,
+            binder,
+            language_version,
+            types,
+            file_node_mapper,
+            diagnostics,
+        );
     }
 }
 
 struct Pass<'a> {
     scope_stack: Vec<ScopeId>,
     binder: &'a mut Binder,
+    language_version: LanguageVersion,
     types: &'a mut TypeRegistry,
     file_node_mapper: &'a FileNodeMapper,
     diagnostics: &'a mut DiagnosticCollection,
     current_receiver_type: Option<TypeId>,
+    // Number of upcoming mapping type nodes that belong to a mapping value
+    // chain already covered by the enclosing chain's parameter-name conflict
+    // check, and so must be skipped rather than checked as their own chain root.
+    nested_mappings_to_skip: usize,
 }
 
 impl<'a> Pass<'a> {
@@ -56,6 +77,7 @@ impl<'a> Pass<'a> {
     fn visit_file(
         file: &'a impl SemanticFile,
         binder: &'a mut Binder,
+        language_version: LanguageVersion,
         types: &'a mut TypeRegistry,
         file_node_mapper: &'a FileNodeMapper,
         diagnostics: &'a mut DiagnosticCollection,
@@ -63,10 +85,12 @@ impl<'a> Pass<'a> {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
+            language_version,
             types,
             file_node_mapper,
             diagnostics,
             current_receiver_type: None,
+            nested_mappings_to_skip: 0,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
         assert!(pass.scope_stack.is_empty());
@@ -81,6 +105,7 @@ impl<'a> Pass<'a> {
     fn visit_file_type_getters(
         file: &'a impl SemanticFile,
         binder: &'a mut Binder,
+        language_version: LanguageVersion,
         types: &'a mut TypeRegistry,
         file_node_mapper: &'a FileNodeMapper,
         diagnostics: &'a mut DiagnosticCollection,
@@ -88,10 +113,12 @@ impl<'a> Pass<'a> {
         let mut pass = Self {
             scope_stack: Vec::new(),
             binder,
+            language_version,
             types,
             file_node_mapper,
             diagnostics,
             current_receiver_type: None,
+            nested_mappings_to_skip: 0,
         };
         pass.type_getters_from(file.ir_root());
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
-use slang_solidity_v2_common::collections::Map;
-use slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter;
+use slang_solidity_v2_common::collections::{DefaultWithCapacity, Map, Set};
+use slang_solidity_v2_common::diagnostics::kinds::structure::{
+    ConflictingMappingParameterName, NamedFunctionTypeReturnParameter,
+};
+use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
@@ -191,6 +194,60 @@ impl Visitor for Pass<'_> {
         }
 
         // Keep recursing so nested function types are checked as well.
+        true
+    }
+
+    fn enter_mapping_type(&mut self, node: &ir::MappingType) -> bool {
+        // Named mapping parameters were introduced in 0.8.18; before that the
+        // parser rejects them, so there is nothing to check. The rule is that a
+        // parameter name may not be reused by another parameter in the same or a
+        // nested mapping type: the key and value names of a mapping and all of
+        // its nested value mappings form a single namespace.
+        //
+        // Each namespace is checked once, from its outermost mapping. Because a
+        // key can never be (or contain) a mapping, the value mappings of that
+        // chain are the very next mapping nodes the traversal visits, so instead
+        // of tracking their ids we just skip the next N of them. The counter
+        // reaches zero at the last chain member (before its value subtree is
+        // visited), so a mapping nested inside e.g. a function-type value is
+        // correctly treated as a new namespace root.
+        if self.language_version >= LanguageVersion::V0_8_18 {
+            if self.nested_mappings_to_skip > 0 {
+                self.nested_mappings_to_skip -= 1;
+            } else {
+                let mut seen: Set<&str> = Set::default_with_capacity(4);
+                let mut mapping = node;
+                let mut nested = 0;
+                loop {
+                    for parameter in [&mapping.key_type, &mapping.value_type] {
+                        if let Some(name) = &parameter.name
+                            && !seen.insert(name.unparse())
+                        {
+                            // Report at the offending name, so each reuse points
+                            // at a distinct, meaningful location.
+                            self.push_diagnostic(
+                                name,
+                                ConflictingMappingParameterName {
+                                    name: name.unparse().to_owned(),
+                                },
+                            );
+                        }
+                    }
+
+                    match &mapping.value_type.type_name {
+                        ir::TypeName::MappingType(inner) => {
+                            nested += 1;
+                            mapping = inner;
+                        }
+                        _ => break,
+                    }
+                }
+                self.nested_mappings_to_skip = nested;
+            }
+        }
+
+        // Keep recursing so any type references inside the key/value types are
+        // still resolved.
         true
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use slang_solidity_v2_common::collections::Map;
+use slang_solidity_v2_common::diagnostics::kinds::structure::NamedFunctionTypeReturnParameter;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
@@ -174,6 +175,23 @@ impl Visitor for Pass<'_> {
         } else {
             true
         }
+    }
+
+    fn enter_function_type(&mut self, node: &ir::FunctionType) -> bool {
+        // The return parameters of a function type may not be named. Reported
+        // here (rather than while collecting definitions) because this pass
+        // reliably visits every function type, including those nested inside
+        // another function type's parameters.
+        if let Some(returns) = &node.returns {
+            for parameter in returns.iter() {
+                if let Some(name) = &parameter.name {
+                    self.push_diagnostic(name, NamedFunctionTypeReturnParameter);
+                }
+            }
+        }
+
+        // Keep recursing so nested function types are checked as well.
+        true
     }
 
     fn enter_override_paths(&mut self, items: &ir::OverridePaths) -> bool {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
@@ -1,10 +1,13 @@
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 
 use crate::binder::{Binder, Scope, ScopeId};
 use crate::built_ins::BuiltInsResolver;
 use crate::context::{FileNodeMapper, SemanticFile};
+use crate::passes::common::node_location;
 use crate::types::TypeRegistry;
 
 mod disambiguation;
@@ -115,6 +118,16 @@ impl<'a> Pass<'a> {
             )
             .copied()
             .unwrap()
+    }
+
+    /// Emits `kind` located at `node`.
+    fn push_diagnostic(
+        &mut self,
+        node: &(impl NodeIdentity + TextRange),
+        kind: impl Into<DiagnosticKind>,
+    ) {
+        let (file_id, range) = node_location(node, self.file_node_mapper);
+        self.diagnostics.push(file_id, range, kind);
     }
 
     fn is_in_modifier_scope(&self) -> bool {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -2,13 +2,11 @@ use std::sync::Arc;
 
 use ruint::aliases::U256;
 use slang_solidity_v2_common::collections::Set;
-use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
 use slang_solidity_v2_common::diagnostics::kinds::type_system::{
     StorageLayoutBaseNonInteger, StorageLayoutBaseNotConstant, StorageLayoutBaseOutOfRange,
 };
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
-use slang_solidity_v2_ir::ir::{NodeIdentity, TextRange};
 
 use super::{Pass, ScopeFrame};
 use crate::binder::{
@@ -19,7 +17,7 @@ use crate::built_ins::BuiltInsResolver;
 use crate::passes::common::constant_evaluator::{
     ConstantResolver, EvaluationError, evaluate_compile_time_constant,
 };
-use crate::passes::common::{find_definition_namespace_scope_id, node_location};
+use crate::passes::common::find_definition_namespace_scope_id;
 use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId, UserMetaType};
 
 /// Lexical style resolution of symbols
@@ -446,15 +444,5 @@ impl Pass<'_> {
             unreachable!("the definition is not a contract");
         };
         contract_definition.base_slot = Some(base_slot);
-    }
-
-    /// Emits `kind` located at `node`.
-    fn push_diagnostic(
-        &mut self,
-        node: &(impl NodeIdentity + TextRange),
-        kind: impl Into<DiagnosticKind>,
-    ) {
-        let (file_id, range) = node_location(node, self.file_node_mapper);
-        self.diagnostics.push(file_id, range, kind);
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use slang_solidity_v2_common::collections::{DefaultWithCapacity, Set};
+use slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::NodeIdentity;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
@@ -649,5 +651,24 @@ impl Visitor for Pass<'_> {
         // All Yul is collected and resolved in `p6_resolve_yul`; this pass does
         // not resolve Yul references, so skip the assembly body entirely.
         false
+    }
+
+    fn enter_named_arguments(&mut self, items: &ir::NamedArguments) -> bool {
+        // A function call's named-argument list must not repeat a name. This is
+        // a purely structural check, but it's done here because this pass is
+        // the one that reliably visits every expression.
+        let mut seen = Set::default_with_capacity(items.len());
+        for argument in items.iter() {
+            let name = argument.name.unparse();
+            if !seen.insert(name) {
+                self.push_diagnostic(
+                    &argument.name,
+                    DuplicateNamedArgument {
+                        name: name.to_owned(),
+                    },
+                );
+            }
+        }
+        true
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/binder.rs
@@ -285,6 +285,7 @@ contract Test is Base {
     p3_type_definitions::run(
         &files,
         &mut binder,
+        language_version,
         &mut types,
         &file_node_mapper,
         &mut diagnostics,
@@ -356,6 +357,7 @@ contract Test is Base {
     p3_type_definitions::run(
         &files,
         &mut binder,
+        language_version,
         &mut types,
         &file_node_mapper,
         &mut diagnostics,
@@ -421,6 +423,7 @@ contract Test {
     p3_type_definitions::run(
         &files,
         &mut binder,
+        language_version,
         &mut types,
         &file_node_mapper,
         &mut diagnostics,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -51,6 +51,7 @@ fn analyze_with_diagnostics(language_version: LanguageVersion, source: &str) -> 
     p3_type_definitions::run(
         &files,
         &mut binder,
+        language_version,
         &mut types,
         &file_node_mapper,
         &mut diagnostics,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/user_defined_operator_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/user_defined_operator_functions.rs
@@ -38,6 +38,7 @@ fn analyze(source: &str) -> (TestFile, Binder) {
     p3_type_definitions::run(
         &files,
         &mut binder,
+        LanguageVersion::LATEST,
         &mut types,
         &file_node_mapper,
         &mut diagnostics,

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1142,6 +1142,52 @@ mod structure {
         run("structure", "break_outside_loop")
     }
 
+    mod conflicting_mapping_parameter_name {
+        use super::*;
+
+        #[test]
+        fn function_type_parameter() -> Result<()> {
+            run(
+                "structure/conflicting_mapping_parameter_name",
+                "function_type_parameter",
+            )
+        }
+
+        #[test]
+        fn function_type_value() -> Result<()> {
+            run(
+                "structure/conflicting_mapping_parameter_name",
+                "function_type_value",
+            )
+        }
+
+        #[test]
+        fn nested_multiple() -> Result<()> {
+            run(
+                "structure/conflicting_mapping_parameter_name",
+                "nested_multiple",
+            )
+        }
+
+        #[test]
+        fn nested_single() -> Result<()> {
+            run(
+                "structure/conflicting_mapping_parameter_name",
+                "nested_single",
+            )
+        }
+
+        #[test]
+        fn same_level() -> Result<()> {
+            run("structure/conflicting_mapping_parameter_name", "same_level")
+        }
+
+        #[test]
+        fn valid() -> Result<()> {
+            run("structure/conflicting_mapping_parameter_name", "valid")
+        }
+    }
+
     #[test]
     fn constructor_in_interface() -> Result<()> {
         run("structure", "constructor_in_interface")

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1400,6 +1400,11 @@ mod structure {
     }
 
     #[test]
+    fn named_function_type_return_parameter() -> Result<()> {
+        run("structure", "named_function_type_return_parameter")
+    }
+
+    #[test]
     fn nested_unchecked_block() -> Result<()> {
         run("structure", "nested_unchecked_block")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1214,6 +1214,23 @@ mod structure {
         }
     }
 
+    mod duplicate_named_argument {
+        use super::*;
+
+        #[test]
+        fn function_call() -> Result<()> {
+            run("structure/duplicate_named_argument", "function_call")
+        }
+
+        #[test]
+        fn state_variable_initializer() -> Result<()> {
+            run(
+                "structure/duplicate_named_argument",
+                "state_variable_initializer",
+            )
+        }
+    }
+
     #[test]
     fn empty_enum() -> Result<()> {
         run("structure", "empty_enum")

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:30]
+   │
+ 7 │     function(mapping(address owner => address owner) storage) internal m;
+   │                              ──┬──  
+   │                                ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:47]
+   │
+ 7 │     function(mapping(address owner => address owner) storage) internal m;
+   │                                               ──┬──  
+   │                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/slang/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'owner' in mapping.
+   ╭─[input.sol:7:47]
+   │
+ 7 │     function(mapping(address owner => address owner) storage) internal m;
+   │                                               ──┬──  
+   │                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:7:30]
+   │
+ 7 │     function(mapping(address owner => address owner) storage) internal m;
+   │                              ──┬──  
+   │                                ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:7:14]
+   │
+ 7 │     function(mapping(address owner => address owner) storage) internal m;
+   │              ───────────────────┬───────────────────  
+   │                                 ╰───────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_parameter/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Invalid: the conflict is inside a mapping nested in a function-type
+    // parameter, which is only reached once type names are traversed.
+    function(mapping(address owner => address owner) storage) internal m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:8:18]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                  ┬  
+   │                  ╰── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:8:45]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                                             ┬  
+   │                                             ╰── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:8:55]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                                                       ┬  
+   │                                                       ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.0-failure.txt
@@ -5,7 +5,7 @@ Diagnostics: 3
 [syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
    ╭─[input.sol:8:18]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                  ┬  
    │                  ╰── Error occurred here.
 ───╯
@@ -13,7 +13,7 @@ Diagnostics: 3
 [syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
    ╭─[input.sol:8:45]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                                             ┬  
    │                                             ╰── Error occurred here.
 ───╯
@@ -21,7 +21,7 @@ Diagnostics: 3
 [syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
    ╭─[input.sol:8:55]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                                                       ┬  
    │                                                       ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'a' in mapping.
+   ╭─[input.sol:8:55]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                                                       ┬  
+   │                                                       ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/slang/0.8.18-failure.txt
@@ -5,7 +5,7 @@ Diagnostics: 1
 [structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'a' in mapping.
    ╭─[input.sol:8:55]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                                                       ┬  
    │                                                       ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.0-failure.txt
@@ -5,7 +5,7 @@ Diagnostics: 1
 [ParserError 2314] Error: Expected '=>' but got identifier
    ╭─[input.sol:8:18]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                  ┬  
    │                  ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:8:18]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                  ┬  
+   │                  ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.18-failure.txt
@@ -5,7 +5,7 @@ Diagnostics: 1
 [DeclarationError 1809] Error: Conflicting parameter name "a" in mapping.
    ╭─[input.sol:8:32]
    │
- 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+ 8 │     mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
    │                                ────────────┬────────────  
    │                                            ╰────────────── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 1809] Error: Conflicting parameter name "a" in mapping.
+   ╭─[input.sol:8:32]
+   │
+ 8 │     mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+   │                                ────────────┬────────────  
+   │                                            ╰────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/input.sol
@@ -4,6 +4,6 @@ pragma solidity *;
 contract C {
     // The value type is a function type whose parameter is itself a mapping.
     // That inner mapping is a separate namespace: its `a => a` reuse is flagged,
-    // while the outer mapping (key `k`, function-type value) has no conflict.
-    mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+    // while the outer mapping (key `a`, function-type value) has no conflict.
+    mapping(uint a => function(mapping(uint a => uint a) storage) internal) m;
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/function_type_value/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The value type is a function type whose parameter is itself a mapping.
+    // That inner mapping is a separate namespace: its `a => a` reuse is flagged,
+    // while the outer mapping (key `k`, function-type value) has no conflict.
+    mapping(uint k => function(mapping(uint a => uint a) storage) internal) m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:21]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:46]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                                              ──┬──  
+   │                                                ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:63]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                                                               ──┬──  
+   │                                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/slang/0.8.18-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'owner' in mapping.
+   ╭─[input.sol:7:46]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                                              ──┬──  
+   │                                                ╰──── Error occurred here.
+───╯
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'owner' in mapping.
+   ╭─[input.sol:7:63]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                                                               ──┬──  
+   │                                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:7:21]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:7:30]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │                              ───────────────────┬───────────────────  
+   │                                                 ╰───────────────────── Error occurred here.
+───╯
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │     ────────────────────────────────┬────────────────────────────────  
+   │                                     ╰────────────────────────────────── Error occurred here.
+───╯
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     mapping(address owner => mapping(address owner => address owner)) m;
+   │     ────────────────────────────────┬────────────────────────────────  
+   │                                     ╰────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_multiple/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Invalid: `owner` is reused several times across the nested mapping; each
+    // reuse is reported at its own location.
+    mapping(address owner => mapping(address owner => address owner)) m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:21]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:46]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │                                              ──┬──  
+   │                                                ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:7:63]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │                                                               ──┬──  
+   │                                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/slang/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'owner' in mapping.
+   ╭─[input.sol:7:63]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │                                                               ──┬──  
+   │                                                                 ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:7:21]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     mapping(address owner => mapping(address hello => address owner)) m;
+   │     ────────────────────────────────┬────────────────────────────────  
+   │                                     ╰────────────────────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/nested_single/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Invalid: the outer key `owner` conflicts with the inner value `owner`,
+    // across the nested mapping.
+    mapping(address owner => mapping(address hello => address owner)) m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:6:21]
+   │
+ 6 │     mapping(address owner => address owner) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:6:38]
+   │
+ 6 │     mapping(address owner => address owner) m;
+   │                                      ──┬──  
+   │                                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/slang/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/slang/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/conflicting-mapping-parameter-name] Error: Conflicting parameter name 'owner' in mapping.
+   ╭─[input.sol:6:38]
+   │
+ 6 │     mapping(address owner => address owner) m;
+   │                                      ──┬──  
+   │                                        ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:6:21]
+   │
+ 6 │     mapping(address owner => address owner) m;
+   │                     ──┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[DeclarationError 1809] Error: Conflicting parameter name "owner" in mapping.
+   ╭─[input.sol:6:5]
+   │
+ 6 │     mapping(address owner => address owner) m;
+   │     ───────────────────┬───────────────────  
+   │                        ╰───────────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/same_level/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Invalid: the key and value parameters share the name `owner`.
+    mapping(address owner => address owner) m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:6:21]
+   │
+ 6 │     mapping(address key => mapping(address inner => address value)) m;
+   │                     ─┬─  
+   │                      ╰─── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:6:44]
+   │
+ 6 │     mapping(address key => mapping(address inner => address value)) m;
+   │                                            ──┬──  
+   │                                              ╰──── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.18'.
+   ╭─[input.sol:6:61]
+   │
+ 6 │     mapping(address key => mapping(address inner => address value)) m;
+   │                                                             ──┬──  
+   │                                                               ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/slang/0.8.18-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/slang/0.8.18-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '=>' but got identifier
+   ╭─[input.sol:6:21]
+   │
+ 6 │     mapping(address key => mapping(address inner => address value)) m;
+   │                     ─┬─  
+   │                      ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/solc/0.8.18-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/generated/solc/0.8.18-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/conflicting_mapping_parameter_name/valid/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Valid: every mapping parameter name is distinct.
+    mapping(address key => mapping(address inner => address value)) m;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/duplicate-named-argument] Error: Duplicate named argument 'a'.
+    ╭─[input.sol:11:25]
+    │
+ 11 │         return f({a: 1, a: 2});
+    │                         ┬  
+    │                         ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6995] Error: Duplicate named argument "a".
+    ╭─[input.sol:11:22]
+    │
+ 11 │         return f({a: 1, a: 2});
+    │                      ┬  
+    │                      ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/function_call/input.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+
+    // Invalid: the named argument `a` is provided twice.
+    function callWithDuplicate() public pure returns (uint256) {
+        return f({a: 1, a: 2});
+    }
+
+    // Valid: each named argument is distinct.
+    function callValid() public pure returns (uint256) {
+        return f({a: 1, b: 2});
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/duplicate-named-argument] Error: Duplicate named argument 'a'.
+    ╭─[input.sol:13:20]
+    │
+ 13 │     S s = S({a: 1, a: 2});
+    │                    ┬  
+    │                    ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6995] Error: Duplicate named argument "a".
+    ╭─[input.sol:13:17]
+    │
+ 13 │     S s = S({a: 1, a: 2});
+    │                 ┬  
+    │                 ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_named_argument/state_variable_initializer/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+struct S {
+    uint256 a;
+    uint256 b;
+}
+
+contract C {
+    // Invalid: the named argument `a` is provided twice, here in a state
+    // variable initializer rather than a function body, to exercise the check
+    // outside of statement position.
+    S s = S({a: 1, a: 2});
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[structure/named-function-type-return-parameter] Error: Return parameters in function types may not be named.
+   ╭─[input.sol:6:42]
+   │
+ 6 │     function() external returns (uint256 x) a;
+   │                                          ┬  
+   │                                          ╰── Error occurred here.
+───╯
+
+[structure/named-function-type-return-parameter] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:10:51]
+    │
+ 10 │     function(function() external returns (uint256 inner)) external b;
+    │                                                   ──┬──  
+    │                                                     ╰──── Error occurred here.
+────╯
+
+[structure/named-function-type-return-parameter] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:13:42]
+    │
+ 13 │     function() external returns (uint256 p, uint256 q) c;
+    │                                          ┬  
+    │                                          ╰── Error occurred here.
+────╯
+
+[structure/named-function-type-return-parameter] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:13:53]
+    │
+ 13 │     function() external returns (uint256 p, uint256 q) c;
+    │                                                     ┬  
+    │                                                     ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[SyntaxError 7304] Error: Return parameters in function types may not be named.
+   ╭─[input.sol:6:34]
+   │
+ 6 │     function() external returns (uint256 x) a;
+   │                                  ────┬────  
+   │                                      ╰────── Error occurred here.
+───╯
+
+[SyntaxError 7304] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:10:43]
+    │
+ 10 │     function(function() external returns (uint256 inner)) external b;
+    │                                           ──────┬──────  
+    │                                                 ╰──────── Error occurred here.
+────╯
+
+[SyntaxError 7304] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:13:34]
+    │
+ 13 │     function() external returns (uint256 p, uint256 q) c;
+    │                                  ────┬────  
+    │                                      ╰────── Error occurred here.
+────╯
+
+[SyntaxError 7304] Error: Return parameters in function types may not be named.
+    ╭─[input.sol:13:45]
+    │
+ 13 │     function() external returns (uint256 p, uint256 q) c;
+    │                                             ────┬────  
+    │                                                 ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/named_function_type_return_parameter/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Invalid: named return parameter in a function type.
+    function() external returns (uint256 x) a;
+
+    // Invalid: named return parameter in a function type that is nested inside
+    // another function type's parameter list.
+    function(function() external returns (uint256 inner)) external b;
+
+    // Invalid: each named return parameter is flagged.
+    function() external returns (uint256 p, uint256 q) c;
+
+    // Valid: unnamed return parameters.
+    function(uint256) external returns (uint256) d;
+}


### PR DESCRIPTION
Closes NomicFoundation/slang-diagnostics-research#1417: duplicate named arguments
Closes NomicFoundation/slang-diagnostics-research#1442: named return params in function types
Closes NomicFoundation/slang-diagnostics-research#782: conflicting parameter names in mapping types
