### PR TITLE
perf(semantic): Speed up alias following and scope resolution in the semantic passes

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -34,7 +34,7 @@ pub fn slang_solidity_v2_semantic::types::Type::try_from(&slang_solidity_v2_sema
 impl core::fmt::Debug for slang_solidity_v2_semantic::binder::Definition
 pub fn slang_solidity_v2_semantic::binder::Definition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum slang_solidity_v2_semantic::binder::Resolution
-pub slang_solidity_v2_semantic::binder::Resolution::Ambiguous(alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>)
+pub slang_solidity_v2_semantic::binder::Resolution::Ambiguous(alloc::boxed::Box<[slang_solidity_v2_common::nodes::NodeId]>)
 pub slang_solidity_v2_semantic::binder::Resolution::BuiltIn(slang_solidity_v2_semantic::built_ins::InternalBuiltIn)
 pub slang_solidity_v2_semantic::binder::Resolution::Definition(slang_solidity_v2_common::nodes::NodeId)
 pub slang_solidity_v2_semantic::binder::Resolution::Unresolved
@@ -43,6 +43,8 @@ pub fn slang_solidity_v2_semantic::binder::Resolution::clone(&self) -> slang_sol
 impl core::cmp::Eq for slang_solidity_v2_semantic::binder::Resolution
 impl core::cmp::PartialEq for slang_solidity_v2_semantic::binder::Resolution
 pub fn slang_solidity_v2_semantic::binder::Resolution::eq(&self, &slang_solidity_v2_semantic::binder::Resolution) -> bool
+impl core::convert::From<&[slang_solidity_v2_common::nodes::NodeId]> for slang_solidity_v2_semantic::binder::Resolution
+pub fn slang_solidity_v2_semantic::binder::Resolution::from(&[slang_solidity_v2_common::nodes::NodeId]) -> Self
 impl core::convert::From<alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>> for slang_solidity_v2_semantic::binder::Resolution
 pub fn slang_solidity_v2_semantic::binder::Resolution::from(alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>) -> Self
 impl core::convert::From<core::option::Option<&slang_solidity_v2_common::nodes::NodeId>> for slang_solidity_v2_semantic::binder::Resolution
@@ -51,6 +53,8 @@ impl core::convert::From<core::option::Option<slang_solidity_v2_common::nodes::N
 pub fn slang_solidity_v2_semantic::binder::Resolution::from(core::option::Option<slang_solidity_v2_common::nodes::NodeId>) -> Self
 impl core::convert::From<core::option::Option<slang_solidity_v2_semantic::built_ins::InternalBuiltIn>> for slang_solidity_v2_semantic::binder::Resolution
 pub fn slang_solidity_v2_semantic::binder::Resolution::from(core::option::Option<slang_solidity_v2_semantic::built_ins::InternalBuiltIn>) -> Self
+impl core::convert::From<smallvec::SmallVec<[slang_solidity_v2_common::nodes::NodeId; 4]>> for slang_solidity_v2_semantic::binder::Resolution
+pub fn slang_solidity_v2_semantic::binder::Resolution::from(smallvec::SmallVec<[slang_solidity_v2_common::nodes::NodeId; 4]>) -> Self
 impl core::fmt::Debug for slang_solidity_v2_semantic::binder::Resolution
 pub fn slang_solidity_v2_semantic::binder::Resolution::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for slang_solidity_v2_semantic::binder::Resolution

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -4,6 +4,7 @@ use ruint::aliases::U256;
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use smallvec::SmallVec;
 
 use super::ScopeId;
 use crate::types::{
@@ -91,11 +92,24 @@ pub struct ImportDefinition {
     pub resolved_file_id: Option<FileId>,
 }
 
+/// The declarations an imported symbol resolves to, empty when it resolves to
+/// none. Stored inline: all but an imported overload set names a single
+/// declaration, and this is held on every imported symbol, so spilling to the
+/// heap for the common case would cost more than it saves.
+pub(crate) type ResolvedDefinitions = SmallVec<[NodeId; 1]>;
+
 #[derive(Debug)]
 pub struct ImportedSymbolDefinition {
     pub ir_node: ir::ImportDeconstructionSymbol,
     pub symbol: String,
     pub resolved_file_id: Option<FileId>,
+    /// The declarations this symbol ultimately names, with any intermediate
+    /// imports already followed, in resolution order. Empty until
+    /// `precompute_imported_symbol_definitions` runs at the end of
+    /// `p1_collect_definitions`, and also afterwards when the symbol resolves
+    /// to nothing (the import path didn't name a file, the imported file
+    /// doesn't declare the symbol, or the chain of imports closes a cycle).
+    pub(crate) resolved_definitions: ResolvedDefinitions,
 }
 
 #[derive(Debug)]
@@ -434,6 +448,7 @@ impl Definition {
             ir_node: Arc::clone(ir_node),
             symbol,
             resolved_file_id,
+            resolved_definitions: ResolvedDefinitions::new(),
         })
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use slang_solidity_v2_common::collections::{DefaultWithCapacity, Map, Set};
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 use super::built_ins::InternalBuiltIn;
 use super::types::TypeId;
@@ -17,7 +17,9 @@ mod scopes;
 pub(crate) use assembly::AssemblyBlock;
 pub(crate) use capacities::BinderCapacities;
 pub use definitions::Definition;
-pub(crate) use definitions::{ContractDefinition, InterfaceDefinition, StructDefinition};
+pub(crate) use definitions::{
+    ContractDefinition, InterfaceDefinition, ResolvedDefinitions, StructDefinition,
+};
 pub use references::{Reference, Resolution};
 use scopes::ContractScope;
 pub(crate) use scopes::{
@@ -713,43 +715,48 @@ impl Binder {
         }
     }
 
-    // If the resolution points to definitions that are symbols aliases (eg.
-    // import deconstruction symbols) this function will recursively follow them
-    // and return an appropriate resulting resolution. Ambiguities and missing
-    // definitions can occur along the followed aliases, so there is no
-    // guarantee that a `Resolved` resolution will yield another `Resolved`
-    // resolution.
-    pub(crate) fn follow_symbol_aliases(&self, resolution: Resolution) -> Resolution {
-        let is_imported_symbol = |id| {
-            matches!(
-                self.find_definition_by_id(id),
-                Some(Definition::ImportedSymbol(_))
-            )
-        };
-        let mut working_set = match resolution {
-            Resolution::Definition(id) if is_imported_symbol(id) => vec![id],
-            Resolution::Ambiguous(ids) if ids.iter().copied().any(is_imported_symbol) => {
-                ids.into_vec()
-            }
-            _ => {
-                // Short-circuit if there are no aliases to follow and avoid
-                // unnecessary allocations
-                return resolution;
-            }
-        };
+    /// Precompute `resolved_definitions` for every `ImportedSymbolDefinition`: the
+    /// declaration(s) the symbol ultimately names, with any intermediate aliases
+    /// followed.
+    ///
+    /// `imported_symbol_ids` are the `Definition::ImportedSymbol` node ids,
+    /// gathered by the caller as it declared them.
+    ///
+    /// Must run once every file scope is populated and the default-import
+    /// closures are in place, since following an alias resolves symbols in
+    /// other files' scopes.
+    pub(crate) fn precompute_imported_symbol_definitions(
+        &mut self,
+        imported_symbol_ids: &[NodeId],
+    ) {
+        for &imported_symbol_id in imported_symbol_ids {
+            let definitions = self.find_imported_symbol_definitions(imported_symbol_id);
+            let Definition::ImportedSymbol(imported_symbol) =
+                self.get_definition_mut(imported_symbol_id)
+            else {
+                unreachable!("Definition {imported_symbol_id:?} is not an imported symbol");
+            };
+            imported_symbol.resolved_definitions = definitions;
+        }
+    }
 
-        // TODO: since this function uses the results from other resolution
-        // functions, we making more allocations than necessary; it may be worth
-        // it to try and avoid them by returning iterators from the delegated
-        // resolution functions
-        let mut found_ids = Vec::new();
-        let mut seen_ids = Set::default();
+    /// Resolves the import chain starting at `imported_symbol_id` down to the
+    /// declaration(s) it names, by resolving each symbol in the scope of the
+    /// file it was imported from. A symbol that resolves to nothing, or whose
+    /// chain closes a cycle, yields no targets.
+    fn find_imported_symbol_definitions(&self, imported_symbol_id: NodeId) -> ResolvedDefinitions {
+        let mut working_set: DefinitionIds = smallvec![imported_symbol_id];
+        let mut found_ids = ResolvedDefinitions::new();
+        // Using a `SmallVec` here rather than a `Set` as the number of walked
+        // IDs is expected to be small and a linear scan is cheaper than hashing
+        let mut seen_ids = DefinitionIds::new();
 
         while let Some(definition_id) = working_set.pop() {
-            if !seen_ids.insert(definition_id) {
+            if seen_ids.contains(&definition_id) {
                 // we already processed this definition
                 continue;
             }
+            seen_ids.push(definition_id);
             let Some(definition) = self.find_definition_by_id(definition_id) else {
                 unreachable!("Definition {definition_id:?} does not exist");
             };
@@ -762,10 +769,11 @@ impl Binder {
                 else {
                     continue;
                 };
-                working_set.extend(
-                    self.resolve_in_scope(scope_id, &imported_symbol.symbol)
-                        .get_definition_ids(),
-                );
+                match self.resolve_in_scope(scope_id, &imported_symbol.symbol) {
+                    Resolution::Definition(id) => working_set.push(id),
+                    Resolution::Ambiguous(ids) => working_set.extend(ids),
+                    Resolution::Unresolved | Resolution::BuiltIn(_) => {}
+                }
             } else {
                 found_ids.push(definition_id);
             }
@@ -774,7 +782,77 @@ impl Binder {
         // reverse the result to maintain the original ordering, since we
         // resolved from last to first in the loop above
         found_ids.reverse();
-        Resolution::from(found_ids)
+        found_ids
+    }
+
+    /// The declarations `definition_id` ultimately names when it is an imported
+    /// symbol, or `None` when it is any other kind of definition (or no
+    /// definition at all). An imported symbol that resolves to nothing yields
+    /// an empty slice, which is distinct from `None`.
+    pub(crate) fn imported_symbol_definitions(
+        &self,
+        definition_id: NodeId,
+    ) -> Option<&ResolvedDefinitions> {
+        match self.find_definition_by_id(definition_id) {
+            Some(Definition::ImportedSymbol(imported_symbol)) => {
+                Some(&imported_symbol.resolved_definitions)
+            }
+            _ => None,
+        }
+    }
+
+    // If the resolution points to definitions that are symbols aliases (eg.
+    // import deconstruction symbols) this function will replace them with the
+    // declarations they name and return an appropriate resulting resolution.
+    // Ambiguities and missing definitions can occur along the followed aliases,
+    // so there is no guarantee that a `Resolved` resolution will yield another
+    // `Resolved` resolution.
+    pub(crate) fn follow_symbol_aliases(&self, resolution: Resolution) -> Resolution {
+        match resolution {
+            Resolution::Definition(id) => match self.imported_symbol_definitions(id) {
+                // Rebuilding from the precomputed targets is a slice read: the
+                // chain was already walked in
+                // `precompute_imported_symbol_definitions`.
+                Some(targets) => Resolution::from(targets.as_slice()),
+                None => resolution,
+            },
+            Resolution::Ambiguous(ref ids) => {
+                if !ids
+                    .iter()
+                    .any(|&id| self.imported_symbol_definitions(id).is_some())
+                {
+                    // No imported symbol to substitute, so the declarations
+                    // already are the answer. Skip rebuilding the set, which
+                    // is not free even when it changes nothing: it scans for
+                    // duplicates and allocates a fresh payload.
+                    return resolution;
+                }
+
+                // Each alias contributes its targets in its own place, so the
+                // surviving declarations keep the order they resolved in.
+                // Duplicates are dropped, since the same declaration can be
+                // reached both directly and through an alias.
+                let mut found_ids = DefinitionIds::with_capacity(ids.len());
+                let mut push_unique = |id: NodeId| {
+                    if !found_ids.contains(&id) {
+                        found_ids.push(id);
+                    }
+                };
+
+                for &id in ids {
+                    match self.imported_symbol_definitions(id) {
+                        Some(targets) => {
+                            for target_id in targets {
+                                push_unique(*target_id);
+                            }
+                        }
+                        None => push_unique(id),
+                    }
+                }
+                Resolution::from(found_ids)
+            }
+            Resolution::Unresolved | Resolution::BuiltIn(_) => resolution,
+        }
     }
 
     // Resolution in this function is strictly limited to the given scope, and

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -24,7 +24,7 @@ pub use references::{Reference, Resolution};
 use scopes::ContractScope;
 pub(crate) use scopes::{
     DefaultImport, FileScope, OperatorMapping, ParameterDefinition, ParametersScope, Scope,
-    UsingDirective, UsingOperator,
+    ScopeDefinitionIds, UsingDirective, UsingOperator,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -543,10 +543,7 @@ impl Binder {
         // Fast path: with no default imports the file's own scope is the whole
         // search set, so resolve with a single map lookup and no traversal:
         if file_scope.default_imports.is_empty() {
-            return file_scope
-                .lookup_symbol(symbol)
-                .collect::<DefinitionIds>()
-                .into();
+            return Resolution::from(file_scope.lookup_symbol(symbol));
         }
 
         // Otherwise scan the precomputed transitive default-import closure
@@ -561,7 +558,7 @@ impl Binder {
             let Scope::File(imported_scope) = self.get_scope_by_id(*scope_id) else {
                 unreachable!("default import closure should only contain file scopes");
             };
-            found_definitions.extend(imported_scope.lookup_symbol(symbol));
+            found_definitions.extend_from_slice(imported_scope.lookup_symbol(symbol));
         }
         Resolution::from(found_definitions)
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use slang_solidity_v2_common::collections::{DefaultWithCapacity, Map, Set};
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
+use smallvec::SmallVec;
 
 use super::built_ins::InternalBuiltIn;
 use super::types::TypeId;
@@ -145,6 +146,14 @@ pub(crate) enum ResolveOptions {
     /// internal lookup.
     Super(NodeId),
 }
+
+/// A group of definitions, identified by their `NodeId`s. Held inline up to a
+/// handful of entries, which covers the sets that occur in practice: the
+/// definitions an ambiguous reference may name, and the working sets built
+/// while resolving one. Used in place of `Vec<NodeId>` and `Set<NodeId>` for
+/// performance reasons; uniqueness, where it matters, is maintained by the code
+/// filling it rather than by the type.
+pub(crate) type DefinitionIds = SmallVec<[NodeId; 4]>;
 
 impl Binder {
     /// Creates a binder with its dominant `NodeId`-keyed maps pre-sized per
@@ -532,7 +541,10 @@ impl Binder {
         // Fast path: with no default imports the file's own scope is the whole
         // search set, so resolve with a single map lookup and no traversal:
         if file_scope.default_imports.is_empty() {
-            return file_scope.lookup_symbol(symbol).collect::<Vec<_>>().into();
+            return file_scope
+                .lookup_symbol(symbol)
+                .collect::<DefinitionIds>()
+                .into();
         }
 
         // Otherwise scan the precomputed transitive default-import closure
@@ -542,7 +554,7 @@ impl Binder {
             "FileScope::default_import_closure should be precomputed"
         );
 
-        let mut found_definitions = Vec::new();
+        let mut found_definitions = DefinitionIds::new();
         for scope_id in &file_scope.default_import_closure {
             let Scope::File(imported_scope) = self.get_scope_by_id(*scope_id) else {
                 unreachable!("default import closure should only contain file scopes");
@@ -579,7 +591,7 @@ impl Binder {
                     }
                 }
             };
-            let mut results = Vec::new();
+            let mut results = DefinitionIds::new();
             for (index, node_id) in linearisations.iter().enumerate() {
                 let Some(base_scope_id) = self.scope_id_for_node_id(*node_id) else {
                     continue;
@@ -620,7 +632,7 @@ impl Binder {
         } else if let Some(definitions) = contract_scope.definitions.get(symbol) {
             // This case shouldn't happen for valid Solidity, as all
             // contracts should have a proper linearisation
-            Resolution::from(definitions.clone())
+            Resolution::from(definitions.as_slice())
         } else {
             Resolution::Unresolved
         }
@@ -675,8 +687,9 @@ impl Binder {
             Scope::Using(using_scope) => using_scope
                 .symbols
                 .get(symbol)
-                .cloned()
-                .map_or(Resolution::Unresolved, Resolution::from),
+                .map_or(Resolution::Unresolved, |definitions| {
+                    Resolution::from(definitions.as_slice())
+                }),
             Scope::YulBlock(yul_block_scope) => yul_block_scope
                 .definitions
                 .get(symbol)
@@ -715,7 +728,9 @@ impl Binder {
         };
         let mut working_set = match resolution {
             Resolution::Definition(id) if is_imported_symbol(id) => vec![id],
-            Resolution::Ambiguous(ids) if ids.iter().copied().any(is_imported_symbol) => ids,
+            Resolution::Ambiguous(ids) if ids.iter().copied().any(is_imported_symbol) => {
+                ids.into_vec()
+            }
             _ => {
                 // Short-circuit if there are no aliases to follow and avoid
                 // unnecessary allocations
@@ -786,8 +801,9 @@ impl Binder {
             Scope::Using(using_scope) => using_scope
                 .symbols
                 .get(symbol)
-                .cloned()
-                .map_or(Resolution::Unresolved, Resolution::from),
+                .map_or(Resolution::Unresolved, |definitions| {
+                    Resolution::from(definitions.as_slice())
+                }),
             Scope::Parameters(parameters_scope) => {
                 parameters_scope.lookup_definition(symbol).into()
             }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/references.rs
@@ -1,6 +1,8 @@
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
+use smallvec::smallvec;
 
+use super::DefinitionIds;
 use crate::built_ins::InternalBuiltIn;
 
 //////////////////////////////////////////////////////////////////////////////
@@ -26,7 +28,7 @@ pub enum Resolution {
     /// apply, as more information is needed (eg. the types of arguments when
     /// the reference is used in a function call, to select the appropriate
     /// overload).
-    Ambiguous(Vec<NodeId>),
+    Ambiguous(Box<[NodeId]>),
     /// The symbol refers to a Solidity built-in of some kind. The possible
     /// variants are encoded in an enum and the behaviour of each is encoded in
     /// the `built_ins.rs` module.
@@ -55,11 +57,11 @@ impl Resolution {
         }
     }
 
-    pub(crate) fn get_definition_ids(&self) -> Vec<NodeId> {
+    pub(crate) fn get_definition_ids(&self) -> DefinitionIds {
         match self {
-            Resolution::Definition(id) => vec![*id],
-            Resolution::Ambiguous(ids) => ids.clone(),
-            _ => Vec::new(),
+            Resolution::Definition(id) => smallvec![*id],
+            Resolution::Ambiguous(ids) => DefinitionIds::from_slice(ids),
+            _ => DefinitionIds::new(),
         }
     }
 
@@ -97,7 +99,37 @@ impl From<Vec<NodeId>> for Resolution {
         match value.len() {
             0 => Resolution::Unresolved,
             1 => Resolution::Definition(value.swap_remove(0)),
-            _ => Resolution::Ambiguous(value),
+            // Takes over the vector's buffer rather than copying it.
+            _ => Resolution::Ambiguous(value.into_boxed_slice()),
+        }
+    }
+}
+
+impl From<DefinitionIds> for Resolution {
+    fn from(mut value: DefinitionIds) -> Self {
+        match value.len() {
+            0 => Resolution::Unresolved,
+            1 => Resolution::Definition(value.swap_remove(0)),
+            // Only an ambiguous result reaches the heap, and it is the rare
+            // case: a name shared by an overload set or by declarations in
+            // several imported files. Keeping it boxed rather than inline
+            // keeps `Resolution` (and so every `Reference` the binder stores)
+            // down to the width of a single pointer plus its length.
+            _ => Resolution::Ambiguous(value.into_vec().into_boxed_slice()),
+        }
+    }
+}
+
+/// Builds a resolution from the definitions a name refers to, borrowing them.
+/// The single-definition case, which is by far the common one, stays a slice
+/// read rather than a copy, so this is preferred over the owning conversions
+/// wherever the definitions are only on loan.
+impl From<&[NodeId]> for Resolution {
+    fn from(value: &[NodeId]) -> Self {
+        match value {
+            [] => Resolution::Unresolved,
+            &[definition_id] => Resolution::Definition(definition_id),
+            _ => Resolution::Ambiguous(value.into()),
         }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/scopes.rs
@@ -9,6 +9,12 @@ use smallvec::SmallVec;
 use super::ScopeId;
 use crate::types::TypeId;
 
+/// The definitions a scope holds under one symbol, whether declared in it or
+/// attached to it by a `using` directive. Only overload sets hold more than
+/// one, so a single entry is stored inline: that takes the same room as the
+/// `Vec` it replaces while saving an allocation per symbol.
+pub(crate) type ScopeDefinitionIds = SmallVec<[NodeId; 1]>;
+
 //////////////////////////////////////////////////////////////////////////////
 // Scopes - types
 
@@ -48,7 +54,7 @@ pub(crate) struct ChainedScope {
 pub(crate) struct ContractScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_scope_id: ScopeId,
-    pub(crate) definitions: Map<String, Vec<NodeId>>,
+    pub(crate) definitions: Map<String, ScopeDefinitionIds>,
     pub(crate) using_directives: Vec<UsingDirective>,
 }
 
@@ -60,7 +66,7 @@ pub(crate) struct EnumScope {
 pub(crate) struct FileScope {
     pub(crate) node_id: NodeId,
     pub(crate) file_id: FileId,
-    pub(crate) definitions: Map<String, Vec<NodeId>>,
+    pub(crate) definitions: Map<String, ScopeDefinitionIds>,
     /// Files brought into scope through (unqualified) default imports, in
     /// source order. The same file may appear more than once if imported by
     /// several directives.
@@ -124,7 +130,7 @@ pub(crate) struct StructScope {
 
 pub(crate) struct UsingScope {
     pub(crate) node_id: NodeId,
-    pub(crate) symbols: Map<String, Vec<NodeId>>,
+    pub(crate) symbols: Map<String, ScopeDefinitionIds>,
 }
 
 pub(crate) struct YulBlockScope {
@@ -229,7 +235,7 @@ impl Scope {
         Self::Struct(StructScope::new(node_id))
     }
 
-    pub(crate) fn new_using(node_id: NodeId, symbols: Map<String, Vec<NodeId>>) -> Self {
+    pub(crate) fn new_using(node_id: NodeId, symbols: Map<String, ScopeDefinitionIds>) -> Self {
         Self::Using(UsingScope::new(node_id, symbols))
     }
 
@@ -300,11 +306,10 @@ impl ContractScope {
     }
 
     pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
-        if let Some(definitions) = self.definitions.get_mut(&symbol) {
-            definitions.push(node_id);
-        } else {
-            self.definitions.insert(symbol, vec![node_id]);
-        }
+        // `entry` hashes the symbol once, where looking up and then inserting
+        // hashes it twice for every symbol declared for the first time, which
+        // is the common case.
+        self.definitions.entry(symbol).or_default().push(node_id);
     }
 }
 
@@ -334,24 +339,24 @@ impl FileScope {
     }
 
     pub(crate) fn insert_definition(&mut self, symbol: String, node_id: NodeId) {
-        if let Some(definitions) = self.definitions.get_mut(&symbol) {
-            definitions.push(node_id);
-        } else {
-            self.definitions.insert(symbol, vec![node_id]);
-        }
+        // `entry` hashes the symbol once, where looking up and then inserting
+        // hashes it twice for every symbol declared for the first time, which
+        // is the common case.
+        self.definitions.entry(symbol).or_default().push(node_id);
     }
 
     pub(crate) fn add_default_import(&mut self, file_id: FileId, range: Range<usize>) {
         self.default_imports.push(DefaultImport { file_id, range });
     }
 
-    pub(crate) fn lookup_symbol<'a>(&'a self, symbol: &str) -> impl Iterator<Item = NodeId> + 'a {
+    /// The definitions this file declares under `symbol`, empty when it
+    /// declares none. Returned as a slice so a caller resolving in a single
+    /// file scope can build a `Resolution` without collecting them.
+    pub(crate) fn lookup_symbol(&self, symbol: &str) -> &[NodeId] {
         self.definitions
             .get(symbol)
-            .map(|defs| defs.as_slice())
+            .map(|definitions| definitions.as_slice())
             .unwrap_or_default()
-            .iter()
-            .copied()
     }
 }
 
@@ -430,7 +435,7 @@ impl StructScope {
 }
 
 impl UsingScope {
-    fn new(node_id: NodeId, symbols: Map<String, Vec<NodeId>>) -> Self {
+    fn new(node_id: NodeId, symbols: Map<String, ScopeDefinitionIds>) -> Self {
         Self { node_id, symbols }
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/conflicts.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/conflicts.rs
@@ -6,8 +6,28 @@
 //! differently, so each lives with its pass.
 
 use slang_solidity_v2_common::nodes::NodeId;
+use smallvec::smallvec;
 
-use crate::binder::{Binder, Definition};
+use crate::binder::{Binder, Definition, DefinitionIds};
+
+// Returns the declaration(s) `definition_id` stands for once any imports have
+// been followed. A definition that isn't an imported symbol stands for itself.
+//
+// An imported symbol that resolves to nothing (because the import path didn't
+// resolve to a file, which gets its own diagnostic, or because the imported
+// file doesn't declare the symbol) also stands for itself. That keeps the
+// unresolvable import a distinct opaque declaration which conflicts with
+// anything else sharing its name, rather than one compatible with everything.
+pub(crate) fn underlying_declarations(binder: &Binder, definition_id: NodeId) -> DefinitionIds {
+    // The definitions were resolved once at the end of `p1_collect_definitions`,
+    // so this is a copy of an inline slice rather than a walk of the imports.
+    match binder.imported_symbol_definitions(definition_id) {
+        Some(definition_ids) if !definition_ids.is_empty() => {
+            DefinitionIds::from_slice(definition_ids)
+        }
+        _ => smallvec![definition_id],
+    }
+}
 
 // Returns `Some(existing_id)` when an existing definition conflicts with the
 // one being declared, or `None` when they may legally coexist (overloads).

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 
-use crate::binder::{Binder, Definition, Reference, Resolution, ScopeId, Typing};
+use crate::binder::{Binder, Definition, DefinitionIds, Reference, Resolution, ScopeId, Typing};
 use crate::types::{FunctionType, Type, TypeRegistry};
 
 /// Resolves an `IdentifierPath` starting from the given scope, creating
@@ -60,7 +60,7 @@ pub(crate) fn filter_overriden_definitions(
         return resolution;
     };
     let mut seen_function_types: Vec<&FunctionType> = Vec::new();
-    let mut filtered_definitions = Vec::new();
+    let mut filtered_definitions = DefinitionIds::new();
     for definition_id in definition_ids {
         match binder.find_definition_by_id(definition_id).unwrap() {
             Definition::Function(_) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
@@ -25,12 +25,11 @@ use std::ops::Range;
 use slang_solidity_v2_common::collections::{Map, Set};
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
-use smallvec::smallvec;
 
-use crate::binder::{
-    Binder, DefaultImport, Definition, DefinitionIds, FileScope, Resolution, Scope, ScopeId,
+use crate::binder::{Binder, DefaultImport, Definition, FileScope, Scope, ScopeId};
+use crate::passes::common::conflicts::{
+    conflicting_definition, first_conflicting_definition, underlying_declarations,
 };
-use crate::passes::common::conflicts::{conflicting_definition, first_conflicting_definition};
 
 // Looks for a previously-registered definition that conflicts with a Solidity
 // `new_definition` being declared under `symbol` in `scope_id`, returning the
@@ -180,40 +179,19 @@ pub(super) fn find_file_scope_conflicts<'a>(
     conflicts
 }
 
-// Follows any import aliases starting at `definition_id` and returns the
-// underlying declaration(s) it ultimately refers to. A non-import definition
-// resolves to itself.
-//
-// An imported symbol whose target cannot be resolved — because the import
-// path didn't resolve to a file (which gets its own diagnostic), or because
-// the imported file doesn't declare the symbol — also falls back to itself.
-// This keeps the unresolvable import a distinct opaque declaration that
-// conflicts with anything else sharing its name (the pre-alias-following
-// behaviour), rather than treating it as compatible with everything.
-fn resolved_targets(binder: &Binder, definition_id: NodeId) -> DefinitionIds {
-    let targets = binder
-        .follow_symbol_aliases(Resolution::Definition(definition_id))
-        .get_definition_ids();
-    if targets.is_empty() {
-        smallvec![definition_id]
-    } else {
-        targets
-    }
-}
-
 // Whether declaring `new_id` under the same name as the already-visible
 // `existing_id` is a redeclaration, resolving both through any import aliases
 // first. They may legally coexist when every underlying declaration pair is
 // either the very same declaration (an idempotent re-import) or a legal
 // overload, as decided by the shared `conflicting_definition` primitive.
 fn aliased_definitions_conflict(binder: &Binder, existing_id: NodeId, new_id: NodeId) -> bool {
-    let existing_targets = resolved_targets(binder, existing_id);
+    let existing_declarations = underlying_declarations(binder, existing_id);
 
-    resolved_targets(binder, new_id).iter().any(|&new| {
+    underlying_declarations(binder, new_id).iter().any(|&new| {
         let new_definition = binder
             .find_definition_by_id(new)
             .expect("definition is registered");
-        existing_targets
+        existing_declarations
             .iter()
             // The same underlying declaration reached through both names is
             // not a conflict.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
@@ -25,8 +25,11 @@ use std::ops::Range;
 use slang_solidity_v2_common::collections::{Map, Set};
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
+use smallvec::smallvec;
 
-use crate::binder::{Binder, DefaultImport, Definition, FileScope, Resolution, Scope, ScopeId};
+use crate::binder::{
+    Binder, DefaultImport, Definition, DefinitionIds, FileScope, Resolution, Scope, ScopeId,
+};
 use crate::passes::common::conflicts::{conflicting_definition, first_conflicting_definition};
 
 // Looks for a previously-registered definition that conflicts with a Solidity
@@ -187,12 +190,12 @@ pub(super) fn find_file_scope_conflicts<'a>(
 // This keeps the unresolvable import a distinct opaque declaration that
 // conflicts with anything else sharing its name (the pre-alias-following
 // behaviour), rather than treating it as compatible with everything.
-fn resolved_targets(binder: &Binder, definition_id: NodeId) -> Vec<NodeId> {
+fn resolved_targets(binder: &Binder, definition_id: NodeId) -> DefinitionIds {
     let targets = binder
         .follow_symbol_aliases(Resolution::Definition(definition_id))
         .get_definition_ids();
     if targets.is_empty() {
-        vec![definition_id]
+        smallvec![definition_id]
     } else {
         targets
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/conflicts.rs
@@ -326,6 +326,7 @@ fn find_local_definition_conflicts(
             let imported: Vec<NodeId> = imported_scopes
                 .iter()
                 .flat_map(|scope| scope.lookup_symbol(symbol))
+                .copied()
                 .collect();
             if imported.is_empty() {
                 continue;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/mod.rs
@@ -28,14 +28,29 @@ pub fn run(
     language_version: LanguageVersion,
     diagnostics: &mut DiagnosticCollection,
 ) {
+    // Import aliases are noted as they are declared, so that the alias
+    // resolution below doesn't have to look for them among all definitions.
+    let mut imported_symbol_ids = Vec::new();
     for file in files {
-        Pass::visit_file(file, binder, language_version, diagnostics);
+        Pass::visit_file(
+            file,
+            binder,
+            language_version,
+            diagnostics,
+            &mut imported_symbol_ids,
+        );
     }
 
     // The default-import graph is now final. Precompute each file's transitive
     // import closure once, so later passes resolve file-scope symbols with a
     // flat scan instead of re-walking the graph on every lookup.
     binder.precompute_default_import_closures();
+
+    // Every file scope is populated, so each import alias can now be followed
+    // to the declaration(s) it names. Resolve them all once here, so the later
+    // passes (and the redeclaration checks just below) read the targets off the
+    // alias instead of re-walking the chain on every query.
+    binder.precompute_imported_symbol_definitions(&imported_symbol_ids);
 
     // Once every file scope is populated and the import closures are in place,
     // detect redeclaration clashes at file scope. These are handled here
@@ -76,6 +91,10 @@ struct Pass<'a, F: SemanticFile> {
     binder: &'a mut Binder,
     language_version: LanguageVersion,
     diagnostics: &'a mut DiagnosticCollection,
+    // Accumulates the node ids of the import aliases declared while visiting,
+    // across all the files of the compilation unit, for `run` to resolve once
+    // every file scope is populated.
+    imported_symbol_ids: &'a mut Vec<NodeId>,
 }
 
 impl<'a, F: SemanticFile> Pass<'a, F> {
@@ -84,6 +103,7 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
         binder: &'a mut Binder,
         language_version: LanguageVersion,
         diagnostics: &'a mut DiagnosticCollection,
+        imported_symbol_ids: &'a mut Vec<NodeId>,
     ) {
         let mut pass = Self {
             current_file: file,
@@ -94,6 +114,7 @@ impl<'a, F: SemanticFile> Pass<'a, F> {
             binder,
             language_version,
             diagnostics,
+            imported_symbol_ids,
         };
         ir::visitor::accept_source_unit(file.ir_root(), &mut pass);
         assert!(pass.scope_stack.is_empty());

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p1_collect_definitions/visitor.rs
@@ -125,6 +125,7 @@ impl<F: SemanticFile> Visitor for Pass<'_, F> {
                 symbol.name.unparse().to_owned(),
                 imported_file_id.clone(),
             );
+            self.imported_symbol_ids.push(symbol.id());
             self.insert_definition_in_current_scope(definition);
         }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -11,7 +11,8 @@ use slang_solidity_v2_ir::ir::visitor::Visitor;
 
 use super::Pass;
 use crate::binder::{
-    Definition, OperatorMapping, Reference, Resolution, Scope, Typing, UsingDirective,
+    Definition, OperatorMapping, Reference, Resolution, Scope, ScopeDefinitionIds, Typing,
+    UsingDirective,
 };
 use crate::built_ins::InternalBuiltIn;
 use crate::types::{ContractType, DataLocation, EnumType, InterfaceType, LibraryType, Type};
@@ -453,10 +454,12 @@ impl Visitor for Pass<'_> {
                                 operators
                                     .entry(operator.into())
                                     .or_default()
-                                    .extend(definition_ids.iter().copied());
+                                    .extend_from_slice(&definition_ids);
                             }
-                            symbols
-                                .insert(symbol_name.unparse().to_string(), definition_ids.to_vec());
+                            symbols.insert(
+                                symbol_name.unparse().to_string(),
+                                ScopeDefinitionIds::from_slice(&definition_ids),
+                            );
                         }
 
                         let scope = Scope::new_using(node.id(), symbols);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/visitor.rs
@@ -455,7 +455,8 @@ impl Visitor for Pass<'_> {
                                     .or_default()
                                     .extend(definition_ids.iter().copied());
                             }
-                            symbols.insert(symbol_name.unparse().to_string(), definition_ids);
+                            symbols
+                                .insert(symbol_name.unparse().to_string(), definition_ids.to_vec());
                         }
 
                         let scope = Scope::new_using(node.id(), symbols);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -10,8 +10,8 @@ use slang_solidity_v2_ir::ir;
 
 use super::{Pass, ScopeFrame};
 use crate::binder::{
-    Definition, Reference, Resolution, ResolveOptions, ScopeId, Typing, UsingDirective,
-    UsingOperator,
+    Definition, DefinitionIds, Reference, Resolution, ResolveOptions, ScopeId, Typing,
+    UsingDirective, UsingOperator,
 };
 use crate::built_ins::BuiltInsResolver;
 use crate::passes::common::constant_evaluator::{
@@ -175,7 +175,7 @@ impl Pass<'_> {
         &self,
         receiver_type_id: TypeId,
         symbol: &str,
-        definition_ids: &mut Vec<NodeId>,
+        definition_ids: &mut DefinitionIds,
     ) {
         let active_directives = self.active_using_directives_for_type(receiver_type_id);
         let mut seen_ids = Set::default();

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
@@ -270,7 +270,7 @@ impl ReferenceCollector<'_> {
         };
         let definition_ids = match &resolution {
             Resolution::Definition(id) => std::slice::from_ref(id),
-            Resolution::Ambiguous(ids) => ids.as_slice(),
+            Resolution::Ambiguous(ids) => ids,
             _ => return,
         };
         let Some(operand_id) = node.operand.node_id() else {
@@ -317,7 +317,7 @@ impl ReferenceCollector<'_> {
         };
         let definition_ids = match &resolution {
             Resolution::Definition(id) => std::slice::from_ref(id),
-            Resolution::Ambiguous(ids) => ids.as_slice(),
+            Resolution::Ambiguous(ids) => ids,
             _ => return,
         };
         for &definition_id in definition_ids {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/alias_following.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/alias_following.rs
@@ -1,0 +1,122 @@
+//! The declarations [`Binder::follow_symbol_aliases`] yields when a resolution
+//! names import aliases, and the order it yields them in.
+
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+
+use super::build_files;
+use crate::binder::{Binder, Resolution};
+use crate::passes::p1_collect_definitions;
+
+/// Collects definitions over `sources` (see [`build_files`]), which is enough
+/// to resolve file-scope symbols and to follow import aliases: `p1` computes
+/// the default-import closures and the aliases' targets before it returns.
+fn collect_definitions(sources: &[(&str, &str)]) -> Binder {
+    let files = build_files(sources, LanguageVersion::LATEST);
+    let mut binder = Binder::default();
+    let mut diagnostics = DiagnosticCollection::default();
+
+    p1_collect_definitions::run(
+        &files,
+        &mut binder,
+        LanguageVersion::LATEST,
+        &mut diagnostics,
+    );
+
+    binder
+}
+
+/// Resolves `symbol` at the file scope of `file_name`.
+fn resolve_at_file_scope(binder: &Binder, file_name: &str, symbol: &str) -> Resolution {
+    let scope_id = binder
+        .scope_id_for_file_id(&file_name.into())
+        .unwrap_or_else(|| panic!("no file scope for {file_name}"));
+
+    binder.resolve_in_scope(scope_id, symbol)
+}
+
+/// The single definition `file_name` declares under `symbol`.
+fn definition_at_file_scope(binder: &Binder, file_name: &str, symbol: &str) -> NodeId {
+    match resolve_at_file_scope(binder, file_name, symbol) {
+        Resolution::Definition(definition_id) => definition_id,
+        other => panic!("expected a single `{symbol}` in {file_name}, got {other:?}"),
+    }
+}
+
+/// The same declaration can be reached twice within one ambiguous resolution:
+/// directly, and again through an import alias naming it. Following the aliases
+/// drops the repeat, keeping the *first* occurrence, so the surviving
+/// declarations stay in the order they were first resolved in.
+///
+/// The two rules only differ when a distinct declaration sits between the two
+/// occurrences: for `[C_b, C_d, alias -> C_b]`, keeping the first yields
+/// `[C_b, C_d]` where keeping the last would yield `[C_d, C_b]`.
+#[test]
+fn test_follow_aliases_keeps_a_repeated_definition_in_its_first_position() {
+    // `a.sol` sees `C` three times over: declared by `b.sol`, declared by
+    // `d.sol`, and re-exported by `c.sol` as an alias of `b.sol`'s. The import
+    // order puts `d.sol`'s declaration between the two that name `b.sol`'s.
+    let binder = collect_definitions(&[
+        (
+            "a.sol",
+            r#"
+import "b.sol";
+import "d.sol";
+import "c.sol";
+            "#,
+        ),
+        ("b.sol", "contract C {}"),
+        ("d.sol", "contract C {}"),
+        ("c.sol", r#"import {C} from "b.sol";"#),
+    ]);
+
+    let c_in_b = definition_at_file_scope(&binder, "b.sol", "C");
+    let c_in_d = definition_at_file_scope(&binder, "d.sol", "C");
+
+    let resolution = resolve_at_file_scope(&binder, "a.sol", "C");
+    let Resolution::Ambiguous(definition_ids) = &resolution else {
+        panic!("expected `C` to resolve ambiguously in a.sol, got {resolution:?}");
+    };
+    assert_eq!(
+        &definition_ids[..],
+        &[
+            c_in_b,
+            c_in_d,
+            definition_at_file_scope(&binder, "c.sol", "C")
+        ],
+        "all three should be visible, with the alias re-exported by c.sol last"
+    );
+
+    assert_eq!(
+        binder.follow_symbol_aliases(resolution),
+        Resolution::Ambiguous([c_in_b, c_in_d].into()),
+        "the repeated declaration should keep the position of its first occurrence"
+    );
+}
+
+/// An alias whose target is not otherwise visible contributes that target in
+/// the alias' own position, leaving the surrounding declarations in place.
+#[test]
+fn test_follow_aliases_substitutes_a_target_in_place() {
+    let binder = collect_definitions(&[
+        (
+            "a.sol",
+            r#"
+import "c.sol";
+import "d.sol";
+            "#,
+        ),
+        ("b.sol", "contract C {}"),
+        ("c.sol", r#"import {C} from "b.sol";"#),
+        ("d.sol", "contract C {}"),
+    ]);
+
+    let c_in_b = definition_at_file_scope(&binder, "b.sol", "C");
+    let c_in_d = definition_at_file_scope(&binder, "d.sol", "C");
+
+    assert_eq!(
+        binder.follow_symbol_aliases(resolve_at_file_scope(&binder, "a.sol", "C")),
+        Resolution::Ambiguous([c_in_b, c_in_d].into()),
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -1,20 +1,25 @@
+mod alias_following;
 mod binder;
 mod contract_dependencies;
 mod getter_overrides;
 mod typing;
 mod user_defined_operator_functions;
 
+use slang_solidity_v2_common::collections::Map;
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_ir::ir::{self, NodeIdGenerator};
 use slang_solidity_v2_parser::{ParseOutput, Parser};
 
-use crate::context::SemanticFile;
+use crate::context::{SemanticFile, extract_import_paths_from_source_unit};
 
 struct TestFile {
     id: FileId,
     ir_root: ir::SourceUnit,
+    /// Empty unless the file was built by [`build_files`], which is the only
+    /// helper that knows about sibling files to resolve imports against.
+    resolved_imports: Map<NodeId, FileId>,
 }
 
 impl SemanticFile for TestFile {
@@ -26,8 +31,8 @@ impl SemanticFile for TestFile {
         &self.ir_root
     }
 
-    fn resolved_import_by_node_id(&self, _node_id: NodeId) -> Option<&FileId> {
-        None
+    fn resolved_import_by_node_id(&self, node_id: NodeId) -> Option<&FileId> {
+        self.resolved_imports.get(&node_id)
     }
 }
 
@@ -66,5 +71,37 @@ fn build_file(
     TestFile {
         id: file_id,
         ir_root,
+        resolved_imports: Map::default(),
     }
+}
+
+/// Builds several files that may import each other, given as `(file name,
+/// contents)` pairs. Import paths name the files verbatim, so a source
+/// importing `"b.sol"` resolves to the entry named `b.sol`; a path naming no
+/// entry stays unresolved, as it would for a missing file.
+///
+/// The files are built in the order given, which is the order the binder sees
+/// their nodes in, and hence the order a file-scope lookup resolves them in.
+fn build_files(sources: &[(&str, &str)], language_version: LanguageVersion) -> Vec<TestFile> {
+    let mut id_generator = NodeIdGenerator::default();
+
+    sources
+        .iter()
+        .map(|(name, contents)| {
+            let mut file = build_file(
+                (*name).into(),
+                contents,
+                &mut id_generator,
+                language_version,
+            );
+
+            file.resolved_imports = extract_import_paths_from_source_unit(&file.ir_root)
+                .into_iter()
+                .filter(|(_, path)| sources.iter().any(|(name, _)| name == path))
+                .map(|(node_id, path)| (node_id, path.as_str().into()))
+                .collect();
+
+            file
+        })
+        .collect()
 }


### PR DESCRIPTION
Reduces work in the binder's hottest paths: following imported symbols, resolving names in scopes, and storing the definitions a scope holds.

Three commits, each self-contained.

* **Use a `SmallVec` for small sets of definition `NodeId`s**

  Introduces `DefinitionIds`, held inline up to four entries, for the working sets built while resolving a name and for `Resolution::get_definition_ids`. The scope-resolution paths (`resolve_in_file_scope`, `resolve_in_contract_scope_internal`) no longer heap-allocate a `Vec` per lookup.

  `Resolution::Ambiguous` moves the other way, from `Vec<NodeId>` to `Box<[NodeId]>`. Ambiguous resolutions are the rare case, and `Resolution` is embedded in every `Reference` the binder stores, so a narrower payload is worth far more than keeping the set inline: a `SmallVec` there widened `Reference` from 32 to 56 bytes and cost several percent of peak memory.

* **Precompute the definitions imported symbols resolve to**

  Following an imported symbol used to resolve it in the scope of the file it came from on every query, walking the whole chain of imports each time. Each chain is now walked once at the end of `p1_collect_definitions`, once every file scope is populated and the default-import closures are in place, and stored on the `ImportedSymbolDefinition` as `resolved_definitions`. `follow_symbol_aliases` and the conflict checks read them off the definition instead.

  **Behaviour change.** Where a declaration is reachable more than once within one ambiguous resolution (directly, and again through an imported symbol naming it) the repeat is dropped keeping its *first* occurrence. It previously kept the last, as a side effect of walking a stack. The two only differ when a distinct declaration sits between the two occurrences, which no test covered; the added unit test now pins it.

* **Use a `SmallVec` for the definitions a scope holds**

  `FileScope`, `ContractScope` and `UsingScope` keyed each symbol to a `Vec<NodeId>`, allocating for every symbol declared even though only overload sets ever hold more than one. They now hold a `ScopeDefinitionIds`, which keeps a single entry inline and takes the same room as the `Vec` it replaces.

---

Callgrind results from `infra perf cargo slang-v2`, against `origin/main`:

| phase | instructions | memory (DHAT total bytes) |
| --- | ---: | ---: |
| `semantic` | **−8.0%** | **−3.0%** |
| `ast_analysis` | **−14.2%** | **−80.6%** |
| `ir_builder`, `ast_visitor` | unchanged (bit-identical) | unchanged |
| `parser` | unchanged (−0.0002%) | unchanged |

Commit 2 is the largest single contributor, accounting for roughly 60% of the `semantic` instruction win and 78% of the `ast_analysis` one. It is also what drives the `ast_analysis` memory drop: re-walking a chain of imports allocated on every query, and that no longer happens at all.
