### PR TITLE
[v2] feat(ast): add InterfaceDefinition::compute_interface_id

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -2346,6 +2346,8 @@ impl slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::as_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::references(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::Reference>
 impl slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
+pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::compute_interface_id(&self) -> core::option::Option<u32>
+impl slang_solidity_v2_ast::ast::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_file_id(&self) -> &slang_solidity_v2_common::files::FileId
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_text_range(&self) -> &core::ops::range::Range<usize>
 pub fn slang_solidity_v2_ast::ast::InterfaceDefinitionStruct::get_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/interface_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/interface_definition.rs
@@ -1,0 +1,13 @@
+use crate::ast::InterfaceDefinitionStruct;
+
+impl InterfaceDefinitionStruct {
+    /// Computes the ERC-165 interface identifier: the XOR of the 4-byte selectors of the functions
+    /// the interface itself declares, excluding inherited ones.
+    pub fn compute_interface_id(&self) -> Option<u32> {
+        let mut interface_id = 0u32;
+        for function in self.members().iter_function_definitions() {
+            interface_id ^= function.compute_selector()?;
+        }
+        Some(interface_id)
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/mod.rs
@@ -2,6 +2,7 @@ mod contract_definition;
 mod error_definition;
 mod event_definition;
 mod function_definition;
+mod interface_definition;
 mod parameters;
 mod source_unit;
 mod state_variable_definition;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/interface_members.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/interface_members.rs
@@ -1,0 +1,15 @@
+use super::super::{ContractMember, FunctionDefinition, InterfaceMembersStruct};
+
+impl InterfaceMembersStruct {
+    pub(crate) fn iter_function_definitions(
+        &self,
+    ) -> impl Iterator<Item = FunctionDefinition> + use<'_> {
+        self.iter().filter_map(|member| {
+            if let ContractMember::FunctionDefinition(function) = member {
+                Some(function)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -15,6 +15,7 @@ mod expression;
 mod function_call_expression;
 mod identifier;
 mod identifier_path;
+mod interface_members;
 mod source_unit;
 mod state_variable_definition;
 mod string_expression;

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/mod.rs
@@ -15,6 +15,7 @@ mod expression;
 mod function_call_expression;
 mod identifier;
 mod identifier_path;
+mod interface_members;
 mod source_unit;
 mod string_expression;
 

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/interface_id.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/interface_id.rs
@@ -17,6 +17,10 @@ interface IThing is IERC165 {
 }
 
 abstract contract Implementer is IThing {}
+
+interface IMarker is IERC165 {}
+
+abstract contract MarkerImplementer is IMarker {}
 "#,
 );
 
@@ -44,4 +48,19 @@ fn interface_id_xors_own_selectors_excluding_inherited() {
         panic!("IERC165 base is not an interface");
     };
     assert_eq!(erc165.compute_interface_id(), Some(0x01ff_c9a7)); // supportsInterface(bytes4)
+}
+
+#[test]
+fn interface_id_is_zero_without_own_functions() {
+    let unit = InterfaceIds::build_compilation_unit();
+    let implementer = unit
+        .find_contract_by_name("MarkerImplementer")
+        .next()
+        .expect("MarkerImplementer contract can be found");
+
+    let bases = implementer.linearised_bases();
+    let ContractBase::Interface(marker) = &bases[1] else {
+        panic!("IMarker base is not an interface");
+    };
+    assert_eq!(marker.compute_interface_id(), Some(0));
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/interface_id.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/interface_id.rs
@@ -1,0 +1,47 @@
+use crate::ast::ContractBase;
+use crate::define_fixture;
+
+define_fixture!(
+    InterfaceIds,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8;
+
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+interface IThing is IERC165 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+abstract contract Implementer is IThing {}
+"#,
+);
+
+#[test]
+fn interface_id_xors_own_selectors_excluding_inherited() {
+    let unit = InterfaceIds::build_compilation_unit();
+    let implementer = unit
+        .find_contract_by_name("Implementer")
+        .next()
+        .expect("Implementer contract can be found");
+
+    let bases = implementer.linearised_bases();
+    assert_eq!(bases.len(), 3);
+
+    let ContractBase::Interface(thing) = &bases[1] else {
+        panic!("IThing base is not an interface");
+    };
+    // transfer(address,uint256) ^ balanceOf(address)
+    assert_eq!(
+        thing.compute_interface_id(),
+        Some(0xa905_9cbb ^ 0x70a0_8231)
+    );
+
+    let ContractBase::Interface(erc165) = &bases[2] else {
+        panic!("IERC165 base is not an interface");
+    };
+    assert_eq!(erc165.compute_interface_id(), Some(0x01ff_c9a7)); // supportsInterface(bytes4)
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
@@ -1,5 +1,6 @@
 mod eip712;
 mod entries;
+mod interface_id;
 mod internal_signature;
 mod selectors;
 mod storage_layout;


### PR DESCRIPTION
Compute the ERC-165 interface identifier as the XOR of the selectors of the functions the interface itself declares, excluding those inherited from base interfaces (matching `type(I).interfaceId`), so consumers read it from the binder instead of recomputing the fold.