### PR TITLE
[v2] feat(typing): type calldata array slices

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -1034,6 +1034,7 @@ pub fn slang_solidity_v2_ast::ast::StringExpression::serialize<S: serde_core::se
 pub enum slang_solidity_v2_ast::ast::Type
 pub slang_solidity_v2_ast::ast::Type::Address(slang_solidity_v2_ast::ast::AddressType)
 pub slang_solidity_v2_ast::ast::Type::Array(slang_solidity_v2_ast::ast::ArrayType)
+pub slang_solidity_v2_ast::ast::Type::ArraySlice(slang_solidity_v2_ast::ast::ArraySliceType)
 pub slang_solidity_v2_ast::ast::Type::Boolean(slang_solidity_v2_ast::ast::BooleanType)
 pub slang_solidity_v2_ast::ast::Type::ByteArray(slang_solidity_v2_ast::ast::ByteArrayType)
 pub slang_solidity_v2_ast::ast::Type::Bytes(slang_solidity_v2_ast::ast::BytesType)
@@ -1306,6 +1307,11 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::ArrayExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::clone(&self) -> slang_solidity_v2_ast::ast::ArrayExpressionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::ArrayExpressionStruct
 pub fn slang_solidity_v2_ast::ast::ArrayExpressionStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub struct slang_solidity_v2_ast::ast::ArraySliceType
+impl slang_solidity_v2_ast::ast::ArraySliceType
+pub fn slang_solidity_v2_ast::ast::ArraySliceType::array_type(&self) -> slang_solidity_v2_ast::ast::Type
+impl core::clone::Clone for slang_solidity_v2_ast::ast::ArraySliceType
+pub fn slang_solidity_v2_ast::ast::ArraySliceType::clone(&self) -> slang_solidity_v2_ast::ast::ArraySliceType
 pub struct slang_solidity_v2_ast::ast::ArrayType
 impl slang_solidity_v2_ast::ast::ArrayType
 pub fn slang_solidity_v2_ast::ast::ArrayType::element_type(&self) -> slang_solidity_v2_ast::ast::Type

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/types.rs
@@ -183,6 +183,8 @@ fn abi_type_from_ast_type(value: &AstType, visited_structs: &mut Set<NodeId>) ->
                 element: Box::new(element),
             })
         }
+        // A slice ABI-encodes exactly like the array it slices.
+        AstType::ArraySlice(slice) => abi_type_from_ast_type(&slice.array_type(), visited_structs),
         AstType::FixedSizeArray(array) => {
             let element = abi_type_from_ast_type(&array.element_type(), visited_structs)?;
             Some(AbiType::FixedSizeArray {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/mod.rs
@@ -16,8 +16,8 @@ mod serialize;
 
 mod types;
 pub use types::{
-    AddressType, ArrayType, BooleanType, ByteArrayType, BytesType, ContractType, EnumType,
-    FixedPointNumberType, FixedSizeArrayType, FunctionType, IntegerType, InterfaceType,
+    AddressType, ArraySliceType, ArrayType, BooleanType, ByteArrayType, BytesType, ContractType,
+    EnumType, FixedPointNumberType, FixedSizeArrayType, FunctionType, IntegerType, InterfaceType,
     LiteralKind, LiteralType, MappingType, MetaType, Number, StringType, StructType, TupleType,
     Type, UserDefinedValueType, UserMetaType, VoidType,
 };

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/types.rs
@@ -17,6 +17,7 @@ use super::Definition;
 pub enum Type {
     Address(AddressType),
     Array(ArrayType),
+    ArraySlice(ArraySliceType),
     Boolean(BooleanType),
     ByteArray(ByteArrayType),
     Bytes(BytesType),
@@ -73,6 +74,7 @@ define_value_type_variant!(String);
 // Variants that need the semantic context to resolve nested types or
 // definitions.
 define_type_variant!(Array);
+define_type_variant!(ArraySlice);
 define_type_variant!(Contract);
 define_type_variant!(Enum);
 define_type_variant!(FixedSizeArray);
@@ -112,6 +114,7 @@ impl Type {
         match type_ {
             types::Type::Address(inner) => Self::Address(AddressType { inner }),
             types::Type::Array(inner) => Self::Array(ArrayType { inner, semantic }),
+            types::Type::ArraySlice(inner) => Self::ArraySlice(ArraySliceType { inner, semantic }),
             types::Type::Boolean => Self::Boolean(BooleanType),
             types::Type::ByteArray(inner) => Self::ByteArray(ByteArrayType { inner }),
             types::Type::Bytes(inner) => Self::Bytes(BytesType { inner }),
@@ -152,6 +155,8 @@ impl Type {
     pub fn data_location(&self) -> Option<DataLocation> {
         match self {
             Type::Array(details) => Some(details.location()),
+            // A slice inherits its underlying array's location (always calldata).
+            Type::ArraySlice(details) => details.array_type().data_location(),
             Type::Bytes(details) => Some(details.location()),
             Type::FixedSizeArray(details) => Some(details.location()),
             Type::String(details) => Some(details.location()),
@@ -167,6 +172,7 @@ impl Type {
         matches!(
             self,
             Type::Array(_)
+                | Type::ArraySlice(_)
                 | Type::FixedSizeArray(_)
                 | Type::Bytes(_)
                 | Type::String(_)
@@ -188,6 +194,14 @@ impl ArrayType {
     }
     pub fn location(&self) -> DataLocation {
         self.inner.location
+    }
+}
+
+impl ArraySliceType {
+    /// The array this is a slice of (an `Array`, `Bytes`, or `String`, always in
+    /// `calldata`).
+    pub fn array_type(&self) -> Type {
+        Type::create(self.inner.array_type_id, &self.semantic)
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -422,6 +422,7 @@ impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::Nu
 pub enum slang_solidity_v2_semantic::types::Type
 pub slang_solidity_v2_semantic::types::Type::Address(slang_solidity_v2_semantic::types::AddressType)
 pub slang_solidity_v2_semantic::types::Type::Array(slang_solidity_v2_semantic::types::ArrayType)
+pub slang_solidity_v2_semantic::types::Type::ArraySlice(slang_solidity_v2_semantic::types::ArraySliceType)
 pub slang_solidity_v2_semantic::types::Type::Boolean
 pub slang_solidity_v2_semantic::types::Type::ByteArray(slang_solidity_v2_semantic::types::ByteArrayType)
 pub slang_solidity_v2_semantic::types::Type::Bytes(slang_solidity_v2_semantic::types::BytesType)
@@ -480,6 +481,18 @@ pub fn slang_solidity_v2_semantic::types::AddressType::fmt(&self, &mut core::fmt
 impl core::hash::Hash for slang_solidity_v2_semantic::types::AddressType
 pub fn slang_solidity_v2_semantic::types::AddressType::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::AddressType
+pub struct slang_solidity_v2_semantic::types::ArraySliceType
+pub slang_solidity_v2_semantic::types::ArraySliceType::array_type_id: slang_solidity_v2_semantic::types::TypeId
+impl core::clone::Clone for slang_solidity_v2_semantic::types::ArraySliceType
+pub fn slang_solidity_v2_semantic::types::ArraySliceType::clone(&self) -> slang_solidity_v2_semantic::types::ArraySliceType
+impl core::cmp::Eq for slang_solidity_v2_semantic::types::ArraySliceType
+impl core::cmp::PartialEq for slang_solidity_v2_semantic::types::ArraySliceType
+pub fn slang_solidity_v2_semantic::types::ArraySliceType::eq(&self, &slang_solidity_v2_semantic::types::ArraySliceType) -> bool
+impl core::fmt::Debug for slang_solidity_v2_semantic::types::ArraySliceType
+pub fn slang_solidity_v2_semantic::types::ArraySliceType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for slang_solidity_v2_semantic::types::ArraySliceType
+pub fn slang_solidity_v2_semantic::types::ArraySliceType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::types::ArraySliceType
 pub struct slang_solidity_v2_semantic::types::ArrayType
 pub slang_solidity_v2_semantic::types::ArrayType::element_type: slang_solidity_v2_semantic::types::TypeId
 pub slang_solidity_v2_semantic::types::ArrayType::location: slang_solidity_v2_semantic::types::DataLocation

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,7 +1,7 @@
 use super::binder::{Binder, Definition, Typing};
 use super::types::{
-    AddressType, ArraySliceType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType,
-    TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
+    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType, TupleType, Type,
+    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 #[path = "internal.generated.rs"]
@@ -257,10 +257,7 @@ impl<'a> BuiltInsResolver<'a> {
                 "push" => Some(InternalBuiltIn::ArrayPush(*element_type)),
                 _ => None,
             },
-            // A slice exposes the same members as the array it slices
-            Type::ArraySlice(ArraySliceType { array_type_id }) => {
-                self.lookup_member_of_type_id(*array_type_id, symbol)
-            }
+            Type::ArraySlice(_) => None,
             Type::Boolean => None,
             Type::ByteArray(_) => match symbol {
                 "length" => Some(InternalBuiltIn::Length),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,7 +1,7 @@
 use super::binder::{Binder, Definition, Typing};
 use super::types::{
-    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType, TupleType, Type,
-    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
+    AddressType, ArraySliceType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType,
+    TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 #[path = "internal.generated.rs"]
@@ -257,6 +257,10 @@ impl<'a> BuiltInsResolver<'a> {
                 "push" => Some(InternalBuiltIn::ArrayPush(*element_type)),
                 _ => None,
             },
+            // A slice exposes the same members as the array it slices
+            Type::ArraySlice(ArraySliceType { array_type_id }) => {
+                self.lookup_member_of_type_id(*array_type_id, symbol)
+            }
             Type::Boolean => None,
             Type::ByteArray(_) => match symbol {
                 "length" => Some(InternalBuiltIn::Length),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -387,13 +387,13 @@ impl SemanticContext {
                 )
             }
 
-            Type::Library(_)
+            Type::ArraySlice(_)
+            | Type::Library(_)
             | Type::Literal(_)
             | Type::MetaType(_)
             | Type::Tuple(_)
             | Type::UserMetaType(_)
-            | Type::Void
-            | Type::ArraySlice(_) => None,
+            | Type::Void => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -17,9 +17,9 @@ use crate::passes::{
     p5_resolve_references, p6_resolve_yul, p7_code_analysis,
 };
 use crate::types::{
-    ArrayType, ByteArrayType, ContractType, EnumType, FixedPointNumberType, FixedSizeArrayType,
-    IntegerType, InterfaceType, LibraryType, MappingType, MetaType, StructType, TupleType, Type,
-    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
+    ArraySliceType, ArrayType, ByteArrayType, ContractType, EnumType, FixedPointNumberType,
+    FixedSizeArrayType, IntegerType, InterfaceType, LibraryType, MappingType, MetaType, StructType,
+    TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 mod contract_data;
@@ -240,6 +240,9 @@ impl SemanticContext {
                     element = self.type_internal_name(*element_type)
                 )
             }
+            Type::ArraySlice(ArraySliceType { array_type_id }) => {
+                format!("{} slice", self.type_internal_name(*array_type_id))
+            }
             Type::Boolean => "bool".to_string(),
             Type::ByteArray(ByteArrayType { width }) => format!("bytes{width}"),
             Type::Bytes(_) => "bytes".to_string(),
@@ -389,7 +392,8 @@ impl SemanticContext {
             | Type::MetaType(_)
             | Type::Tuple(_)
             | Type::UserMetaType(_)
-            | Type::Void => None,
+            | Type::Void
+            | Type::ArraySlice(_) => None,
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -264,6 +264,7 @@ impl Pass<'_> {
 
                 // invalid types
                 Type::Library(_)
+                | Type::ArraySlice(_)
                 | Type::Literal(_)
                 | Type::MetaType(_)
                 | Type::Tuple(_)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -8,7 +8,7 @@ use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::passes::common::node_location;
 use crate::types::{
-    AddressType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
+    AddressType, ArraySliceType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
     FunctionTypeVisibility, IntegerType, LiteralKind, MetaType, Number, StringType, Type, TypeId,
     UserMetaType, literals,
 };
@@ -147,6 +147,22 @@ impl Pass<'_> {
                 Some(self.types.boolean())
             }
             ir::PrefixExpressionOperator::DeleteKeyword(_) => Some(self.types.void()),
+        }
+    }
+
+    /// Types a range index (`a[i:j]`) whose operand is the array `array_type_id`
+    /// in `location`. Only dynamically-sized calldata arrays can be sliced, so a
+    /// calldata operand yields a [`Type::ArraySlice`] wrapping it and anything
+    /// else is left unresolved.
+    pub(super) fn slice_typing(&mut self, array_type_id: TypeId, location: DataLocation) -> Typing {
+        if location == DataLocation::Calldata {
+            Typing::Resolved(
+                self.types
+                    .register_type(Type::ArraySlice(ArraySliceType { array_type_id })),
+            )
+        } else {
+            // TODO(validation) SDR[46]: slicing a non-calldata array is invalid.
+            Typing::Unresolved
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -414,14 +414,13 @@ impl Visitor for Pass<'_> {
     fn leave_index_access_expression(&mut self, node: &ir::IndexAccessExpression) {
         let typing = match self.typing_of_expression(&node.operand) {
             Typing::Resolved(operand_type_id) => {
-                let range_access = node.end.is_some();
                 match self.types.get_type_by_id(operand_type_id) {
                     Type::Array(ArrayType {
                         element_type,
                         location,
                     }) => {
                         let (element_type, location) = (*element_type, *location);
-                        if range_access {
+                        if node.is_slice {
                             // A range index of a (calldata) array is a slice.
                             self.slice_typing(operand_type_id, location)
                         } else {
@@ -434,28 +433,28 @@ impl Visitor for Pass<'_> {
                         // out-of-bounds accesses. Fixed-size arrays aren't
                         // dynamically sized, so they can't be sliced.
                         let element_type = *element_type;
-                        if range_access {
+                        if node.is_slice {
                             Typing::Unresolved
                         } else {
                             Typing::Resolved(element_type)
                         }
                     }
                     Type::ByteArray(_) => {
-                        if range_access {
+                        if node.is_slice {
                             Typing::Unresolved
                         } else {
                             Typing::Resolved(self.types.bytes1())
                         }
                     }
                     Type::Bytes(BytesType { location }) => {
-                        if range_access {
+                        if node.is_slice {
                             self.slice_typing(operand_type_id, *location)
                         } else {
                             Typing::Resolved(self.types.bytes1())
                         }
                     }
                     Type::String(StringType { location }) => {
-                        if range_access {
+                        if node.is_slice {
                             // `string` can be sliced in calldata, but not indexed.
                             self.slice_typing(operand_type_id, *location)
                         } else {
@@ -464,7 +463,7 @@ impl Visitor for Pass<'_> {
                     }
                     Type::ArraySlice(ArraySliceType { array_type_id }) => {
                         let array_type_id = *array_type_id;
-                        if range_access {
+                        if node.is_slice {
                             // Re-slicing a slice yields the same slice type.
                             Typing::Resolved(operand_type_id)
                         } else {
@@ -479,7 +478,7 @@ impl Visitor for Pass<'_> {
                         }
                     }
                     Type::Mapping(MappingType { value_type_id, .. }) => {
-                        if range_access {
+                        if node.is_slice {
                             Typing::Unresolved
                         } else {
                             Typing::Resolved(*value_type_id)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -9,8 +9,8 @@ use crate::binder::{Reference, Resolution, Typing, UsingOperator};
 use crate::built_ins::InternalBuiltIn;
 use crate::passes::common::filter_overriden_definitions;
 use crate::types::{
-    AddressType, ArrayType, DataLocation, FixedSizeArrayType, MappingType, MetaType, Number,
-    TupleType, Type, UserMetaType,
+    AddressType, ArraySliceType, ArrayType, BytesType, DataLocation, FixedSizeArrayType,
+    MappingType, MetaType, Number, StringType, TupleType, Type, UserMetaType,
 };
 
 impl Visitor for Pass<'_> {
@@ -416,19 +416,28 @@ impl Visitor for Pass<'_> {
             Typing::Resolved(operand_type_id) => {
                 let range_access = node.end.is_some();
                 match self.types.get_type_by_id(operand_type_id) {
-                    Type::Array(ArrayType { element_type, .. })
-                    | Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) => {
-                        // TODO(validation) SDR[58]: for fixed-size arrays, if the range
-                        // is resolvable at compile time we should check for out
-                        // of bounds accesses.
-                        // TODO(validation) SDR[46]: array slices should only be
-                        // implemented for calldata arrays (as of 0.8.33).
-                        // TODO(validation) SDR[50]: we should return a new
-                        // (intermediate) type for array slices.
+                    Type::Array(ArrayType {
+                        element_type,
+                        location,
+                    }) => {
+                        let (element_type, location) = (*element_type, *location);
                         if range_access {
-                            Typing::Resolved(operand_type_id)
+                            // A range index of a (calldata) array is a slice.
+                            self.slice_typing(operand_type_id, location)
                         } else {
-                            Typing::Resolved(*element_type)
+                            Typing::Resolved(element_type)
+                        }
+                    }
+                    Type::FixedSizeArray(FixedSizeArrayType { element_type, .. }) => {
+                        // TODO(validation) SDR[58]: for fixed-size arrays, if the
+                        // index is resolvable at compile time we should check for
+                        // out-of-bounds accesses. Fixed-size arrays aren't
+                        // dynamically sized, so they can't be sliced.
+                        let element_type = *element_type;
+                        if range_access {
+                            Typing::Unresolved
+                        } else {
+                            Typing::Resolved(element_type)
                         }
                     }
                     Type::ByteArray(_) => {
@@ -438,11 +447,35 @@ impl Visitor for Pass<'_> {
                             Typing::Resolved(self.types.bytes1())
                         }
                     }
-                    Type::Bytes(_) => {
+                    Type::Bytes(BytesType { location }) => {
                         if range_access {
-                            Typing::Resolved(operand_type_id)
+                            self.slice_typing(operand_type_id, *location)
                         } else {
                             Typing::Resolved(self.types.bytes1())
+                        }
+                    }
+                    Type::String(StringType { location }) => {
+                        if range_access {
+                            // `string` can be sliced in calldata, but not indexed.
+                            self.slice_typing(operand_type_id, *location)
+                        } else {
+                            Typing::Unresolved
+                        }
+                    }
+                    Type::ArraySlice(ArraySliceType { array_type_id }) => {
+                        let array_type_id = *array_type_id;
+                        if range_access {
+                            // Re-slicing a slice yields the same slice type.
+                            Typing::Resolved(operand_type_id)
+                        } else {
+                            // Indexing a slice yields its array's element type.
+                            match self.types.get_type_by_id(array_type_id) {
+                                Type::Array(ArrayType { element_type, .. }) => {
+                                    Typing::Resolved(*element_type)
+                                }
+                                Type::Bytes(_) => Typing::Resolved(self.types.bytes1()),
+                                _ => Typing::Unresolved,
+                            }
                         }
                     }
                     Type::Mapping(MappingType { value_type_id, .. }) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -382,6 +382,9 @@ impl Type {
             | Self::String(StringType { location })
             | Self::Struct(StructType { location, .. }) => Some(*location),
             Self::Mapping(_) => Some(DataLocation::Storage),
+            // A slice only ever wraps a calldata array (see `ArraySliceType`),
+            // so its location is always calldata.
+            Self::ArraySlice(_) => Some(DataLocation::Calldata),
             _ => None,
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -22,6 +22,7 @@ pub struct TypeId(usize);
 pub enum Type {
     Address(AddressType),
     Array(ArrayType),
+    ArraySlice(ArraySliceType),
     Boolean,
     ByteArray(ByteArrayType),
     Bytes(BytesType),
@@ -58,6 +59,13 @@ pub struct AddressType {
 pub struct ArrayType {
     pub element_type: TypeId,
     pub location: DataLocation,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ArraySliceType {
+    /// The underlying array type this is a slice of (an `Array`, `Bytes`, or
+    /// `String`, always in `calldata`).
+    pub array_type_id: TypeId,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -408,6 +416,7 @@ impl Type {
 
             // Can be returned, just not inside a struct
             Type::Array(_)
+            | Type::ArraySlice(_)
             | Type::FixedSizeArray(_)
             | Type::Mapping(_)
             // Actually can't return from a getter

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -6,7 +6,7 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 
 use super::literals::numbers;
 use super::{
-    AddressType, ArrayType, ByteArrayType, BytesType, ContractType, DataLocation,
+    AddressType, ArraySliceType, ArrayType, ByteArrayType, BytesType, ContractType, DataLocation,
     FixedSizeArrayType, FunctionType, FunctionTypeVisibility, IntegerType, InterfaceType,
     LiteralKind, Number, StringType, StructType, TupleType, Type, TypeId,
 };
@@ -148,6 +148,14 @@ impl TypeRegistry {
         }
         let from_type = self.get_type_by_id(from_type_id);
         let to_type = self.get_type_by_id(to_type_id);
+
+        // A calldata slice converts wherever its underlying array converts (and
+        // to itself, handled above). Mirrors solc's
+        // `ArraySliceType::isImplicitlyConvertibleTo`.
+        if let Type::ArraySlice(ArraySliceType { array_type_id }) = from_type {
+            let array_type_id = *array_type_id;
+            return self.implicitly_convertible_to(array_type_id, to_type_id);
+        }
 
         match (from_type, to_type) {
             (
@@ -479,6 +487,12 @@ impl TypeRegistry {
                     location: DataLocation::Inherited,
                 })
             }
+            // Canonicalise through the underlying array (slices don't appear in
+            // struct fields, but keep the wrapper consistent if one reaches here).
+            Type::ArraySlice(ArraySliceType { array_type_id }) => {
+                let array_type_id = self.find_canonical_type_id(*array_type_id)?;
+                Type::ArraySlice(ArraySliceType { array_type_id })
+            }
             Type::Bytes(_) => Type::Bytes(BytesType {
                 location: DataLocation::Inherited,
             }),
@@ -554,6 +568,14 @@ impl TypeRegistry {
                 element_type: self.register_type_id_with_data_location(element_type, location),
                 location,
             }),
+            // A slice's location follows its underlying array.
+            Type::ArraySlice(ArraySliceType { array_type_id }) => {
+                debug_assert_eq!(location, DataLocation::Calldata);
+                Type::ArraySlice(ArraySliceType {
+                    array_type_id: self
+                        .register_type_id_with_data_location(array_type_id, location),
+                })
+            }
             Type::Bytes(_) => Type::Bytes(BytesType { location }),
             Type::FixedSizeArray(FixedSizeArrayType {
                 element_type, size, ..
@@ -603,6 +625,10 @@ impl TypeRegistry {
                 let mobile = kind.mobile_type()?;
                 Some(self.register_type(mobile))
             }
+            // A calldata slice decays to the array it slices — this is what lets
+            // `bytes calldata b = data[:3];` type-check. Mirrors solc's
+            // `ArraySliceType::mobileType`.
+            Type::ArraySlice(ArraySliceType { array_type_id }) => Some(array_type_id),
             Type::Tuple(TupleType { types: element_ids }) => {
                 let mobile_ids: Option<Vec<TypeId>> = element_ids
                     .iter()

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -487,8 +487,8 @@ impl TypeRegistry {
                     location: DataLocation::Inherited,
                 })
             }
-            // Canonicalise through the underlying array (slices don't appear in
-            // struct fields, but keep the wrapper consistent if one reaches here).
+            // Canonicalise a slice to a slice of the canonical array, keeping
+            // the `ArraySlice` wrapper on purpose.
             Type::ArraySlice(ArraySliceType { array_type_id }) => {
                 let array_type_id = self.find_canonical_type_id(*array_type_id)?;
                 Type::ArraySlice(ArraySliceType { array_type_id })
@@ -568,13 +568,13 @@ impl TypeRegistry {
                 element_type: self.register_type_id_with_data_location(element_type, location),
                 location,
             }),
-            // A slice's location follows its underlying array.
-            Type::ArraySlice(ArraySliceType { array_type_id }) => {
-                debug_assert_eq!(location, DataLocation::Calldata);
-                Type::ArraySlice(ArraySliceType {
-                    array_type_id: self
-                        .register_type_id_with_data_location(array_type_id, location),
-                })
+            // A calldata slice is only ever produced by a range-index
+            // expression `a[i:j]`, never written in source as a parameter,
+            // struct field, or cast target. Location relocation only runs on
+            // such source-declared types (and elements nested within them, none
+            // of which can be a slice), so a slice never reaches here.
+            Type::ArraySlice(_) => {
+                unreachable!("array slices are calldata-only and are never relocated")
             }
             Type::Bytes(_) => Type::Bytes(BytesType { location }),
             Type::FixedSizeArray(FixedSizeArrayType {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
@@ -155,6 +155,20 @@ contract C {
 "#,
 );
 
+define_fixture!(
+    CalldataSlice,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract C {
+    function f(string calldata data) external pure {
+        string calldata s = data[:3];
+    }
+}
+"#,
+);
+
 #[test]
 fn test_literal_plus_integer_get_type() {
     let unit = LiteralPlusInteger::build_compilation_unit();
@@ -296,6 +310,45 @@ fn test_binary_operator_common_type() {
         assert!(!integer.is_signed(), "`{function_name}` result is unsigned");
         assert_eq!(integer.bits(), 16, "`{function_name}` result is 16-bit");
     }
+}
+
+/// Captures the resolved type of the (single) index-access expression in a unit.
+#[derive(Default)]
+struct IndexAccessType {
+    found: bool,
+    resolved: Option<ast::Type>,
+}
+
+impl Visitor for IndexAccessType {
+    fn enter_index_access_expression(&mut self, node: &ast::IndexAccessExpression) -> bool {
+        self.found = true;
+        self.resolved = node.get_type();
+        true
+    }
+}
+
+#[test]
+fn test_calldata_slice_get_type() {
+    let unit = CalldataSlice::build_compilation_unit();
+
+    let mut finder = IndexAccessType::default();
+    for file in unit.files() {
+        accept_source_unit(&file.ast(), &mut finder);
+    }
+    assert!(finder.found, "the range index `data[:3]` is found");
+
+    // `data[:3]` slices a `string calldata`, so it types as an array slice
+    // whose underlying array is that `string`.
+    let ast::Type::ArraySlice(slice) = finder
+        .resolved
+        .expect("the range index has a resolved type")
+    else {
+        panic!("expected the range index to type as an array slice");
+    };
+    assert!(
+        matches!(slice.array_type(), ast::Type::String(_)),
+        "the slice is of a `string` array"
+    );
 }
 
 define_fixture!(

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
@@ -162,8 +162,12 @@ define_fixture!(
 pragma solidity ^0.8.0;
 
 contract C {
-    function f(string calldata data) external pure {
-        string calldata s = data[:3];
+    function f(string calldata s, bytes calldata b, uint[] calldata u) external pure {
+        s[:3];       // string slice
+        b[1:2];      // bytes slice
+        b[1:2][1];   // byte
+        u[3:];       // uint[] slice
+        u[3:][0];    // uint
     }
 }
 "#,
@@ -312,42 +316,165 @@ fn test_binary_operator_common_type() {
     }
 }
 
-/// Captures the resolved type of the (single) index-access expression in a unit.
-#[derive(Default)]
-struct IndexAccessType {
-    found: bool,
-    resolved: Option<ast::Type>,
-}
-
-impl Visitor for IndexAccessType {
-    fn enter_index_access_expression(&mut self, node: &ast::IndexAccessExpression) -> bool {
-        self.found = true;
-        self.resolved = node.get_type();
-        true
-    }
-}
-
 #[test]
 fn test_calldata_slice_get_type() {
     let unit = CalldataSlice::build_compilation_unit();
 
-    let mut finder = IndexAccessType::default();
-    for file in unit.files() {
-        accept_source_unit(&file.ast(), &mut finder);
-    }
-    assert!(finder.found, "the range index `data[:3]` is found");
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract C is found");
 
-    // `data[:3]` slices a `string calldata`, so it types as an array slice
-    // whose underlying array is that `string`.
-    let ast::Type::ArraySlice(slice) = finder
-        .resolved
-        .expect("the range index has a resolved type")
-    else {
-        panic!("expected the range index to type as an array slice");
+    let function = contract
+        .members()
+        .iter()
+        .find_map(|member| match member {
+            ast::ContractMember::FunctionDefinition(function)
+                if function.name().is_some_and(|name| name.name() == "f") =>
+            {
+                Some(function)
+            }
+            _ => None,
+        })
+        .expect("function f is found");
+
+    // `f`'s body is five expression statements, each a slice or an index into a
+    // slice, in source order.
+    let types: Vec<ast::Type> = function
+        .body()
+        .expect("function has a body")
+        .statements()
+        .iter()
+        .map(|statement| {
+            let ast::Statement::ExpressionStatement(statement) = statement else {
+                panic!("expected an expression statement");
+            };
+            let ast::Expression::IndexAccessExpression(index) = statement.expression() else {
+                panic!("expected an index-access expression");
+            };
+            index
+                .get_type()
+                .expect("the index-access expression has a resolved type")
+        })
+        .collect();
+
+    let [s_slice, b_slice, b_byte, u_slice, u_element] = types.as_slice() else {
+        panic!("expected exactly five index-access expressions");
+    };
+
+    // `s[:3]` slices a `string calldata` -> a slice of that `string`.
+    let ast::Type::ArraySlice(slice) = s_slice else {
+        panic!("expected `s[:3]` to type as an array slice");
     };
     assert!(
         matches!(slice.array_type(), ast::Type::String(_)),
-        "the slice is of a `string` array"
+        "`s[:3]` is a slice of a `string`"
+    );
+
+    // `b[1:2]` slices a `bytes calldata` -> a slice of that `bytes`.
+    let ast::Type::ArraySlice(slice) = b_slice else {
+        panic!("expected `b[1:2]` to type as an array slice");
+    };
+    assert!(
+        matches!(slice.array_type(), ast::Type::Bytes(_)),
+        "`b[1:2]` is a slice of a `bytes`"
+    );
+
+    // Indexing the `bytes` slice yields a single `bytes1`.
+    let ast::Type::ByteArray(byte) = b_byte else {
+        panic!("expected `b[1:2][1]` to type as a byte array");
+    };
+    assert_eq!(byte.width(), 1, "`b[1:2][1]` is a `bytes1`");
+
+    // `u[3:]` slices a `uint[] calldata` -> a slice of that array.
+    let ast::Type::ArraySlice(slice) = u_slice else {
+        panic!("expected `u[3:]` to type as an array slice");
+    };
+    assert!(
+        matches!(slice.array_type(), ast::Type::Array(_)),
+        "`u[3:]` is a slice of a `uint[]`"
+    );
+
+    // Indexing the `uint[]` slice yields a `uint256`.
+    let ast::Type::Integer(integer) = u_element else {
+        panic!("expected `u[3:][0]` to type as an integer");
+    };
+    assert!(!integer.is_signed(), "`u[3:][0]` is unsigned");
+    assert_eq!(integer.bits(), 256, "`u[3:][0]` is 256-bit");
+}
+
+define_fixture!(
+    OpenEndedSliceOfNonSliceable,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract C {
+    mapping(uint256 => uint256) m;
+    bytes32 b;
+
+    function f() internal view {
+        b[1:];   // slicing a fixed `bytes32` is not valid
+        m[1:];   // slicing a mapping is not valid
+    }
+}
+"#,
+);
+
+#[test]
+fn test_open_ended_slice_of_non_sliceable_is_unresolved() {
+    let unit = OpenEndedSliceOfNonSliceable::build_compilation_unit();
+
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract C is found");
+
+    let function = contract
+        .members()
+        .iter()
+        .find_map(|member| match member {
+            ast::ContractMember::FunctionDefinition(function)
+                if function.name().is_some_and(|name| name.name() == "f") =>
+            {
+                Some(function)
+            }
+            _ => None,
+        })
+        .expect("function f is found");
+
+    // `f`'s body is two open-ended slice expressions, in source order.
+    let types: Vec<Option<ast::Type>> = function
+        .body()
+        .expect("function has a body")
+        .statements()
+        .iter()
+        .map(|statement| {
+            let ast::Statement::ExpressionStatement(statement) = statement else {
+                panic!("expected an expression statement");
+            };
+            let ast::Expression::IndexAccessExpression(index) = statement.expression() else {
+                panic!("expected an index-access expression");
+            };
+            assert!(
+                index.is_slice(),
+                "the expression is an open-ended slice `x[1:]`"
+            );
+            index.get_type()
+        })
+        .collect();
+
+    let [b_slice, m_slice] = types.as_slice() else {
+        panic!("expected exactly two slice expressions");
+    };
+
+    assert!(
+        b_slice.is_none(),
+        "slicing a fixed `bytes32` does not resolve to a type"
+    );
+    assert!(
+        m_slice.is_none(),
+        "slicing a mapping does not resolve to a type"
     );
 }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/report_data.rs
@@ -391,6 +391,9 @@ fn type_display(type_: &Type) -> String {
             element_type = type_display(&array.element_type()),
             location = data_location_display(array.location()),
         ),
+        Type::ArraySlice(slice) => {
+            format!("{array} slice", array = type_display(&slice.array_type()))
+        }
         Type::Boolean(_) => "bool".to_string(),
         Type::ByteArray(byte_array) => format!("bytes{width}", width = byte_array.width()),
         Type::Bytes(bytes) => {

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -1174,6 +1174,11 @@ mod using {
     }
 
     #[test]
+    fn calldata_slice() -> Result<()> {
+        run("using", "calldata_slice")
+    }
+
+    #[test]
     fn can_override_built_ins() -> Result<()> {
         run("using", "can_override_built_ins")
     }

--- a/crates/solidity-v2/testing/snapshots/binder_output/using/calldata_slice/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/using/calldata_slice/generated/0.8.0-failure.txt
@@ -1,0 +1,96 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (11):
+- Def: #1 ["L" @ input.sol:9:9] (library)
+- Def: #2 ["firstByte" @ input.sol:10:14] (function, type: function (bytes calldata) returns bytes1)
+- Def: #3 ["b" @ input.sol:10:39] (parameter, type: bytes calldata)
+- Def: #4 ["TypeSpecific" @ input.sol:15:10] (contract)
+- Def: #5 ["whole" @ input.sol:19:14] (function, type: function (bytes calldata) returns bytes1)
+- Def: #6 ["data" @ input.sol:19:35] (parameter, type: bytes calldata)
+- Def: #7 ["slice" @ input.sol:25:14] (function, type: function (bytes calldata) returns bytes1)
+- Def: #8 ["data" @ input.sol:25:35] (parameter, type: bytes calldata)
+- Def: #9 ["Wildcard" @ input.sol:30:10] (contract)
+- Def: #10 ["slice" @ input.sol:34:14] (function, type: function (bytes calldata) returns bytes1)
+- Def: #11 ["data" @ input.sol:34:35] (parameter, type: bytes calldata)
+
+------------------------------------------------------------------------
+
+References (9):
+- Ref: ["b" @ input.sol:11:16] -> #3
+- Ref: ["L" @ input.sol:16:11] -> #1
+- Ref: ["data" @ input.sol:20:16] -> #6
+- Ref: ["firstByte" @ input.sol:20:21] -> #2
+- Ref: ["data" @ input.sol:26:16] -> #8
+- Ref: ["firstByte" @ input.sol:26:26] -> unresolved
+- Ref: ["L" @ input.sol:31:11] -> #1
+- Ref: ["data" @ input.sol:35:16] -> #11
+- Ref: ["firstByte" @ input.sol:35:26] -> #2
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  9 │ library L {
+    │         ┬  
+    │         ╰── name: 1
+ 10 │     function firstByte(bytes calldata b) internal pure returns (bytes1) {
+    │              ────┬────                ┬  
+    │                  ╰─────────────────────── name: 2
+    │                                       │  
+    │                                       ╰── name: 3
+ 11 │         return b[0];
+    │                ┬  
+    │                ╰── ref: 3
+    │ 
+ 15 │ contract TypeSpecific {
+    │          ──────┬─────  
+    │                ╰─────── name: 4
+ 16 │     using L for bytes;
+    │           ┬  
+    │           ╰── ref: 1
+    │ 
+ 19 │     function whole(bytes calldata data) external pure returns (bytes1) {
+    │              ──┬──                ──┬─  
+    │                ╰──────────────────────── name: 5
+    │                                     │   
+    │                                     ╰─── name: 6
+ 20 │         return data.firstByte();
+    │                ──┬─ ────┬────  
+    │                  ╰───────────── ref: 6
+    │                         │      
+    │                         ╰────── ref: 2
+    │ 
+ 25 │     function slice(bytes calldata data) external pure returns (bytes1) {
+    │              ──┬──                ──┬─  
+    │                ╰──────────────────────── name: 7
+    │                                     │   
+    │                                     ╰─── name: 8
+ 26 │         return data[1:3].firstByte();
+    │                ──┬─      ────┬────  
+    │                  ╰────────────────── ref: 8
+    │                              │      
+    │                              ╰────── unresolved
+    │ 
+ 30 │ contract Wildcard {
+    │          ────┬───  
+    │              ╰───── name: 9
+ 31 │     using L for *;
+    │           ┬  
+    │           ╰── ref: 1
+    │ 
+ 34 │     function slice(bytes calldata data) external pure returns (bytes1) {
+    │              ──┬──                ──┬─  
+    │                ╰──────────────────────── name: 10
+    │                                     │   
+    │                                     ╰─── name: 11
+ 35 │         return data[1:3].firstByte();
+    │                ──┬─      ────┬────  
+    │                  ╰────────────────── ref: 11
+    │                              │      
+    │                              ╰────── ref: 2
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/using/calldata_slice/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/using/calldata_slice/input.sol
@@ -1,0 +1,37 @@
+// A calldata range index `a[i:j]` produces a "calldata slice" type, which solc
+// treats as distinct from the underlying array for `using` resolution:
+//
+//   - A type-specific `using L for T` directive applies to the whole array but
+//     NOT to a slice of it (solc: `Member ... not found ... in T calldata
+//     slice`), so `firstByte` is unresolved on the slice below.
+//   - A `using L for *` directive applies to every type, including a slice.
+
+library L {
+    function firstByte(bytes calldata b) internal pure returns (bytes1) {
+        return b[0];
+    }
+}
+
+contract TypeSpecific {
+    using L for bytes;
+
+    // Receiver is `bytes`: the directive applies, so this resolves.
+    function whole(bytes calldata data) external pure returns (bytes1) {
+        return data.firstByte();
+    }
+
+    // Receiver is a `bytes` slice: the directive does not apply, so
+    // `firstByte` is left unresolved (matching solc).
+    function slice(bytes calldata data) external pure returns (bytes1) {
+        return data[1:3].firstByte();
+    }
+}
+
+contract Wildcard {
+    using L for *;
+
+    // `for *` reaches every type, including the slice, so this resolves.
+    function slice(bytes calldata data) external pure returns (bytes1) {
+        return data[1:3].firstByte();
+    }
+}


### PR DESCRIPTION
An option would've been to add a single bool to all three of Array, Bytes, String, but I think this is less error prone, and even more concise in certain cases.