### PR TITLE
[v2] fix(diagnostic): keep the contract visible when typing inheritance-specifier arguments

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/mod.rs
@@ -76,6 +76,16 @@ impl<'a> Pass<'a> {
         });
     }
 
+    /// Pushes a frame whose *structural* scope is the one associated with
+    /// `node_id`, while names keep resolving in the enclosing lexical scope.
+    fn enter_structural_scope_for_node_id(&mut self, node_id: NodeId) {
+        let structural_scope_id = self.binder.scope_id_for_node_id(node_id).unwrap();
+        self.scope_stack.push(ScopeFrame {
+            structural_scope_id,
+            lexical_scope_id: self.current_scope_id(),
+        });
+    }
+
     fn replace_scope_for_node_id(&mut self, node_id: NodeId) {
         let Some(ScopeFrame {
             structural_scope_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -32,10 +32,19 @@ impl Visitor for Pass<'_> {
         self.leave_scope_for_node_id(node.id());
 
         // But any reference in the inheritance types and the storage layout
-        // specifier should resolve in the parent scope
+        // specifier should resolve in the parent scope.
+        //
+        // The inheritance types still need the contract to be visible
+        // *structurally* though: a base-constructor argument may call a base
+        // function through its qualified name (eg. `is Base(Base.g())`), which
+        // is only legal because the enclosing contract derives from `Base` — so
+        // `is_foreign_contract` has to be able to see which contract is being
+        // defined, even while names resolve outside of it.
+        self.enter_structural_scope_for_node_id(node.id());
         for inheritance_type in node.inheritance_types.iter() {
             ir::visitor::accept_inheritance_type(inheritance_type, self);
         }
+        self.leave_scope_for_node_id(node.id());
         if let Some(ref storage_layout) = node.storage_layout {
             // TODO(validation) SDR[56]: check that the expression is not binding constant variables up until 0.8.31
             // https://www.soliditylang.org/blog/2025/12/03/solidity-0.8.31-release-announcement

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -270,6 +270,11 @@ mod contracts {
     }
 
     #[test]
+    fn inheritance_arguments_with_base_call() -> Result<()> {
+        run("contracts", "inheritance_arguments_with_base_call")
+    }
+
+    #[test]
     fn inheritance_arguments_with_inner_constant() -> Result<()> {
         run("contracts", "inheritance_arguments_with_inner_constant")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1993,6 +1993,14 @@ mod type_system {
         use super::*;
 
         #[test]
+        fn base_constructor_argument() -> Result<()> {
+            run(
+                "type_system/cannot_call_via_contract_type_name",
+                "base_constructor_argument",
+            )
+        }
+
+        #[test]
         fn external_base() -> Result<()> {
             run(
                 "type_system/cannot_call_via_contract_type_name",

--- a/crates/solidity-v2/testing/snapshots/binder_output/contracts/inheritance_arguments_with_base_call/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/contracts/inheritance_arguments_with_base_call/generated/0.8.0-success.txt
@@ -1,0 +1,41 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (3):
+- Def: #1 ["Base" @ input.sol:1:10] (contract)
+- Def: #2 ["g" @ input.sol:4:14] (function, type: function () returns uint256)
+- Def: #3 ["Derived" @ input.sol:11:10] (contract)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["Base" @ input.sol:11:21] -> #1
+- Ref: ["Base" @ input.sol:11:26] -> #1
+- Ref: ["g" @ input.sol:11:31] -> #2
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Base {
+    │          ──┬─  
+    │            ╰─── name: 1
+    │ 
+  4 │     function g() public pure returns (uint) {
+    │              ┬  
+    │              ╰── name: 2
+    │ 
+ 11 │ contract Derived is Base(Base.g()) {}
+    │          ───┬───    ──┬─ ──┬─ ┬  
+    │             ╰──────────────────── name: 3
+    │                       │    │  │  
+    │                       ╰────────── ref: 1
+    │                            │  │  
+    │                            ╰───── ref: 1
+    │                               │  
+    │                               ╰── ref: 2
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/contracts/inheritance_arguments_with_base_call/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/contracts/inheritance_arguments_with_base_call/input.sol
@@ -1,0 +1,11 @@
+contract Base {
+    constructor(uint) {}
+
+    function g() public pure returns (uint) {
+        return 1;
+    }
+}
+
+// A qualified call to a base function: the names resolve in the file scope, but
+// `Base` must still be recognised as a base of the contract being defined.
+contract Derived is Base(Base.g()) {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/cannot_call_via_contract_type_name/base_constructor_argument/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract Base {
+    constructor(uint256) {}
+
+    function g() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+// A qualified call to a base function is valid in a base-constructor argument,
+// even though the names there resolve in the enclosing file scope.
+contract Derived is Base(Base.g()) {}


### PR DESCRIPTION
`enter_contract_definition` pops the contract scope before visiting the inheritance types, so that names there resolve in the enclosing file scope. That also left `current_contract_scope_id` empty, which made `is_foreign_contract` report every contract as foreign: a legal qualified call to a base function in a base-constructor argument (eg. `is BaseBase(BaseBase.g())`) was rewritten as a foreign declaration and rejected with `CannotCallViaContractTypeName`.

Visit the inheritance types under a frame that keeps the contract as the *structural* scope while names still resolve lexically in the parent scope, so the base check can see which contract is being defined.