### PR TITLE
[v2] fix(semantic): externalize a function type's results too

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1224,6 +1224,70 @@ fn test_data_locations_of_state_variable_and_getter_accesses() {
 }
 
 #[test]
+fn test_external_signature_relocates_parameters_and_results() {
+    // The ABI boundary decodes a calldata-located reference into fresh memory,
+    // so an externally callable signature names both its parameters and its
+    // results there. In source order:
+    //  - `keep` — an *internal* reference is not an ABI boundary, so its
+    //    `bytes calldata` parameter and result both stay in calldata;
+    //  - `this.echo` — the same signature reached externally: parameter and
+    //    result both read back as `bytes memory`;
+    //  - `this.echo(bs)` — the call result is `bytes memory`;
+    //  - `this.echo(bs)[0]` — indexing that result reads memory rather than a
+    //    calldata offset, yielding `bytes1`.
+    let (typings, types) = type_of_expressions(
+        LanguageVersion::LATEST,
+        None,
+        Some(
+            r#"
+            bytes bs;
+            function echo(bytes calldata xs) external pure returns (bytes calldata) { return xs; }
+            function keep(bytes calldata xs) internal pure returns (bytes calldata) { return xs; }
+            "#,
+        ),
+        &["keep", "this.echo", "this.echo(bs)", "this.echo(bs)[0]"],
+    );
+    let [internal_reference, external_reference, call, indexed] = typings.as_slice() else {
+        panic!("expected four expression statements, got {typings:?}");
+    };
+
+    // Both function references carry the same declared signature, differing
+    // only in whether it was relocated for the ABI boundary.
+    let signature_locations = |typing: &Option<Type>| {
+        let Some(Type::Function(function_type)) = typing else {
+            panic!("expected a function type, got {typing:?}");
+        };
+        let [parameter_type_id] = function_type.parameter_types.as_slice() else {
+            panic!("expected a single parameter");
+        };
+        (
+            types.get_type_by_id(*parameter_type_id).clone(),
+            types.get_type_by_id(function_type.return_type).clone(),
+        )
+    };
+
+    let calldata_bytes = Type::Bytes(BytesType {
+        location: DataLocation::Calldata,
+    });
+    let memory_bytes = Type::Bytes(BytesType {
+        location: DataLocation::Memory,
+    });
+
+    assert_eq!(
+        signature_locations(internal_reference),
+        (calldata_bytes.clone(), calldata_bytes),
+        "an internal reference keeps its declared calldata locations",
+    );
+    assert_eq!(
+        signature_locations(external_reference),
+        (memory_bytes.clone(), memory_bytes.clone()),
+        "an external reference relocates both its parameter and its result",
+    );
+    assert_eq!(call, &Some(memory_bytes));
+    assert_eq!(indexed, &Some(Type::ByteArray(ByteArrayType { width: 1 })));
+}
+
+#[test]
 fn test_cast_address_to_library_is_library_typed() {
     // Casting an address to a library (`MyLib(x)`) is valid Solidity and
     // yields a value of the library type, which can then be compared against

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -1234,7 +1234,11 @@ fn test_external_signature_relocates_parameters_and_results() {
     //    result both read back as `bytes memory`;
     //  - `this.echo(bs)` — the call result is `bytes memory`;
     //  - `this.echo(bs)[0]` — indexing that result reads memory rather than a
-    //    calldata offset, yielding `bytes1`.
+    //    calldata offset, yielding `bytes1`;
+    //  - `this.split(bs)` — multiple results are modeled as a tuple, which
+    //    carries no location of its own, so the relocation has to reach each
+    //    element separately: the `bytes calldata` result becomes memory while
+    //    the results that were not in calldata keep their declared type.
     let (typings, types) = type_of_expressions(
         LanguageVersion::LATEST,
         None,
@@ -1243,12 +1247,32 @@ fn test_external_signature_relocates_parameters_and_results() {
             bytes bs;
             function echo(bytes calldata xs) external pure returns (bytes calldata) { return xs; }
             function keep(bytes calldata xs) internal pure returns (bytes calldata) { return xs; }
+            function split(bytes calldata xs)
+                external
+                pure
+                returns (bytes calldata, string memory, uint)
+            {
+                return (xs, "", 1);
+            }
             "#,
         ),
-        &["keep", "this.echo", "this.echo(bs)", "this.echo(bs)[0]"],
+        &[
+            "keep",
+            "this.echo",
+            "this.echo(bs)",
+            "this.echo(bs)[0]",
+            "this.split(bs)",
+        ],
     );
-    let [internal_reference, external_reference, call, indexed] = typings.as_slice() else {
-        panic!("expected four expression statements, got {typings:?}");
+    let [
+        internal_reference,
+        external_reference,
+        call,
+        indexed,
+        tuple_call,
+    ] = typings.as_slice()
+    else {
+        panic!("expected five expression statements, got {typings:?}");
     };
 
     // Both function references carry the same declared signature, differing
@@ -1283,8 +1307,30 @@ fn test_external_signature_relocates_parameters_and_results() {
         (memory_bytes.clone(), memory_bytes.clone()),
         "an external reference relocates both its parameter and its result",
     );
-    assert_eq!(call, &Some(memory_bytes));
+    assert_eq!(call, &Some(memory_bytes.clone()));
     assert_eq!(indexed, &Some(Type::ByteArray(ByteArrayType { width: 1 })));
+
+    let Some(Type::Tuple(TupleType { types: elements })) = tuple_call else {
+        panic!("expected `this.split(bs)` to be typed as a tuple, got {tuple_call:?}");
+    };
+    let element_types: Vec<Type> = elements
+        .iter()
+        .map(|type_id| types.get_type_by_id(*type_id).clone())
+        .collect();
+    assert_eq!(
+        element_types,
+        vec![
+            memory_bytes,
+            Type::String(StringType {
+                location: DataLocation::Memory,
+            }),
+            Type::Integer(IntegerType {
+                is_signed: false,
+                bits: 256,
+            }),
+        ],
+        "only the calldata result is relocated",
+    );
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -438,8 +438,22 @@ impl TypeRegistry {
         }
     }
 
-    // Changes a function type to have external visibility and any parameters
-    // normalized for that (ie. `calldata` location is changed to `memory`)
+    // The ABI boundary decodes a calldata-located reference into fresh memory,
+    // so an externally callable signature names it there.
+    fn externalize_type(&mut self, type_id: TypeId) -> TypeId {
+        let type_ = self.get_type_by_id(type_id);
+        if type_
+            .data_location()
+            .is_some_and(|location| location == DataLocation::Calldata)
+        {
+            self.register_type_with_data_location(type_.clone(), DataLocation::Memory)
+        } else {
+            type_id
+        }
+    }
+
+    // Changes a function type to have external visibility and its parameters and
+    // results normalized for that (ie. `calldata` location is changed to `memory`)
     pub(crate) fn externalize_function_type(
         &mut self,
         function_type: FunctionType,
@@ -449,21 +463,9 @@ impl TypeRegistry {
             parameter_types: function_type
                 .parameter_types
                 .into_iter()
-                .map(|parameter_type_id| {
-                    let parameter_type = self.get_type_by_id(parameter_type_id);
-                    if parameter_type
-                        .data_location()
-                        .is_some_and(|location| location == DataLocation::Calldata)
-                    {
-                        self.register_type_with_data_location(
-                            parameter_type.clone(),
-                            DataLocation::Memory,
-                        )
-                    } else {
-                        parameter_type_id
-                    }
-                })
+                .map(|parameter_type_id| self.externalize_type(parameter_type_id))
                 .collect(),
+            return_type: self.externalize_type(function_type.return_type),
             ..function_type
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -446,10 +446,26 @@ impl TypeRegistry {
             .data_location()
             .is_some_and(|location| location == DataLocation::Calldata)
         {
-            self.register_type_with_data_location(type_.clone(), DataLocation::Memory)
-        } else {
-            type_id
+            return self.register_type_with_data_location(type_.clone(), DataLocation::Memory);
         }
+        // A tuple has no location of its own — it only models a signature's
+        // multiple results — so each of its elements is relocated on its own.
+        // Recursing per element rather than relocating the tuple as a whole
+        // leaves a result that wasn't in calldata at its declared location,
+        // matching solc: a public library function declared
+        // `returns (uint256[] storage, bytes calldata)` is externally typed
+        // `returns (uint256[] storage pointer, bytes memory)`.
+        if let Type::Tuple(TupleType { types }) = type_ {
+            let element_type_ids = types.clone();
+            let externalized = element_type_ids
+                .into_iter()
+                .map(|element_type_id| self.externalize_type(element_type_id))
+                .collect();
+            return self.register_type(Type::Tuple(TupleType {
+                types: externalized,
+            }));
+        }
+        type_id
     }
 
     // Changes a function type to have external visibility and its parameters and


### PR DESCRIPTION
An externally callable signature normalized its parameters and kept its return type verbatim, so a calldata-located result stayed calldata where the ABI decodes it into fresh memory at the call boundary. Lift the relocation out of the parameter loop and apply it to the return type, which covers a tuple of results through the registry's own recursion.

Fixes an external call returning `bytes calldata`, whose indexed result read calldata at a memory address, and the `sol.cast` verifier failure on a function reference typed from such a callee:

https://github.com/NomicFoundation/solx-solidity/blob/e8565c9def898a1f2253b931c35f6e35eb9626a4/test/libsolidity/semanticTests/calldata/calldata_bytes_external.sol

