### PR TITLE
diagnose duplicate and trailing Yul switch cases

### DIFF
--- a/crates/codegen-v2/semantic/src/ir/builder.rs
+++ b/crates/codegen-v2/semantic/src/ir/builder.rs
@@ -31,6 +31,7 @@ pub fn build_v2_ir_model(language: &Language) -> ModelWithBuilder {
     rename_operator_fields(&mut mutator);
     rename_operator_choice_types(&mut mutator);
     simplify_booleans(&mut mutator);
+    reshape_yul_switch_cases(&mut mutator);
 
     // Final clean-up:
     remove_unused_types(&mut mutator);
@@ -377,6 +378,22 @@ fn simplify_mapping_type_parameters(mutator: &mut IrModelMutator) {
 
     mutator.add_sequence_field("MappingType", "key_type", "Parameter", false);
     mutator.add_sequence_field("MappingType", "value_type", "Parameter", false);
+}
+
+fn reshape_yul_switch_cases(mutator: &mut IrModelMutator) {
+    // Tighten the shape of `YulSwitchStatement` so the IR can only represent a
+    // well-formed switch: a list of value cases plus at most one `default` case.
+    mutator.add_collection_type("YulValueCases", "YulValueCase");
+
+    mutator.remove_sequence_field("YulSwitchStatement", "cases");
+    mutator.add_sequence_field("YulSwitchStatement", "value_cases", "YulValueCases", false);
+    mutator.add_sequence_field("YulSwitchStatement", "default_case", "YulDefaultCase", true);
+
+    // Remove the collection before its item type: `remove_type` on the item
+    // would otherwise cascade-drop `YulSwitchCases`, leaving the second call
+    // with nothing to find.
+    mutator.remove_type("YulSwitchCases");
+    mutator.remove_type("YulSwitchCase");
 }
 
 fn remove_unused_types(mutator: &mut IrModelMutator) {

--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -358,10 +358,9 @@ pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_path(&mut self, &
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_paths(&mut self, &slang_solidity_v2_ast::ast::YulPaths) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_statement(&mut self, &slang_solidity_v2_ast::ast::YulStatement) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_statements(&mut self, &slang_solidity_v2_ast::ast::YulStatements) -> bool
-pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_switch_case(&mut self, &slang_solidity_v2_ast::ast::YulSwitchCase) -> bool
-pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_switch_cases(&mut self, &slang_solidity_v2_ast::ast::YulSwitchCases) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_switch_statement(&mut self, &slang_solidity_v2_ast::ast::YulSwitchStatement) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_value_case(&mut self, &slang_solidity_v2_ast::ast::YulValueCase) -> bool
+pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_value_cases(&mut self, &slang_solidity_v2_ast::ast::YulValueCases) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_variable_assignment_statement(&mut self, &slang_solidity_v2_ast::ast::YulVariableAssignmentStatement) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_variable_declaration_statement(&mut self, &slang_solidity_v2_ast::ast::YulVariableDeclarationStatement) -> bool
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::enter_yul_variable_declaration_value(&mut self, &slang_solidity_v2_ast::ast::YulVariableDeclarationValue) -> bool
@@ -530,10 +529,9 @@ pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_path(&mut self, &
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_paths(&mut self, &slang_solidity_v2_ast::ast::YulPaths)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_statement(&mut self, &slang_solidity_v2_ast::ast::YulStatement)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_statements(&mut self, &slang_solidity_v2_ast::ast::YulStatements)
-pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_switch_case(&mut self, &slang_solidity_v2_ast::ast::YulSwitchCase)
-pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_switch_cases(&mut self, &slang_solidity_v2_ast::ast::YulSwitchCases)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_switch_statement(&mut self, &slang_solidity_v2_ast::ast::YulSwitchStatement)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_value_case(&mut self, &slang_solidity_v2_ast::ast::YulValueCase)
+pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_value_cases(&mut self, &slang_solidity_v2_ast::ast::YulValueCases)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_variable_assignment_statement(&mut self, &slang_solidity_v2_ast::ast::YulVariableAssignmentStatement)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_variable_declaration_statement(&mut self, &slang_solidity_v2_ast::ast::YulVariableDeclarationStatement)
 pub fn slang_solidity_v2_ast::ast::visitor::Visitor::leave_yul_variable_declaration_value(&mut self, &slang_solidity_v2_ast::ast::YulVariableDeclarationValue)
@@ -681,7 +679,6 @@ pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_if_statement(&slang_solid
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_leave_statement(&slang_solidity_v2_ast::ast::YulLeaveStatement, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_literal(&slang_solidity_v2_ast::ast::YulLiteral, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_statement(&slang_solidity_v2_ast::ast::YulStatement, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
-pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_switch_case(&slang_solidity_v2_ast::ast::YulSwitchCase, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_switch_statement(&slang_solidity_v2_ast::ast::YulSwitchStatement, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_value_case(&slang_solidity_v2_ast::ast::YulValueCase, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
 pub fn slang_solidity_v2_ast::ast::visitor::accept_yul_variable_assignment_statement(&slang_solidity_v2_ast::ast::YulVariableAssignmentStatement, &mut impl slang_solidity_v2_ast::ast::visitor::Visitor)
@@ -1179,13 +1176,6 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::YulStatement
 pub fn slang_solidity_v2_ast::ast::YulStatement::clone(&self) -> slang_solidity_v2_ast::ast::YulStatement
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulStatement
 pub fn slang_solidity_v2_ast::ast::YulStatement::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub enum slang_solidity_v2_ast::ast::YulSwitchCase
-pub slang_solidity_v2_ast::ast::YulSwitchCase::YulDefaultCase(slang_solidity_v2_ast::ast::YulDefaultCase)
-pub slang_solidity_v2_ast::ast::YulSwitchCase::YulValueCase(slang_solidity_v2_ast::ast::YulValueCase)
-impl core::clone::Clone for slang_solidity_v2_ast::ast::YulSwitchCase
-pub fn slang_solidity_v2_ast::ast::YulSwitchCase::clone(&self) -> slang_solidity_v2_ast::ast::YulSwitchCase
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulSwitchCase
-pub fn slang_solidity_v2_ast::ast::YulSwitchCase::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 impl slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct
 pub fn slang_solidity_v2_ast::ast::ABIEncoderV2KeywordStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
@@ -3757,23 +3747,15 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::YulStatementsStruct
 pub fn slang_solidity_v2_ast::ast::YulStatementsStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulStatementsStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulStatementsStruct
 pub fn slang_solidity_v2_ast::ast::YulStatementsStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-pub struct slang_solidity_v2_ast::ast::YulSwitchCasesStruct
-impl slang_solidity_v2_ast::ast::YulSwitchCasesStruct
-pub fn slang_solidity_v2_ast::ast::YulSwitchCasesStruct::is_empty(&self) -> bool
-pub fn slang_solidity_v2_ast::ast::YulSwitchCasesStruct::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::YulSwitchCase> + use<'_>
-pub fn slang_solidity_v2_ast::ast::YulSwitchCasesStruct::len(&self) -> usize
-impl core::clone::Clone for slang_solidity_v2_ast::ast::YulSwitchCasesStruct
-pub fn slang_solidity_v2_ast::ast::YulSwitchCasesStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulSwitchCasesStruct
-impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulSwitchCasesStruct
-pub fn slang_solidity_v2_ast::ast::YulSwitchCasesStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 impl slang_solidity_v2_ast::ast::YulSwitchStatementStruct
-pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::cases(&self) -> slang_solidity_v2_ast::ast::YulSwitchCases
+pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::default_case(&self) -> core::option::Option<slang_solidity_v2_ast::ast::YulDefaultCase>
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::YulExpression
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::node_id(&self) -> slang_solidity_v2_common::nodes::NodeId
+pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::value_cases(&self) -> slang_solidity_v2_ast::ast::YulValueCases
 impl core::clone::Clone for slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulSwitchStatementStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulSwitchStatementStruct
@@ -3790,6 +3772,15 @@ impl core::clone::Clone for slang_solidity_v2_ast::ast::YulValueCaseStruct
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulValueCaseStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulValueCaseStruct
 pub fn slang_solidity_v2_ast::ast::YulValueCaseStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub struct slang_solidity_v2_ast::ast::YulValueCasesStruct
+impl slang_solidity_v2_ast::ast::YulValueCasesStruct
+pub fn slang_solidity_v2_ast::ast::YulValueCasesStruct::is_empty(&self) -> bool
+pub fn slang_solidity_v2_ast::ast::YulValueCasesStruct::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = slang_solidity_v2_ast::ast::YulValueCase> + use<'_>
+pub fn slang_solidity_v2_ast::ast::YulValueCasesStruct::len(&self) -> usize
+impl core::clone::Clone for slang_solidity_v2_ast::ast::YulValueCasesStruct
+pub fn slang_solidity_v2_ast::ast::YulValueCasesStruct::clone(&self) -> slang_solidity_v2_ast::ast::YulValueCasesStruct
+impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::YulValueCasesStruct
+pub fn slang_solidity_v2_ast::ast::YulValueCasesStruct::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub struct slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct
 impl slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct::expression(&self) -> slang_solidity_v2_ast::ast::YulExpression
@@ -4172,9 +4163,9 @@ pub type slang_solidity_v2_ast::ast::YulParameters = slang_solidity_v2_ast::ast:
 pub type slang_solidity_v2_ast::ast::YulPath = slang_solidity_v2_ast::ast::YulPathStruct
 pub type slang_solidity_v2_ast::ast::YulPaths = slang_solidity_v2_ast::ast::YulPathsStruct
 pub type slang_solidity_v2_ast::ast::YulStatements = slang_solidity_v2_ast::ast::YulStatementsStruct
-pub type slang_solidity_v2_ast::ast::YulSwitchCases = slang_solidity_v2_ast::ast::YulSwitchCasesStruct
 pub type slang_solidity_v2_ast::ast::YulSwitchStatement = slang_solidity_v2_ast::ast::YulSwitchStatementStruct
 pub type slang_solidity_v2_ast::ast::YulValueCase = slang_solidity_v2_ast::ast::YulValueCaseStruct
+pub type slang_solidity_v2_ast::ast::YulValueCases = slang_solidity_v2_ast::ast::YulValueCasesStruct
 pub type slang_solidity_v2_ast::ast::YulVariableAssignmentStatement = slang_solidity_v2_ast::ast::YulVariableAssignmentStatementStruct
 pub type slang_solidity_v2_ast::ast::YulVariableDeclarationStatement = slang_solidity_v2_ast::ast::YulVariableDeclarationStatementStruct
 pub type slang_solidity_v2_ast::ast::YulVariableDeclarationValue = slang_solidity_v2_ast::ast::YulVariableDeclarationValueStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/nodes.generated.rs
@@ -4224,8 +4224,15 @@ impl YulSwitchStatementStruct {
         create_yul_expression(&self.ir_node.expression, &self.semantic)
     }
 
-    pub fn cases(&self) -> YulSwitchCases {
-        create_yul_switch_cases(&self.ir_node.cases, &self.semantic)
+    pub fn value_cases(&self) -> YulValueCases {
+        create_yul_value_cases(&self.ir_node.value_cases, &self.semantic)
+    }
+
+    pub fn default_case(&self) -> Option<YulDefaultCase> {
+        self.ir_node
+            .default_case
+            .as_ref()
+            .map(|ir_node| create_yul_default_case(ir_node, &self.semantic))
     }
 
     pub fn get_type(&self) -> Option<Type> {
@@ -5833,28 +5840,6 @@ pub(crate) fn create_yul_statement(
     }
 }
 
-#[derive(Clone)]
-pub enum YulSwitchCase {
-    YulDefaultCase(YulDefaultCase),
-    YulValueCase(YulValueCase),
-}
-
-#[allow(clippy::too_many_lines)]
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub(crate) fn create_yul_switch_case(
-    ir_node: &ir::YulSwitchCase,
-    semantic: &Arc<SemanticContext>,
-) -> YulSwitchCase {
-    match ir_node {
-        ir::YulSwitchCase::YulDefaultCase(variant) => {
-            YulSwitchCase::YulDefaultCase(create_yul_default_case(variant, semantic))
-        }
-        ir::YulSwitchCase::YulValueCase(variant) => {
-            YulSwitchCase::YulValueCase(create_yul_value_case(variant, semantic))
-        }
-    }
-}
-
 //
 // Repeated & Separated
 //
@@ -6939,29 +6924,29 @@ impl YulStatementsStruct {
         self.ir_nodes.is_empty()
     }
 }
-pub type YulSwitchCases = YulSwitchCasesStruct;
+pub type YulValueCases = YulValueCasesStruct;
 
-pub(crate) fn create_yul_switch_cases(
-    nodes: &ir::YulSwitchCases,
+pub(crate) fn create_yul_value_cases(
+    nodes: &ir::YulValueCases,
     semantic: &Arc<SemanticContext>,
-) -> YulSwitchCases {
-    YulSwitchCasesStruct {
+) -> YulValueCases {
+    YulValueCasesStruct {
         ir_nodes: Arc::clone(nodes),
         semantic: Arc::clone(semantic),
     }
 }
 
 #[derive(Clone)]
-pub struct YulSwitchCasesStruct {
-    pub(crate) ir_nodes: ir::YulSwitchCases,
+pub struct YulValueCasesStruct {
+    pub(crate) ir_nodes: ir::YulValueCases,
     pub(crate) semantic: Arc<SemanticContext>,
 }
 
-impl YulSwitchCasesStruct {
-    pub fn iter(&self) -> impl Iterator<Item = YulSwitchCase> + use<'_> {
+impl YulValueCasesStruct {
+    pub fn iter(&self) -> impl Iterator<Item = YulValueCase> + use<'_> {
         self.ir_nodes
             .iter()
-            .map(|ir_node| create_yul_switch_case(ir_node, &self.semantic))
+            .map(|ir_node| create_yul_value_case(ir_node, &self.semantic))
     }
 
     pub fn len(&self) -> usize {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/serialize.generated.rs
@@ -1232,13 +1232,14 @@ impl Serialize for YulLeaveStatementStruct {
 
 impl Serialize for YulSwitchStatementStruct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(6))?;
+        let mut map = serializer.serialize_map(Some(7))?;
         map.serialize_entry("id", &self.node_id())?;
         map.serialize_entry("type", "YulSwitchStatement")?;
         map.serialize_entry("range", &SerializeRange(self.get_text_range()))?;
         map.serialize_entry("file", self.get_file_id())?;
         map.serialize_entry("expression", &self.expression())?;
-        map.serialize_entry("cases", &self.cases())?;
+        map.serialize_entry("value_cases", &self.value_cases())?;
+        map.serialize_entry("default_case", &self.default_case())?;
         map.end()
     }
 }
@@ -1882,15 +1883,6 @@ impl Serialize for YulStatement {
     }
 }
 
-impl Serialize for YulSwitchCase {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            YulSwitchCase::YulDefaultCase(inner) => inner.serialize(serializer),
-            YulSwitchCase::YulValueCase(inner) => inner.serialize(serializer),
-        }
-    }
-}
-
 //
 // Repeated & Separated
 //
@@ -2225,7 +2217,7 @@ impl Serialize for YulStatementsStruct {
     }
 }
 
-impl Serialize for YulSwitchCasesStruct {
+impl Serialize for YulValueCasesStruct {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(self.len()))?;
         for item in self.iter() {

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/visitor.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/visitor.generated.rs
@@ -720,11 +720,6 @@ pub trait Visitor {
     }
     fn leave_yul_statement(&mut self, _node: &YulStatement) {}
 
-    fn enter_yul_switch_case(&mut self, _node: &YulSwitchCase) -> bool {
-        true
-    }
-    fn leave_yul_switch_case(&mut self, _node: &YulSwitchCase) {}
-
     fn enter_array_values(&mut self, _items: &ArrayValues) -> bool {
         true
     }
@@ -896,10 +891,10 @@ pub trait Visitor {
     }
     fn leave_yul_statements(&mut self, _items: &YulStatements) {}
 
-    fn enter_yul_switch_cases(&mut self, _items: &YulSwitchCases) -> bool {
+    fn enter_yul_value_cases(&mut self, _items: &YulValueCases) -> bool {
         true
     }
-    fn leave_yul_switch_cases(&mut self, _items: &YulSwitchCases) {}
+    fn leave_yul_value_cases(&mut self, _items: &YulValueCases) {}
 
     fn enter_yul_variable_names(&mut self, _items: &YulVariableNames) -> bool {
         true
@@ -1876,7 +1871,10 @@ pub fn accept_yul_switch_statement(node: &YulSwitchStatement, visitor: &mut impl
         return;
     }
     accept_yul_expression(&node.expression(), visitor);
-    accept_yul_switch_cases(&node.cases(), visitor);
+    accept_yul_value_cases(&node.value_cases(), visitor);
+    if let Some(ref default_case) = node.default_case() {
+        accept_yul_default_case(default_case, visitor);
+    }
     visitor.leave_yul_switch_statement(node);
 }
 
@@ -2774,21 +2772,6 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
     visitor.leave_yul_statement(node);
 }
 
-pub fn accept_yul_switch_case(node: &YulSwitchCase, visitor: &mut impl Visitor) {
-    if !visitor.enter_yul_switch_case(node) {
-        return;
-    }
-    match node {
-        YulSwitchCase::YulDefaultCase(yul_default_case) => {
-            accept_yul_default_case(yul_default_case, visitor);
-        }
-        YulSwitchCase::YulValueCase(yul_value_case) => {
-            accept_yul_value_case(yul_value_case, visitor);
-        }
-    }
-    visitor.leave_yul_switch_case(node);
-}
-
 //
 // Repeated & Separated
 //
@@ -3166,14 +3149,14 @@ fn accept_yul_statements(items: &YulStatements, visitor: &mut impl Visitor) {
 }
 
 #[inline]
-fn accept_yul_switch_cases(items: &YulSwitchCases, visitor: &mut impl Visitor) {
-    if !visitor.enter_yul_switch_cases(items) {
+fn accept_yul_value_cases(items: &YulValueCases, visitor: &mut impl Visitor) {
+    if !visitor.enter_yul_value_cases(items) {
         return;
     }
     for item in items.iter() {
-        accept_yul_switch_case(&item, visitor);
+        accept_yul_value_case(&item, visitor);
     }
-    visitor.leave_yul_switch_cases(items);
+    visitor.leave_yul_value_cases(items);
 }
 
 #[inline]

--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -736,6 +736,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::ContractShouldBeAbstract(slang_solidity_v2_common::diagnostics::kinds::structure::ContractShouldBeAbstract)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::DuplicateCatchClause(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateCatchClause)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::DuplicateNamedArgument(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::DuplicateSwitchDefaultCase(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyEnum(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyStruct(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::EmptyTupleComponent(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyTupleComponent)
@@ -773,6 +774,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnostic
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::PlaceholderInUncheckedBlock(slang_solidity_v2_common::diagnostics::kinds::structure::PlaceholderInUncheckedBlock)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::RedefinedBuiltInError(slang_solidity_v2_common::diagnostics::kinds::structure::RedefinedBuiltInError)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::StorageLayoutForAbstractContract(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract)
+pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::TrailingSwitchValueCase(slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UncheckedBlockNotInRegularBlock(slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedFunctionWithModifiers(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedFunctionWithModifiers)
 pub slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::UnimplementedModifierMustBeVirtual(slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedModifierMustBeVirtual)
@@ -803,6 +805,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateCatchClause) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -879,6 +883,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedFunctionWithModifiers> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
@@ -1062,6 +1068,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
@@ -1767,6 +1792,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase> for slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock
@@ -2659,6 +2703,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateCatchClause) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::EmptyStruct> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -2735,6 +2781,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StorageLayoutForAbstractContract) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::structure::UnimplementedFunctionWithModifiers> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -3027,6 +3075,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateNamedArgument::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::DuplicateSwitchDefaultCase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::EmptyEnum::message(&self) -> alloc::string::String
@@ -3179,6 +3231,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::StructureDiagnosticKind::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::structure::TrailingSwitchValueCase::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::structure::UncheckedBlockNotInRegularBlock::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/duplicate_switch_default_case.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/duplicate_switch_default_case.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a Yul `switch` statement declares more than one
+/// `default` case.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DuplicateSwitchDefaultCase;
+
+impl DiagnosticExtensions for DuplicateSwitchDefaultCase {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/duplicate-switch-default-case"
+    }
+
+    fn message(&self) -> String {
+        "A switch statement cannot have more than one default case.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/mod.rs
@@ -6,6 +6,7 @@ mod continue_outside_loop;
 mod contract_should_be_abstract;
 mod duplicate_catch_clause;
 mod duplicate_named_argument;
+mod duplicate_switch_default_case;
 mod empty_enum;
 mod empty_struct;
 mod empty_tuple_component;
@@ -43,6 +44,7 @@ mod payable_internal_or_private_function;
 mod placeholder_in_unchecked_block;
 mod redefined_built_in_error;
 mod storage_layout_for_abstract_contract;
+mod trailing_switch_value_case;
 mod unchecked_block_not_in_regular_block;
 mod unimplemented_function_with_modifiers;
 mod unimplemented_modifier_must_be_virtual;
@@ -61,6 +63,7 @@ pub use continue_outside_loop::ContinueOutsideLoop;
 pub use contract_should_be_abstract::ContractShouldBeAbstract;
 pub use duplicate_catch_clause::{CatchClauseKind, DuplicateCatchClause};
 pub use duplicate_named_argument::DuplicateNamedArgument;
+pub use duplicate_switch_default_case::DuplicateSwitchDefaultCase;
 pub use empty_enum::EmptyEnum;
 pub use empty_struct::EmptyStruct;
 pub use empty_tuple_component::EmptyTupleComponent;
@@ -99,6 +102,7 @@ pub use placeholder_in_unchecked_block::PlaceholderInUncheckedBlock;
 pub use redefined_built_in_error::RedefinedBuiltInError;
 use serde::Serialize;
 pub use storage_layout_for_abstract_contract::StorageLayoutForAbstractContract;
+pub use trailing_switch_value_case::TrailingSwitchValueCase;
 pub use unchecked_block_not_in_regular_block::UncheckedBlockNotInRegularBlock;
 pub use unimplemented_function_with_modifiers::UnimplementedFunctionWithModifiers;
 pub use unimplemented_modifier_must_be_virtual::UnimplementedModifierMustBeVirtual;
@@ -264,5 +268,10 @@ define_diagnostic_kind! {
 
         /// An abstract contract declares a storage layout (`layout at`) specifier.
         StorageLayoutForAbstractContract(StorageLayoutForAbstractContract),
+
+        /// A Yul `switch` statement declared more than one `default` case.
+        DuplicateSwitchDefaultCase(DuplicateSwitchDefaultCase),
+        /// A Yul `switch` statement declared a `value` case after its `default` case.
+        TrailingSwitchValueCase(TrailingSwitchValueCase),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/trailing_switch_value_case.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/structure/trailing_switch_value_case.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when a Yul `switch` statement declares a 'value' case after
+/// its 'default' case.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TrailingSwitchValueCase;
+
+impl DiagnosticExtensions for TrailingSwitchValueCase {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "structure/trailing-switch-value-case"
+    }
+
+    fn message(&self) -> String {
+        "A switch statement cannot have a value case after the default case.".to_string()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -168,10 +168,9 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_path(&mut self, &sl
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_paths(&mut self, &slang_solidity_v2_ir::ir::YulPaths) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_statement(&mut self, &slang_solidity_v2_ir::ir::YulStatement) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_statements(&mut self, &slang_solidity_v2_ir::ir::YulStatements) -> bool
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_switch_case(&mut self, &slang_solidity_v2_ir::ir::YulSwitchCase) -> bool
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_switch_cases(&mut self, &slang_solidity_v2_ir::ir::YulSwitchCases) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_switch_statement(&mut self, &slang_solidity_v2_ir::ir::YulSwitchStatement) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_value_case(&mut self, &slang_solidity_v2_ir::ir::YulValueCase) -> bool
+pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_value_cases(&mut self, &slang_solidity_v2_ir::ir::YulValueCases) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_variable_assignment_statement(&mut self, &slang_solidity_v2_ir::ir::YulVariableAssignmentStatement) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_variable_declaration_statement(&mut self, &slang_solidity_v2_ir::ir::YulVariableDeclarationStatement) -> bool
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::enter_yul_variable_declaration_value(&mut self, &slang_solidity_v2_ir::ir::YulVariableDeclarationValue) -> bool
@@ -340,10 +339,9 @@ pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_path(&mut self, &sl
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_paths(&mut self, &slang_solidity_v2_ir::ir::YulPaths)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_statement(&mut self, &slang_solidity_v2_ir::ir::YulStatement)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_statements(&mut self, &slang_solidity_v2_ir::ir::YulStatements)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_switch_case(&mut self, &slang_solidity_v2_ir::ir::YulSwitchCase)
-pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_switch_cases(&mut self, &slang_solidity_v2_ir::ir::YulSwitchCases)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_switch_statement(&mut self, &slang_solidity_v2_ir::ir::YulSwitchStatement)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_value_case(&mut self, &slang_solidity_v2_ir::ir::YulValueCase)
+pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_value_cases(&mut self, &slang_solidity_v2_ir::ir::YulValueCases)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_variable_assignment_statement(&mut self, &slang_solidity_v2_ir::ir::YulVariableAssignmentStatement)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_variable_declaration_statement(&mut self, &slang_solidity_v2_ir::ir::YulVariableDeclarationStatement)
 pub fn slang_solidity_v2_ir::ir::visitor::Visitor::leave_yul_variable_declaration_value(&mut self, &slang_solidity_v2_ir::ir::YulVariableDeclarationValue)
@@ -556,7 +554,6 @@ pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_if_statement(&slang_solidit
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_leave_statement(&slang_solidity_v2_ir::ir::YulLeaveStatement, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_literal(&slang_solidity_v2_ir::ir::YulLiteral, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_statement(&slang_solidity_v2_ir::ir::YulStatement, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
-pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_switch_case(&slang_solidity_v2_ir::ir::YulSwitchCase, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_switch_statement(&slang_solidity_v2_ir::ir::YulSwitchStatement, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_value_case(&slang_solidity_v2_ir::ir::YulValueCase, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
 pub fn slang_solidity_v2_ir::ir::visitor::accept_yul_variable_assignment_statement(&slang_solidity_v2_ir::ir::YulVariableAssignmentStatement, &mut impl slang_solidity_v2_ir::ir::visitor::Visitor)
@@ -1387,17 +1384,6 @@ impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSta
 pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-pub enum slang_solidity_v2_ir::ir::YulSwitchCase
-pub slang_solidity_v2_ir::ir::YulSwitchCase::YulDefaultCase(slang_solidity_v2_ir::ir::YulDefaultCase)
-pub slang_solidity_v2_ir::ir::YulSwitchCase::YulValueCase(slang_solidity_v2_ir::ir::YulValueCase)
-impl core::clone::Clone for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::clone(&self) -> slang_solidity_v2_ir::ir::YulSwitchCase
-impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
 pub slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ABIEncoderV2KeywordStruct
@@ -3860,9 +3846,10 @@ pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::node_id(&self) -> core
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 pub struct slang_solidity_v2_ir::ir::YulSwitchStatementStruct
-pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::cases: slang_solidity_v2_ir::ir::YulSwitchCases
+pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::default_case: core::option::Option<slang_solidity_v2_ir::ir::YulDefaultCase>
 pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::expression: slang_solidity_v2_ir::ir::YulExpression
 pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::range: core::ops::range::Range<usize>
+pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::value_cases: slang_solidity_v2_ir::ir::YulValueCases
 impl slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
@@ -4336,8 +4323,6 @@ impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLit
 pub fn slang_solidity_v2_ir::ir::YulLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
-impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulValueCaseStruct
@@ -4780,8 +4765,6 @@ impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLitera
 pub fn slang_solidity_v2_ir::ir::YulLiteral::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
-impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchCase
-pub fn slang_solidity_v2_ir::ir::YulSwitchCase::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::calculate_text_range(&self) -> core::option::Option<core::ops::range::Range<usize>>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulValueCaseStruct
@@ -5001,9 +4984,9 @@ pub type slang_solidity_v2_ir::ir::YulParameters = alloc::sync::Arc<[slang_solid
 pub type slang_solidity_v2_ir::ir::YulPath = alloc::sync::Arc<[slang_solidity_v2_ir::ir::Identifier]>
 pub type slang_solidity_v2_ir::ir::YulPaths = alloc::sync::Arc<[slang_solidity_v2_ir::ir::YulPath]>
 pub type slang_solidity_v2_ir::ir::YulStatements = alloc::sync::Arc<[slang_solidity_v2_ir::ir::YulStatement]>
-pub type slang_solidity_v2_ir::ir::YulSwitchCases = alloc::sync::Arc<[slang_solidity_v2_ir::ir::YulSwitchCase]>
 pub type slang_solidity_v2_ir::ir::YulSwitchStatement = alloc::sync::Arc<slang_solidity_v2_ir::ir::YulSwitchStatementStruct>
 pub type slang_solidity_v2_ir::ir::YulValueCase = alloc::sync::Arc<slang_solidity_v2_ir::ir::YulValueCaseStruct>
+pub type slang_solidity_v2_ir::ir::YulValueCases = alloc::sync::Arc<[slang_solidity_v2_ir::ir::YulValueCase]>
 pub type slang_solidity_v2_ir::ir::YulVariableAssignmentStatement = alloc::sync::Arc<slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct>
 pub type slang_solidity_v2_ir::ir::YulVariableDeclarationStatement = alloc::sync::Arc<slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct>
 pub type slang_solidity_v2_ir::ir::YulVariableDeclarationValue = alloc::sync::Arc<slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct>

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/default.generated.rs
@@ -1338,23 +1338,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         Arc::new(output::YulLeaveStatementStruct { id, range })
     }
 
-    pub(super) fn build_yul_switch_statement(
-        &mut self,
-        source: &input::YulSwitchStatement,
-    ) -> output::YulSwitchStatement {
-        let id = self.next_id(output::NodeKind::YulSwitchStatement);
-        let range = source.calculate_text_range().unwrap_or_default();
-        let expression = self.build_yul_expression(&source.expression);
-        let cases = self.build_yul_switch_cases(&source.cases);
-
-        Arc::new(output::YulSwitchStatementStruct {
-            id,
-            range,
-            expression,
-            cases,
-        })
-    }
-
     pub(super) fn build_yul_value_case(
         &mut self,
         source: &input::YulValueCase,
@@ -2643,23 +2626,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
         }
     }
 
-    #[allow(clippy::unused_self)]
-    pub(super) fn build_yul_switch_case(
-        &mut self,
-        source: &input::YulSwitchCase,
-    ) -> output::YulSwitchCase {
-        #[allow(clippy::match_wildcard_for_single_variants)]
-        #[allow(clippy::match_single_binding)]
-        match source {
-            input::YulSwitchCase::YulDefaultCase(yul_default_case) => {
-                output::YulSwitchCase::YulDefaultCase(self.build_yul_default_case(yul_default_case))
-            }
-            input::YulSwitchCase::YulValueCase(yul_value_case) => {
-                output::YulSwitchCase::YulValueCase(self.build_yul_value_case(yul_value_case))
-            }
-        }
-    }
-
     //
     // Collapsed choices
     //
@@ -3122,20 +3088,6 @@ impl<S: Source> CstToIrBuilder<'_, S> {
             .elements
             .iter()
             .map(|item| self.build_yul_statement(item))
-            .collect()
-    }
-
-    pub(super) fn build_yul_switch_cases(
-        &mut self,
-        source: &input::YulSwitchCases,
-    ) -> output::YulSwitchCases {
-        if source.elements.is_empty() {
-            return Arc::default();
-        }
-        source
-            .elements
-            .iter()
-            .map(|item| self.build_yul_switch_case(item))
             .collect()
     }
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/mod.rs
@@ -2,6 +2,7 @@ mod attributes;
 #[path = "default.generated.rs"]
 mod default;
 pub(crate) mod node_id_generator;
+mod yul;
 
 use std::sync::Arc;
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/yul.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/builder/yul.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use slang_solidity_v2_common::diagnostics::kinds::structure::{
+    DuplicateSwitchDefaultCase, TrailingSwitchValueCase,
+};
+use slang_solidity_v2_cst::structured_cst::nodes as input;
+use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
+
+use crate::ir::builder::{CstToIrBuilder, Source};
+use crate::ir::nodes as output;
+
+impl<S: Source> CstToIrBuilder<'_, S> {
+    pub(super) fn build_yul_switch_statement(
+        &mut self,
+        source: &input::YulSwitchStatement,
+    ) -> output::YulSwitchStatement {
+        let id = self.next_id(output::NodeKind::YulSwitchStatement);
+        let range = source.calculate_text_range().unwrap_or_default();
+        let expression = self.build_yul_expression(&source.expression);
+
+        let mut value_cases: Vec<output::YulValueCase> = Vec::new();
+        let mut default_case: Option<output::YulDefaultCase> = None;
+        for case in &source.cases.elements {
+            match case {
+                input::YulSwitchCase::YulValueCase(value_case) => {
+                    if default_case.is_some() {
+                        self.report(&value_case.case_keyword, TrailingSwitchValueCase);
+                    }
+                    value_cases.push(self.build_yul_value_case(value_case));
+                }
+                input::YulSwitchCase::YulDefaultCase(default) => {
+                    if default_case.is_some() {
+                        self.report(&default.default_keyword, DuplicateSwitchDefaultCase);
+                    } else {
+                        default_case = Some(self.build_yul_default_case(default));
+                    }
+                }
+            }
+        }
+
+        Arc::new(output::YulSwitchStatementStruct {
+            id,
+            range,
+            expression,
+            value_cases: value_cases.into(),
+            default_case,
+        })
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/node_identity.generated.rs
@@ -1298,16 +1298,6 @@ impl NodeIdentity for YulStatement {
     }
 }
 
-impl NodeIdentity for YulSwitchCase {
-    fn node_id(&self) -> Option<NodeId> {
-        match self {
-            YulSwitchCase::YulDefaultCase(inner) => inner.node_id(),
-
-            YulSwitchCase::YulValueCase(inner) => inner.node_id(),
-        }
-    }
-}
-
 impl NodeIdentity for ABIEncoderV2KeywordStruct {
     fn node_id(&self) -> Option<NodeId> {
         Some(self.id)

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -1503,7 +1503,8 @@ pub struct YulSwitchStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
     pub expression: YulExpression,
-    pub cases: YulSwitchCases,
+    pub value_cases: YulValueCases,
+    pub default_case: Option<YulDefaultCase>,
 }
 
 impl YulSwitchStatementStruct {
@@ -2142,12 +2143,6 @@ pub enum YulStatement {
     YulExpression(YulExpression),
 }
 
-#[derive(Clone, Debug)]
-pub enum YulSwitchCase {
-    YulDefaultCase(YulDefaultCase),
-    YulValueCase(YulValueCase),
-}
-
 //
 // Repeated & Separated
 //
@@ -2218,7 +2213,7 @@ pub type YulPaths = Arc<[YulPath]>;
 
 pub type YulStatements = Arc<[YulStatement]>;
 
-pub type YulSwitchCases = Arc<[YulSwitchCase]>;
+pub type YulValueCases = Arc<[YulValueCase]>;
 
 pub type YulVariableNames = Arc<[Identifier]>;
 

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/text_range.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/text_range.generated.rs
@@ -1309,16 +1309,6 @@ impl TextRange for YulStatement {
     }
 }
 
-impl TextRange for YulSwitchCase {
-    fn calculate_text_range(&self) -> Option<Range<usize>> {
-        match self {
-            YulSwitchCase::YulDefaultCase(inner) => inner.calculate_text_range(),
-
-            YulSwitchCase::YulValueCase(inner) => inner.calculate_text_range(),
-        }
-    }
-}
-
 impl TextRange for ABIEncoderV2KeywordStruct {
     fn calculate_text_range(&self) -> Option<Range<usize>> {
         Some(self.range.clone())

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/visitor.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/visitor.generated.rs
@@ -722,11 +722,6 @@ pub trait Visitor {
     }
     fn leave_yul_statement(&mut self, _node: &YulStatement) {}
 
-    fn enter_yul_switch_case(&mut self, _node: &YulSwitchCase) -> bool {
-        true
-    }
-    fn leave_yul_switch_case(&mut self, _node: &YulSwitchCase) {}
-
     fn enter_array_values(&mut self, _items: &ArrayValues) -> bool {
         true
     }
@@ -898,10 +893,10 @@ pub trait Visitor {
     }
     fn leave_yul_statements(&mut self, _items: &YulStatements) {}
 
-    fn enter_yul_switch_cases(&mut self, _items: &YulSwitchCases) -> bool {
+    fn enter_yul_value_cases(&mut self, _items: &YulValueCases) -> bool {
         true
     }
-    fn leave_yul_switch_cases(&mut self, _items: &YulSwitchCases) {}
+    fn leave_yul_value_cases(&mut self, _items: &YulValueCases) {}
 
     fn enter_yul_variable_names(&mut self, _items: &YulVariableNames) -> bool {
         true
@@ -2017,7 +2012,10 @@ pub fn accept_yul_switch_statement(node: &YulSwitchStatement, visitor: &mut impl
         return;
     }
     accept_yul_expression(&node.expression, visitor);
-    accept_yul_switch_cases(&node.cases, visitor);
+    accept_yul_value_cases(&node.value_cases, visitor);
+    if let Some(default_case) = &node.default_case {
+        accept_yul_default_case(default_case, visitor);
+    }
     visitor.leave_yul_switch_statement(node);
 }
 
@@ -3093,21 +3091,6 @@ pub fn accept_yul_statement(node: &YulStatement, visitor: &mut impl Visitor) {
     visitor.leave_yul_statement(node);
 }
 
-pub fn accept_yul_switch_case(node: &YulSwitchCase, visitor: &mut impl Visitor) {
-    if !visitor.enter_yul_switch_case(node) {
-        return;
-    }
-    match &node {
-        YulSwitchCase::YulDefaultCase(yul_default_case) => {
-            accept_yul_default_case(yul_default_case, visitor);
-        }
-        YulSwitchCase::YulValueCase(yul_value_case) => {
-            accept_yul_value_case(yul_value_case, visitor);
-        }
-    }
-    visitor.leave_yul_switch_case(node);
-}
-
 //
 // Repeated & Separated
 //
@@ -3518,16 +3501,16 @@ fn accept_yul_statements(items: &YulStatements, visitor: &mut impl Visitor) {
     visitor.leave_yul_statements(items);
 }
 #[inline]
-fn accept_yul_switch_cases(items: &YulSwitchCases, visitor: &mut impl Visitor) {
-    if !visitor.enter_yul_switch_cases(items) {
+fn accept_yul_value_cases(items: &YulValueCases, visitor: &mut impl Visitor) {
+    if !visitor.enter_yul_value_cases(items) {
         return;
     }
 
     for item in items.iter() {
-        accept_yul_switch_case(item, visitor);
+        accept_yul_value_case(item, visitor);
     }
 
-    visitor.leave_yul_switch_cases(items);
+    visitor.leave_yul_value_cases(items);
 }
 #[inline]
 fn accept_yul_variable_names(items: &YulVariableNames, visitor: &mut impl Visitor) {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1585,6 +1585,11 @@ mod structure {
     }
 
     #[test]
+    fn duplicate_default_case() -> Result<()> {
+        run("structure", "duplicate_default_case")
+    }
+
+    #[test]
     fn duplicate_error_catch_clause() -> Result<()> {
         run("structure", "duplicate_error_catch_clause")
     }
@@ -1920,6 +1925,11 @@ mod structure {
     #[test]
     fn storage_layout_for_abstract_contract() -> Result<()> {
         run("structure", "storage_layout_for_abstract_contract")
+    }
+
+    #[test]
+    fn trailing_non_default_case() -> Result<()> {
+        run("structure", "trailing_non_default_case")
     }
 
     mod unchecked_block_not_in_regular_block {

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/duplicate-switch-default-case] Error: A switch statement cannot have more than one default case.
+    ╭─[input.sol:18:13]
+    │
+ 18 │             default { }
+    │             ───┬───  
+    │                ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 6931] Error: Only one default case allowed.
+    ╭─[input.sol:18:13]
+    │
+ 18 │             default { }
+    │             ───┬───  
+    │                ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/duplicate_default_case/input.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f() public pure {
+        assembly {
+            let x := 0
+
+            // Valid: a single default case is not flagged.
+            switch x
+            case 0 { }
+            default { }
+
+            // Two default cases: the second `default` is flagged.
+            switch x
+            case 1 { }
+            default { }
+            default { }
+        }
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[structure/trailing-switch-value-case] Error: A switch statement cannot have a value case after the default case.
+    ╭─[input.sol:17:13]
+    │
+ 17 │             case 1 { }
+    │             ──┬─  
+    │               ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 4904] Error: Case not allowed after default case.
+    ╭─[input.sol:17:13]
+    │
+ 17 │             case 1 { }
+    │             ──┬─  
+    │               ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/structure/trailing_non_default_case/input.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f() public pure {
+        assembly {
+            let x := 0
+
+            // Valid: the default case is the last case.
+            switch x
+            case 0 { }
+            default { }
+
+            // A `case` following the `default` case: the trailing `case` is flagged.
+            switch x
+            default { }
+            case 1 { }
+        }
+    }
+}


### PR DESCRIPTION
adds the following two diagnostics + tests:

- `structure/duplicate-switch-default-case`
- `structure/trailing-switch-value-case`