### PR TITLE
[v2] fix(semantic): resolve named arguments on an error construction

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -696,10 +696,10 @@ impl Pass<'_> {
 
     /// Types a call with named arguments whose operand is (or was
     /// disambiguated to) `type_id`, additionally returning the definition the
-    /// operand resolves to (if any). Only function values and struct
-    /// constructions are callable this way; the user meta type of a function is
-    /// a non-callable declaration reached through a contract/interface type
-    /// name.
+    /// operand resolves to (if any). Only function values, struct constructions
+    /// and error constructions are callable this way; the user meta type of a
+    /// function is a non-callable declaration reached through a
+    /// contract/interface type name.
     fn typing_of_type_called_with_named_arguments(
         &mut self,
         node: &ir::FunctionCallExpression,
@@ -728,6 +728,12 @@ impl Pass<'_> {
                             .expect("struct definitions are handled by type_of_definition");
                         let type_id = self.types.register_type(type_);
                         (Typing::Resolved(type_id), Some(definition_id))
+                    }
+                    Some(Definition::Error(_)) => {
+                        // An error construction has no value type of its own,
+                        // matching the positional form. Return the definition
+                        // so the argument names resolve against its parameters.
+                        (Typing::Unresolved, Some(definition_id))
                     }
                     Some(Definition::Function(_)) => {
                         // Calling a function via a contract/interface type name is

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -760,6 +760,11 @@ mod expressions {
     }
 
     #[test]
+    fn require_named_args() -> Result<()> {
+        run("expressions", "require_named_args")
+    }
+
+    #[test]
     fn revert_named_args() -> Result<()> {
         run("expressions", "revert_named_args")
     }

--- a/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/generated/0.8.0-failure.txt
@@ -1,0 +1,71 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Parse errors:
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.4'.
+   ╭─[input.sol:2:5]
+   │
+ 2 │ ╭─▶     error Failure(
+   ┆ ┆   
+ 5 │ ├─▶     );
+   │ │            
+   │ ╰──────────── Error occurred here.
+───╯
+
+------------------------------------------------------------------------
+
+Definitions (6):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["Failure" @ input.sol:2:11] (error)
+- Def: #3 ["severity" @ input.sol:3:14] (parameter, type: uint256)
+- Def: #4 ["cause" @ input.sol:4:16] (parameter, type: string memory)
+- Def: #5 ["test" @ input.sol:7:14] (function, type: function (bool) returns void)
+- Def: #6 ["ok" @ input.sol:7:24] (parameter, type: bool)
+
+------------------------------------------------------------------------
+
+References (5):
+- Ref: ["require" @ input.sol:8:9] -> built-in
+- Ref: ["ok" @ input.sol:8:17] -> #6
+- Ref: ["Failure" @ input.sol:8:21] -> #2
+- Ref: ["severity" @ input.sol:8:30] -> #3
+- Ref: ["cause" @ input.sol:8:45] -> #4
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     error Failure(
+   │           ───┬───  
+   │              ╰───── name: 2
+ 3 │         uint severity,
+   │              ────┬───  
+   │                  ╰───── name: 3
+ 4 │         string cause
+   │                ──┬──  
+   │                  ╰──── name: 4
+   │ 
+ 7 │     function test(bool ok) public {
+   │              ──┬─      ─┬  
+   │                ╰─────────── name: 5
+   │                         │  
+   │                         ╰── name: 6
+ 8 │         require(ok, Failure({severity: 100, cause: "Testing"}));
+   │         ───┬─── ─┬  ───┬───  ────┬───       ──┬──  
+   │            ╰─────────────────────────────────────── built-in
+   │                  │     │         │            │    
+   │                  ╰───────────────────────────────── ref: 6
+   │                        │         │            │    
+   │                        ╰─────────────────────────── ref: 2
+   │                                  │            │    
+   │                                  ╰───────────────── ref: 3
+   │                                               │    
+   │                                               ╰──── ref: 4
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/generated/0.8.4-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/generated/0.8.4-success.txt
@@ -1,0 +1,58 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (6):
+- Def: #1 ["Test" @ input.sol:1:10] (contract)
+- Def: #2 ["Failure" @ input.sol:2:11] (error)
+- Def: #3 ["severity" @ input.sol:3:14] (parameter, type: uint256)
+- Def: #4 ["cause" @ input.sol:4:16] (parameter, type: string memory)
+- Def: #5 ["test" @ input.sol:7:14] (function, type: function (bool) returns void)
+- Def: #6 ["ok" @ input.sol:7:24] (parameter, type: bool)
+
+------------------------------------------------------------------------
+
+References (5):
+- Ref: ["require" @ input.sol:8:9] -> built-in
+- Ref: ["ok" @ input.sol:8:17] -> #6
+- Ref: ["Failure" @ input.sol:8:21] -> #2
+- Ref: ["severity" @ input.sol:8:30] -> #3
+- Ref: ["cause" @ input.sol:8:45] -> #4
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[input.sol:1:1]
+   │
+ 1 │ contract Test {
+   │          ──┬─  
+   │            ╰─── name: 1
+ 2 │     error Failure(
+   │           ───┬───  
+   │              ╰───── name: 2
+ 3 │         uint severity,
+   │              ────┬───  
+   │                  ╰───── name: 3
+ 4 │         string cause
+   │                ──┬──  
+   │                  ╰──── name: 4
+   │ 
+ 7 │     function test(bool ok) public {
+   │              ──┬─      ─┬  
+   │                ╰─────────── name: 5
+   │                         │  
+   │                         ╰── name: 6
+ 8 │         require(ok, Failure({severity: 100, cause: "Testing"}));
+   │         ───┬─── ─┬  ───┬───  ────┬───       ──┬──  
+   │            ╰─────────────────────────────────────── built-in
+   │                  │     │         │            │    
+   │                  ╰───────────────────────────────── ref: 6
+   │                        │         │            │    
+   │                        ╰─────────────────────────── ref: 2
+   │                                  │            │    
+   │                                  ╰───────────────── ref: 3
+   │                                               │    
+   │                                               ╰──── ref: 4
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/expressions/require_named_args/input.sol
@@ -1,0 +1,10 @@
+contract Test {
+    error Failure(
+        uint severity,
+        string cause
+    );
+
+    function test(bool ok) public {
+        require(ok, Failure({severity: 100, cause: "Testing"}));
+    }
+}


### PR DESCRIPTION
An error construction in expression position, as in `require(ok, E({a: 1}))`, left every argument label unresolved: the user meta type arm only handled struct and function definitions. Return the error definition so the labels resolve against its parameters scope, keeping the typing `Unresolved` as the positional form already does.