### PR TITLE
[v2] feat(common): convert NodeId into usize

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -3293,6 +3293,8 @@ impl core::cmp::PartialEq for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::eq(&self, &slang_solidity_v2_common::nodes::NodeId) -> bool
 impl core::cmp::PartialOrd for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::partial_cmp(&self, &slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<slang_solidity_v2_common::nodes::NodeId> for usize
+pub fn usize::from(slang_solidity_v2_common::nodes::NodeId) -> Self
 impl core::convert::From<usize> for slang_solidity_v2_common::nodes::NodeId
 pub fn slang_solidity_v2_common::nodes::NodeId::from(usize) -> Self
 impl core::fmt::Debug for slang_solidity_v2_common::nodes::NodeId

--- a/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/nodes/mod.rs
@@ -13,6 +13,12 @@ impl From<usize> for NodeId {
     }
 }
 
+impl From<NodeId> for usize {
+    fn from(value: NodeId) -> Self {
+        value.0
+    }
+}
+
 impl fmt::Display for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
`NodeId` wraps a private `usize` and only offered the inbound `From<usize>`, so downstream crates could construct one but never recover the index, leaving `to_string()` as the only way out.

Add the outbound `From<NodeId> for usize`, mirroring the v1 `NodeId` in `crates/metaslang/cst/src/nodes.rs`.