### PR TITLE
[v2] fix(semantic): decode an address as address payable

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -458,7 +458,7 @@ impl<'a> BuiltInsResolver<'a> {
 
                 // `abi.decode(data, (T))`: a single-element tuple collapses to the
                 // meta-type of `T`, which decodes to `T` itself.
-                if let Some(decoded) = self.decoding_type(*type_id) {
+                if let Some(decoded) = self.abi_decoded_type_from_meta_type(*type_id) {
                     return Typing::Resolved(decoded);
                 }
 
@@ -470,7 +470,7 @@ impl<'a> BuiltInsResolver<'a> {
                     let element_ids = types.clone();
                     let mut decoded = Vec::with_capacity(element_ids.len());
                     for element_id in element_ids {
-                        let Some(element) = self.decoding_type(element_id) else {
+                        let Some(element) = self.abi_decoded_type_from_meta_type(element_id) else {
                             // TODO(validation) SDR[42]: report an error when a tuple
                             // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
                             return Typing::Unresolved;
@@ -560,20 +560,20 @@ impl<'a> BuiltInsResolver<'a> {
     /// address decodes as `address payable`, the widest address type and the one the
     /// type-argument grammar cannot spell.
     /// Returns `None` when `type_id` is not a meta-type.
-    fn decoding_type(&mut self, type_id: TypeId) -> Option<TypeId> {
-        let denoted = match self.types.get_type_by_id(type_id) {
-            Type::MetaType(MetaType { type_id }) => *type_id,
+    fn abi_decoded_type_from_meta_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        match self.types.get_type_by_id(type_id) {
+            Type::MetaType(MetaType { type_id }) => Some(if *type_id == self.types.address() {
+                self.types.address_payable()
+            } else {
+                *type_id
+            }),
             Type::UserMetaType(UserMetaType { definition_id }) => {
                 let definition_id = *definition_id;
                 let definition = self.binder.find_definition_by_id(definition_id)?;
                 let type_ = definition.try_into().ok()?;
-                self.types.register_type(type_)
+                Some(self.types.register_type(type_))
             }
-            _ => return None,
-        };
-        Some(match self.types.get_type_by_id(denoted) {
-            Type::Address(_) => self.types.address_payable(),
-            _ => denoted,
-        })
+            _ => None,
+        }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -464,7 +464,7 @@ impl<'a> BuiltInsResolver<'a> {
 
                 // `abi.decode(data, (T))`: a single-element tuple collapses to the
                 // meta-type of `T`, which decodes to `T` itself.
-                if let Some(decoded) = self.decoding_type(*type_id) {
+                if let Some(decoded) = self.abi_decoded_type_from_meta_type(*type_id) {
                     return Typing::Resolved(decoded);
                 }
 
@@ -476,7 +476,7 @@ impl<'a> BuiltInsResolver<'a> {
                     let element_ids = types.clone();
                     let mut decoded = Vec::with_capacity(element_ids.len());
                     for element_id in element_ids {
-                        let Some(element) = self.decoding_type(element_id) else {
+                        let Some(element) = self.abi_decoded_type_from_meta_type(element_id) else {
                             // TODO(validation) SDR[42]: report an error when a tuple
                             // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
                             return Typing::Unresolved;
@@ -566,20 +566,20 @@ impl<'a> BuiltInsResolver<'a> {
     /// address decodes as `address payable`, the widest address type and the one the
     /// type-argument grammar cannot spell.
     /// Returns `None` when `type_id` is not a meta-type.
-    fn decoding_type(&mut self, type_id: TypeId) -> Option<TypeId> {
-        let denoted = match self.types.get_type_by_id(type_id) {
-            Type::MetaType(MetaType { type_id }) => *type_id,
+    fn abi_decoded_type_from_meta_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        match self.types.get_type_by_id(type_id) {
+            Type::MetaType(MetaType { type_id }) => Some(if *type_id == self.types.address() {
+                self.types.address_payable()
+            } else {
+                *type_id
+            }),
             Type::UserMetaType(UserMetaType { definition_id }) => {
                 let definition_id = *definition_id;
                 let definition = self.binder.find_definition_by_id(definition_id)?;
                 let type_ = definition.try_into().ok()?;
-                self.types.register_type(type_)
+                Some(self.types.register_type(type_))
             }
-            _ => return None,
-        };
-        Some(match self.types.get_type_by_id(denoted) {
-            Type::Address(_) => self.types.address_payable(),
-            _ => denoted,
-        })
+            _ => None,
+        }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -458,7 +458,7 @@ impl<'a> BuiltInsResolver<'a> {
 
                 // `abi.decode(data, (T))`: a single-element tuple collapses to the
                 // meta-type of `T`, which decodes to `T` itself.
-                if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
+                if let Some(decoded) = self.decoding_type(*type_id) {
                     return Typing::Resolved(decoded);
                 }
 
@@ -470,7 +470,7 @@ impl<'a> BuiltInsResolver<'a> {
                     let element_ids = types.clone();
                     let mut decoded = Vec::with_capacity(element_ids.len());
                     for element_id in element_ids {
-                        let Some(element) = self.type_denoted_by_meta_type(element_id) else {
+                        let Some(element) = self.decoding_type(element_id) else {
                             // TODO(validation) SDR[42]: report an error when a tuple
                             // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
                             return Typing::Unresolved;
@@ -555,19 +555,25 @@ impl<'a> BuiltInsResolver<'a> {
         }
     }
 
-    /// Returns the value type a meta-type denotes: `type(T)` unwraps to `T`,
-    /// and the meta-type of a named definition to the definition's type.
+    /// Returns the type an `abi.decode` type argument decodes to: `type(T)` unwraps
+    /// to `T`, and the meta-type of a named definition to the definition's type. An
+    /// address decodes as `address payable`, the widest address type and the one the
+    /// type-argument grammar cannot spell.
     /// Returns `None` when `type_id` is not a meta-type.
-    fn type_denoted_by_meta_type(&mut self, type_id: TypeId) -> Option<TypeId> {
-        match self.types.get_type_by_id(type_id) {
-            Type::MetaType(MetaType { type_id }) => Some(*type_id),
+    fn decoding_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        let denoted = match self.types.get_type_by_id(type_id) {
+            Type::MetaType(MetaType { type_id }) => *type_id,
             Type::UserMetaType(UserMetaType { definition_id }) => {
                 let definition_id = *definition_id;
                 let definition = self.binder.find_definition_by_id(definition_id)?;
                 let type_ = definition.try_into().ok()?;
-                Some(self.types.register_type(type_))
+                self.types.register_type(type_)
             }
-            _ => None,
-        }
+            _ => return None,
+        };
+        Some(match self.types.get_type_by_id(denoted) {
+            Type::Address(_) => self.types.address_payable(),
+            _ => denoted,
+        })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -464,7 +464,7 @@ impl<'a> BuiltInsResolver<'a> {
 
                 // `abi.decode(data, (T))`: a single-element tuple collapses to the
                 // meta-type of `T`, which decodes to `T` itself.
-                if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
+                if let Some(decoded) = self.decoding_type(*type_id) {
                     return Typing::Resolved(decoded);
                 }
 
@@ -476,7 +476,7 @@ impl<'a> BuiltInsResolver<'a> {
                     let element_ids = types.clone();
                     let mut decoded = Vec::with_capacity(element_ids.len());
                     for element_id in element_ids {
-                        let Some(element) = self.type_denoted_by_meta_type(element_id) else {
+                        let Some(element) = self.decoding_type(element_id) else {
                             // TODO(validation) SDR[42]: report an error when a tuple
                             // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
                             return Typing::Unresolved;
@@ -561,19 +561,25 @@ impl<'a> BuiltInsResolver<'a> {
         }
     }
 
-    /// Returns the value type a meta-type denotes: `type(T)` unwraps to `T`,
-    /// and the meta-type of a named definition to the definition's type.
+    /// Returns the type an `abi.decode` type argument decodes to: `type(T)` unwraps
+    /// to `T`, and the meta-type of a named definition to the definition's type. An
+    /// address decodes as `address payable`, the widest address type and the one the
+    /// type-argument grammar cannot spell.
     /// Returns `None` when `type_id` is not a meta-type.
-    fn type_denoted_by_meta_type(&mut self, type_id: TypeId) -> Option<TypeId> {
-        match self.types.get_type_by_id(type_id) {
-            Type::MetaType(MetaType { type_id }) => Some(*type_id),
+    fn decoding_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        let denoted = match self.types.get_type_by_id(type_id) {
+            Type::MetaType(MetaType { type_id }) => *type_id,
             Type::UserMetaType(UserMetaType { definition_id }) => {
                 let definition_id = *definition_id;
                 let definition = self.binder.find_definition_by_id(definition_id)?;
                 let type_ = definition.try_into().ok()?;
-                Some(self.types.register_type(type_))
+                self.types.register_type(type_)
             }
-            _ => None,
-        }
+            _ => return None,
+        };
+        Some(match self.types.get_type_by_id(denoted) {
+            Type::Address(_) => self.types.address_payable(),
+            _ => denoted,
+        })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -2065,6 +2065,21 @@ fn test_abi_decode_tuple_of_types() {
 }
 
 #[test]
+fn test_abi_decode_address_is_payable() {
+    // `address payable` is unspellable as a type argument, so an address decodes as
+    // the payable one, which converts down to `address` but not the other way.
+    let (decoded, types) = type_of_expression_in_context("bytes b;", "abi.decode(b, (address))");
+    assert_eq!(decoded, *types.get_type_by_id(types.address_payable()));
+
+    let (decoded, types) =
+        type_of_expression_in_context("bytes b;", "abi.decode(b, (uint, address))");
+    let Type::Tuple(TupleType { types: element_ids }) = decoded else {
+        panic!("expected a tuple type, got {decoded:?}");
+    };
+    assert_eq!(element_ids[1], types.address_payable());
+}
+
+#[test]
 fn test_tuple_of_type_names_is_a_tuple_of_meta_types() {
     // A tuple of type names is a *tuple of meta-types* (not a meta-type
     // itself): `(uint, bool)` types as `Tuple(type(uint256), type(bool))`.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -2137,6 +2137,21 @@ fn test_abi_decode_tuple_of_types() {
 }
 
 #[test]
+fn test_abi_decode_address_is_payable() {
+    // `address payable` is unspellable as a type argument, so an address decodes as
+    // the payable one, which converts down to `address` but not the other way.
+    let (decoded, types) = type_of_expression_in_context("bytes b;", "abi.decode(b, (address))");
+    assert_eq!(decoded, *types.get_type_by_id(types.address_payable()));
+
+    let (decoded, types) =
+        type_of_expression_in_context("bytes b;", "abi.decode(b, (uint, address))");
+    let Type::Tuple(TupleType { types: element_ids }) = decoded else {
+        panic!("expected a tuple type, got {decoded:?}");
+    };
+    assert_eq!(element_ids[1], types.address_payable());
+}
+
+#[test]
 fn test_tuple_of_type_names_is_a_tuple_of_meta_types() {
     // A tuple of type names is a *tuple of meta-types* (not a meta-type
     // itself): `(uint, bool)` types as `Tuple(type(uint256), type(bool))`.


### PR DESCRIPTION
DISCLAIMER:
```
Feel free to discard it if we don't need this shim anymore.
It's done for compatibility reasons I don't fully know, and I don't know if we need this anywhere.
Both solc legacy and solc MLIR (the latter inherits it from their version of the binder) do this and emit `payable` address type.
```

`abi.decode`'s second argument is a tuple of bare type names, which the grammar cannot qualify — `abi.decode(d, (address payable))` is a parse error. Decoding an address as the non-payable type therefore puts a payable result out of reach, since `address payable` converts to `address` implicitly but not the other way, so the payable type is the only one both targets can be reached from.

This mirrors solc, which forces the same normalization in `TypeChecker::typeCheckABIDecodeAndRetrieveReturnType`, next to the sibling rule relocating a reference type to memory:

- [`TypeChecker.cpp#L308-L314`](https://github.com/ethereum/solidity/blob/develop/libsolidity/analysis/TypeChecker.cpp#L308-L314) — both rules, the memory relocation and the payable forcing
- [`12aaca16`](https://github.com/ethereum/solidity/commit/12aaca16458861e9b622818d49a82c1a7026594e) — the commit that added it, alongside `address payable` itself, so the split would not take away the ability to decode a payable address

Folded into the meta-type unwrapping rather than applied at each use, and narrowed to the `MetaType` arm, where an `address` is the only type that can appear: a user-defined type never is one, so the other arm needs no normalization and the second type lookup goes away. Its only callers are the two `abi.decode` paths, hence the name `abi_decoded_type_from_meta_type`.

Only the payable rule is included here; the sibling memory relocation is a separate concern.
