### PR TITLE
[v2] fix(semantic): follow free functions called through an import alias

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
@@ -217,6 +217,15 @@ impl ReferenceCollector<'_> {
                                 CallableReference::Static(definition_id),
                             );
                         }
+                        // A function member of an import alias is a free
+                        // function of the imported file and runs within
+                        // the caller.
+                        Some(Definition::Import(_)) => {
+                            self.insert_function_reference(
+                                node_id,
+                                CallableReference::Static(definition_id),
+                            );
+                        }
                         _ => {}
                     }
                 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -977,6 +977,11 @@ mod semantic {
         }
 
         #[test]
+        fn import_alias_function_cycle() -> Result<()> {
+            run("semantic/bytecode_cycles", "import_alias_function_cycle")
+        }
+
+        #[test]
         fn imported_cycle() -> Result<()> {
             run("semantic/bytecode_cycles", "imported_cycle")
         }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/.tests.config.json
@@ -1,0 +1,8 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": "Istanbul",
+    "reason": "Using the latest EVM target supported by solc '0.8.0', to avoid triggering any additional 'Evm Version not supported' errors when comparing outputs."
+  },
+  "expected_solc_divergence": "Before '0.8.4' solc recorded dependencies only for expressions written inside contracts, so the `new A()` inside the free function is never attributed and it accepts this program, then fails with an internal error during code generation. Since '0.8.4' solc follows the call from `f` and reports the cycle like slang."
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[semantic/cyclic-bytecode-dependency] Error: Circular contract bytecode dependency.
+   ╭─[other.sol:7:5]
+   │
+ 7 │     new A();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7813] Error: Circular reference to contract bytecode either via "new" or "type(...).creationCode" / "type(...).runtimeCode".
+   ╭─[other.sol:7:5]
+   │
+ 7 │     new A();
+   │     ──┬──  
+   │       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/bytecode_cycles/import_alias_function_cycle/input.sol
@@ -1,0 +1,21 @@
+// ---- path: main.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./other.sol" as M;
+
+contract A {
+    function f() public {
+        M.create();
+    }
+}
+
+// ---- path: other.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+import "./main.sol";
+
+function create() {
+    new A();
+}


### PR DESCRIPTION
The dependency walk dropped function members of an import alias, so a bytecode cycle reached through those calls went unreported.