### PR TITLE
[v2] fix(diagnostics): detect constant cycles through public constants

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -317,6 +317,31 @@ impl Definition {
         }
     }
 
+    /// Whether this definition is a constant. Covers both constant shapes,
+    /// a `ConstantDefinition` or a `public` `constant` state variable.
+    pub(crate) fn is_constant(&self) -> bool {
+        match self {
+            Self::Constant(_) => true,
+            Self::StateVariable(variable_definition) => matches!(
+                variable_definition.ir_node.attributes.mutability,
+                ir::StateVariableMutability::Constant
+            ),
+            _ => false,
+        }
+    }
+
+    /// The value expression of a constant. Returns `None` for non-constants
+    /// and for a constant with no value.
+    pub(crate) fn constant_value(&self) -> Option<&ir::Expression> {
+        match self {
+            Self::Constant(constant_definition) => constant_definition.ir_node.value.as_ref(),
+            Self::StateVariable(variable_definition) if self.is_constant() => {
+                variable_definition.ir_node.value.as_ref()
+            }
+            _ => None,
+        }
+    }
+
     /// Whether `self` is allowed to share a name with `other` in the same
     /// scope. Only same-kind overloadable definitions may coexist: functions
     /// overload other functions, and events overload other events.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/cycle_detection/constants.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/cycle_detection/constants.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use slang_solidity_v2_common::collections::{SortedMap, SortedSet};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::diagnostics::kinds::semantic::{
@@ -8,7 +10,7 @@ use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
 use super::{CycleSearchResult, DependencyGraph};
-use crate::binder::{Binder, ConstantDefinition, Definition};
+use crate::binder::{Binder, Definition};
 use crate::context::FileNodeMapper;
 
 pub(super) fn detect_constant_value_dependency_cycles(
@@ -20,22 +22,22 @@ pub(super) fn detect_constant_value_dependency_cycles(
     for (constant_id, result) in graph.find_all_cycles() {
         match result {
             CycleSearchResult::Cycle { via } => {
-                let constant = constant_definition(binder, constant_id);
-                let via = constant_definition(binder, via);
+                let (name, range) = constant_name_and_range(binder, constant_id);
+                let (via_name, _) = constant_name_and_range(binder, via);
                 diagnostics.push(
                     file_node_mapper.file_id_from_node_id(constant_id).clone(),
-                    constant.ir_node.range.clone(),
+                    range.clone(),
                     CyclicConstantDependency {
-                        name: constant.ir_node.name.unparse().to_owned(),
-                        via: via.ir_node.name.unparse().to_owned(),
+                        name: name.unparse().to_owned(),
+                        via: via_name.unparse().to_owned(),
                     },
                 );
             }
             CycleSearchResult::DepthExceeded { node } => {
-                let constant = constant_definition(binder, node);
+                let (_, range) = constant_name_and_range(binder, node);
                 diagnostics.push(
                     file_node_mapper.file_id_from_node_id(node).clone(),
-                    constant.ir_node.range.clone(),
+                    range.clone(),
                     CyclicDependencyValidatorExhausted,
                 );
             }
@@ -49,14 +51,12 @@ fn build_dependencies(binder: &Binder) -> SortedMap<NodeId, Vec<NodeId>> {
         .definitions()
         .iter()
         .filter_map(|(definition_id, definition)| {
-            let Definition::Constant(constant) = definition else {
+            if !definition.is_constant() {
                 return None;
-            };
+            }
 
-            let dependencies: Vec<NodeId> = constant
-                .ir_node
-                .value
-                .as_ref()
+            let dependencies: Vec<NodeId> = definition
+                .constant_value()
                 .map_or_else(SortedSet::default, |value| {
                     collect_constant_dependencies(binder, value)
                 })
@@ -74,9 +74,17 @@ fn build_dependencies(binder: &Binder) -> SortedMap<NodeId, Vec<NodeId>> {
         .collect()
 }
 
-fn constant_definition(binder: &Binder, constant_id: NodeId) -> &ConstantDefinition {
+// The name and declaration range of a graph node. Graph nodes are always
+// constants, in either constant shape.
+fn constant_name_and_range(
+    binder: &Binder,
+    constant_id: NodeId,
+) -> (&ir::Identifier, &Range<usize>) {
     match binder.find_definition_by_id(constant_id) {
-        Some(Definition::Constant(constant)) => constant,
+        Some(Definition::Constant(constant)) => (&constant.ir_node.name, &constant.ir_node.range),
+        Some(Definition::StateVariable(variable)) => {
+            (&variable.ir_node.name, &variable.ir_node.range)
+        }
         _ => panic!("graph nodes should be constant definitions"),
     }
 }
@@ -114,10 +122,9 @@ impl Visitor for DependencyCollector<'_> {
             })
             .and_then(|resolution| resolution.as_definition_id())
             .filter(|&id| {
-                matches!(
-                    self.binder.find_definition_by_id(id),
-                    Some(Definition::Constant(_))
-                )
+                self.binder
+                    .find_definition_by_id(id)
+                    .is_some_and(Definition::is_constant)
             })
         {
             self.dependencies.insert(definition_id);

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -947,6 +947,16 @@ mod semantic {
             }
 
             #[test]
+            fn public_mixed_cycle() -> Result<()> {
+                run("semantic/constant_cycles/constants", "public_mixed_cycle")
+            }
+
+            #[test]
+            fn public_self_cycle() -> Result<()> {
+                run("semantic/constant_cycles/constants", "public_self_cycle")
+            }
+
+            #[test]
             fn qualified_self_reference_cycle() -> Result<()> {
                 run(
                     "semantic/constant_cycles/constants",

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 internal constant A = B;
+   │     ────────────────┬───────────────  
+   │                     ╰───────────────── Error occurred here.
+───╯
+
+[semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     uint256 public constant B = A;
+   │     ───────────────┬──────────────  
+   │                    ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 6161] Error: The value of the constant A has a cyclic dependency via B.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 internal constant A = B;
+   │     ───────────────┬───────────────  
+   │                    ╰───────────────── Error occurred here.
+───╯
+
+[TypeError 6161] Error: The value of the constant B has a cyclic dependency via A.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     uint256 public constant B = A;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The cycle crosses both constant shapes. The edge out of A targets a
+    // public constant, and the edge out of B targets a non-public one.
+    uint256 internal constant A = B;
+    uint256 public constant B = A;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via A.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 public constant A = A;
+   │     ───────────────┬──────────────  
+   │                    ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6161] Error: The value of the constant A has a cyclic dependency via A.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 public constant A = A;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A public constant keeps its state variable shape in the IR, but still
+    // takes part in constant cycle detection.
+    uint256 public constant A = A;
+}


### PR DESCRIPTION
A public constant keeps its state variable shape in the IR, so the constant cycle detector missed it both as a graph node and as an edge target, and cycles through it went unreported.