### PR TITLE
[v2] feat(diagnostics): detect cyclic contract bytecode dependencies

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -495,6 +495,8 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibrar
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::semantic
 pub enum slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::BytecodeDependencyValidatorExhausted(slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted)
+pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicBytecodeDependency(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency)
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicConstantDefinition(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition)
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicConstantDependency(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency)
 pub slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::CyclicDependencyValidatorExhausted(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicDependencyValidatorExhausted)
@@ -507,6 +509,10 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosti
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
@@ -532,6 +538,44 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency> for slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::SemanticDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition
@@ -2579,6 +2623,10 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolutio
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::NonFreeOrLibraryFunctionInUsingDirective) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDependency> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2907,6 +2955,14 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::resolution::ResolutionDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::BytecodeDependencyValidatorExhausted::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicConstantDefinition::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/bytecode_dependency_validator_exhausted.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/bytecode_dependency_validator_exhausted.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted at the contract where the bytecode dependency cycle
+/// detection gave up on a dependency path longer than its depth limit.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BytecodeDependencyValidatorExhausted;
+
+impl DiagnosticExtensions for BytecodeDependencyValidatorExhausted {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "semantic/bytecode-dependency-validator-exhausted"
+    }
+
+    fn message(&self) -> String {
+        "Contract dependencies exhausting cyclic dependency validator.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/cyclic_bytecode_dependency.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/cyclic_bytecode_dependency.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted at the `new` expression or `type(...).creationCode` /
+/// `type(...).runtimeCode` access through which a contract reaches a cycle in
+/// the contract bytecode dependency graph.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CyclicBytecodeDependency;
+
+impl DiagnosticExtensions for CyclicBytecodeDependency {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "semantic/cyclic-bytecode-dependency"
+    }
+
+    fn message(&self) -> String {
+        "Circular contract bytecode dependency.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/semantic/mod.rs
@@ -1,3 +1,5 @@
+mod bytecode_dependency_validator_exhausted;
+mod cyclic_bytecode_dependency;
 mod cyclic_constant_definition;
 mod cyclic_constant_dependency;
 mod cyclic_dependency_validator_exhausted;
@@ -6,6 +8,8 @@ mod linearisation_impossible;
 mod recursive_struct;
 mod recursive_struct_validator_exhausted;
 
+pub use bytecode_dependency_validator_exhausted::BytecodeDependencyValidatorExhausted;
+pub use cyclic_bytecode_dependency::CyclicBytecodeDependency;
 pub use cyclic_constant_definition::CyclicConstantDefinition;
 pub use cyclic_constant_dependency::CyclicConstantDependency;
 pub use cyclic_dependency_validator_exhausted::CyclicDependencyValidatorExhausted;
@@ -24,6 +28,12 @@ define_diagnostic_kind! {
     /// Group of diagnostics produced by semantic analysis.
     #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
     pub enum SemanticDiagnosticKind {
+        /// Contract bytecode dependency graph traversal exceeded the depth
+        /// limit.
+        BytecodeDependencyValidatorExhausted(BytecodeDependencyValidatorExhausted),
+        /// A contract references its own bytecode through a cycle of `new`
+        /// or `type(...).creationCode` / `type(...).runtimeCode` uses.
+        CyclicBytecodeDependency(CyclicBytecodeDependency),
         /// Compile-time constant evaluation hit a cycle or exceeded the
         /// recursion limit.
         CyclicConstantDefinition(CyclicConstantDefinition),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -111,6 +111,7 @@ impl SemanticContext {
         p7_contract_properties::run(&binder, &mut contract_data, &types);
         p8_code_analysis::run(
             &binder,
+            &contract_data,
             language_version,
             evm_target,
             &file_node_mapper,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/bytecode.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/bytecode.rs
@@ -1,0 +1,63 @@
+use std::ops::Range;
+
+use slang_solidity_v2_common::collections::Set;
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::diagnostics::kinds::semantic::{
+    BytecodeDependencyValidatorExhausted, CyclicBytecodeDependency,
+};
+use slang_solidity_v2_common::nodes::NodeId;
+
+use super::{CycleSearchResult, DependencyGraph};
+use crate::binder::{Binder, Definition};
+use crate::context::{ContractData, FileNodeMapper};
+
+pub(super) fn detect_bytecode_dependency_cycles(
+    binder: &Binder,
+    contract_data: &ContractData,
+    file_node_mapper: &FileNodeMapper,
+    diagnostics: &mut DiagnosticCollection,
+) {
+    let dependencies = contract_data.contract_dependencies();
+    let edges = dependencies
+        .iter()
+        .map(|(contract_id, targets)| (*contract_id, targets.keys().copied().collect()))
+        .collect();
+    let graph = DependencyGraph::new(edges);
+
+    let mut reported_references = Set::default();
+    for (contract_id, result) in graph.find_all_cycles() {
+        match result {
+            CycleSearchResult::Cycle { via } => {
+                let reference = &dependencies[&contract_id][&via];
+                // Each referencing expression is reported once, even when
+                // several contracts reach the cycle through it.
+                if reported_references.insert(reference.node_id()) {
+                    diagnostics.push(
+                        file_node_mapper
+                            .file_id_from_node_id(reference.node_id())
+                            .clone(),
+                        reference.range(),
+                        CyclicBytecodeDependency,
+                    );
+                }
+            }
+            CycleSearchResult::DepthExceeded { node } => {
+                diagnostics.push(
+                    file_node_mapper.file_id_from_node_id(node).clone(),
+                    contract_range(binder, node),
+                    BytecodeDependencyValidatorExhausted,
+                );
+            }
+            CycleSearchResult::None => unreachable!("cycle-free nodes are not returned"),
+        }
+    }
+}
+
+fn contract_range(binder: &Binder, contract_id: NodeId) -> Range<usize> {
+    match binder.find_definition_by_id(contract_id) {
+        Some(Definition::Contract(contract)) => contract.ir_node.range.clone(),
+        Some(Definition::Interface(interface)) => interface.ir_node.range.clone(),
+        Some(Definition::Library(library)) => library.ir_node.range.clone(),
+        _ => panic!("graph nodes should be contract definitions"),
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/mod.rs
@@ -3,20 +3,28 @@ use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use crate::binder::Binder;
-use crate::context::FileNodeMapper;
+use crate::context::{ContractData, FileNodeMapper};
 use crate::types::TypeRegistry;
 
+mod bytecode;
 mod constants;
 mod structs;
 
 pub(crate) fn run(
     binder: &Binder,
+    contract_data: &ContractData,
     types: &TypeRegistry,
     file_node_mapper: &FileNodeMapper,
     diagnostics: &mut DiagnosticCollection,
 ) {
     constants::detect_constant_value_dependency_cycles(binder, file_node_mapper, diagnostics);
     structs::detect_recursive_structs(binder, types, file_node_mapper, diagnostics);
+    bytecode::detect_bytecode_dependency_cycles(
+        binder,
+        contract_data,
+        file_node_mapper,
+        diagnostics,
+    );
 }
 
 struct DependencyGraph {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/mod.rs
@@ -8,7 +8,7 @@ use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
 
 use crate::binder::Binder;
-use crate::context::FileNodeMapper;
+use crate::context::{ContractData, FileNodeMapper};
 use crate::types::TypeRegistry;
 
 /// This pass hosts analyses that emit diagnostics over the fully resolved
@@ -16,13 +16,14 @@ use crate::types::TypeRegistry;
 /// It produces no data for later consumption.
 pub fn run(
     binder: &Binder,
+    contract_data: &ContractData,
     language_version: LanguageVersion,
     evm_target: EvmTarget,
     file_node_mapper: &FileNodeMapper,
     types: &TypeRegistry,
     diagnostics: &mut DiagnosticCollection,
 ) {
-    cycle_detection::run(binder, types, file_node_mapper, diagnostics);
+    cycle_detection::run(binder, contract_data, types, file_node_mapper, diagnostics);
 
     built_ins::validate_built_in_references(
         binder,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/contract_dependencies.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/contract_dependencies.rs
@@ -5,6 +5,8 @@
 //! expression than solc for a dependency they both find.
 
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
+use slang_solidity_v2_common::diagnostics::kinds::semantic::CyclicBytecodeDependency;
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -15,6 +17,17 @@ use crate::binder::Definition;
 use crate::context::SemanticContext;
 
 fn build_context(source: &str) -> SemanticContext {
+    let (context, diagnostics) = build_context_with_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "Semantic diagnostics: {diagnostics:?}"
+    );
+    context
+}
+
+/// Builds the context without asserting on the diagnostics, for sources
+/// whose dependencies form a cycle.
+fn build_context_with_diagnostics(source: &str) -> (SemanticContext, DiagnosticCollection) {
     let mut id_generator = NodeIdGenerator::default();
     let file = build_file(
         "test.sol".into(),
@@ -32,11 +45,7 @@ fn build_context(source: &str) -> SemanticContext {
         None,
         &mut diagnostics,
     );
-    assert!(
-        diagnostics.is_empty(),
-        "Semantic diagnostics: {diagnostics:?}"
-    );
-    context
+    (context, diagnostics)
 }
 
 fn contract_id(context: &SemanticContext, name: &str) -> NodeId {
@@ -429,7 +438,20 @@ fn code_access_records_a_deployed_dependency_for_the_library() {
                 return type(L).creationCode;
             }
         }";
-    let context = build_context(source);
+    let (context, diagnostics) = build_context_with_diagnostics(source);
+    // The self dependency is reported as a cycle at the code access.
+    let diagnostics: Vec<_> = diagnostics.iter().collect();
+    let [diagnostic] = diagnostics[..] else {
+        panic!("Expected one diagnostic: {diagnostics:?}");
+    };
+    assert_eq!(
+        DiagnosticKind::from(CyclicBytecodeDependency),
+        *diagnostic.kind()
+    );
+    assert_eq!(
+        "type(L).creationCode",
+        &source[diagnostic.text_range().clone()]
+    );
 
     let l = library_id(&context, "L");
 
@@ -476,7 +498,20 @@ fn a_constant_embedding_the_reader_records_a_self_dependency() {
         contract A {
             function f() public pure returns (bytes memory) { return B.CODE; }
         }";
-    let context = build_context(source);
+    let (context, diagnostics) = build_context_with_diagnostics(source);
+    // The self dependency is reported as a cycle at the code access.
+    let diagnostics: Vec<_> = diagnostics.iter().collect();
+    let [diagnostic] = diagnostics[..] else {
+        panic!("Expected one diagnostic: {diagnostics:?}");
+    };
+    assert_eq!(
+        DiagnosticKind::from(CyclicBytecodeDependency),
+        *diagnostic.kind()
+    );
+    assert_eq!(
+        "type(A).creationCode",
+        &source[diagnostic.text_range().clone()]
+    );
 
     let a = contract_id(&context, "A");
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/runner.rs
@@ -106,6 +106,15 @@ fn compare_outcomes(
         .zip(solc_outcomes)
         .all(|(slang, solc)| slang.status == solc.status);
     if statuses_match {
+        if config.expected_solc_divergence {
+            bail!(
+                "`{group_name}/{test_name}` is marked `expected_solc_divergence`, but slang and \
+                 solc agree on every compilation status. Remove the marker."
+            );
+        }
+        return Ok(());
+    }
+    if config.expected_solc_divergence {
         return Ok(());
     }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -868,6 +868,293 @@ mod resolution {
 mod semantic {
     use super::*;
 
+    mod bytecode_cycles {
+        use super::*;
+
+        #[test]
+        fn abstract_contract_reaching_cycle() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "abstract_contract_reaching_cycle",
+            )
+        }
+
+        #[test]
+        fn attached_function_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "attached_function_cycle")
+        }
+
+        #[test]
+        fn attached_function_on_contract_value() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "attached_function_on_contract_value",
+            )
+        }
+
+        #[test]
+        fn base_constructor_and_derived_initializer() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "base_constructor_and_derived_initializer",
+            )
+        }
+
+        #[test]
+        fn base_constructor_arguments() -> Result<()> {
+            run("semantic/bytecode_cycles", "base_constructor_arguments")
+        }
+
+        #[test]
+        fn base_constructor_modifier_arguments() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "base_constructor_modifier_arguments",
+            )
+        }
+
+        #[test]
+        fn chain_reaching_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "chain_reaching_cycle")
+        }
+
+        #[test]
+        fn constant_getter_override_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "constant_getter_override_cycle")
+        }
+
+        #[test]
+        fn constant_value_attribution() -> Result<()> {
+            run("semantic/bytecode_cycles", "constant_value_attribution")
+        }
+
+        #[test]
+        fn creation_code_of_base() -> Result<()> {
+            run("semantic/bytecode_cycles", "creation_code_of_base")
+        }
+
+        #[test]
+        fn creation_code_of_self_and_base() -> Result<()> {
+            run("semantic/bytecode_cycles", "creation_code_of_self_and_base")
+        }
+
+        #[test]
+        fn diamond_super_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "diamond_super_cycle")
+        }
+
+        #[test]
+        fn external_call_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "external_call_no_cycle")
+        }
+
+        #[test]
+        fn free_function_call_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "free_function_call_cycle")
+        }
+
+        #[test]
+        fn function_and_fallback_attribution() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "function_and_fallback_attribution",
+            )
+        }
+
+        #[test]
+        fn function_pointer_reference() -> Result<()> {
+            run("semantic/bytecode_cycles", "function_pointer_reference")
+        }
+
+        #[test]
+        fn getter_override_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "getter_override_no_cycle")
+        }
+
+        #[test]
+        fn import_alias_constant_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "import_alias_constant_cycle")
+        }
+
+        #[test]
+        fn imported_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "imported_cycle")
+        }
+
+        #[test]
+        fn inherited_entry_point_attribution() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "inherited_entry_point_attribution",
+            )
+        }
+
+        #[test]
+        fn inherited_public_constant_getter() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "inherited_public_constant_getter",
+            )
+        }
+
+        #[test]
+        fn inherited_shared_site() -> Result<()> {
+            run("semantic/bytecode_cycles", "inherited_shared_site")
+        }
+
+        #[test]
+        fn internal_library_call_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "internal_library_call_cycle")
+        }
+
+        #[test]
+        fn library_creation_code_of_self() -> Result<()> {
+            run("semantic/bytecode_cycles", "library_creation_code_of_self")
+        }
+
+        #[test]
+        fn library_public_constant_getter() -> Result<()> {
+            run("semantic/bytecode_cycles", "library_public_constant_getter")
+        }
+
+        #[test]
+        fn member_access_constant_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "member_access_constant_cycle")
+        }
+
+        #[test]
+        fn member_access_public_constant_cycle() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "member_access_public_constant_cycle",
+            )
+        }
+
+        #[test]
+        fn modifier_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "modifier_cycle")
+        }
+
+        #[test]
+        fn modifier_invocation_arguments() -> Result<()> {
+            run("semantic/bytecode_cycles", "modifier_invocation_arguments")
+        }
+
+        #[test]
+        fn mutual_state_variables() -> Result<()> {
+            run("semantic/bytecode_cycles", "mutual_state_variables")
+        }
+
+        #[test]
+        fn new_in_constructor() -> Result<()> {
+            run("semantic/bytecode_cycles", "new_in_constructor")
+        }
+
+        #[test]
+        fn private_library_function_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "private_library_function_cycle")
+        }
+
+        #[test]
+        fn public_constant_getter() -> Result<()> {
+            run("semantic/bytecode_cycles", "public_constant_getter")
+        }
+
+        #[test]
+        fn public_constant_getter_of_self() -> Result<()> {
+            run("semantic/bytecode_cycles", "public_constant_getter_of_self")
+        }
+
+        #[test]
+        fn public_library_call_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "public_library_call_no_cycle")
+        }
+
+        #[test]
+        fn qualified_modifier_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "qualified_modifier_cycle")
+        }
+
+        #[test]
+        fn qualified_modifier_override_no_cycle() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "qualified_modifier_override_no_cycle",
+            )
+        }
+
+        #[test]
+        fn receive_and_fallback_attribution() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "receive_and_fallback_attribution",
+            )
+        }
+
+        #[test]
+        fn referenced_constant_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "referenced_constant_cycle")
+        }
+
+        #[test]
+        fn runtime_code_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "runtime_code_cycle")
+        }
+
+        #[test]
+        fn selector_access_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "selector_access_no_cycle")
+        }
+
+        #[test]
+        fn shared_dependency_attribution() -> Result<()> {
+            run("semantic/bytecode_cycles", "shared_dependency_attribution")
+        }
+
+        #[test]
+        fn super_call_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "super_call_cycle")
+        }
+
+        #[test]
+        fn super_unimplemented_override_cycle() -> Result<()> {
+            run(
+                "semantic/bytecode_cycles",
+                "super_unimplemented_override_cycle",
+            )
+        }
+
+        #[test]
+        fn three_contract_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "three_contract_cycle")
+        }
+
+        #[test]
+        fn unreferenced_constant_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "unreferenced_constant_no_cycle")
+        }
+
+        #[test]
+        fn unused_overload_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "unused_overload_no_cycle")
+        }
+
+        #[test]
+        fn user_defined_operator_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "user_defined_operator_cycle")
+        }
+
+        #[test]
+        fn validator_exhausted() -> Result<()> {
+            run("semantic/bytecode_cycles", "validator_exhausted")
+        }
+
+        #[test]
+        fn virtual_override_no_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "virtual_override_no_cycle")
+        }
+    }
+
     mod constant_cycles {
         use super::*;
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/snapshots/config.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/snapshots/config.rs
@@ -14,6 +14,10 @@ const CONFIG_FILE_NAME: &str = ".tests.config.json";
 #[derive(Clone, Copy, Debug)]
 pub struct TestConfig {
     pub matrix: TestMatrix,
+    /// Whether slang and solc are expected to disagree on the compilation
+    /// status of at least one matrix entry. Snapshots for both are still
+    /// generated, keeping the divergence visible.
+    pub expected_solc_divergence: bool,
 }
 
 /// Configuration controlling how a snapshot test iterates over the
@@ -68,6 +72,11 @@ impl TestConfig {
 #[serde(deny_unknown_fields)]
 struct RawConfigFile {
     matrix: RawTestMatrix,
+    /// Reason why slang intentionally diverges from solc on this test (for
+    /// documentation purposes). The runner requires the divergence to occur,
+    /// so the marker cannot go stale.
+    #[serde(default)]
+    expected_solc_divergence: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -103,6 +112,17 @@ impl From<RawConfigFile> for TestConfig {
             }
         };
 
-        Self { matrix }
+        let expected_solc_divergence = match raw.expected_solc_divergence {
+            Some(reason) => {
+                assert!(!reason.trim().is_empty(), "Reason must be non-empty");
+                true
+            }
+            None => false,
+        };
+
+        Self {
+            matrix,
+            expected_solc_divergence,
+        }
     }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:11]
+   │
+ 9 │     B x = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:13:11]
+    │
+ 13 │     C x = new C();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:17:11]
+    │
+ 17 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:17:11]
+    │
+ 17 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:11]
+   │
+ 9 │     B x = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:13:11]
+    │
+ 13 │     C x = new C();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:17:11]
+    │
+ 17 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/abstract_contract_reaching_cycle/input.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A is abstract, so it is never deployed and nothing can embed its bytecode.
+// Its initializer still reaches the B and C cycle, so it reports like any
+// other contract.
+
+abstract contract A {
+    B x = new B();
+}
+
+contract B {
+    C x = new C();
+}
+
+contract C {
+    B x = new B();
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_cycle/input.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A function attached with `using for` executes within the caller's
+// bytecode when it is an internal library function.
+
+library L {
+    function g(uint256) internal {
+        new C();
+    }
+}
+
+contract C {
+    using L for uint256;
+
+    function h() public {
+        uint256 x;
+        x.g();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:23:9]
+    │
+ 23 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 5667] Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
+   ╭─[input.sol:8:16]
+   │
+ 8 │     function g(C self) internal {
+   │                ───┬──  
+   │                   ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:23:9]
+    │
+ 23 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/attached_function_on_contract_value/input.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `using L for C` attaches g to values of the contract type C. The call
+// runs within the caller's bytecode like any internal library call.
+
+library L {
+    function g(C self) internal {
+        new B();
+    }
+}
+
+contract C {
+    using L for C;
+
+    function f(C other) public {
+        other.g();
+    }
+}
+
+contract B {
+    constructor() {
+        new C();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new Mid();
+    │         ───┬───  
+    │            ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new Mid();
+    │         ───┬───  
+    │            ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:19:11]
+    │
+ 19 │     D d = new D();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new Mid();
+    │         ───┬───  
+    │            ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_and_derived_initializer/input.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Base's constructor and Mid's initializer both create D. Slang puts every
+// creation unit on one queue, so Base's constructor is walked before Mid's
+// initializer and Mid is attributed to Base's `new D()`. That expression was
+// already reported for Base, so the second report is dropped. solc visits
+// every base's initializers before any constructor body, attributes Mid to
+// its own initializer, and reports all three. Both agree that Mid depends on
+// D, only the expression standing for it differs.
+
+contract Base {
+    constructor() {
+        new D();
+    }
+}
+
+contract Mid is Base {
+    D d = new D();
+}
+
+contract D {
+    constructor() {
+        new Mid();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     new B();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:5]
+   │
+ 8 │     new B();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_arguments/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Base constructor arguments run during B's creation, so the creation inside
+// the free function belongs to B.
+
+function f() returns (uint256) {
+    new B();
+    return 0;
+}
+
+contract A {
+    constructor(uint256) {}
+}
+
+contract B is A(f()) {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:16:5]
+    │
+ 16 │     new B();
+    │     ──┬──  
+    │       ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:22:9]
+    │
+ 22 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:16:5]
+    │
+ 16 │     new B();
+    │     ──┬──  
+    │       ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:22:9]
+    │
+ 22 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/base_constructor_modifier_arguments/input.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Base constructor arguments written as a constructor modifier run when
+// the deriving contract is created.
+
+contract A {
+    constructor(uint256 x) {}
+}
+
+contract C is A {
+    constructor() A(f()) {}
+}
+
+function f() returns (uint256) {
+    new B();
+    return 0;
+}
+
+contract B {
+    constructor() {
+        new C();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:7:11]
+   │
+ 7 │     B x = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:11]
+    │
+ 11 │     C x = new C();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:15:11]
+    │
+ 15 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:15:11]
+    │
+ 15 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:7:11]
+   │
+ 7 │     B x = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:11:11]
+    │
+ 11 │     C x = new C();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:11]
+    │
+ 15 │     B x = new B();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/chain_reaching_cycle/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A is not part of the B and C cycle but reaches it, so it also reports.
+
+contract A {
+    B x = new B();
+}
+
+contract B {
+    C x = new C();
+}
+
+contract C {
+    B x = new B();
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4224 on any code access to the enclosing contract, without reachability analysis. Since '0.8.4' solc leaves getters out of its reachability analysis, so it never records the dependency and accepts this program, then fails with an internal error during code generation. Slang counts a public constant's getter as an entry point and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:12:40]
+    │
+ 12 │     bytes public constant override x = type(B).creationCode;
+    │                                        ──────────┬─────────  
+    │                                                  ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+    ╭─[input.sol:12:40]
+    │
+ 12 │     bytes public constant override x = type(B).creationCode;
+    │                                        ──────────┬─────────  
+    │                                                  ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_getter_override_cycle/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant overrides x. Its getter serves the selector, so B's deployed
+// code embeds B's own creation code.
+
+abstract contract Base {
+    function x() external pure virtual returns (bytes memory);
+}
+
+contract B is Base {
+    bytes public constant override x = type(B).creationCode;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc had no reachability analysis and only rejected a code access written inside the accessed contract, so it accepts this program. Slang implements the '0.8.4' call graph semantics for every version and reports the cycle on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:12:20]
+    │
+ 12 │ bytes constant K = type(X).creationCode;
+    │                    ──────────┬─────────  
+    │                              ╰─────────── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:23:36]
+    │
+ 23 │         return abi.encodePacked(a, type(X).creationCode);
+    │                                    ──────────┬─────────  
+    │                                              ╰─────────── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:29:9]
+    │
+ 29 │         new Base();
+    │         ────┬───  
+    │             ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:12:20]
+    │
+ 12 │ bytes constant K = type(X).creationCode;
+    │                    ──────────┬─────────  
+    │                              ╰─────────── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:29:9]
+    │
+ 29 │         new Base();
+    │         ────┬───  
+    │             ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/constant_value_attribution/input.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Base reaches X only through the constant. Derived reaches it through the
+// constant and through its own expression. A unit's own references are
+// recorded before the constants it uses, so slang reports Derived's own
+// expression and Base's constant separately. solc compiles a constant in
+// where it is used, reports the constant's expression for both, and emits
+// one error less. The dependency itself is the same either way, only the
+// expression standing for it differs, so slang keeps the cheaper order.
+
+bytes constant K = type(X).creationCode;
+
+contract Base {
+    function f() public pure returns (bytes memory) {
+        return K;
+    }
+}
+
+contract Derived is Base {
+    function g() public pure returns (bytes memory) {
+        bytes memory a = K;
+        return abi.encodePacked(a, type(X).creationCode);
+    }
+}
+
+contract X {
+    constructor() {
+        new Base();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_base/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accessing a base's creation code embeds the base's bytecode in the derived
+// contract, but not the other way around, so there is no cycle.
+
+contract Base {
+    function f() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract Test is Base {
+    function creationBase() public pure returns (bytes memory) {
+        return type(Base).creationCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:15:16]
+    │
+ 15 │         return type(Test1).creationCode;
+    │                ────────────┬───────────  
+    │                            ╰───────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+    ╭─[input.sol:15:16]
+    │
+ 15 │         return type(Test1).creationCode;
+    │                ────────────┬───────────  
+    │                            ╰───────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:16]
+    │
+ 15 │         return type(Test1).creationCode;
+    │                ────────────┬───────────  
+    │                            ╰───────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/creation_code_of_self_and_base/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accessing your own creation code is a cycle. Accessing a base's creation
+// code is not, since inheritance embeds no bytecode.
+
+contract Base {
+    function f() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract Test1 is Base {
+    function creation() public pure returns (bytes memory) {
+        return type(Test1).creationCode;
+    }
+}
+
+contract Test2 is Base {
+    function creationBase() public pure returns (bytes memory) {
+        return type(Base).creationCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/diamond_super_cycle/input.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// In D's bytecode, `super.f()` inside C resolves along D's linearisation to
+// B.f, which creates D. Resolving super along C's own linearisation would
+// miss the cycle.
+
+contract A {
+    function f() public virtual {}
+}
+
+contract B is A {
+    function f() public virtual override {
+        new D();
+    }
+}
+
+contract C is A {
+    function f() public virtual override {
+        super.f();
+    }
+}
+
+contract D is B, C {
+    function f() public override(B, C) {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/external_call_no_cycle/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// External calls run in the callee's already deployed bytecode, so no
+// bytecode is embedded and there is no cycle.
+
+contract A {
+    B b;
+
+    function f() public {
+        b.g();
+    }
+}
+
+contract B {
+    function g() public {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:23:5]
+    │
+ 23 │     new C();
+    │     ──┬──  
+    │       ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:23:5]
+    │
+ 23 │     new C();
+    │     ──┬──  
+    │       ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/free_function_call_cycle/input.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The cycle runs through two free function calls.
+
+contract D {
+    function f() public {
+        l();
+    }
+}
+
+contract C {
+    constructor() {
+        new D();
+    }
+}
+
+function l() {
+    s();
+}
+
+function s() {
+    new C();
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:12:9]
+    │
+ 12 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:22:9]
+    │
+ 22 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:22:9]
+    │
+ 22 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:16:16]
+    │
+ 16 │         return type(B).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:22:9]
+    │
+ 22 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_and_fallback_attribution/input.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The named function and the fallback both reference B. Slang walks the
+// linearised function list, which puts the unnamed fallback first, so it
+// reports the fallback. solc walks the external interface first and only
+// then the fallback, so it reports `f`. The dependency is the same either
+// way, only the expression standing for it differs.
+
+contract A {
+    fallback() external {
+        new B();
+    }
+
+    function f() public pure returns (bytes memory) {
+        return type(B).creationCode;
+    }
+}
+
+contract B {
+    constructor() {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     new D();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:5]
+   │
+ 8 │     new D();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/function_pointer_reference/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `f` is only referenced as a value, never called. It could still run
+// through the function pointer, so its body is reachable.
+
+function f() {
+    new D();
+}
+
+contract D {
+    function() internal ptr = f;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4579 on the `new D()` written inside `Base`, without reachability analysis. Slang implements the '0.8.4' call graph semantics for every version and accepts this on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/getter_override_no_cycle/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// D's generated getter serves x's selector, so Base.x's body is not part of
+// D's deployed bytecode. Only Base embeds D, which is no cycle.
+
+contract Base {
+    function x() external virtual returns (uint256) {
+        new D();
+        return 0;
+    }
+}
+
+contract D is Base {
+    uint256 public override x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc's reachability analysis does not follow constants referenced as members, so it never records A's dependency on itself and accepts this program on every version, then fails with an internal error during code generation. Slang follows the reference and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[other.sol:6:23]
+   │
+ 6 │ bytes constant CODE = type(A).creationCode;
+   │                       ──────────┬─────────  
+   │                                 ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_constant_cycle/input.sol
@@ -1,0 +1,22 @@
+// ---- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./other.sol" as M;
+
+// f compiles the file level constant's value in, so A's deployed code
+// embeds A's own creation code.
+
+contract A {
+    function f() public pure returns (bytes memory) {
+        return M.CODE;
+    }
+}
+
+// ---- path: other.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./main.sol";
+
+bytes constant CODE = type(A).creationCode;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[main.sol:10:9]
+    │
+ 10 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[other.sol:8:9]
+   │
+ 8 │         new A();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[main.sol:10:9]
+    │
+ 10 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[other.sol:8:9]
+   │
+ 8 │         new A();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[main.sol:10:9]
+    │
+ 10 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/imported_cycle/input.sol
@@ -1,0 +1,25 @@
+// ---- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./other.sol";
+
+// The cycle spans two files importing each other.
+
+contract A {
+    function f() public {
+        new B();
+    }
+}
+
+// ---- path: other.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./main.sol";
+
+contract B {
+    function g() public {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new X();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:30:9]
+    │
+ 30 │         new Base();
+    │         ────┬───  
+    │             ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:30:9]
+    │
+ 30 │         new Base();
+    │         ────┬───  
+    │             ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:18:16]
+    │
+ 18 │         return type(X).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new X();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:30:9]
+    │
+ 30 │         new Base();
+    │         ────┬───  
+    │             ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_entry_point_attribution/input.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Base and Derived both reach X, and Derived inherits the fallback. Slang
+// walks entry points in linearised function list order, which puts the
+// unnamed fallback first for both contracts, so both are attributed to the
+// same `new X()` and the second report is dropped as already reported. solc
+// walks the external interface functions before the fallback, attributes
+// Base to `f` and Derived to `g`, and reports both. The dependencies
+// themselves match, only the expressions standing for them differ.
+
+contract Base {
+    fallback() external {
+        new X();
+    }
+
+    function f() public pure returns (bytes memory) {
+        return type(X).creationCode;
+    }
+}
+
+contract Derived is Base {
+    function g() public {
+        new X();
+    }
+}
+
+contract X {
+    constructor() {
+        new Base();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4224 on any code access to a deriving contract, without reachability analysis. Since '0.8.4' solc leaves getters out of its reachability analysis, so it never records the dependency and accepts this program, then fails with an internal error during code generation. Slang counts a public constant's getter as an entry point and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:34]
+   │
+ 8 │     bytes public constant CODE = type(Derived).creationCode;
+   │                                  ─────────────┬────────────  
+   │                                               ╰────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+   ╭─[input.sol:8:34]
+   │
+ 8 │     bytes public constant CODE = type(Derived).creationCode;
+   │                                  ─────────────┬────────────  
+   │                                               ╰────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_public_constant_getter/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Derived inherits the constant. Its getter serves the selector in both
+// contracts, so Derived's deployed code embeds Derived's own creation code.
+
+contract Base {
+    bytes public constant CODE = type(Derived).creationCode;
+}
+
+contract Derived is Base {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:15:9]
+    │
+ 15 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:15:9]
+    │
+ 15 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:9]
+    │
+ 15 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/inherited_shared_site/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// D inherits foo from C, so both depend on A through the same `new A`
+// expression. Each referencing expression is reported only once.
+
+contract A {
+    function foo() public {
+        new D();
+    }
+}
+
+contract C {
+    function foo() public {
+        new A();
+    }
+}
+
+contract D is C {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new D();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/internal_library_call_cycle/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Internal library functions execute within the caller's bytecode, so the
+// creation inside `L.f` belongs to D.
+
+library L {
+    function f() internal {
+        new C();
+    }
+}
+
+contract D {
+    function f() public {
+        L.f();
+    }
+}
+
+contract C {
+    constructor() {
+        new D();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc detects bytecode cycles across all function calls only since '0.8.4'. Slang implements the '0.8.4' semantics for every version, so it also reports this cycle on '0.8.0' to '0.8.3', where solc misses it."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:15:16]
+    │
+ 15 │         return type(L1).creationCode;
+    │                ──────────┬──────────  
+    │                          ╰──────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:16]
+    │
+ 15 │         return type(L1).creationCode;
+    │                ──────────┬──────────  
+    │                          ╰──────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_creation_code_of_self/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The library's public function reaches an access to the library's own
+// creation code through an internal function of another library.
+
+library L1 {
+    function foo() public pure returns (bytes memory) {
+        return L2.foo();
+    }
+}
+
+library L2 {
+    function foo() internal pure returns (bytes memory) {
+        return type(L1).creationCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4224 on any code access to the enclosing library, without reachability analysis. Since '0.8.4' solc leaves getters out of its reachability analysis, so it never records the dependency and accepts this program, then fails with an internal error during code generation. Slang counts a public constant's getter as an entry point and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:7:34]
+   │
+ 7 │     bytes public constant CODE = type(L).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+   ╭─[input.sol:7:34]
+   │
+ 7 │     bytes public constant CODE = type(L).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/library_public_constant_getter/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A library's public constant has a getter too, so L embeds itself.
+
+library L {
+    bytes public constant CODE = type(L).creationCode;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc's reachability analysis does not follow constants referenced as members, so it never records A's dependency on itself and accepts this program on every version, then fails with an internal error during code generation. Slang follows the reference and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:27]
+   │
+ 8 │     bytes constant CODE = type(A).creationCode;
+   │                           ──────────┬─────────  
+   │                                     ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_constant_cycle/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// f compiles the library constant's value in, so A's deployed code embeds
+// A's own creation code.
+
+library B {
+    bytes constant CODE = type(A).creationCode;
+}
+
+contract A {
+    function f() public pure returns (bytes memory) {
+        return B.CODE;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc's reachability analysis does not follow constants referenced as members, so it never records A's dependency on itself and accepts this program on every version, then fails with an internal error during code generation. Slang follows the reference and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:34]
+   │
+ 9 │     bytes public constant CODE = type(A).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/member_access_public_constant_cycle/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reading the public constant through the library name compiles its value
+// into f, the same as a constant without a getter, so A's deployed code
+// embeds A's own creation code.
+
+library B {
+    bytes public constant CODE = type(A).creationCode;
+}
+
+contract A {
+    function f() public pure returns (bytes memory) {
+        return B.CODE;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new A();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new A();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new A();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_cycle/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Modifier bodies are part of the functions they are applied to.
+
+contract A {
+    modifier m() {
+        new A();
+        _;
+    }
+
+    function f() public m {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:14:9]
+    │
+ 14 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/modifier_invocation_arguments/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The arguments of a modifier invocation run within the function.
+
+contract A {
+    modifier m(uint256 x) {
+        _;
+    }
+
+    function f() public m(g()) {}
+
+    function g() internal returns (uint256) {
+        new B();
+        return 0;
+    }
+}
+
+contract B {
+    constructor() {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:11]
+   │
+ 8 │     B b = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:12:11]
+    │
+ 12 │     A a = new A();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:12:11]
+    │
+ 12 │     A a = new A();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:11]
+   │
+ 8 │     B b = new B();
+   │           ──┬──  
+   │             ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:12:11]
+    │
+ 12 │     A a = new A();
+    │           ──┬──  
+    │             ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/mutual_state_variables/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Mutual creation through state variable initializers, which are part of the
+// creation bytecode.
+
+contract A {
+    B b = new B();
+}
+
+contract B {
+    A a = new A();
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new C();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/new_in_constructor/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A contract creating itself embeds its own creation bytecode.
+
+contract C {
+    constructor() {
+        new C();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return type(L).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return type(L).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return type(L).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/private_library_function_cycle/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Private library functions execute within the caller's bytecode just like
+// internal ones, so the library reaches its own creation code.
+
+library L {
+    function f() public pure returns (bytes memory) {
+        return g();
+    }
+
+    function g() private pure returns (bytes memory) {
+        return type(L).creationCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4579 on the `new A()`, without reachability analysis. Since '0.8.4' solc leaves getters out of its reachability analysis, so it never records A's dependency on B and accepts this program, then fails with an internal error during code generation. Slang counts a public constant's getter as an entry point and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:34]
+   │
+ 8 │     bytes public constant CODE = type(B).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:13:9]
+    │
+ 13 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:13:9]
+    │
+ 13 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The getter of a public constant returns the embedded creation code, so A's
+// deployed code embeds B and B's creation code embeds A.
+
+contract A {
+    bytes public constant CODE = type(B).creationCode;
+}
+
+contract B {
+    constructor() {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4224 on any code access to the enclosing contract, without reachability analysis. Since '0.8.4' solc leaves getters out of its reachability analysis, so it never records the dependency and accepts this program, then fails with an internal error during code generation. Slang counts a public constant's getter as an entry point and reports the cycle on every version."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:7:34]
+   │
+ 7 │     bytes public constant CODE = type(B).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+   ╭─[input.sol:7:34]
+   │
+ 7 │     bytes public constant CODE = type(B).creationCode;
+   │                                  ──────────┬─────────  
+   │                                            ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_constant_getter_of_self/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// B's own getter returns B's creation code, so B embeds itself.
+
+contract B {
+    bytes public constant CODE = type(B).creationCode;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/public_library_call_no_cycle/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Calling a public library function is a delegatecall into the deployed
+// library, so C does not embed L's bytecode.
+
+library L {
+    function g() public {
+        new C();
+    }
+}
+
+contract C {
+    function f() public {
+        L.g();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,29 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
+    ╭─[input.sol:8:5]
+    │
+  8 │ ╭─▶     modifier m() virtual {
+    ┆ ┆   
+ 11 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_cycle/input.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A modifier invoked by qualified name runs the named contract's
+// modifier, not its most derived override. A.m runs in C.f and creates B.
+
+contract A {
+    modifier m() virtual {
+        new B();
+        _;
+    }
+}
+
+contract C is A {
+    modifier m() override {
+        _;
+    }
+
+    function f() public A.m {}
+}
+
+contract B {
+    constructor() {
+        new C();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc before '0.8.4' reports the `new B()` inside the never-invoked override, without reachability analysis, and solc since '0.8.31' emits a deprecation warning for virtual modifiers, which counts as a failing status because the runner does not filter by severity. Slang implements the '0.8.4' reachability semantics for every version and emits no such warning, so it accepts this input on '0.8.0' to '0.8.3' and on '0.8.31' onwards, where solc does not."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:24:9]
+    │
+ 24 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.31-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.31-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 8429] Warning: Virtual modifiers are deprecated and scheduled for removal.
+    ╭─[input.sol:8:5]
+    │
+  8 │ ╭─▶     modifier m() virtual {
+    ┆ ┆   
+ 10 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/qualified_modifier_override_no_cycle/input.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The qualified invocation runs A.m, so the overriding modifier that
+// creates B never runs and no bytecode cycle exists.
+
+contract A {
+    modifier m() virtual {
+        _;
+    }
+}
+
+contract C is A {
+    modifier m() override {
+        new B();
+        _;
+    }
+
+    function f() public A.m {}
+}
+
+contract B {
+    constructor() {
+        new C();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:9]
+    │
+ 11 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:9]
+    │
+ 15 │         type(B).creationCode;
+    │         ──────────┬─────────  
+    │                   ╰─────────── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/receive_and_fallback_attribution/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The receive and fallback functions both reference B. Slang walks them in
+// declaration order, so it reports the receive. solc always walks the
+// fallback before the receive, so it reports the fallback. The dependency
+// is the same either way, only the expression standing for it differs.
+
+contract A {
+    receive() external payable {
+        new B();
+    }
+
+    fallback() external {
+        type(B).creationCode;
+    }
+}
+
+contract B {
+    constructor() {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:24]
+   │
+ 8 │     bytes constant c = type(B).creationCode;
+   │                        ──────────┬─────────  
+   │                                  ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+   ╭─[input.sol:8:24]
+   │
+ 8 │     bytes constant c = type(B).creationCode;
+   │                        ──────────┬─────────  
+   │                                  ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:24]
+   │
+ 8 │     bytes constant c = type(B).creationCode;
+   │                        ──────────┬─────────  
+   │                                  ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/referenced_constant_cycle/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The constant's value is compiled into `f`, embedding B's own creation
+// code into B.
+
+contract B {
+    bytes constant c = type(B).creationCode;
+
+    function f() public pure returns (bytes memory) {
+        return c;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:16]
+   │
+ 8 │         return type(B).runtimeCode;
+   │                ─────────┬─────────  
+   │                         ╰─────────── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:14:16]
+    │
+ 14 │         return type(A).runtimeCode;
+    │                ─────────┬─────────  
+    │                         ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+    ╭─[input.sol:14:16]
+    │
+ 14 │         return type(A).runtimeCode;
+    │                ─────────┬─────────  
+    │                         ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:16]
+   │
+ 8 │         return type(B).runtimeCode;
+   │                ─────────┬─────────  
+   │                         ╰─────────── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:14:16]
+    │
+ 14 │         return type(A).runtimeCode;
+    │                ─────────┬─────────  
+    │                         ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/runtime_code_cycle/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Mutual runtime code access is a bytecode cycle just like `new`.
+
+contract A {
+    function f() public pure returns (bytes memory) {
+        return type(B).runtimeCode;
+    }
+}
+
+contract B {
+    function f() public pure returns (bytes memory) {
+        return type(A).runtimeCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/selector_access_no_cycle/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `C.f` here is only a declaration used for its selector, not a call, so A
+// does not embed C's bytecode and there is no cycle.
+
+contract A {
+    function sel() public pure returns (bytes4) {
+        return C.f.selector;
+    }
+}
+
+contract C {
+    function f() public {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:17:16]
+    │
+ 17 │         return type(B).creationCode;
+    │                ──────────┬─────────  
+    │                          ╰─────────── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:23:9]
+    │
+ 23 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:23:9]
+    │
+ 23 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:13:9]
+    │
+ 13 │         new B();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:23:9]
+    │
+ 23 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/shared_dependency_attribution/input.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Both deployed functions reference B, so the entry point order decides
+// which reference is reported. Slang walks the linearised function list,
+// which is sorted by name, so it reaches `alpha` first. solc walks the
+// external interface in declaration order and reaches `zebra` first. The
+// dependency is the same either way, only the expression standing for it
+// differs, so slang keeps the order the linearised list already has.
+
+contract A {
+    function zebra() public {
+        new B();
+    }
+
+    function alpha() public pure returns (bytes memory) {
+        return type(B).creationCode;
+    }
+}
+
+contract B {
+    constructor() {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_call_cycle/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// In B's bytecode, `super.f()` runs A's implementation, which creates B.
+
+contract A {
+    function f() public virtual {
+        new B();
+    }
+}
+
+contract B is A {
+    function f() public override {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "solc '0.8.4' missed super calls that skip an unimplemented declaration in the virtual resolution order, fixed in '0.8.5'. Slang implements the fixed semantics for every version, so it also reports this cycle on '0.8.4'."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.5-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/generated/solc/0.8.5-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:8:9]
+   │
+ 8 │         new D();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/super_unimplemented_override_cycle/input.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// C.f has no body, so `super.f()` in D runs B.f, which creates D.
+
+abstract contract B {
+    function f() public virtual {
+        new D();
+    }
+}
+
+abstract contract C {
+    function f() public virtual;
+}
+
+contract D is B, C {
+    function f() public override(B, C) {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:15:9]
+    │
+ 15 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[input.sol:9:9]
+   │
+ 9 │         new B();
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:15:9]
+    │
+ 15 │         new C();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:21:9]
+    │
+ 21 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/three_contract_cycle/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Every contract on the cycle reports the reference through which it reaches
+// the cycle.
+
+contract A {
+    function f() public {
+        new B();
+    }
+}
+
+contract B {
+    function f() public {
+        new C();
+    }
+}
+
+contract C {
+    function f() public {
+        new A();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4224 on any `type(B).creationCode` written inside `B`, without reachability analysis. Slang implements the '0.8.4' call graph semantics for every version and accepts this on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4224] Error: Circular reference for contract code access.
+   ╭─[input.sol:8:24]
+   │
+ 8 │     bytes constant c = type(B).creationCode;
+   │                        ──────────┬─────────  
+   │                                  ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unreferenced_constant_no_cycle/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A constant without a getter is not an entry point. An unreferenced value is
+// never compiled into any bytecode, so B does not embed its own creation code.
+
+contract B {
+    bytes constant c = type(B).creationCode;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported error 4579 on any `new A()` written inside `A`, without reachability analysis. Slang implements the '0.8.4' call graph semantics for every version and accepts this on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:11:9]
+    │
+ 11 │         new A();
+    │         ──┬──  
+    │           ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/unused_overload_no_cycle/input.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Only the string overload is ever called, so the uint256 overload's `new A`
+// is unreachable and there is no cycle.
+
+contract A {
+    uint256 counter;
+
+    function f(uint256) internal {
+        new A();
+    }
+
+    function f(string memory) internal {
+        counter = 1;
+    }
+
+    function g() public {
+        f("");
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/.tests.config.json
@@ -1,0 +1,7 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,51 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 6
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.8'.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ type Int is int256;
+   │ ─────────┬─────────  
+   │          ╰─────────── Error occurred here.
+───╯
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:22]
+    │
+ 11 │     bytes memory b = type(C).creationCode;
+    │                      ──────────┬─────────  
+    │                                ╰─────────── Error occurred here.
+────╯
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.8'.
+    ╭─[input.sol:12:16]
+    │
+ 12 │     return Int.wrap(int256(uint256(b.length)));
+    │                ──┬─  
+    │                  ╰─── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+    ╭─[input.sol:15:1]
+    │
+ 15 │ using {add as +} for Int global;
+    │ ────────────────┬───────────────  
+    │                 ╰───────────────── Error occurred here.
+────╯
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.8'.
+    ╭─[input.sol:19:20]
+    │
+ 19 │         return Int.wrap(1) + Int.wrap(2);
+    │                    ──┬─  
+    │                      ╰─── Error occurred here.
+────╯
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.8'.
+    ╭─[input.sol:19:34]
+    │
+ 19 │         return Int.wrap(1) + Int.wrap(2);
+    │                                  ──┬─  
+    │                                    ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.13-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:22]
+    │
+ 11 │     bytes memory b = type(C).creationCode;
+    │                      ──────────┬─────────  
+    │                                ╰─────────── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.19'.
+    ╭─[input.sol:15:12]
+    │
+ 15 │ using {add as +} for Int global;
+    │            ──┬─  
+    │              ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:22]
+    │
+ 11 │     bytes memory b = type(C).creationCode;
+    │                      ──────────┬─────────  
+    │                                ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/slang/0.8.8-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+    ╭─[input.sol:11:22]
+    │
+ 11 │     bytes memory b = type(C).creationCode;
+    │                      ──────────┬─────────  
+    │                                ╰─────────── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.13'.
+    ╭─[input.sol:15:1]
+    │
+ 15 │ using {add as +} for Int global;
+    │ ────────────────┬───────────────  
+    │                 ╰───────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+   ╭─[input.sol:8:1]
+   │
+ 8 │ type Int is int256;
+   │ ──┬─  
+   │   ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.13-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.13-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected '}' but got 'as'
+    ╭─[input.sol:15:12]
+    │
+ 15 │ using {add as +} for Int global;
+    │            ─┬  
+    │             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.19-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.19-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+    ╭─[input.sol:11:22]
+    │
+ 11 │     bytes memory b = type(C).creationCode;
+    │                      ──────────┬─────────  
+    │                                ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/generated/solc/0.8.8-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 7858] Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+    ╭─[input.sol:15:1]
+    │
+ 15 │ using {add as +} for Int global;
+    │ ──┬──  
+    │   ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/user_defined_operator_cycle/input.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `Int.wrap(1) + Int.wrap(2)` executes `add`, which embeds C's own creation
+// code, so this is a real cycle, reported at the creation code access the
+// operator function body reaches.
+
+type Int is int256;
+
+function add(Int, Int) pure returns (Int) {
+    bytes memory b = type(C).creationCode;
+    return Int.wrap(int256(uint256(b.length)));
+}
+
+using {add as +} for Int global;
+
+contract C {
+    function f() public pure returns (Int) {
+        return Int.wrap(1) + Int.wrap(2);
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc derived no contract dependency graph, so it has no chain to walk and accepts this program. Slang implements the '0.8.4' call graph semantics for every version and reports the depth limit on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/bytecode-dependency-validator-exhausted] Error: Contract dependencies exhausting cyclic dependency validator.
+      ╭─[input.sol:1283:1]
+      │
+ 1283 │ contract C255 {}
+      │ ────────┬───────  
+      │         ╰───────── Error occurred here.
+──────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7864] Error: Contract dependencies exhausting cyclic dependency validator
+      ╭─[input.sol:1283:1]
+      │
+ 1283 │ contract C255 {}
+      │ ────────┬───────  
+      │         ╰───────── Error occurred here.
+──────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/input.sol
@@ -1,0 +1,1283 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// A dependency chain of 256 contracts, with no cycle in it. The search from
+// C0 gives up on reaching the depth limit at C255. Every later contract sits
+// one step further along, so no other search is deep enough to hit it.
+
+contract C0 {
+    constructor() {
+        new C1();
+    }
+}
+contract C1 {
+    constructor() {
+        new C2();
+    }
+}
+contract C2 {
+    constructor() {
+        new C3();
+    }
+}
+contract C3 {
+    constructor() {
+        new C4();
+    }
+}
+contract C4 {
+    constructor() {
+        new C5();
+    }
+}
+contract C5 {
+    constructor() {
+        new C6();
+    }
+}
+contract C6 {
+    constructor() {
+        new C7();
+    }
+}
+contract C7 {
+    constructor() {
+        new C8();
+    }
+}
+contract C8 {
+    constructor() {
+        new C9();
+    }
+}
+contract C9 {
+    constructor() {
+        new C10();
+    }
+}
+contract C10 {
+    constructor() {
+        new C11();
+    }
+}
+contract C11 {
+    constructor() {
+        new C12();
+    }
+}
+contract C12 {
+    constructor() {
+        new C13();
+    }
+}
+contract C13 {
+    constructor() {
+        new C14();
+    }
+}
+contract C14 {
+    constructor() {
+        new C15();
+    }
+}
+contract C15 {
+    constructor() {
+        new C16();
+    }
+}
+contract C16 {
+    constructor() {
+        new C17();
+    }
+}
+contract C17 {
+    constructor() {
+        new C18();
+    }
+}
+contract C18 {
+    constructor() {
+        new C19();
+    }
+}
+contract C19 {
+    constructor() {
+        new C20();
+    }
+}
+contract C20 {
+    constructor() {
+        new C21();
+    }
+}
+contract C21 {
+    constructor() {
+        new C22();
+    }
+}
+contract C22 {
+    constructor() {
+        new C23();
+    }
+}
+contract C23 {
+    constructor() {
+        new C24();
+    }
+}
+contract C24 {
+    constructor() {
+        new C25();
+    }
+}
+contract C25 {
+    constructor() {
+        new C26();
+    }
+}
+contract C26 {
+    constructor() {
+        new C27();
+    }
+}
+contract C27 {
+    constructor() {
+        new C28();
+    }
+}
+contract C28 {
+    constructor() {
+        new C29();
+    }
+}
+contract C29 {
+    constructor() {
+        new C30();
+    }
+}
+contract C30 {
+    constructor() {
+        new C31();
+    }
+}
+contract C31 {
+    constructor() {
+        new C32();
+    }
+}
+contract C32 {
+    constructor() {
+        new C33();
+    }
+}
+contract C33 {
+    constructor() {
+        new C34();
+    }
+}
+contract C34 {
+    constructor() {
+        new C35();
+    }
+}
+contract C35 {
+    constructor() {
+        new C36();
+    }
+}
+contract C36 {
+    constructor() {
+        new C37();
+    }
+}
+contract C37 {
+    constructor() {
+        new C38();
+    }
+}
+contract C38 {
+    constructor() {
+        new C39();
+    }
+}
+contract C39 {
+    constructor() {
+        new C40();
+    }
+}
+contract C40 {
+    constructor() {
+        new C41();
+    }
+}
+contract C41 {
+    constructor() {
+        new C42();
+    }
+}
+contract C42 {
+    constructor() {
+        new C43();
+    }
+}
+contract C43 {
+    constructor() {
+        new C44();
+    }
+}
+contract C44 {
+    constructor() {
+        new C45();
+    }
+}
+contract C45 {
+    constructor() {
+        new C46();
+    }
+}
+contract C46 {
+    constructor() {
+        new C47();
+    }
+}
+contract C47 {
+    constructor() {
+        new C48();
+    }
+}
+contract C48 {
+    constructor() {
+        new C49();
+    }
+}
+contract C49 {
+    constructor() {
+        new C50();
+    }
+}
+contract C50 {
+    constructor() {
+        new C51();
+    }
+}
+contract C51 {
+    constructor() {
+        new C52();
+    }
+}
+contract C52 {
+    constructor() {
+        new C53();
+    }
+}
+contract C53 {
+    constructor() {
+        new C54();
+    }
+}
+contract C54 {
+    constructor() {
+        new C55();
+    }
+}
+contract C55 {
+    constructor() {
+        new C56();
+    }
+}
+contract C56 {
+    constructor() {
+        new C57();
+    }
+}
+contract C57 {
+    constructor() {
+        new C58();
+    }
+}
+contract C58 {
+    constructor() {
+        new C59();
+    }
+}
+contract C59 {
+    constructor() {
+        new C60();
+    }
+}
+contract C60 {
+    constructor() {
+        new C61();
+    }
+}
+contract C61 {
+    constructor() {
+        new C62();
+    }
+}
+contract C62 {
+    constructor() {
+        new C63();
+    }
+}
+contract C63 {
+    constructor() {
+        new C64();
+    }
+}
+contract C64 {
+    constructor() {
+        new C65();
+    }
+}
+contract C65 {
+    constructor() {
+        new C66();
+    }
+}
+contract C66 {
+    constructor() {
+        new C67();
+    }
+}
+contract C67 {
+    constructor() {
+        new C68();
+    }
+}
+contract C68 {
+    constructor() {
+        new C69();
+    }
+}
+contract C69 {
+    constructor() {
+        new C70();
+    }
+}
+contract C70 {
+    constructor() {
+        new C71();
+    }
+}
+contract C71 {
+    constructor() {
+        new C72();
+    }
+}
+contract C72 {
+    constructor() {
+        new C73();
+    }
+}
+contract C73 {
+    constructor() {
+        new C74();
+    }
+}
+contract C74 {
+    constructor() {
+        new C75();
+    }
+}
+contract C75 {
+    constructor() {
+        new C76();
+    }
+}
+contract C76 {
+    constructor() {
+        new C77();
+    }
+}
+contract C77 {
+    constructor() {
+        new C78();
+    }
+}
+contract C78 {
+    constructor() {
+        new C79();
+    }
+}
+contract C79 {
+    constructor() {
+        new C80();
+    }
+}
+contract C80 {
+    constructor() {
+        new C81();
+    }
+}
+contract C81 {
+    constructor() {
+        new C82();
+    }
+}
+contract C82 {
+    constructor() {
+        new C83();
+    }
+}
+contract C83 {
+    constructor() {
+        new C84();
+    }
+}
+contract C84 {
+    constructor() {
+        new C85();
+    }
+}
+contract C85 {
+    constructor() {
+        new C86();
+    }
+}
+contract C86 {
+    constructor() {
+        new C87();
+    }
+}
+contract C87 {
+    constructor() {
+        new C88();
+    }
+}
+contract C88 {
+    constructor() {
+        new C89();
+    }
+}
+contract C89 {
+    constructor() {
+        new C90();
+    }
+}
+contract C90 {
+    constructor() {
+        new C91();
+    }
+}
+contract C91 {
+    constructor() {
+        new C92();
+    }
+}
+contract C92 {
+    constructor() {
+        new C93();
+    }
+}
+contract C93 {
+    constructor() {
+        new C94();
+    }
+}
+contract C94 {
+    constructor() {
+        new C95();
+    }
+}
+contract C95 {
+    constructor() {
+        new C96();
+    }
+}
+contract C96 {
+    constructor() {
+        new C97();
+    }
+}
+contract C97 {
+    constructor() {
+        new C98();
+    }
+}
+contract C98 {
+    constructor() {
+        new C99();
+    }
+}
+contract C99 {
+    constructor() {
+        new C100();
+    }
+}
+contract C100 {
+    constructor() {
+        new C101();
+    }
+}
+contract C101 {
+    constructor() {
+        new C102();
+    }
+}
+contract C102 {
+    constructor() {
+        new C103();
+    }
+}
+contract C103 {
+    constructor() {
+        new C104();
+    }
+}
+contract C104 {
+    constructor() {
+        new C105();
+    }
+}
+contract C105 {
+    constructor() {
+        new C106();
+    }
+}
+contract C106 {
+    constructor() {
+        new C107();
+    }
+}
+contract C107 {
+    constructor() {
+        new C108();
+    }
+}
+contract C108 {
+    constructor() {
+        new C109();
+    }
+}
+contract C109 {
+    constructor() {
+        new C110();
+    }
+}
+contract C110 {
+    constructor() {
+        new C111();
+    }
+}
+contract C111 {
+    constructor() {
+        new C112();
+    }
+}
+contract C112 {
+    constructor() {
+        new C113();
+    }
+}
+contract C113 {
+    constructor() {
+        new C114();
+    }
+}
+contract C114 {
+    constructor() {
+        new C115();
+    }
+}
+contract C115 {
+    constructor() {
+        new C116();
+    }
+}
+contract C116 {
+    constructor() {
+        new C117();
+    }
+}
+contract C117 {
+    constructor() {
+        new C118();
+    }
+}
+contract C118 {
+    constructor() {
+        new C119();
+    }
+}
+contract C119 {
+    constructor() {
+        new C120();
+    }
+}
+contract C120 {
+    constructor() {
+        new C121();
+    }
+}
+contract C121 {
+    constructor() {
+        new C122();
+    }
+}
+contract C122 {
+    constructor() {
+        new C123();
+    }
+}
+contract C123 {
+    constructor() {
+        new C124();
+    }
+}
+contract C124 {
+    constructor() {
+        new C125();
+    }
+}
+contract C125 {
+    constructor() {
+        new C126();
+    }
+}
+contract C126 {
+    constructor() {
+        new C127();
+    }
+}
+contract C127 {
+    constructor() {
+        new C128();
+    }
+}
+contract C128 {
+    constructor() {
+        new C129();
+    }
+}
+contract C129 {
+    constructor() {
+        new C130();
+    }
+}
+contract C130 {
+    constructor() {
+        new C131();
+    }
+}
+contract C131 {
+    constructor() {
+        new C132();
+    }
+}
+contract C132 {
+    constructor() {
+        new C133();
+    }
+}
+contract C133 {
+    constructor() {
+        new C134();
+    }
+}
+contract C134 {
+    constructor() {
+        new C135();
+    }
+}
+contract C135 {
+    constructor() {
+        new C136();
+    }
+}
+contract C136 {
+    constructor() {
+        new C137();
+    }
+}
+contract C137 {
+    constructor() {
+        new C138();
+    }
+}
+contract C138 {
+    constructor() {
+        new C139();
+    }
+}
+contract C139 {
+    constructor() {
+        new C140();
+    }
+}
+contract C140 {
+    constructor() {
+        new C141();
+    }
+}
+contract C141 {
+    constructor() {
+        new C142();
+    }
+}
+contract C142 {
+    constructor() {
+        new C143();
+    }
+}
+contract C143 {
+    constructor() {
+        new C144();
+    }
+}
+contract C144 {
+    constructor() {
+        new C145();
+    }
+}
+contract C145 {
+    constructor() {
+        new C146();
+    }
+}
+contract C146 {
+    constructor() {
+        new C147();
+    }
+}
+contract C147 {
+    constructor() {
+        new C148();
+    }
+}
+contract C148 {
+    constructor() {
+        new C149();
+    }
+}
+contract C149 {
+    constructor() {
+        new C150();
+    }
+}
+contract C150 {
+    constructor() {
+        new C151();
+    }
+}
+contract C151 {
+    constructor() {
+        new C152();
+    }
+}
+contract C152 {
+    constructor() {
+        new C153();
+    }
+}
+contract C153 {
+    constructor() {
+        new C154();
+    }
+}
+contract C154 {
+    constructor() {
+        new C155();
+    }
+}
+contract C155 {
+    constructor() {
+        new C156();
+    }
+}
+contract C156 {
+    constructor() {
+        new C157();
+    }
+}
+contract C157 {
+    constructor() {
+        new C158();
+    }
+}
+contract C158 {
+    constructor() {
+        new C159();
+    }
+}
+contract C159 {
+    constructor() {
+        new C160();
+    }
+}
+contract C160 {
+    constructor() {
+        new C161();
+    }
+}
+contract C161 {
+    constructor() {
+        new C162();
+    }
+}
+contract C162 {
+    constructor() {
+        new C163();
+    }
+}
+contract C163 {
+    constructor() {
+        new C164();
+    }
+}
+contract C164 {
+    constructor() {
+        new C165();
+    }
+}
+contract C165 {
+    constructor() {
+        new C166();
+    }
+}
+contract C166 {
+    constructor() {
+        new C167();
+    }
+}
+contract C167 {
+    constructor() {
+        new C168();
+    }
+}
+contract C168 {
+    constructor() {
+        new C169();
+    }
+}
+contract C169 {
+    constructor() {
+        new C170();
+    }
+}
+contract C170 {
+    constructor() {
+        new C171();
+    }
+}
+contract C171 {
+    constructor() {
+        new C172();
+    }
+}
+contract C172 {
+    constructor() {
+        new C173();
+    }
+}
+contract C173 {
+    constructor() {
+        new C174();
+    }
+}
+contract C174 {
+    constructor() {
+        new C175();
+    }
+}
+contract C175 {
+    constructor() {
+        new C176();
+    }
+}
+contract C176 {
+    constructor() {
+        new C177();
+    }
+}
+contract C177 {
+    constructor() {
+        new C178();
+    }
+}
+contract C178 {
+    constructor() {
+        new C179();
+    }
+}
+contract C179 {
+    constructor() {
+        new C180();
+    }
+}
+contract C180 {
+    constructor() {
+        new C181();
+    }
+}
+contract C181 {
+    constructor() {
+        new C182();
+    }
+}
+contract C182 {
+    constructor() {
+        new C183();
+    }
+}
+contract C183 {
+    constructor() {
+        new C184();
+    }
+}
+contract C184 {
+    constructor() {
+        new C185();
+    }
+}
+contract C185 {
+    constructor() {
+        new C186();
+    }
+}
+contract C186 {
+    constructor() {
+        new C187();
+    }
+}
+contract C187 {
+    constructor() {
+        new C188();
+    }
+}
+contract C188 {
+    constructor() {
+        new C189();
+    }
+}
+contract C189 {
+    constructor() {
+        new C190();
+    }
+}
+contract C190 {
+    constructor() {
+        new C191();
+    }
+}
+contract C191 {
+    constructor() {
+        new C192();
+    }
+}
+contract C192 {
+    constructor() {
+        new C193();
+    }
+}
+contract C193 {
+    constructor() {
+        new C194();
+    }
+}
+contract C194 {
+    constructor() {
+        new C195();
+    }
+}
+contract C195 {
+    constructor() {
+        new C196();
+    }
+}
+contract C196 {
+    constructor() {
+        new C197();
+    }
+}
+contract C197 {
+    constructor() {
+        new C198();
+    }
+}
+contract C198 {
+    constructor() {
+        new C199();
+    }
+}
+contract C199 {
+    constructor() {
+        new C200();
+    }
+}
+contract C200 {
+    constructor() {
+        new C201();
+    }
+}
+contract C201 {
+    constructor() {
+        new C202();
+    }
+}
+contract C202 {
+    constructor() {
+        new C203();
+    }
+}
+contract C203 {
+    constructor() {
+        new C204();
+    }
+}
+contract C204 {
+    constructor() {
+        new C205();
+    }
+}
+contract C205 {
+    constructor() {
+        new C206();
+    }
+}
+contract C206 {
+    constructor() {
+        new C207();
+    }
+}
+contract C207 {
+    constructor() {
+        new C208();
+    }
+}
+contract C208 {
+    constructor() {
+        new C209();
+    }
+}
+contract C209 {
+    constructor() {
+        new C210();
+    }
+}
+contract C210 {
+    constructor() {
+        new C211();
+    }
+}
+contract C211 {
+    constructor() {
+        new C212();
+    }
+}
+contract C212 {
+    constructor() {
+        new C213();
+    }
+}
+contract C213 {
+    constructor() {
+        new C214();
+    }
+}
+contract C214 {
+    constructor() {
+        new C215();
+    }
+}
+contract C215 {
+    constructor() {
+        new C216();
+    }
+}
+contract C216 {
+    constructor() {
+        new C217();
+    }
+}
+contract C217 {
+    constructor() {
+        new C218();
+    }
+}
+contract C218 {
+    constructor() {
+        new C219();
+    }
+}
+contract C219 {
+    constructor() {
+        new C220();
+    }
+}
+contract C220 {
+    constructor() {
+        new C221();
+    }
+}
+contract C221 {
+    constructor() {
+        new C222();
+    }
+}
+contract C222 {
+    constructor() {
+        new C223();
+    }
+}
+contract C223 {
+    constructor() {
+        new C224();
+    }
+}
+contract C224 {
+    constructor() {
+        new C225();
+    }
+}
+contract C225 {
+    constructor() {
+        new C226();
+    }
+}
+contract C226 {
+    constructor() {
+        new C227();
+    }
+}
+contract C227 {
+    constructor() {
+        new C228();
+    }
+}
+contract C228 {
+    constructor() {
+        new C229();
+    }
+}
+contract C229 {
+    constructor() {
+        new C230();
+    }
+}
+contract C230 {
+    constructor() {
+        new C231();
+    }
+}
+contract C231 {
+    constructor() {
+        new C232();
+    }
+}
+contract C232 {
+    constructor() {
+        new C233();
+    }
+}
+contract C233 {
+    constructor() {
+        new C234();
+    }
+}
+contract C234 {
+    constructor() {
+        new C235();
+    }
+}
+contract C235 {
+    constructor() {
+        new C236();
+    }
+}
+contract C236 {
+    constructor() {
+        new C237();
+    }
+}
+contract C237 {
+    constructor() {
+        new C238();
+    }
+}
+contract C238 {
+    constructor() {
+        new C239();
+    }
+}
+contract C239 {
+    constructor() {
+        new C240();
+    }
+}
+contract C240 {
+    constructor() {
+        new C241();
+    }
+}
+contract C241 {
+    constructor() {
+        new C242();
+    }
+}
+contract C242 {
+    constructor() {
+        new C243();
+    }
+}
+contract C243 {
+    constructor() {
+        new C244();
+    }
+}
+contract C244 {
+    constructor() {
+        new C245();
+    }
+}
+contract C245 {
+    constructor() {
+        new C246();
+    }
+}
+contract C246 {
+    constructor() {
+        new C247();
+    }
+}
+contract C247 {
+    constructor() {
+        new C248();
+    }
+}
+contract C248 {
+    constructor() {
+        new C249();
+    }
+}
+contract C249 {
+    constructor() {
+        new C250();
+    }
+}
+contract C250 {
+    constructor() {
+        new C251();
+    }
+}
+contract C251 {
+    constructor() {
+        new C252();
+    }
+}
+contract C252 {
+    constructor() {
+        new C253();
+    }
+}
+contract C253 {
+    constructor() {
+        new C254();
+    }
+}
+contract C254 {
+    constructor() {
+        new C255();
+    }
+}
+contract C255 {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc reported a false cycle here (error 4579) because it did not resolve the virtual call to the empty override. Slang implements the '0.8.4' call graph semantics for every version and accepts this on '0.8.0' to '0.8.3' as well."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+    ╭─[input.sol:11:9]
+    │
+ 11 │         new Derived();
+    │         ─────┬─────  
+    │              ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/solc/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/generated/solc/0.8.4-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/virtual_override_no_cycle/input.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// In Derived's bytecode, `f()` runs the empty override, so Derived does not
+// depend on itself. Only Base embeds Derived's bytecode, which is no cycle.
+
+contract Base {
+    uint256 counter;
+
+    function f() internal virtual {
+        new Derived();
+    }
+
+    function g() public {
+        f();
+    }
+}
+
+contract Derived is Base {
+    function f() internal override {
+        counter = 1;
+    }
+}


### PR DESCRIPTION
Reports a diagnostic when a contract's bytecode would transitively embed itself.