### PR TITLE
[v2] fix(semantic): externalize a state variable's getter type

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -3061,6 +3061,8 @@ pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::compute_select
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::is_externally_visible(&self) -> bool
 impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
+impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
+pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::getter_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl core::clone::Clone for slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::clone(&self) -> slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 impl serde_core::ser::Serialize for slang_solidity_v2_ast::ast::StateVariableDefinitionStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -16,6 +16,7 @@ mod function_call_expression;
 mod identifier;
 mod identifier_path;
 mod source_unit;
+mod state_variable_definition;
 mod string_expression;
 
 mod user_defined_operators;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/state_variable_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/state_variable_definition.rs
@@ -1,0 +1,18 @@
+use slang_solidity_v2_semantic::binder;
+
+use super::super::{StateVariableDefinitionStruct, Type};
+
+impl StateVariableDefinitionStruct {
+    /// Returns the type of the getter generated for this state variable, or
+    /// `None` if it is not public.
+    pub fn getter_type(&self) -> Option<Type> {
+        let binder::Definition::StateVariable(definition) = self
+            .semantic
+            .binder()
+            .find_definition_by_id(self.ir_node.id())?
+        else {
+            unreachable!("definition is not a state variable");
+        };
+        Some(Type::create(definition.getter_type_id?, &self.semantic))
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/resolution.rs
@@ -158,11 +158,14 @@ impl Pass<'_> {
                 })))
             }
             ir::TypeName::MappingType(mapping_type) => {
-                let data_location = Some(DataLocation::Storage);
-                let key_type_id =
-                    self.resolve_type_name(&mapping_type.key_type.type_name, data_location)?;
-                let value_type_id =
-                    self.resolve_type_name(&mapping_type.value_type.type_name, data_location)?;
+                let key_type_id = self.resolve_type_name(
+                    &mapping_type.key_type.type_name,
+                    Some(DataLocation::Memory),
+                )?;
+                let value_type_id = self.resolve_type_name(
+                    &mapping_type.value_type.type_name,
+                    Some(DataLocation::Storage),
+                )?;
                 Some(self.types.register_type(Type::Mapping(MappingType {
                     key_type_id,
                     value_type_id,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -280,7 +280,7 @@ impl Pass<'_> {
             implicit_receiver_type: Some(receiver_type_id),
             parameter_types,
             return_type,
-            visibility: FunctionTypeVisibility::Public,
+            visibility: FunctionTypeVisibility::External,
             mutability: FunctionTypeMutability::View,
             partially_applied: false,
         });

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
@@ -142,6 +142,55 @@ fn test_function_get_type() {
 }
 
 define_fixture!(
+    PublicMapping,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract C {
+    mapping(string => uint256) public balances;
+}
+"#,
+);
+
+#[test]
+fn test_public_mapping_getter_type() {
+    let unit = PublicMapping::build_compilation_unit();
+
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract C is found");
+
+    let balances = contract
+        .members()
+        .iter()
+        .find_map(|member| match member {
+            ast::ContractMember::StateVariableDefinition(state_variable) => Some(state_variable),
+            _ => None,
+        })
+        .expect("state variable balances is found");
+
+    let ast::Type::Function(getter) = balances
+        .getter_type()
+        .expect("a public state variable has a getter")
+    else {
+        panic!("expected the getter to type as a function");
+    };
+
+    assert_eq!(getter.visibility(), ast::FunctionTypeVisibility::External);
+
+    let parameter_types = getter.parameter_types();
+    let [key_type] = parameter_types.as_slice() else {
+        panic!("expected the getter to take the mapping key as its only parameter");
+    };
+    let ast::Type::String(key) = key_type else {
+        panic!("expected the key to type as a string");
+    };
+    assert_eq!(key.location(), ast::DataLocation::Memory);
+}
+
+define_fixture!(
     LiteralPlusInteger,
     file: "main.sol", r#"
 // SPDX-License-Identifier: UNLICENSED

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
@@ -142,34 +142,38 @@ fn test_function_get_type() {
 }
 
 define_fixture!(
-    PublicMapping,
+    MappingGetters,
     file: "main.sol", r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 contract C {
     mapping(string => uint256) public balances;
+    mapping(string => uint256) internal _allowances;
 }
 "#,
 );
 
 #[test]
-fn test_public_mapping_getter_type() {
-    let unit = PublicMapping::build_compilation_unit();
+fn test_state_variable_getter_type() {
+    let unit = MappingGetters::build_compilation_unit();
 
     let contract = unit
         .find_contract_by_name("C")
         .next()
         .expect("contract C is found");
 
-    let balances = contract
+    let state_variables = contract
         .members()
         .iter()
-        .find_map(|member| match member {
+        .filter_map(|member| match member {
             ast::ContractMember::StateVariableDefinition(state_variable) => Some(state_variable),
             _ => None,
         })
-        .expect("state variable balances is found");
+        .collect::<Vec<_>>();
+    let [balances, allowances] = state_variables.as_slice() else {
+        panic!("expected the contract to declare two state variables");
+    };
 
     let ast::Type::Function(getter) = balances
         .getter_type()
@@ -188,6 +192,17 @@ fn test_public_mapping_getter_type() {
         panic!("expected the key to type as a string");
     };
     assert_eq!(key.location(), ast::DataLocation::Memory);
+
+    let ast::Type::Integer(value) = getter.return_type() else {
+        panic!("expected the getter to return the mapping value");
+    };
+    assert!(!value.is_signed(), "the mapping value is unsigned");
+    assert_eq!(value.bits(), 256, "the mapping value is 256-bit");
+
+    assert!(
+        allowances.getter_type().is_none(),
+        "a non-public state variable has no getter"
+    );
 }
 
 define_fixture!(


### PR DESCRIPTION
solc types a public state variable's getter as `function (...) external view`, and resolves a mapping's key type in memory — only its value lives in storage. Type them the same way, so the getter over `mapping(string => uint256)` takes `string memory`, and expose the result through the new `StateVariableDefinition::getter_type`.