### PR TITLE
[v2] fix(diagnostics): report cyclic dependency validator exhaustion once

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/mod.rs
@@ -54,20 +54,24 @@ impl DependencyGraph {
         Self { edges }
     }
 
-    /// Runs [`Self::find_cycle`] on every node, dropping cycle-free results.
-    /// Searches from different roots can give up at the same node, so
-    /// depth-exceeded results are reported once per node.
+    /// Runs [`Self::find_cycle`] on every node and drops the cycle-free results.
+    /// Returns every cycle, but only the first depth-exceeded result. A graph
+    /// past the depth limit exceeds it from many nodes, so keeping them all
+    /// would mean hundreds of identical errors.
     fn find_all_cycles(&self) -> impl Iterator<Item = (NodeId, CycleSearchResult)> + '_ {
-        let mut reported_depth_exceeded = Set::default();
+        let mut reported_exhaustion = false;
 
         self.edges
             .keys()
             .copied()
             .filter_map(move |node| match self.find_cycle(node) {
                 CycleSearchResult::None => None,
-                CycleSearchResult::DepthExceeded { node: capped } => reported_depth_exceeded
-                    .insert(capped)
-                    .then_some((node, CycleSearchResult::DepthExceeded { node: capped })),
+                CycleSearchResult::DepthExceeded { node: capped } => {
+                    (!reported_exhaustion).then(|| {
+                        reported_exhaustion = true;
+                        (node, CycleSearchResult::DepthExceeded { node: capped })
+                    })
+                }
                 CycleSearchResult::Cycle { via } => Some((node, CycleSearchResult::Cycle { via })),
             })
     }
@@ -284,19 +288,44 @@ mod tests {
         assert_eq!(find_cycle(&graph, 0), CycleSearchResult::None);
     }
 
-    #[test]
-    fn find_all_cycles_reports_each_capped_node_once() {
-        // Roots 0 and 1 enter the same chain at the same offset, so both
-        // searches give up at the same node and only the first is kept. Root 2
-        // sits one step deeper into the chain, gives up one node later, and is
-        // still reported. Deeper roots stay under the cap and are dropped.
+    /// An oversized chain `2 -> 3 -> ... -> end`, entered by roots 0 and 1.
+    /// Searches from 0, 1 and 2 all give up, each at a different node.
+    fn oversized_chain(extra_edges: Vec<(usize, Vec<usize>)>) -> DependencyGraph {
         let chain_end = DependencyGraph::MAX_DEPTH + 1;
         let mut edges = vec![(0, vec![2]), (1, vec![2])];
         edges.extend((2..=chain_end).map(|id| {
             let successors = if id < chain_end { vec![id + 1] } else { vec![] };
             (id, successors)
         }));
-        let graph = graph(edges);
+        edges.extend(extra_edges);
+        graph(edges)
+    }
+
+    #[test]
+    fn find_all_cycles_reports_exhaustion_once() {
+        // Three roots give up on the same oversized chain, at three different
+        // nodes, and only the first is kept. Deeper roots stay under the cap and
+        // are dropped.
+        let graph = oversized_chain(vec![]);
+
+        assert_eq!(
+            graph.find_all_cycles().collect::<Vec<_>>(),
+            vec![(
+                NodeId::from(0),
+                CycleSearchResult::DepthExceeded {
+                    node: NodeId::from(DependencyGraph::MAX_DEPTH)
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn cycles_are_still_reported_after_an_exhaustion() {
+        // A cycle declared after the oversized chain. Dropping the repeated
+        // give-ups must not drop the cycle behind them.
+        let first = DependencyGraph::MAX_DEPTH + 2;
+        let second = first + 1;
+        let graph = oversized_chain(vec![(first, vec![second]), (second, vec![first])]);
 
         assert_eq!(
             graph.find_all_cycles().collect::<Vec<_>>(),
@@ -308,9 +337,15 @@ mod tests {
                     }
                 ),
                 (
-                    NodeId::from(2),
-                    CycleSearchResult::DepthExceeded {
-                        node: NodeId::from(chain_end)
+                    NodeId::from(first),
+                    CycleSearchResult::Cycle {
+                        via: NodeId::from(second)
+                    }
+                ),
+                (
+                    NodeId::from(second),
+                    CycleSearchResult::Cycle {
+                        via: NodeId::from(first)
                     }
                 ),
             ]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/.tests.config.json
@@ -1,8 +1,0 @@
-{
-  "matrix": {
-    "type": "SingleTargetAllVersions",
-    "target": "Istanbul",
-    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
-  },
-  "expected_solc_divergence": "Before '0.8.4' solc derived no contract dependency graph, so it has no chain to walk and accepts this program. Slang implements the '0.8.4' call graph semantics for every version and reports the depth limit on '0.8.0' to '0.8.3' as well."
-}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,11 @@
 Diagnostics: 1
 
 [semantic/bytecode-dependency-validator-exhausted] Error: Contract dependencies exhausting cyclic dependency validator.
-      ╭─[input.sol:1283:1]
+      ╭─[input.sol:1284:1]
       │
- 1283 │ contract C255 {}
-      │ ────────┬───────  
-      │         ╰───────── Error occurred here.
+ 1284 │ ╭─▶ contract C254 {
+      ┆ ┆   
+ 1288 │ ├─▶ }
+      │ │       
+      │ ╰─────── Error occurred here.
 ──────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4579] Error: Circular reference for contract creation (cannot create instance of derived or same contract).
+      ╭─[input.sol:1291:9]
+      │
+ 1291 │         new C0();
+      │         ───┬──  
+      │            ╰──── Error occurred here.
+──────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.0-success.txt
@@ -1,3 +1,0 @@
-# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
-
-Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/generated/solc/0.8.4-failure.txt
@@ -3,9 +3,11 @@
 Diagnostics: 1
 
 [TypeError 7864] Error: Contract dependencies exhausting cyclic dependency validator
-      ╭─[input.sol:1283:1]
+      ╭─[input.sol:1284:1]
       │
- 1283 │ contract C255 {}
-      │ ────────┬───────  
-      │         ╰───────── Error occurred here.
+ 1284 │ ╭─▶ contract C254 {
+      ┆ ┆   
+ 1288 │ ├─▶ }
+      │ │       
+      │ ╰─────── Error occurred here.
 ──────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/validator_exhausted/input.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity *;
 
-// A dependency chain of 256 contracts, with no cycle in it. The search from
-// C0 gives up on reaching the depth limit at C255. Every later contract sits
-// one step further along, so no other search is deep enough to hit it.
+// A dependency chain of 257 contracts. The cycle detector gives up at a
+// depth of 256, at contract C254, before ever reaching the cycle at the
+// end of the chain.
+
+contract D {
+    function f() public {
+        new C0();
+    }
+}
 
 contract C0 {
     constructor() {
@@ -1280,4 +1286,8 @@ contract C254 {
         new C255();
     }
 }
-contract C255 {}
+contract C255 {
+    constructor() {
+        new C0();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/slang/0.8.0-failure.txt
@@ -1,51 +1,11 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 6
-
-[semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:259:1]
-     │
- 259 │ uint256 constant C255 = C256 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
-─────╯
-
-[semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:260:1]
-     │
- 260 │ uint256 constant C256 = C257 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
-─────╯
-
-[semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:261:1]
-     │
- 261 │ uint256 constant C257 = C258 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
-─────╯
-
-[semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:262:1]
-     │
- 262 │ uint256 constant C258 = C259 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
-─────╯
-
-[semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:263:1]
-     │
- 263 │ uint256 constant C259 = C260 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
-─────╯
+Diagnostics: 1
 
 [semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
      ╭─[input.sol:264:1]
      │
- 264 │ uint256 constant C260 = 1;
-     │ ─────────────┬────────────  
-     │              ╰────────────── Error occurred here.
+ 264 │ uint256 constant C255 = C256 + 1;
+     │ ────────────────┬────────────────  
+     │                 ╰────────────────── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/solc/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [DeclarationError 7380] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:259:1]
+     ╭─[input.sol:264:1]
      │
- 259 │ uint256 constant C255 = C256 + 1;
+ 264 │ uint256 constant C255 = C256 + 1;
      │ ────────────────┬───────────────  
      │                 ╰───────────────── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/input.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity *;
 
+// A dependency chain of 261 constants that loops back to its head. The
+// validator gives up at a depth of 256, before ever reaching the cycle at
+// the end of the chain. Every constant heads such a path, so only the first
+// give-up is reported.
+
 uint256 constant C0 = C1 + 1;
 uint256 constant C1 = C2 + 1;
 uint256 constant C2 = C3 + 1;
@@ -261,4 +266,4 @@ uint256 constant C256 = C257 + 1;
 uint256 constant C257 = C258 + 1;
 uint256 constant C258 = C259 + 1;
 uint256 constant C259 = C260 + 1;
-uint256 constant C260 = 1;
+uint256 constant C260 = C0 + 1;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/generated/slang/0.8.0-failure.txt
@@ -1,43 +1,11 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 5
+Diagnostics: 1
 
 [semantic/recursive-struct-validator-exhausted] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:263:5]
+     ╭─[input.sol:270:5]
      │
- 263 │     struct S255 { S256 m; }
+ 270 │     struct S255 { S256 m; }
      │     ───────────┬───────────  
      │                ╰───────────── Error occurred here.
-─────╯
-
-[semantic/recursive-struct-validator-exhausted] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:264:5]
-     │
- 264 │     struct S256 { S257 m; }
-     │     ───────────┬───────────  
-     │                ╰───────────── Error occurred here.
-─────╯
-
-[semantic/recursive-struct-validator-exhausted] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:265:5]
-     │
- 265 │     struct S257 { S258 m; }
-     │     ───────────┬───────────  
-     │                ╰───────────── Error occurred here.
-─────╯
-
-[semantic/recursive-struct-validator-exhausted] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:266:5]
-     │
- 266 │     struct S258 { S259 m; }
-     │     ───────────┬───────────  
-     │                ╰───────────── Error occurred here.
-─────╯
-
-[semantic/recursive-struct-validator-exhausted] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:267:5]
-     │
- 267 │     struct S259 { int m; }
-     │     ───────────┬──────────  
-     │                ╰──────────── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/generated/solc/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [DeclarationError 5651] Error: Struct definition exhausts cyclic dependency validator.
-     ╭─[input.sol:267:5]
-     │
- 267 │     struct S259 { int m; }
-     │     ───────────┬──────────  
-     │                ╰──────────── Error occurred here.
-─────╯
+    ╭─[input.sol:15:5]
+    │
+ 15 │     struct S0 { S1 m; }
+    │     ─────────┬─────────  
+    │              ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/recursive_structs/depth_exhausted/input.sol
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity *;
 
-// A chain of distinct structs nested deeper than the cyclic-dependency
-// validator limit is rejected even though it contains no cycle.
+// A chain of 260 structs that loops back to its head. The validator gives up
+// at a depth of 256, before ever reaching the cycle at the end of the chain.
+// Every struct heads such a path, so only the first give-up is reported.
+//
+// Slang searches the fully typed graph in declaration order, so it gives up at
+// S255. solc searches during nested visits, where an in-progress ancestor's
+// members are still untyped, so each of its searches dead-ends at S0. The first
+// one deep enough to give up starts at S5 and reports S0. Only the reported
+// location differs.
 
 contract Main {
     struct S0 { S1 m; }
@@ -264,5 +271,5 @@ contract Main {
     struct S256 { S257 m; }
     struct S257 { S258 m; }
     struct S258 { S259 m; }
-    struct S259 { int m; }
+    struct S259 { S0 m; }
 }


### PR DESCRIPTION
A cycle longer than the search depth limit makes every node give up, so emitting more than one error floods the output with hundreds of them.