### PR TITLE
[v2] refactor(common): use solc's camelCase spelling for EvmTarget strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ iterate every language version:
 {
     "matrix": {
         "type": "SingleTargetAllVersions",
-        "target": "Istanbul",
+        "target": "istanbul",
         "reason": "Explain why this target was pinned..."
     }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,7 +4559,6 @@ version = "1.3.7"
 name = "solidity_testing_perf_cargo"
 version = "1.3.7"
 dependencies = [
- "Inflector",
  "anyhow",
  "gungraun",
  "infra_utils",
@@ -4651,7 +4650,6 @@ dependencies = [
 name = "solidity_v2_cargo_tests"
 version = "1.3.7"
 dependencies = [
- "Inflector",
  "anyhow",
  "ariadne",
  "indoc",

--- a/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.generated.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 /// All supported EVM targets of `Solidity`, in chronological order.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum EvmTarget {
     Frontier = 0,
     Homestead = 1,
@@ -54,25 +55,26 @@ impl EvmTarget {
     ];
 }
 
+/// Formats the target matching `solc`'s format (camelCase).
 impl Display for EvmTarget {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            EvmTarget::Frontier => write!(f, "Frontier"),
-            EvmTarget::Homestead => write!(f, "Homestead"),
-            EvmTarget::TangerineWhistle => write!(f, "TangerineWhistle"),
-            EvmTarget::SpuriousDragon => write!(f, "SpuriousDragon"),
-            EvmTarget::Byzantium => write!(f, "Byzantium"),
-            EvmTarget::Constantinople => write!(f, "Constantinople"),
-            EvmTarget::Petersburg => write!(f, "Petersburg"),
-            EvmTarget::Istanbul => write!(f, "Istanbul"),
-            EvmTarget::Berlin => write!(f, "Berlin"),
-            EvmTarget::London => write!(f, "London"),
-            EvmTarget::Paris => write!(f, "Paris"),
-            EvmTarget::Shanghai => write!(f, "Shanghai"),
-            EvmTarget::Cancun => write!(f, "Cancun"),
-            EvmTarget::Prague => write!(f, "Prague"),
-            EvmTarget::Osaka => write!(f, "Osaka"),
-            EvmTarget::Amsterdam => write!(f, "Amsterdam"),
+            EvmTarget::Frontier => write!(f, "frontier"),
+            EvmTarget::Homestead => write!(f, "homestead"),
+            EvmTarget::TangerineWhistle => write!(f, "tangerineWhistle"),
+            EvmTarget::SpuriousDragon => write!(f, "spuriousDragon"),
+            EvmTarget::Byzantium => write!(f, "byzantium"),
+            EvmTarget::Constantinople => write!(f, "constantinople"),
+            EvmTarget::Petersburg => write!(f, "petersburg"),
+            EvmTarget::Istanbul => write!(f, "istanbul"),
+            EvmTarget::Berlin => write!(f, "berlin"),
+            EvmTarget::London => write!(f, "london"),
+            EvmTarget::Paris => write!(f, "paris"),
+            EvmTarget::Shanghai => write!(f, "shanghai"),
+            EvmTarget::Cancun => write!(f, "cancun"),
+            EvmTarget::Prague => write!(f, "prague"),
+            EvmTarget::Osaka => write!(f, "osaka"),
+            EvmTarget::Amsterdam => write!(f, "amsterdam"),
         }
     }
 }
@@ -88,22 +90,22 @@ impl TryFrom<&str> for EvmTarget {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "Frontier" => Ok(EvmTarget::Frontier),
-            "Homestead" => Ok(EvmTarget::Homestead),
-            "TangerineWhistle" => Ok(EvmTarget::TangerineWhistle),
-            "SpuriousDragon" => Ok(EvmTarget::SpuriousDragon),
-            "Byzantium" => Ok(EvmTarget::Byzantium),
-            "Constantinople" => Ok(EvmTarget::Constantinople),
-            "Petersburg" => Ok(EvmTarget::Petersburg),
-            "Istanbul" => Ok(EvmTarget::Istanbul),
-            "Berlin" => Ok(EvmTarget::Berlin),
-            "London" => Ok(EvmTarget::London),
-            "Paris" => Ok(EvmTarget::Paris),
-            "Shanghai" => Ok(EvmTarget::Shanghai),
-            "Cancun" => Ok(EvmTarget::Cancun),
-            "Prague" => Ok(EvmTarget::Prague),
-            "Osaka" => Ok(EvmTarget::Osaka),
-            "Amsterdam" => Ok(EvmTarget::Amsterdam),
+            "frontier" => Ok(EvmTarget::Frontier),
+            "homestead" => Ok(EvmTarget::Homestead),
+            "tangerineWhistle" => Ok(EvmTarget::TangerineWhistle),
+            "spuriousDragon" => Ok(EvmTarget::SpuriousDragon),
+            "byzantium" => Ok(EvmTarget::Byzantium),
+            "constantinople" => Ok(EvmTarget::Constantinople),
+            "petersburg" => Ok(EvmTarget::Petersburg),
+            "istanbul" => Ok(EvmTarget::Istanbul),
+            "berlin" => Ok(EvmTarget::Berlin),
+            "london" => Ok(EvmTarget::London),
+            "paris" => Ok(EvmTarget::Paris),
+            "shanghai" => Ok(EvmTarget::Shanghai),
+            "cancun" => Ok(EvmTarget::Cancun),
+            "prague" => Ok(EvmTarget::Prague),
+            "osaka" => Ok(EvmTarget::Osaka),
+            "amsterdam" => Ok(EvmTarget::Amsterdam),
             _ => Err(EvmTargetConversionError::UnrecognizedEvmTarget),
         }
     }

--- a/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/common/src/evm_targets/target.rs.jinja2
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 /// All supported EVM targets of `{{ model.language.name }}`, in chronological order.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum EvmTarget {
     {% for evm_target in model.language.evm_targets %}
         {{ evm_target }} = {{ loop.index0 }},
@@ -26,11 +27,12 @@ impl EvmTarget {
     ];
 }
 
+/// Formats the target matching `solc`'s format (camelCase).
 impl Display for EvmTarget {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             {%- for evm_target in model.language.evm_targets %}
-                EvmTarget::{{ evm_target }} => write!(f, "{{ evm_target }}"),
+                EvmTarget::{{ evm_target }} => write!(f, "{{ evm_target | camel_case }}"),
             {%- endfor %}
         }
     }
@@ -48,7 +50,7 @@ impl TryFrom<&str> for EvmTarget {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             {%- for evm_target in model.language.evm_targets %}
-                "{{ evm_target }}" => Ok(EvmTarget::{{ evm_target }}),
+                "{{ evm_target | camel_case }}" => Ok(EvmTarget::{{ evm_target }}),
             {%- endfor %}
             _ => Err(EvmTargetConversionError::UnrecognizedEvmTarget),
         }

--- a/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/tests/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 publish = false
 
 [dev-dependencies]
-Inflector = { workspace = true }
 anyhow = { workspace = true }
 ariadne = { workspace = true }
 indoc = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/solc.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, anyhow};
-use inflector::Inflector;
 use infra_utils::solc::{
     Binary, CliInput, CliSettings, InputSource, LanguageSelector, render_solc_error,
 };
@@ -60,7 +59,7 @@ impl TestTarget for SolcTarget {
                 })
                 .collect(),
             settings: CliSettings {
-                evm_version: Some(evm_target.to_string().to_camel_case()),
+                evm_version: Some(evm_target.to_string()),
                 experimental: if version < LanguageVersion::V0_8_35 {
                     // 'experimental' flag was introduced in '0.8.35'
                     None

--- a/crates/solidity-v2/testing/snapshots/binder_output/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/binder_output/.tests.config.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "type": "SingleTargetAllVersions",
-    "target": "Istanbul",
+    "target": "istanbul",
     "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
   }
 }

--- a/crates/solidity-v2/testing/snapshots/cst_output/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/cst_output/.tests.config.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "type": "SingleTargetAllVersions",
-    "target": "Istanbul",
+    "target": "istanbul",
     "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
   }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/.tests.config.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "type": "SingleTargetAllVersions",
-    "target": "Istanbul",
+    "target": "istanbul",
     "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
   }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_post_paris/.tests.config.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "type": "SingleTargetAllVersions",
-    "target": "Paris",
+    "target": "paris",
     "reason": "'difficulty' was replaced by 'prevrandao' in 'Paris', so it must be rejected on that target regardless of the language version."
   }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/yul_difficulty_pre_paris/.tests.config.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "type": "SingleTargetAllVersions",
-    "target": "Istanbul",
+    "target": "istanbul",
     "reason": "The Yul 'difficulty' built-in is gated by EVM target only, so on a pre-Paris target it must stay available on every language version."
   }
 }

--- a/crates/solidity/testing/perf/cargo/Cargo.toml
+++ b/crates/solidity/testing/perf/cargo/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 gungraun = { workspace = true }
-Inflector = { workspace = true }
 infra_utils = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -17,7 +17,6 @@ use tests::setup::setup;
 
 mod __dependencies_used_in_lib__ {
     use anyhow as _;
-    use inflector as _;
     use infra_utils as _;
     use paste as _;
     use semver as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -22,7 +22,6 @@ use tests::slang::query::setup as query_setup;
 
 mod __dependencies_used_in_lib__ {
     use anyhow as _;
-    use inflector as _;
     use infra_utils as _;
     use paste as _;
     use semver as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -16,7 +16,6 @@ use tests::slang_v2::semantic::setup as semantic_setup;
 
 mod __dependencies_used_in_lib__ {
     use anyhow as _;
-    use inflector as _;
     use infra_utils as _;
     use paste as _;
     use semver as _;

--- a/crates/solidity/testing/perf/cargo/src/tests/slang_v2/common.rs
+++ b/crates/solidity/testing/perf/cargo/src/tests/slang_v2/common.rs
@@ -1,4 +1,3 @@
-use inflector::Inflector;
 use semver::{BuildMetadata, Prerelease, Version};
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
@@ -13,5 +12,5 @@ pub fn parse_version(project: &SolidityProject) -> LanguageVersion {
 }
 
 pub fn parse_evm_target(project: &SolidityProject) -> EvmTarget {
-    EvmTarget::try_from(project.evm_version.to_pascal_case().as_str()).unwrap()
+    EvmTarget::try_from(project.evm_version.as_str()).unwrap()
 }


### PR DESCRIPTION
Matches `solc` formatting