### PR TITLE
[v2] fix(built-ins): don't gate `block.difficulty`/`block.prevrandao` by EVM target

### DIFF
--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -4526,14 +4526,10 @@ IdentifierPathTailElements: Vec<IdentifierPathElement> = {
                         ),
                         BuiltInDefinition(name = BlockChainid, evm_enabled = From(Istanbul)),
                         BuiltInDefinition(name = BlockCoinbase),
-                        BuiltInDefinition(name = BlockDifficulty, evm_enabled = Till(Paris)),
+                        BuiltInDefinition(name = BlockDifficulty),
                         BuiltInDefinition(name = BlockGaslimit),
                         BuiltInDefinition(name = BlockNumber),
-                        BuiltInDefinition(
-                            name = BlockPrevrandao,
-                            enabled = From("0.8.18"),
-                            evm_enabled = From(Paris)
-                        ),
+                        BuiltInDefinition(name = BlockPrevrandao, enabled = From("0.8.18")),
                         BuiltInDefinition(name = BlockTimestamp)
                     ]
                 ),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/built_ins/validate_built_ins.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/built_ins/validate_built_ins.generated.rs
@@ -88,16 +88,12 @@ impl<'a> BuiltInValidator<'a> {
                     EvmTargetSpecifier::from(EvmTarget::Istanbul),
                 );
             }
-            InternalBuiltIn::BlockDifficulty => {
-                self.check_target(node_id, range, EvmTargetSpecifier::till(EvmTarget::Paris));
-            }
             InternalBuiltIn::BlockPrevrandao => {
                 self.check_version(
                     node_id,
                     range,
                     LanguageVersionSpecifier::from(LanguageVersion::V0_8_18),
                 );
-                self.check_target(node_id, range, EvmTargetSpecifier::from(EvmTarget::Paris));
             }
             InternalBuiltIn::AddressCodehash => {
                 self.check_target(

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -895,6 +895,30 @@ mod resolution {
         }
 
         #[test]
+        fn block_difficulty_all_targets() -> Result<()> {
+            run(
+                "resolution/incompatible_built_in_target",
+                "block_difficulty_all_targets",
+            )
+        }
+
+        #[test]
+        fn block_prevrandao_all_targets() -> Result<()> {
+            run(
+                "resolution/incompatible_built_in_target",
+                "block_prevrandao_all_targets",
+            )
+        }
+
+        #[test]
+        fn block_prevrandao_pre_paris() -> Result<()> {
+            run(
+                "resolution/incompatible_built_in_target",
+                "block_prevrandao_pre_paris",
+            )
+        }
+
+        #[test]
         fn yul_difficulty_post_paris() -> Result<()> {
             run(
                 "resolution/incompatible_built_in_target",

--- a/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.0-failure.txt
@@ -29,13 +29,6 @@ Parse errors:
    │                         ─────┬─────  
    │                              ╰─────── Error occurred here.
 ───╯
-[resolution/incompatible-built-in-target] Error: This built-in was introduced in EVM target 'Paris'.
-    ╭─[input.sol:15:25]
-    │
- 15 │         uint v8 = block.prevrandao;
-    │                         ─────┬────  
-    │                              ╰────── Error occurred here.
-────╯
 [resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.18'.
     ╭─[input.sol:15:25]
     │

--- a/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.18-failure.txt
@@ -22,13 +22,6 @@ Parse errors:
    │                         ─────┬─────  
    │                              ╰─────── Error occurred here.
 ───╯
-[resolution/incompatible-built-in-target] Error: This built-in was introduced in EVM target 'Paris'.
-    ╭─[input.sol:15:25]
-    │
- 15 │         uint v8 = block.prevrandao;
-    │                         ─────┬────  
-    │                              ╰────── Error occurred here.
-────╯
 
 ------------------------------------------------------------------------
 

--- a/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.24-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.24-failure.txt
@@ -15,13 +15,6 @@ Parse errors:
    │                         ─────┬─────  
    │                              ╰─────── Error occurred here.
 ───╯
-[resolution/incompatible-built-in-target] Error: This built-in was introduced in EVM target 'Paris'.
-    ╭─[input.sol:15:25]
-    │
- 15 │         uint v8 = block.prevrandao;
-    │                         ─────┬────  
-    │                              ╰────── Error occurred here.
-────╯
 
 ------------------------------------------------------------------------
 

--- a/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.7-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/built_ins/global_properties/generated/0.8.7-failure.txt
@@ -22,13 +22,6 @@ Parse errors:
    │                         ─────┬─────  
    │                              ╰─────── Error occurred here.
 ───╯
-[resolution/incompatible-built-in-target] Error: This built-in was introduced in EVM target 'Paris'.
-    ╭─[input.sol:15:25]
-    │
- 15 │         uint v8 = block.prevrandao;
-    │                         ─────┬────  
-    │                              ╰────── Error occurred here.
-────╯
 [resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.18'.
     ╭─[input.sol:15:25]
     │

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/.tests.config.json
@@ -1,0 +1,34 @@
+{
+  "matrix": {
+    "type": "SingleVersionAllTargets",
+    "version": {
+      "value": "0.8.36",
+      "reason": "`block.difficulty` is not gated by language version; the interesting axis is the EVM target, since the Paris rename is what solc warns about."
+    },
+    "expected_solc_divergence": [
+      {
+        "specifier": {
+          "type": "Range",
+          "from": "Frontier",
+          "till": "Homestead"
+        },
+        "reason": "solc 0.8.36 declines the Frontier target outright ('Invalid EVM version requested'), which counts as a rejection, while slang compiles the input. Unrelated to `block.difficulty`: solc never looks at the source on this target."
+      },
+      {
+        "specifier": {
+          "type": "Range",
+          "from": "Homestead",
+          "till": "Constantinople"
+        },
+        "reason": "On pre-Constantinople targets solc emits 'Support for EVM versions older than constantinople is deprecated', a warning that counts as a rejection. slang is silent, so the statuses differ."
+      },
+      {
+        "specifier": {
+          "type": "From",
+          "from": "Paris"
+        },
+        "reason": "From Paris on solc emits Warning 8417 ('difficulty' was replaced by 'prevrandao'), a warning that counts as a rejection. slang accepts `block.difficulty` on every target and is silent, so the statuses differ."
+      }
+    ]
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/slang/00-frontier-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/slang/00-frontier-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/00-frontier-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/00-frontier-failure.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[JSONError <no-code>] Error: Invalid EVM version requested.

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/01-homestead-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/01-homestead-failure.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning <no-code>] Warning: Support for EVM versions older than constantinople is deprecated and will be removed in the future.

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/05-constantinople-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/05-constantinople-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/10-paris-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/generated/solc/10-paris-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 8417] Warning: Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
+   ╭─[input.sol:9:16]
+   │
+ 9 │         return block.difficulty;
+   │                ────────┬───────  
+   │                        ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_difficulty_all_targets/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `block.difficulty` is available on every EVM target. From Paris onwards the
+// underlying opcode was renamed to `prevrandao`, but `solc` only *warns* about
+// this (8417) and still accepts the input, so slang must not reject it either.
+contract C {
+    function f() public view returns (uint256) {
+        return block.difficulty;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/.tests.config.json
@@ -1,0 +1,27 @@
+{
+  "matrix": {
+    "type": "SingleVersionAllTargets",
+    "version": {
+      "value": "0.8.36",
+      "reason": "`block.prevrandao` is not gated by EVM target; iterating the targets covers both the pre-Paris warning and the clean Paris-onwards case."
+    },
+    "expected_solc_divergence": [
+      {
+        "specifier": {
+          "type": "Range",
+          "from": "Frontier",
+          "till": "Homestead"
+        },
+        "reason": "solc 0.8.36 declines the Frontier target outright ('Invalid EVM version requested'), which counts as a rejection, while slang compiles the input. Unrelated to `block.prevrandao`: solc never looks at the source on this target."
+      },
+      {
+        "specifier": {
+          "type": "Range",
+          "from": "Homestead",
+          "till": "Paris"
+        },
+        "reason": "On pre-Paris targets solc emits Warning 9432 ('prevrandao' is not supported by the VM version and will be treated as 'difficulty'), plus 'Support for EVM versions older than constantinople is deprecated' on the oldest ones. Both are warnings that count as a rejection, while slang is silent, so the statuses differ. From Paris on `prevrandao` is native and both are clean."
+      }
+    ]
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/slang/00-frontier-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/slang/00-frontier-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/00-frontier-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/00-frontier-failure.txt
@@ -1,0 +1,5 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[JSONError <no-code>] Error: Invalid EVM version requested.

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/01-homestead-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/01-homestead-failure.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[Warning <no-code>] Warning: Support for EVM versions older than constantinople is deprecated and will be removed in the future.
+
+[Warning 9432] Warning: "prevrandao" is not supported by the VM version and will be treated as "difficulty".
+   ╭─[input.sol:9:16]
+   │
+ 9 │         return block.prevrandao;
+   │                ────────┬───────  
+   │                        ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/05-constantinople-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/05-constantinople-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 9432] Warning: "prevrandao" is not supported by the VM version and will be treated as "difficulty".
+   ╭─[input.sol:9:16]
+   │
+ 9 │         return block.prevrandao;
+   │                ────────┬───────  
+   │                        ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/10-paris-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/generated/solc/10-paris-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_all_targets/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `block.prevrandao` is accepted on every EVM target: from Paris on it maps to
+// the opcode of the same name, and before Paris `solc` only *warns* (9432) that
+// it will be treated as `difficulty`, still compiling the input.
+contract C {
+    function f() public view returns (uint256) {
+        return block.prevrandao;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/.tests.config.json
@@ -1,0 +1,18 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "target": {
+      "value": "Istanbul",
+      "reason": "Istanbul is pre-Paris and accepted by every supported solc, so the version axis shows both the pre-0.8.18 error and the warning-only behaviour after it."
+    },
+    "expected_solc_divergence": [
+      {
+        "specifier": {
+          "type": "From",
+          "from": "0.8.18"
+        },
+        "reason": "From 0.8.18 `block.prevrandao` exists but on the pre-Paris Istanbul target solc emits Warning 9432 ('prevrandao' is not supported by the VM version and will be treated as 'difficulty'), a warning that counts as a rejection. slang is silent, so the statuses differ. Below 0.8.18 both reject the member (solc TypeError 9582), so those versions agree."
+      }
+    ]
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.18'.
+    ╭─[input.sol:10:22]
+    │
+ 10 │         return block.prevrandao;
+    │                      ─────┬────  
+    │                           ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/slang/0.8.18-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/slang/0.8.18-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "prevrandao" not found or not visible after argument-dependent lookup in block.
+    ╭─[input.sol:10:16]
+    │
+ 10 │         return block.prevrandao;
+    │                ────────┬───────  
+    │                        ╰───────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 9432] Warning: "prevrandao" is not supported by the VM version and will be treated as "difficulty".
+    ╭─[input.sol:10:16]
+    │
+ 10 │         return block.prevrandao;
+    │                ────────┬───────  
+    │                        ╰───────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/incompatible_built_in_target/block_prevrandao_pre_paris/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `block.prevrandao` requires 0.8.18: before that the member does not exist and
+// `solc` reports a genuine error. From 0.8.18 on it is accepted even on a
+// pre-Paris target, where `solc` only *warns* (9432) that it will be treated as
+// `difficulty` — so slang must not reject it there.
+contract C {
+    function f() public view returns (uint256) {
+        return block.prevrandao;
+    }
+}


### PR DESCRIPTION
`solc` only gates `block.prevrandao` and `block.difficulty` based on `solc` version, adding a warning if they're used on the wrong EVM target, but allowing it and defaulting to the supported option. Fixes it on slang