### PR TITLE
[v2] feat(ast): read user-defined operator functions off the AST

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1243,6 +1243,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::AdditiveExpressi
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::AddressType
 impl slang_solidity_v2_ast::ast::AddressType
 pub fn slang_solidity_v2_ast::ast::AddressType::is_payable(&self) -> bool
@@ -1441,6 +1443,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseAndExpres
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1455,6 +1459,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseOrExpress
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 impl slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1469,6 +1475,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::BitwiseXorExpres
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::BlockStruct
 impl slang_solidity_v2_ast::ast::BlockStruct
 pub fn slang_solidity_v2_ast::ast::BlockStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -1843,6 +1851,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::EqualityExpressi
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::EqualityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::EqualityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::ErrorDefinitionStruct
 impl slang_solidity_v2_ast::ast::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::ErrorDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
@@ -2327,6 +2337,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::InequalityExpres
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::InequalityExpressionStruct
 pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::InequalityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::InheritanceTypeStruct
 impl slang_solidity_v2_ast::ast::InheritanceTypeStruct
 pub fn slang_solidity_v2_ast::ast::InheritanceTypeStruct::arguments(&self) -> core::option::Option<slang_solidity_v2_ast::ast::ArgumentsDeclaration>
@@ -2627,6 +2639,8 @@ impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::MultiplicativeEx
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::NamedArgumentStruct
 impl slang_solidity_v2_ast::ast::NamedArgumentStruct
 pub fn slang_solidity_v2_ast::ast::NamedArgumentStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -2910,6 +2924,8 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::PrefixExpressionStruct
 pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::PrefixExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::PrefixExpressionStruct
 pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::PrefixExpressionStruct
+pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub struct slang_solidity_v2_ast::ast::Reference
 impl slang_solidity_v2_ast::ast::Reference
 pub fn slang_solidity_v2_ast::ast::Reference::name(&self) -> &str
@@ -3824,6 +3840,24 @@ impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_
 pub fn slang_solidity_v2_ast::ast::OrExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl slang_solidity_v2_ast::ast::BinaryOperatorExpression for slang_solidity_v2_ast::ast::ShiftExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ShiftExpressionStruct::common_operand_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
+pub trait slang_solidity_v2_ast::ast::UserDefinedOperatorExpression
+pub fn slang_solidity_v2_ast::ast::UserDefinedOperatorExpression::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ast::ast::AdditiveExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseAndExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseOrExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ast::ast::BitwiseXorExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::EqualityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::EqualityExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::InequalityExpressionStruct
+pub fn slang_solidity_v2_ast::ast::InequalityExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ast::ast::MultiplicativeExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
+impl slang_solidity_v2_ast::ast::UserDefinedOperatorExpression for slang_solidity_v2_ast::ast::PrefixExpressionStruct
+pub fn slang_solidity_v2_ast::ast::PrefixExpressionStruct::resolve_operator_to_function(&self) -> core::option::Option<slang_solidity_v2_ast::ast::FunctionDefinition>
 pub fn slang_solidity_v2_ast::ast::create_abicoder_pragma(&slang_solidity_v2_ir::ir::nodes::AbicoderPragma, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AbicoderPragma
 pub fn slang_solidity_v2_ast::ast::create_additive_expression(&slang_solidity_v2_ir::ir::nodes::AdditiveExpression, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AdditiveExpression
 pub fn slang_solidity_v2_ast::ast::create_address_type(&slang_solidity_v2_ir::ir::nodes::AddressType, &alloc::sync::Arc<slang_solidity_v2_semantic::context::SemanticContext>) -> slang_solidity_v2_ast::ast::AddressTypeStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -17,4 +17,8 @@ mod identifier;
 mod identifier_path;
 mod source_unit;
 mod string_expression;
+
+mod user_defined_operators;
+pub use user_defined_operators::UserDefinedOperatorExpression;
+
 mod yul_literal;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/user_defined_operators.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/user_defined_operators.rs
@@ -1,0 +1,47 @@
+use crate::ast::{
+    AdditiveExpressionStruct, BitwiseAndExpressionStruct, BitwiseOrExpressionStruct,
+    BitwiseXorExpressionStruct, Definition, EqualityExpressionStruct, FunctionDefinition,
+    InequalityExpressionStruct, MultiplicativeExpressionStruct, PrefixExpressionStruct,
+};
+
+/// An operator expression a `using {f as op} for T global;` directive can
+/// rebind to a free function.
+pub trait UserDefinedOperatorExpression {
+    /// The function this operator is bound to, or `None` when it keeps its
+    /// built-in meaning.
+    fn resolve_operator_to_function(&self) -> Option<FunctionDefinition>;
+}
+
+/// The reference pass resolves every operator expression that a `using`
+/// directive rebinds, so the AST reads the function back from the binder.
+macro_rules! impl_resolve_operator_to_function {
+    ($($node:ident),* $(,)?) => {
+        $(
+            impl UserDefinedOperatorExpression for $node {
+                fn resolve_operator_to_function(&self) -> Option<FunctionDefinition> {
+                    let definition_id = self
+                        .semantic
+                        .binder()
+                        .resolved_operator_function(self.ir_node.id())?;
+                    let Some(Definition::Function(function)) =
+                        Definition::try_create(definition_id, &self.semantic)
+                    else {
+                        unreachable!("a using directive binds an operator to a function definition");
+                    };
+                    Some(function)
+                }
+            }
+        )*
+    };
+}
+
+impl_resolve_operator_to_function!(
+    AdditiveExpressionStruct,
+    BitwiseAndExpressionStruct,
+    BitwiseOrExpressionStruct,
+    BitwiseXorExpressionStruct,
+    EqualityExpressionStruct,
+    InequalityExpressionStruct,
+    MultiplicativeExpressionStruct,
+    PrefixExpressionStruct,
+);


### PR DESCRIPTION
Adds `UserDefinedOperatorExpression::resolve_operator_to_function`, the function the reference pass bound an operator occurrence to. The binder already resolves these functions but exposes them as a raw node id, which a consumer working from the AST cannot turn into a definition.