### PR TITLE
[v2] fix(diagnostics): detect constant cycles through public constants

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -317,6 +317,24 @@ impl Definition {
         }
     }
 
+    /// The value expression of a constant, in either constant shape: a
+    /// `ConstantDefinition`, or a `public` `constant` state variable. Returns
+    /// `None` for non-constants, and for a constant declared without a value.
+    pub(crate) fn as_constant_value(&self) -> Option<&ir::Expression> {
+        match self {
+            Self::Constant(constant_definition) => constant_definition.ir_node.value.as_ref(),
+            Self::StateVariable(variable_definition)
+                if matches!(
+                    variable_definition.ir_node.attributes.mutability,
+                    ir::StateVariableMutability::Constant
+                ) =>
+            {
+                variable_definition.ir_node.value.as_ref()
+            }
+            _ => None,
+        }
+    }
+
     /// Whether `self` is allowed to share a name with `other` in the same
     /// scope. Only same-kind overloadable definitions may coexist: functions
     /// overload other functions, and events overload other events.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -16,9 +16,7 @@ mod scopes;
 pub(crate) use assembly::AssemblyBlock;
 pub(crate) use capacities::BinderCapacities;
 pub use definitions::Definition;
-pub(crate) use definitions::{
-    ConstantDefinition, ContractDefinition, InterfaceDefinition, StructDefinition,
-};
+pub(crate) use definitions::{ContractDefinition, InterfaceDefinition, StructDefinition};
 pub use references::{Reference, Resolution};
 use scopes::ContractScope;
 pub(crate) use scopes::{

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/constants.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/cycle_detection/constants.rs
@@ -8,7 +8,7 @@ use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::visitor::Visitor;
 
 use super::{CycleSearchResult, DependencyGraph};
-use crate::binder::{Binder, ConstantDefinition, Definition};
+use crate::binder::Binder;
 use crate::context::FileNodeMapper;
 
 pub(super) fn detect_constant_value_dependency_cycles(
@@ -20,22 +20,28 @@ pub(super) fn detect_constant_value_dependency_cycles(
     for (constant_id, result) in graph.find_all_cycles() {
         match result {
             CycleSearchResult::Cycle { via } => {
-                let constant = constant_definition(binder, constant_id);
-                let via = constant_definition(binder, via);
+                let name = binder
+                    .find_definition_by_id(constant_id)
+                    .unwrap()
+                    .identifier();
+
+                let via_name = binder.find_definition_by_id(via).unwrap().identifier();
+
                 diagnostics.push(
                     file_node_mapper.file_id_from_node_id(constant_id).clone(),
-                    constant.ir_node.range.clone(),
+                    name.range.clone(),
                     CyclicConstantDependency {
-                        name: constant.ir_node.name.unparse().to_owned(),
-                        via: via.ir_node.name.unparse().to_owned(),
+                        name: name.unparse().to_owned(),
+                        via: via_name.unparse().to_owned(),
                     },
                 );
             }
             CycleSearchResult::DepthExceeded { node } => {
-                let constant = constant_definition(binder, node);
+                let name = binder.find_definition_by_id(node).unwrap().identifier();
+
                 diagnostics.push(
                     file_node_mapper.file_id_from_node_id(node).clone(),
-                    constant.ir_node.range.clone(),
+                    name.range.clone(),
                     CyclicDependencyValidatorExhausted,
                 );
             }
@@ -49,17 +55,9 @@ fn build_dependencies(binder: &Binder) -> SortedMap<NodeId, Vec<NodeId>> {
         .definitions()
         .iter()
         .filter_map(|(definition_id, definition)| {
-            let Definition::Constant(constant) = definition else {
-                return None;
-            };
+            let value = definition.as_constant_value()?;
 
-            let dependencies: Vec<NodeId> = constant
-                .ir_node
-                .value
-                .as_ref()
-                .map_or_else(SortedSet::default, |value| {
-                    collect_constant_dependencies(binder, value)
-                })
+            let dependencies: Vec<NodeId> = collect_constant_dependencies(binder, value)
                 .into_iter()
                 .collect();
 
@@ -72,13 +70,6 @@ fn build_dependencies(binder: &Binder) -> SortedMap<NodeId, Vec<NodeId>> {
             Some((*definition_id, dependencies))
         })
         .collect()
-}
-
-fn constant_definition(binder: &Binder, constant_id: NodeId) -> &ConstantDefinition {
-    match binder.find_definition_by_id(constant_id) {
-        Some(Definition::Constant(constant)) => constant,
-        _ => panic!("graph nodes should be constant definitions"),
-    }
 }
 
 fn collect_constant_dependencies(
@@ -113,11 +104,13 @@ impl Visitor for DependencyCollector<'_> {
                     .follow_symbol_aliases(reference.resolution.clone())
             })
             .and_then(|resolution| resolution.as_definition_id())
+            // A constant declared without a value has no outgoing edges, so it
+            // is not a graph node either. Skipping it here keeps every edge
+            // pointing at a node the search can reach.
             .filter(|&id| {
-                matches!(
-                    self.binder.find_definition_by_id(id),
-                    Some(Definition::Constant(_))
-                )
+                self.binder
+                    .find_definition_by_id(id)
+                    .is_some_and(|definition| definition.as_constant_value().is_some())
             })
         {
             self.dependencies.insert(definition_id);

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1335,6 +1335,16 @@ mod semantic {
             }
 
             #[test]
+            fn public_mixed_cycle() -> Result<()> {
+                run("semantic/constant_cycles/constants", "public_mixed_cycle")
+            }
+
+            #[test]
+            fn public_self_cycle() -> Result<()> {
+                run("semantic/constant_cycles/constants", "public_self_cycle")
+            }
+
+            #[test]
             fn qualified_self_reference_cycle() -> Result<()> {
                 run(
                     "semantic/constant_cycles/constants",

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/array_size/cyclic/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/array_size/cyclic/generated/slang/0.8.0-failure.txt
@@ -3,19 +3,19 @@
 Diagnostics: 3
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
-   ╭─[input.sol:5:5]
+   ╭─[input.sol:5:22]
    │
  5 │     uint256 constant A = B;
-   │     ───────────┬───────────  
-   │                ╰───────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
-   ╭─[input.sol:6:5]
+   ╭─[input.sol:6:22]
    │
  6 │     uint256 constant B = A;
-   │     ───────────┬───────────  
-   │                ╰───────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-definition] Error: Cyclic constant definition (or maximum recursion depth exhausted).

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/approach_declared_first_exceeds_depth_limit_a1_b1/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/approach_declared_first_exceeds_depth_limit_a1_b1/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:265:1]
+     ╭─[input.sol:265:18]
      │
  265 │ uint256 constant A205 = 1;
-     │ ─────────────┬────────────  
-     │              ╰────────────── Error occurred here.
+     │                  ──┬─  
+     │                    ╰─── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/approach_declared_first_exceeds_depth_limit_b1_a1/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/approach_declared_first_exceeds_depth_limit_b1_a1/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:265:1]
+     ╭─[input.sol:265:18]
      │
  265 │ uint256 constant A205 = 1;
-     │ ─────────────┬────────────  
-     │              ╰────────────── Error occurred here.
+     │                  ──┬─  
+     │                    ╰─── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/cycle_through_call_arguments/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/cycle_through_call_arguments/generated/slang/0.8.0-failure.txt
@@ -3,25 +3,25 @@
 Diagnostics: 3
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant a has a cyclic dependency via c.
-   ╭─[input.sol:5:5]
+   ╭─[input.sol:5:22]
    │
  5 │     uint256 constant a = b * c;
-   │     ─────────────┬─────────────  
-   │                  ╰─────────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant c has a cyclic dependency via d.
-   ╭─[input.sol:7:5]
+   ╭─[input.sol:7:22]
    │
  7 │     uint256 constant c = b + uint256(keccak256(abi.encodePacked(d)));
-   │     ────────────────────────────────┬────────────────────────────────  
-   │                                     ╰────────────────────────────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant d has a cyclic dependency via a.
-   ╭─[input.sol:8:5]
+   ╭─[input.sol:8:22]
    │
  8 │     uint256 constant d = 2 + a;
-   │     ─────────────┬─────────────  
-   │                  ╰─────────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_boundary/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_boundary/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:259:1]
+     ╭─[input.sol:259:18]
      │
  259 │ uint256 constant C255 = 1;
-     │ ─────────────┬────────────  
-     │              ╰────────────── Error occurred here.
+     │                  ──┬─  
+     │                    ╰─── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/dependency_depth_exceeded/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [semantic/cyclic-dependency-validator-exhausted] Error: Variable definition exhausting cyclic dependency validator.
-     ╭─[input.sol:264:1]
+     ╭─[input.sol:264:18]
      │
  264 │ uint256 constant C255 = C256 + 1;
-     │ ────────────────┬────────────────  
-     │                 ╰────────────────── Error occurred here.
+     │                  ──┬─  
+     │                    ╰─── Error occurred here.
 ─────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/imported_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/imported_cycle/generated/slang/0.8.0-failure.txt
@@ -3,19 +3,19 @@
 Diagnostics: 3
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
-   ╭─[constants.sol:4:1]
+   ╭─[constants.sol:4:18]
    │
  4 │ uint256 constant A = B;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
-   ╭─[constants.sol:5:1]
+   ╭─[constants.sol:5:18]
    │
  5 │ uint256 constant B = A;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-definition] Error: Cyclic constant definition (or maximum recursion depth exhausted).

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/indirect_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/indirect_cycle/generated/slang/0.8.0-failure.txt
@@ -3,27 +3,27 @@
 Diagnostics: 4
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant C has a cyclic dependency via D.
-   ╭─[input.sol:8:5]
+   ╭─[input.sol:8:22]
    │
  8 │     uint256 constant C = D;
-   │     ───────────┬───────────  
-   │                ╰───────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant D has a cyclic dependency via C.
-   ╭─[input.sol:9:5]
+   ╭─[input.sol:9:22]
    │
  9 │     uint256 constant D = C;
-   │     ───────────┬───────────  
-   │                ╰───────────── Error occurred here.
+   │                      ┬  
+   │                      ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via C.
-    ╭─[input.sol:10:5]
+    ╭─[input.sol:10:22]
     │
  10 │     uint256 constant A = C + 1;
-    │     ─────────────┬─────────────  
-    │                  ╰─────────────── Error occurred here.
+    │                      ┬  
+    │                      ╰── Error occurred here.
 ────╯
 
 [semantic/cyclic-constant-definition] Error: Cyclic constant definition (or maximum recursion depth exhausted).

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/member_access_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/member_access_cycle/generated/slang/0.8.0-failure.txt
@@ -3,17 +3,17 @@
 Diagnostics: 2
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via X.
-   ╭─[input.sol:5:5]
+   ╭─[input.sol:5:31]
    │
  5 │     uint256 internal constant A = X;
-   │     ────────────────┬───────────────  
-   │                     ╰───────────────── Error occurred here.
+   │                               ┬  
+   │                               ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant X has a cyclic dependency via A.
-   ╭─[input.sol:8:1]
+   ╭─[input.sol:8:18]
    │
  8 │ uint256 constant X = L.A;
-   │ ────────────┬────────────  
-   │             ╰────────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/module_member_access_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/module_member_access_cycle/generated/slang/0.8.0-failure.txt
@@ -3,17 +3,17 @@
 Diagnostics: 2
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via X.
-   ╭─[constants.sol:6:1]
+   ╭─[constants.sol:6:18]
    │
  6 │ uint256 constant A = X;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant X has a cyclic dependency via A.
-   ╭─[main.sol:6:1]
+   ╭─[main.sol:6:18]
    │
  6 │ uint256 constant X = M.A;
-   │ ────────────┬────────────  
-   │             ╰────────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/parenthesized_member_access_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/parenthesized_member_access_cycle/generated/slang/0.8.0-failure.txt
@@ -3,17 +3,17 @@
 Diagnostics: 2
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via X.
-   ╭─[input.sol:5:5]
+   ╭─[input.sol:5:31]
    │
  5 │     uint256 internal constant A = X;
-   │     ────────────────┬───────────────  
-   │                     ╰───────────────── Error occurred here.
+   │                               ┬  
+   │                               ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant X has a cyclic dependency via A.
-   ╭─[input.sol:8:1]
+   ╭─[input.sol:8:18]
    │
  8 │ uint256 constant X = (L).A;
-   │ ─────────────┬─────────────  
-   │              ╰─────────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/slang/0.8.0-failure.txt
@@ -3,17 +3,17 @@
 Diagnostics: 2
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
-   ╭─[input.sol:4:18]
+   ╭─[input.sol:7:31]
    │
- 4 │ uint256 constant A = B;
-   │                  ┬  
-   │                  ╰── Error occurred here.
+ 7 │     uint256 internal constant A = B;
+   │                               ┬  
+   │                               ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
-   ╭─[input.sol:5:18]
+   ╭─[input.sol:8:29]
    │
- 5 │ uint256 constant B = A;
-   │                  ┬  
-   │                  ╰── Error occurred here.
+ 8 │     uint256 public constant B = A;
+   │                             ┬  
+   │                             ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 6161] Error: The value of the constant A has a cyclic dependency via B.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 internal constant A = B;
+   │     ───────────────┬───────────────  
+   │                    ╰───────────────── Error occurred here.
+───╯
+
+[TypeError 6161] Error: The value of the constant B has a cyclic dependency via A.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     uint256 public constant B = A;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_mixed_cycle/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The cycle crosses both constant shapes. The edge out of A targets a
+    // public constant, and the edge out of B targets a non-public one.
+    uint256 internal constant A = B;
+    uint256 public constant B = A;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/slang/0.8.0-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via A.
-   ╭─[input.sol:5:31]
+   ╭─[input.sol:7:29]
    │
- 5 │     uint256 internal constant A = B.A;
-   │                               ┬  
-   │                               ╰── Error occurred here.
+ 7 │     uint256 public constant A = A;
+   │                             ┬  
+   │                             ╰── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6161] Error: The value of the constant A has a cyclic dependency via A.
+   ╭─[input.sol:7:5]
+   │
+ 7 │     uint256 public constant A = A;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/constants/public_self_cycle/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // A public constant keeps its state variable shape in the IR, but still
+    // takes part in constant cycle detection.
+    uint256 public constant A = A;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/storage_base_slot/cyclic/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/storage_base_slot/cyclic/generated/slang/0.8.0-failure.txt
@@ -3,19 +3,19 @@
 Diagnostics: 4
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
-   ╭─[input.sol:4:1]
+   ╭─[input.sol:4:18]
    │
  4 │ uint256 constant A = B;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
-   ╭─[input.sol:5:1]
+   ╭─[input.sol:5:18]
    │
  5 │ uint256 constant B = A;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.29'.

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/storage_base_slot/cyclic/generated/slang/0.8.29-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/semantic/constant_cycles/storage_base_slot/cyclic/generated/slang/0.8.29-failure.txt
@@ -3,19 +3,19 @@
 Diagnostics: 3
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant A has a cyclic dependency via B.
-   ╭─[input.sol:4:1]
+   ╭─[input.sol:4:18]
    │
  4 │ uint256 constant A = B;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-dependency] Error: The value of the constant B has a cyclic dependency via A.
-   ╭─[input.sol:5:1]
+   ╭─[input.sol:5:18]
    │
  5 │ uint256 constant B = A;
-   │ ───────────┬───────────  
-   │            ╰───────────── Error occurred here.
+   │                  ┬  
+   │                  ╰── Error occurred here.
 ───╯
 
 [semantic/cyclic-constant-definition] Error: Cyclic constant definition (or maximum recursion depth exhausted).


### PR DESCRIPTION
Replaces #1993, rebasing on latest `main`.

Note: One minor suggestion I applied was to restrict the location of the diagnostic to the identifier/name in question, instead of the whole definition IR node.