### PR TITLE
[v2] fix(semantic): type an indexed meta-type by its length

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -18,7 +18,10 @@ use crate::passes::common::constant_evaluator::{
     ConstantResolver, EvaluationError, evaluate_compile_time_constant,
 };
 use crate::passes::common::find_definition_namespace_scope_id;
-use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId, UserMetaType};
+use crate::types::{
+    ArrayType, ContractType, DataLocation, FixedSizeArrayType, InterfaceType, StructType, Type,
+    TypeId, UserMetaType,
+};
 
 /// Lexical style resolution of symbols
 impl Pass<'_> {
@@ -389,6 +392,33 @@ impl Pass<'_> {
             let reference = Reference::new(Arc::clone(identifier), resolution);
             self.binder.insert_reference(reference);
         }
+    }
+
+    /// The array an indexed type denotes: `T[n]` for a constant `size`, `T[]` otherwise.
+    pub(super) fn array_of(&mut self, element_type: TypeId, size: Option<&ir::Expression>) -> Type {
+        if let Some(expression) = size
+            && let Ok(value) = evaluate_compile_time_constant(
+                expression,
+                self.current_scope_id(),
+                self.types,
+                &ConstantResolver {
+                    binder: self.binder,
+                    use_site: None,
+                },
+            )
+            && let Some(integer) = value.as_integer()
+            && let Ok(size) = U256::try_from(integer)
+        {
+            return Type::FixedSizeArray(FixedSizeArrayType {
+                element_type,
+                size,
+                location: DataLocation::Memory,
+            });
+        }
+        Type::Array(ArrayType {
+            element_type,
+            location: DataLocation::Memory,
+        })
     }
 
     /// Resolves and validates a contract's `layout at <expr>` storage base

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -18,10 +18,7 @@ use crate::passes::common::constant_evaluator::{
     ConstantResolver, EvaluationError, evaluate_compile_time_constant,
 };
 use crate::passes::common::find_definition_namespace_scope_id;
-use crate::types::{
-    ArrayType, ContractType, DataLocation, FixedSizeArrayType, InterfaceType, StructType, Type,
-    TypeId, UserMetaType,
-};
+use crate::types::{ContractType, InterfaceType, StructType, Type, TypeId, UserMetaType};
 
 /// Lexical style resolution of symbols
 impl Pass<'_> {
@@ -392,33 +389,6 @@ impl Pass<'_> {
             let reference = Reference::new(Arc::clone(identifier), resolution);
             self.binder.insert_reference(reference);
         }
-    }
-
-    /// The array an indexed type denotes: `T[n]` for a constant `size`, `T[]` otherwise.
-    pub(super) fn array_of(&mut self, element_type: TypeId, size: Option<&ir::Expression>) -> Type {
-        if let Some(expression) = size
-            && let Ok(value) = evaluate_compile_time_constant(
-                expression,
-                self.current_scope_id(),
-                self.types,
-                &ConstantResolver {
-                    binder: self.binder,
-                    use_site: None,
-                },
-            )
-            && let Some(integer) = value.as_integer()
-            && let Ok(size) = U256::try_from(integer)
-        {
-            return Type::FixedSizeArray(FixedSizeArrayType {
-                element_type,
-                size,
-                location: DataLocation::Memory,
-            });
-        }
-        Type::Array(ArrayType {
-            element_type,
-            location: DataLocation::Memory,
-        })
     }
 
     /// Resolves and validates a contract's `layout at <expr>` storage base

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -8,9 +8,9 @@ use super::Pass;
 use crate::binder::{Definition, Resolution, Typing};
 use crate::passes::common::node_location;
 use crate::types::{
-    AddressType, ArraySliceType, ContractType, DataLocation, FixedSizeArrayType, FunctionType,
-    FunctionTypeVisibility, IntegerType, LiteralKind, MetaType, Number, StringType, Type, TypeId,
-    UserMetaType, literals,
+    AddressType, ArraySliceType, ArrayType, ContractType, DataLocation, FixedSizeArrayType,
+    FunctionType, FunctionTypeVisibility, IntegerType, LiteralKind, MetaType, Number, StringType,
+    Type, TypeId, UserMetaType, literals,
 };
 
 impl Pass<'_> {
@@ -164,6 +164,38 @@ impl Pass<'_> {
             // TODO(validation) SDR[46]: slicing a non-calldata array is invalid.
             Typing::Unresolved
         }
+    }
+
+    /// Unlike an array type name's length, a constant is not a length here: in
+    /// expression position solc folds literals only, and rejects `uint[N]`.
+    pub(super) fn typing_of_indexed_meta_type(
+        &mut self,
+        element_type: TypeId,
+        size: Option<&ir::Expression>,
+    ) -> Typing {
+        let Some(size) = size else {
+            return self.meta_typing_of(Type::Array(ArrayType {
+                element_type,
+                location: DataLocation::Memory,
+            }));
+        };
+        let Some(size) = self.literal_array_size(size) else {
+            // TODO(validation): a non-literal index is not an array length
+            return Typing::Unresolved;
+        };
+        self.meta_typing_of(Type::FixedSizeArray(FixedSizeArrayType {
+            element_type,
+            size,
+            location: DataLocation::Memory,
+        }))
+    }
+
+    /// The length an array index denotes, or `None` unless it is a non-negative
+    /// integer literal that fits a `U256`.
+    fn literal_array_size(&self, size: &ir::Expression) -> Option<U256> {
+        let type_id = self.typing_of_expression(size).as_type_id()?;
+        let value = self.types.number_value_of_type_id(type_id)?;
+        U256::try_from(value.as_integer()?).ok()
     }
 
     pub(super) fn type_of_array_expression(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -191,7 +191,8 @@ impl Pass<'_> {
     }
 
     /// The length an array index denotes, or `None` unless it is a non-negative
-    /// integer literal that fits a `U256`.
+    /// integer literal that fits a `U256`. The value is taken from the
+    /// expression type to benefit from the constant folding of literals.
     fn literal_array_size(&self, size: &ir::Expression) -> Option<U256> {
         let type_id = self.typing_of_expression(size).as_type_id()?;
         let value = self.types.number_value_of_type_id(type_id)?;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -11,8 +11,8 @@ use crate::binder::{Reference, Resolution, Typing, UsingOperator};
 use crate::built_ins::InternalBuiltIn;
 use crate::passes::common::filter_overriden_definitions;
 use crate::types::{
-    AddressType, ArraySliceType, ArrayType, BytesType, DataLocation, FixedSizeArrayType,
-    MappingType, MetaType, Number, StringType, TupleType, Type, UserMetaType,
+    AddressType, ArraySliceType, ArrayType, BytesType, FixedSizeArrayType, MappingType, MetaType,
+    Number, StringType, TupleType, Type, UserMetaType,
 };
 
 impl Visitor for Pass<'_> {
@@ -510,20 +510,18 @@ impl Visitor for Pass<'_> {
                     // fixed-size `uint[3]`.
                     Type::MetaType(MetaType {
                         type_id: element_type,
-                    }) => self.meta_typing_of(Type::Array(ArrayType {
-                        element_type: *element_type,
-                        location: DataLocation::Memory,
-                    })),
+                    }) => {
+                        let array = self.array_of(*element_type, node.start.as_ref());
+                        self.meta_typing_of(array)
+                    }
                     // Indexing a user meta-type likewise creates the meta-type
                     // of an array (eg. `MyStruct[]`).
                     Type::UserMetaType(UserMetaType { definition_id }) => {
                         let definition_id = *definition_id;
                         if let Some(operand_type) = self.type_of_definition(definition_id) {
                             let element_type = self.types.register_type(operand_type);
-                            self.meta_typing_of(Type::Array(ArrayType {
-                                element_type,
-                                location: DataLocation::Memory,
-                            }))
+                            let array = self.array_of(element_type, node.start.as_ref());
+                            self.meta_typing_of(array)
                         } else {
                             Typing::Unresolved
                         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -510,18 +510,14 @@ impl Visitor for Pass<'_> {
                     // fixed-size `uint[3]`.
                     Type::MetaType(MetaType {
                         type_id: element_type,
-                    }) => {
-                        let array = self.array_of(*element_type, node.start.as_ref());
-                        self.meta_typing_of(array)
-                    }
+                    }) => self.typing_of_indexed_meta_type(*element_type, node.start.as_ref()),
                     // Indexing a user meta-type likewise creates the meta-type
                     // of an array (eg. `MyStruct[]`).
                     Type::UserMetaType(UserMetaType { definition_id }) => {
                         let definition_id = *definition_id;
                         if let Some(operand_type) = self.type_of_definition(definition_id) {
                             let element_type = self.types.register_type(operand_type);
-                            let array = self.array_of(element_type, node.start.as_ref());
-                            self.meta_typing_of(array)
+                            self.typing_of_indexed_meta_type(element_type, node.start.as_ref())
                         } else {
                             Typing::Unresolved
                         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1662,6 +1662,44 @@ fn test_index_access_on_elementary_meta_type_yields_array_meta_type() {
 }
 
 #[test]
+fn test_index_access_on_elementary_meta_type_with_literal_index_yields_fixed_size_array() {
+    // A number literal index is the array's length, whether written directly,
+    // folded from literal arithmetic, or written in hex.
+    let expressions = ["uint[3]", "uint[1 + 2]", "uint[0x3]"];
+    let (typings, types) = type_of_expressions(LanguageVersion::LATEST, None, None, &expressions);
+
+    for (expression, typing) in expressions.iter().zip(&typings) {
+        let Some(Type::MetaType(MetaType { type_id: array_id })) = typing else {
+            panic!("expected `{expression}` to be a MetaType, got {typing:?}");
+        };
+        let Type::FixedSizeArray(FixedSizeArrayType {
+            element_type,
+            size,
+            location,
+        }) = types.get_type_by_id(*array_id).clone()
+        else {
+            panic!(
+                "expected `{expression}` to wrap a FixedSizeArray, got {:?}",
+                types.get_type_by_id(*array_id)
+            );
+        };
+        assert_eq!(size, U256::from(3), "`{expression}` has length 3");
+        assert_eq!(element_type, types.uint256());
+        assert_eq!(location, DataLocation::Memory);
+    }
+}
+
+#[test]
+fn test_index_access_on_elementary_meta_type_with_non_literal_index_is_unresolved() {
+    // Only a literal is a length in expression position, so neither a constant
+    // nor a cast is one (matches solc error 3940).
+    for expression in ["uint[N]", "uint[uint8(3)]"] {
+        let (typing, _) = try_type_of_expression_in_context("uint constant N = 3;", expression);
+        assert_eq!(typing, None, "`{expression}` is not a valid array length");
+    }
+}
+
+#[test]
 fn test_index_access_on_user_meta_type_yields_array_meta_type() {
     // `MyStruct[]` is a *type expression*: indexing the user meta-type of a
     // struct produces the meta-type of an array whose element is that struct.
@@ -1683,6 +1721,36 @@ fn test_index_access_on_user_meta_type_yields_array_meta_type() {
     assert_eq!(location, DataLocation::Memory);
 
     // The array element is the struct's own value type.
+    assert!(
+        matches!(
+            types.get_type_by_id(element_type),
+            Type::Struct(StructType { .. })
+        ),
+        "expected the array element to be the struct type, got {:?}",
+        types.get_type_by_id(element_type),
+    );
+}
+
+#[test]
+fn test_index_access_on_user_meta_type_with_literal_index_yields_fixed_size_array() {
+    let (meta, types) = type_of_expression_in_context("struct MyStruct { uint a; }", "MyStruct[3]");
+
+    let Type::MetaType(MetaType { type_id: array_id }) = meta else {
+        panic!("expected the `MyStruct[3]` expression to be a MetaType, got {meta:?}");
+    };
+    let Type::FixedSizeArray(FixedSizeArrayType {
+        element_type,
+        size,
+        location,
+    }) = types.get_type_by_id(array_id).clone()
+    else {
+        panic!(
+            "expected the meta-type to wrap a FixedSizeArray, got {:?}",
+            types.get_type_by_id(array_id)
+        );
+    };
+    assert_eq!(size, U256::from(3));
+    assert_eq!(location, DataLocation::Memory);
     assert!(
         matches!(
             types.get_type_by_id(element_type),


### PR DESCRIPTION
Indexing a meta-type built its array from the element type alone, so a length in expression position — the `uint[3]` of `abi.decode(data, (uint[3]))` — denoted a dynamic array, and every fixed dimension at every nesting level was lost. Take the length from the index's own typing, which is a number literal in exactly the cases solc reads as a length: `uint[3]`, `uint[1 + 2]` and `uint[0x3]` fold, while `uint[N]` for a constant `N` does not. Unlike an array type name's length, this position resolves no constants — solc rejects them with error 3940.

Fixes decoding a static array, and with it the decoder's own validation, which ran the dynamic path over an encoding that carries no length word:

https://github.com/NomicFoundation/solx-solidity/blob/e8565c9def898a1f2253b931c35f6e35eb9626a4/test/libsolidity/semanticTests/abiEncoderV1/abi_decode_static_array.sol
https://github.com/NomicFoundation/solx-solidity/blob/e8565c9def898a1f2253b931c35f6e35eb9626a4/test/libsolidity/semanticTests/abiEncoderV1/abi_decode_static_array_v2.sol
https://github.com/NomicFoundation/solx-solidity/blob/e8565c9def898a1f2253b931c35f6e35eb9626a4/test/libsolidity/semanticTests/abiEncodeDecode/offset_overflow_in_array_decoding.sol
