### PR TITLE
[v2] fix(types): allow return data locations to differ when overriding an external function

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -674,43 +674,46 @@ impl TypeRegistry {
         ftype: &FunctionType,
         other: &FunctionType,
     ) -> bool {
-        if ftype.parameter_types.len() != other.parameter_types.len()
-            || ftype.return_type != other.return_type
-        {
+        if ftype.parameter_types.len() != other.parameter_types.len() {
             return false;
         }
 
-        // In general, parameter types must match exactly for functions to
-        // override others.
-        if ftype.parameter_types == other.parameter_types {
-            true
+        // In general, parameter and return types must match exactly for
+        // functions to override others.
+        if ftype.parameter_types == other.parameter_types && ftype.return_type == other.return_type
+        {
+            return true;
+        }
 
-        // The exception is if the `other` function is external which allows
-        // changing the data location of parameters from `memory` to `calldata`
-        // (or viceversa) if the visibility of `ftype` is external or public.
-        } else if matches!(other.visibility, FunctionTypeVisibility::External)
-            && matches!(
+        // The exception is if the `other` function is external, which allows
+        // changing the data location of parameters *and return values* from
+        // `memory` to `calldata` (or viceversa) if the visibility of `ftype` is
+        // external or public.
+        if !matches!(other.visibility, FunctionTypeVisibility::External)
+            || !matches!(
                 ftype.visibility,
                 FunctionTypeVisibility::External | FunctionTypeVisibility::Public
             )
         {
-            ftype
+            // Types don't match: `ftype` *does not* override `other`.
+            return false;
+        }
+
+        self.type_overrides_in_external_function(ftype.return_type, other.return_type)
+            && ftype
                 .parameter_types
                 .iter()
                 .zip(other.parameter_types.iter())
                 .all(|(ptype_left, ptype_right)| {
-                    self.parameter_type_overrides_in_external_function(*ptype_left, *ptype_right)
+                    self.type_overrides_in_external_function(*ptype_left, *ptype_right)
                 })
-        } else {
-            // Parameter types don't match: `ftype` *does not* override `other`.
-            false
-        }
     }
 
-    // Returns true if a the `left` type can override the `right` type in an
+    // Returns true if the `left` type can override the `right` type in an
     // external function signature. External functions allow changing data
-    // location from `memory` to `calldata` and viceversa.
-    fn parameter_type_overrides_in_external_function(&self, left: TypeId, right: TypeId) -> bool {
+    // location from `memory` to `calldata` and viceversa. This applies to both
+    // parameter and return types (a multi-value return is a tuple).
+    fn type_overrides_in_external_function(&self, left: TypeId, right: TypeId) -> bool {
         if left == right {
             return true;
         }
@@ -728,7 +731,7 @@ impl TypeRegistry {
                 }),
             ) => {
                 location_left.overrides_in_external_function(*location_right)
-                    && self.parameter_type_overrides_in_external_function(
+                    && self.type_overrides_in_external_function(
                         *element_type_left,
                         *element_type_right,
                     )
@@ -747,7 +750,7 @@ impl TypeRegistry {
             ) => {
                 size_left == size_right
                     && location_left.overrides_in_external_function(*location_right)
-                    && self.parameter_type_overrides_in_external_function(
+                    && self.type_overrides_in_external_function(
                         *element_type_left,
                         *element_type_right,
                     )
@@ -780,6 +783,23 @@ impl TypeRegistry {
             ) => {
                 definition_id_left == definition_id_right
                     && location_left.overrides_in_external_function(*location_right)
+            }
+            // A function returning multiple values returns a tuple, so the
+            // relaxation applies element-wise to reach their data locations.
+            (
+                Type::Tuple(TupleType {
+                    types: left_elements,
+                }),
+                Type::Tuple(TupleType {
+                    types: right_elements,
+                }),
+            ) => {
+                left_elements.len() == right_elements.len()
+                    && left_elements.iter().zip(right_elements.iter()).all(
+                        |(left_element, right_element)| {
+                            self.type_overrides_in_external_function(*left_element, *right_element)
+                        },
+                    )
             }
             _ => {
                 // anything else is not compatible because it should have

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -687,7 +687,7 @@ impl TypeRegistry {
 
         // The exception is if the `other` function is external, which allows
         // changing the data location of parameters *and return values* from
-        // `memory` to `calldata` (or viceversa) if the visibility of `ftype` is
+        // `memory` to `calldata` (or vice versa) if the visibility of `ftype` is
         // external or public.
         if !matches!(other.visibility, FunctionTypeVisibility::External)
             || !matches!(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -695,7 +695,7 @@ impl TypeRegistry {
                 FunctionTypeVisibility::External | FunctionTypeVisibility::Public
             )
         {
-            // Types don't match: `ftype` *does not* override `other`.
+            // Not overriding an external function and we already checked that the types don't match.
             return false;
         }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1161,6 +1161,22 @@ mod structure {
         use super::*;
 
         #[test]
+        fn external_override_data_location() -> Result<()> {
+            run(
+                "structure/contract_should_be_abstract",
+                "external_override_data_location",
+            )
+        }
+
+        #[test]
+        fn external_override_return_type_differs() -> Result<()> {
+            run(
+                "structure/contract_should_be_abstract",
+                "external_override_return_type_differs",
+            )
+        }
+
+        #[test]
         fn fully_implemented() -> Result<()> {
             run("structure/contract_should_be_abstract", "fully_implemented")
         }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_data_location/input.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Overriding an `external` function may change the data location of both
+// parameters and return values, so every override below is recognised and `B`
+// does not need to be abstract.
+abstract contract A {
+    struct S {
+        uint256 x;
+    }
+
+    // A single reference-type return value.
+    function f(uint256[] calldata a)
+        external
+        pure
+        virtual
+        returns (uint256[] calldata);
+
+    // A tuple mixing a reference type with a value type: the value type still
+    // has to match exactly, since it carries no data location.
+    function g(uint256[] calldata a)
+        external
+        pure
+        virtual
+        returns (uint256[] calldata, uint256);
+
+    // A tuple where the override *swaps* both locations, so the relaxation has
+    // to apply per element and in both directions.
+    function h(int256[] calldata b)
+        external
+        pure
+        virtual
+        returns (uint256[] calldata, int256[] memory);
+
+    // Nested arrays: the inner element type carries a location of its own.
+    function i(uint256[][] calldata c)
+        external
+        pure
+        virtual
+        returns (uint256[][] calldata);
+
+    // Structs, compared by definition and location.
+    function j(S calldata s) external pure virtual returns (S calldata);
+
+    // Fixed-size arrays, which also compare their length.
+    function k(uint256[2] calldata d)
+        external
+        pure
+        virtual
+        returns (uint256[2] calldata);
+
+    // `bytes` and `string`.
+    function l(bytes calldata e, string calldata t)
+        external
+        pure
+        virtual
+        returns (bytes calldata, string calldata);
+}
+
+contract B is A {
+    function f(uint256[] memory a)
+        public
+        pure
+        override
+        returns (uint256[] memory)
+    {
+        return a;
+    }
+
+    function g(uint256[] memory a)
+        public
+        pure
+        override
+        returns (uint256[] memory, uint256)
+    {
+        return (a, a.length);
+    }
+
+    function h(int256[] calldata b)
+        public
+        pure
+        override
+        returns (uint256[] memory, int256[] calldata)
+    {
+        return (new uint256[](0), b);
+    }
+
+    function i(uint256[][] memory c)
+        public
+        pure
+        override
+        returns (uint256[][] memory)
+    {
+        return c;
+    }
+
+    function j(S memory s) public pure override returns (S memory) {
+        return s;
+    }
+
+    function k(uint256[2] memory d)
+        public
+        pure
+        override
+        returns (uint256[2] memory)
+    {
+        return d;
+    }
+
+    function l(bytes memory e, string memory t)
+        public
+        pure
+        override
+        returns (bytes memory, string memory)
+    {
+        return (e, t);
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/contract-should-be-abstract] Error: Contract "B" should be marked as abstract.
+    ╭─[input.sol:15:1]
+    │
+ 15 │ ╭─▶ contract B is A {
+    ┆ ┆   
+ 24 │ ├─▶ }
+    │ │       
+    │ ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4822] Error: Overriding function return types differ.
+    ╭─[input.sol:16:5]
+    │
+ 16 │ ╭─▶     function f(uint256[] memory a)
+    ┆ ┆   
+ 23 │ ├─▶     }
+    │ │           
+    │ ╰─────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/contract_should_be_abstract/external_override_return_type_differs/input.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// The data-location relaxation for `external` overrides must not extend to the
+// underlying type: `int256[]` is not `uint256[]` whatever its location, so this
+// does not override and `B` should be abstract.
+abstract contract A {
+    function f(uint256[] calldata a)
+        external
+        pure
+        virtual
+        returns (uint256[] calldata);
+}
+
+contract B is A {
+    function f(uint256[] memory a)
+        public
+        pure
+        override
+        returns (int256[] memory)
+    {
+        return new int256[](a.length);
+    }
+}


### PR DESCRIPTION
`function_type_overrides` compared `return_type` by exact `TypeId` before reaching the external-function relaxation, so an `external` function returning `uint256[] calldata` was not considered overridden by a `public` one returning `uint256[] memory`. The base function's slot stayed unimplemented and the deriving contract was wrongly reported as needing to be `abstract`.

solc applies the relaxation to return values as well as parameters, so check the return type through the same predicate, and handle `Type::Tuple` so multi-value returns reach their element locations.