### PR TITLE
[v2] fix(built-ins): don't gate the Yul `difficulty` built-in by language version

### DIFF
--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -4667,11 +4667,7 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                         BuiltInDefinition(name = YulCreate),
                         BuiltInDefinition(name = YulCreate2, evm_enabled = From(Constantinople)),
                         BuiltInDefinition(name = YulDelegatecall),
-                        BuiltInDefinition(
-                            name = YulDifficulty,
-                            enabled = Till("0.8.18"),
-                            evm_enabled = Till(Paris)
-                        ),
+                        BuiltInDefinition(name = YulDifficulty, evm_enabled = Till(Paris)),
                         BuiltInDefinition(name = YulDiv),
                         BuiltInDefinition(name = YulEq),
                         BuiltInDefinition(name = YulExp),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/built_ins/validate_built_ins.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_code_analysis/built_ins/validate_built_ins.generated.rs
@@ -209,11 +209,6 @@ impl<'a> BuiltInValidator<'a> {
                 );
             }
             InternalBuiltIn::YulDifficulty => {
-                self.check_version(
-                    node_id,
-                    range,
-                    LanguageVersionSpecifier::till(LanguageVersion::V0_8_18),
-                );
                 self.check_target(node_id, range, EvmTargetSpecifier::till(EvmTarget::Paris));
             }
             InternalBuiltIn::YulExtcodehash => {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -837,6 +837,22 @@ mod resolution {
         fn blobhash() -> Result<()> {
             run("resolution/incompatible_built_in_target", "blobhash")
         }
+
+        #[test]
+        fn yul_difficulty_post_paris() -> Result<()> {
+            run(
+                "resolution/incompatible_built_in_target",
+                "yul_difficulty_post_paris",
+            )
+        }
+
+        #[test]
+        fn yul_difficulty_pre_paris() -> Result<()> {
+            run(
+                "resolution/incompatible_built_in_target",
+                "yul_difficulty_pre_paris",
+            )
+        }
     }
 
     mod incompatible_built_in_version {

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/.tests.config.json
@@ -1,0 +1,7 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Paris",
+    "reason": "'difficulty' was replaced by 'prevrandao' in 'Paris', so it must be rejected on that target regardless of the language version."
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/incompatible-built-in-target] Error: This built-in was deprecated in EVM target 'Paris'.
+   ╭─[input.sol:7:23]
+   │
+ 7 │             result := difficulty()
+   │                       ─────┬────  
+   │                            ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[JSONError <no-code>] Error: Invalid EVM version requested.

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[DeclarationError 4619] Error: Function "difficulty" not found.
+   ╭─[input.sol:7:23]
+   │
+ 7 │             result := difficulty()
+   │                       ─────┬────  
+   │                            ╰────── Error occurred here.
+───╯
+
+[DeclarationError 8678] Error: Variable count for assignment to "result" does not match number of values (1 vs. 0)
+   ╭─[input.sol:7:13]
+   │
+ 7 │             result := difficulty()
+   │             ───────────┬──────────  
+   │                        ╰──────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Foo {
+    function f() public view returns (uint256 result) {
+        assembly {
+            result := difficulty()
+        }
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/.tests.config.json
@@ -1,0 +1,7 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "The Yul 'difficulty' built-in is gated by EVM target only, so on a pre-Paris target it must stay available on every language version."
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Foo {
+    function f() public view returns (uint256 result) {
+        assembly {
+            result := difficulty()
+        }
+    }
+}


### PR DESCRIPTION
`YulDifficulty` was declared `enabled = Till("0.8.18")` alongside `evm_enabled = Till(Paris)`, so referencing `difficulty()` in assembly was rejected on 0.8.18 and later even when targeting a pre-Paris EVM.
