### PR TITLE
remove `vscode-ebnf` extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,6 @@
       "extensions": [
         // Language Support
         "dtsvet.vscode-wasm",
-        "igochkov.vscode-ebnf",
         "NomicFoundation.hardhat-solidity",
         "redhat.vscode-yaml",
         "rust-lang.rust-analyzer",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
   "recommendations": [
     // Language Support
     "dtsvet.vscode-wasm",
-    "igochkov.vscode-ebnf",
     "NomicFoundation.hardhat-solidity",
     "redhat.vscode-yaml",
     "rust-lang.rust-analyzer",


### PR DESCRIPTION
Extension added some diagnostics that don't match the EBNF flavor we generate, which triggers 1k+ errors whenever the file is opened. Removing it since it is no longer compatible.

<img width="1067" height="547" alt="image" src="https://github.com/user-attachments/assets/7c4dd152-9231-47e6-83f3-80ec8ef89089" />
