### PR TITLE
show generated v2 test snapshots in PR reviews

### DIFF
--- a/crates/solidity-v2/testing/snapshots/.gitattributes
+++ b/crates/solidity-v2/testing/snapshots/.gitattributes
@@ -1,0 +1,2 @@
+# Force reveal genearated testing snapshots during GitHub PR code reviews:
+**/generated/** linguist-generated=false


### PR DESCRIPTION
Added `.gitattributes` matching the existing v1 at `crates/solidity/testing/snapshots/.gitattributes`.