### PR TITLE
fix(parser): Fix lexer panic when opening brace for `assembly` is missing

### DIFF
--- a/crates/solidity-v2/outputs/cargo/parser/src/lexer/definition.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/lexer/definition.rs
@@ -39,7 +39,18 @@ impl<'source> Lexer<'source> {
                 self.brace_depth += 1;
             }
             LexemeKind::YulCloseBrace => {
-                self.brace_depth -= 1;
+                // The brace is unmatched when the assembly block is missing its opening brace
+                // ('assembly }'), in which case it actually closes an enclosing Solidity
+                // construct. Either way, it ends the Yul context.
+                //
+                // TODO(v2): Note that the lexeme is still reported as a 'YulCloseBrace', since
+                // the context has already been morphed by the time we can tell the brace is
+                // unmatched. That is harmless today, because the parser stops at the first
+                // syntax error. Once error recovery is implemented, the parser will keep going
+                // past it, and will need the brace to carry its Solidity kind to close the
+                // enclosing construct. Fixing that requires looking ahead for the opening brace
+                // before morphing to the Yul context.
+                self.brace_depth = self.brace_depth.saturating_sub(1);
                 if self.brace_depth == 0 {
                     self.context = self.context.clone().morph_to_solidity();
                 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -13,6 +13,11 @@ mod assembly_statement {
     }
 
     #[test]
+    fn missing_open_brace() -> Result<()> {
+        run("AssemblyStatement", "missing_open_brace")
+    }
+
+    #[test]
     fn simple() -> Result<()> {
         run("AssemblyStatement", "simple")
     }

--- a/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/missing_open_brace/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/missing_open_brace/generated/0.8.0-failure.yml
@@ -1,0 +1,21 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     function f() public pure {                                                   │ 13..43
+  3  │         assembly                                                                 │ 44..60
+  4  │     }                                                                            │ 61..66
+  5  │ }                                                                                │ 67..68
+
+Errors: # 1 total
+  - >
+    [syntax/unexpected-terminal] Error: Unexpected YulCloseBrace. One of YulOpenBrace, YulOpenParen, YulStringLiteral was expected
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/missing_open_brace/input.sol:4:5]
+       │
+     4 │     }
+       │     ┬  
+       │     ╰── Error occurred here.
+    ───╯
+Tree:
+  - (root꞉ SourceUnit):
+      - (members꞉ SourceUnitMembers): []

--- a/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/missing_open_brace/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/AssemblyStatement/missing_open_brace/input.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() public pure {
+        assembly
+    }
+}


### PR DESCRIPTION
If the opening brace after an `assembly` statement is missing, the lexer context has already morphed to the Yul context and upon finding the closing brace (from a Solidity block) the lexer would panic when decreasing the nesting depth.