### PR TITLE
[v2] feat(ast): Expose the struct members a getter returns

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -3062,6 +3062,7 @@ pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::is_externally_
 impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>
 impl slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
+pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::getter_struct_members(&self) -> alloc::vec::Vec<slang_solidity_v2_ast::ast::StructMember>
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::getter_type(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Type>
 impl core::clone::Clone for slang_solidity_v2_ast::ast::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::StateVariableDefinitionStruct::clone(&self) -> slang_solidity_v2_ast::ast::StateVariableDefinitionStruct

--- a/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/state_variable_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/ast/node_extensions/state_variable_definition.rs
@@ -1,6 +1,6 @@
 use slang_solidity_v2_semantic::binder;
 
-use super::super::{StateVariableDefinitionStruct, Type};
+use super::super::{Definition, StateVariableDefinitionStruct, StructMember, Type};
 
 impl StateVariableDefinitionStruct {
     /// Returns the type of the getter generated for this state variable, or
@@ -14,5 +14,29 @@ impl StateVariableDefinitionStruct {
             unreachable!("definition is not a state variable");
         };
         Some(Type::create(definition.getter_type_id?, &self.semantic))
+    }
+
+    /// Returns the struct members the getter's return type is built from, in
+    /// declaration order, or an empty list if it is not built from a struct.
+    pub fn getter_struct_members(&self) -> Vec<StructMember> {
+        let Some(binder::Definition::StateVariable(definition)) = self
+            .semantic
+            .binder()
+            .find_definition_by_id(self.ir_node.id())
+        else {
+            unreachable!("definition is not a state variable");
+        };
+        definition
+            .getter_member_ids
+            .iter()
+            .map(|member_id| {
+                let Some(Definition::StructMember(member)) =
+                    Definition::try_create(*member_id, &self.semantic)
+                else {
+                    unreachable!("getter member is not a struct member");
+                };
+                member
+            })
+            .collect()
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/definitions.rs
@@ -123,6 +123,9 @@ pub struct ParameterDefinition {
 pub struct StateVariableDefinition {
     pub ir_node: ir::StateVariableDefinition,
     pub getter_type_id: Option<TypeId>,
+    // The struct members the getter's return type is built from, in declaration
+    // order.
+    pub getter_member_ids: Vec<NodeId>,
     // This is the scope the variable is defined in, and is used to change the
     // resolution context in the `CompileConstantEvaluator`.
     pub(crate) enclosing_scope_id: ScopeId,
@@ -460,6 +463,7 @@ impl Definition {
         Self::StateVariable(StateVariableDefinition {
             ir_node: Arc::clone(ir_node),
             getter_type_id: None,
+            getter_member_ids: Vec::new(),
             enclosing_scope_id,
         })
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/mod.rs
@@ -150,7 +150,7 @@ impl<'a> Pass<'a> {
                     continue;
                 };
 
-                let Some(getter_type_id) =
+                let Some((getter_type_id, getter_member_ids)) =
                     self.compute_getter_type(receiver_type_id, node_id, type_id)
                 else {
                     continue;
@@ -160,6 +160,7 @@ impl<'a> Pass<'a> {
                     unreachable!("definition is not a state variable");
                 };
                 definition.getter_type_id = Some(getter_type_id);
+                definition.getter_member_ids = getter_member_ids;
             }
         }
     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p3_type_definitions/typing.rs
@@ -163,14 +163,17 @@ impl Pass<'_> {
         })))
     }
 
+    /// Computes the type of the getter generated for a public state variable,
+    /// together with the struct members its return type is built from.
     pub(super) fn compute_getter_type(
         &mut self,
         receiver_type_id: TypeId,
         definition_id: NodeId,
         type_id: TypeId,
-    ) -> Option<TypeId> {
+    ) -> Option<(TypeId, Vec<NodeId>)> {
         let mut return_type = type_id;
         let mut parameter_types = Vec::new();
+        let mut returned_member_ids = Vec::new();
 
         loop {
             match self.types.get_type_by_id(return_type) {
@@ -239,6 +242,7 @@ impl Pass<'_> {
                                 .register_type_with_data_location(member_type, DataLocation::Memory)
                         };
                         types.push(member_type_id);
+                        returned_member_ids.push(member_id);
                     }
                     return_type = match types.len() {
                         0 => return None,
@@ -284,7 +288,7 @@ impl Pass<'_> {
             mutability: FunctionTypeMutability::View,
             partially_applied: false,
         });
-        Some(self.types.register_type(getter_type))
+        Some((self.types.register_type(getter_type), returned_member_ids))
     }
 
     pub(super) fn visit_parameters(&mut self, parameters: &ir::Parameters) {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/ast/typing.rs
@@ -206,6 +206,79 @@ fn test_state_variable_getter_type() {
 }
 
 define_fixture!(
+    StructGetters,
+    file: "main.sol", r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract C {
+    struct Account {
+        uint256 id;
+        mapping(uint256 => uint256) entries;
+        uint256[] history;
+        address owner;
+    }
+
+    Account public account;
+    uint256 public counter;
+}
+"#,
+);
+
+#[test]
+fn test_state_variable_getter_struct_members() {
+    let unit = StructGetters::build_compilation_unit();
+
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract C is found");
+
+    let state_variables = contract
+        .members()
+        .iter()
+        .filter_map(|member| match member {
+            ast::ContractMember::StateVariableDefinition(state_variable) => Some(state_variable),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let [account, counter] = state_variables.as_slice() else {
+        panic!("expected the contract to declare two state variables");
+    };
+
+    let member_names: Vec<String> = account
+        .getter_struct_members()
+        .iter()
+        .map(|member| member.name().name().to_owned())
+        .collect();
+    assert_eq!(
+        member_names,
+        ["id", "owner"],
+        "the mapping and array members are not returned by the getter"
+    );
+
+    let ast::Type::Function(getter) = account
+        .getter_type()
+        .expect("a public state variable has a getter")
+    else {
+        panic!("expected the getter to type as a function");
+    };
+    let ast::Type::Tuple(returned) = getter.return_type() else {
+        panic!("expected the getter to return a tuple");
+    };
+    assert_eq!(
+        returned.types().len(),
+        member_names.len(),
+        "the getter returns one value per returned member"
+    );
+
+    assert!(
+        counter.getter_struct_members().is_empty(),
+        "a getter whose return type is not built from a struct has no members"
+    );
+}
+
+define_fixture!(
     LiteralPlusInteger,
     file: "main.sol", r#"
 // SPDX-License-Identifier: UNLICENSED


### PR DESCRIPTION
`compute_getter_type` walks a public state variable's type down to the struct at its bottom and builds the return tuple from the members that can be returned directly, dropping which members those were. A consumer that needs their positions — to read the fields the tuple stands for, or to name the ABI outputs — has to re-derive the returnable-member rule, and a second copy can drift from this one.

The binder now keeps those member ids beside `getter_type_id`, and `StateVariableDefinition` exposes them in declaration order as `getter_struct_members()`.