### PR TITLE
fix(bindings): Narrow override filtering and public function conversion

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
@@ -69,7 +69,8 @@ pub(crate) fn filter_overriden_definitions(
                         unreachable!("type of function definition is not a function");
                     };
                     if seen_function_types.iter().any(|seen_function_type| {
-                        types.function_type_overrides(seen_function_type, function_type)
+                        types
+                            .function_type_overrides_in_hierarchy(seen_function_type, function_type)
                     }) {
                         // the function type is overriden by some other previously seen definition
                         continue;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/mod.rs
@@ -2,6 +2,7 @@ mod alias_following;
 mod binder;
 mod contract_dependencies;
 mod getter_overrides;
+mod overload_resolution;
 mod support;
 mod typing;
 mod user_defined_operator_functions;

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/overload_resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/overload_resolution.rs
@@ -1,0 +1,219 @@
+use slang_solidity_v2_common::nodes::NodeId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+use slang_solidity_v2_ir::ir;
+
+use crate::binder::{Binder, Resolution};
+use crate::passes::tests::{Analyse, Analysis};
+use crate::types::{
+    ContractType, FunctionType, FunctionTypeMutability, FunctionTypeVisibility, Type, TypeId,
+    TypeRegistry,
+};
+
+/// The resolutions of every reference made through an identifier named `name`.
+fn resolutions_of(binder: &Binder, name: &str) -> Vec<Resolution> {
+    binder
+        .references()
+        .values()
+        .filter(|reference| reference.identifier.unparse() == name)
+        .map(|reference| reference.resolution.clone())
+        .collect()
+}
+
+/// The node ids of `contract`'s function definitions named `name`, in
+/// declaration order.
+fn function_definition_ids(contract: &ir::ContractDefinition, name: &str) -> Vec<NodeId> {
+    contract
+        .members
+        .iter()
+        .filter_map(|member| match member {
+            ir::ContractMember::FunctionDefinition(function)
+                if function.name.as_ref().is_some_and(|n| n.unparse() == name) =>
+            {
+                Some(function.id())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Two unrelated functions attached to the same type under one name by
+/// different `using` directives are genuinely ambiguous. They have identical
+/// signatures, but neither is a contract member, so neither can override the
+/// other.
+#[test]
+fn test_attached_functions_from_different_directives_stay_ambiguous() {
+    const SOURCE: &str = r###"
+struct S {
+    uint256 x;
+}
+
+function f(S memory s) pure returns (uint256) {
+    return s.x;
+}
+
+library L {
+    function f(S memory s) internal pure returns (uint256) {
+        return s.x + 1;
+    }
+}
+
+contract C {
+    using {f} for S;
+    using L for S;
+
+    function test(S memory s) internal pure {
+        s.f;
+    }
+}
+    "###;
+
+    let analysis = Analysis::of_source(SOURCE)
+        .run(Analyse::References)
+        .expect_no_diagnostics();
+
+    // The `f` in the `using {f} for S` clause resolves to the free function,
+    // and the `f` in `s.f` sees both attached candidates.
+    let ambiguous = resolutions_of(analysis.binder(), "f")
+        .into_iter()
+        .filter_map(|resolution| match resolution {
+            Resolution::Ambiguous(definition_ids) => Some(definition_ids),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        1,
+        ambiguous.len(),
+        "expected exactly one ambiguous reference to `f`"
+    );
+    let definition_ids = &ambiguous[0];
+    assert_eq!(
+        2,
+        definition_ids.len(),
+        "expected both attached functions as candidates"
+    );
+    assert_ne!(definition_ids[0], definition_ids[1]);
+}
+
+/// Overriding is a contract-member relationship: two functions without a
+/// receiver never override each other, however identical their signatures.
+///
+/// Members do *not* need to be declared in contracts that derive from one
+/// another. A resolution gathers members from one linearisation and yields them
+/// most-derived first, so a sibling base's declaration is shadowed just as a
+/// base's is; `super.f()` in a contract whose two bases both declare `f` relies
+/// on it.
+#[test]
+fn test_override_is_a_contract_member_relationship() {
+    let mut types = TypeRegistry::new(LanguageVersion::LATEST);
+    let return_type = types.void();
+
+    let mut contract_type_of = |definition_id: usize| {
+        types.register_type(Type::Contract(ContractType {
+            definition_id: definition_id.into(),
+        }))
+    };
+    let base = contract_type_of(1);
+    let derived = contract_type_of(2);
+    let sibling = contract_type_of(3);
+    types.register_super_types(derived, &[derived, base]);
+
+    let function_declared_in = |receiver: Option<TypeId>| FunctionType {
+        definition_id: None,
+        parameter_types: Vec::new(),
+        return_type,
+        visibility: FunctionTypeVisibility::Internal,
+        mutability: FunctionTypeMutability::NonPayable,
+        implicit_receiver_type: receiver,
+        partially_applied: false,
+    };
+    let in_base = function_declared_in(Some(base));
+    let in_derived = function_declared_in(Some(derived));
+    let in_sibling = function_declared_in(Some(sibling));
+    let free = function_declared_in(None);
+
+    // All of these share a signature, so the plain check accepts every pair.
+    assert!(types.function_type_overrides(&in_derived, &in_base));
+    assert!(types.function_type_overrides(&free, &free));
+
+    // Contract members override, whether related by inheritance or not.
+    assert!(types.function_type_overrides_in_hierarchy(&in_derived, &in_base));
+    assert!(types.function_type_overrides_in_hierarchy(&in_base, &in_derived));
+    assert!(types.function_type_overrides_in_hierarchy(&in_sibling, &in_base));
+
+    // Anything without a receiver does not.
+    assert!(!types.function_type_overrides_in_hierarchy(&free, &free));
+    assert!(!types.function_type_overrides_in_hierarchy(&free, &in_base));
+    assert!(!types.function_type_overrides_in_hierarchy(&in_base, &free));
+}
+
+/// A function value carrying `Public` visibility is a plain reference, which
+/// denotes the internal function: it converts to an internal function type but
+/// not to an external one. Reaching a public function externally externalises
+/// it at the point of access, so it no longer carries `Public` here.
+#[test]
+fn test_public_function_type_does_not_convert_to_external() {
+    let mut types = TypeRegistry::new(LanguageVersion::LATEST);
+    let return_type = types.void();
+
+    let mut function_type_with = |visibility| {
+        types.register_type(Type::Function(FunctionType {
+            definition_id: None,
+            parameter_types: Vec::new(),
+            return_type,
+            visibility,
+            mutability: FunctionTypeMutability::NonPayable,
+            implicit_receiver_type: None,
+            partially_applied: false,
+        }))
+    };
+    let public = function_type_with(FunctionTypeVisibility::Public);
+    let internal = function_type_with(FunctionTypeVisibility::Internal);
+    let external = function_type_with(FunctionTypeVisibility::External);
+
+    assert!(types.implicitly_convertible_to(public, public));
+    assert!(types.implicitly_convertible_to(public, internal));
+    assert!(!types.implicitly_convertible_to(public, external));
+
+    // The other visibilities are unaffected.
+    assert!(types.implicitly_convertible_to(internal, internal));
+    assert!(!types.implicitly_convertible_to(internal, external));
+    assert!(types.implicitly_convertible_to(external, external));
+    assert!(!types.implicitly_convertible_to(external, internal));
+}
+
+/// The consequence of the rule above for overload selection: passing a public
+/// function as a value picks the overload taking an *internal* function, even
+/// though the one taking an external function is declared first and would win
+/// if the conversion were allowed.
+#[test]
+fn test_public_function_argument_selects_internal_overload() {
+    const SOURCE: &str = r###"
+contract C {
+    function target(bytes memory) public {}
+
+    function callback(function(bytes memory) external) private pure {}
+
+    function callback(function(bytes memory) internal) private pure {}
+
+    function test() internal pure {
+        callback(target);
+    }
+}
+    "###;
+
+    let analysis = Analysis::of_source(SOURCE)
+        .run(Analyse::References)
+        .expect_no_diagnostics();
+
+    let contract = analysis.find_contract("C");
+    let callbacks = function_definition_ids(contract, "callback");
+    assert_eq!(2, callbacks.len(), "expected both `callback` overloads");
+
+    let resolutions = resolutions_of(analysis.binder(), "callback");
+    assert_eq!(
+        vec![Resolution::Definition(callbacks[1])],
+        resolutions,
+        "expected the overload taking an internal function"
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/mod.rs
@@ -285,13 +285,14 @@ impl ImplicitlyConvertible<FunctionTypeVisibility> for FunctionTypeVisibility {
     fn implicitly_convertible_to(&self, target: Self) -> bool {
         matches!(
             (self, target),
-            // public can convert to public, external or internal (if called
-            // internally)
+            // public converts to public or internal. It does *not* convert to
+            // external: a public function reached externally (through `this` or
+            // a contract reference) is already externalised at the point of
+            // access, so a value still carrying `Public` here is a plain
+            // reference, which denotes the internal function.
             (
                 FunctionTypeVisibility::Public,
-                FunctionTypeVisibility::Public
-                    | FunctionTypeVisibility::Internal
-                    | FunctionTypeVisibility::External,
+                FunctionTypeVisibility::Public | FunctionTypeVisibility::Internal,
             )
                 // private converts to private or internal
                 | (

--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/registry.rs
@@ -756,6 +756,32 @@ impl TypeRegistry {
                 })
     }
 
+    /// Returns true if a function type overrides another within the hierarchy
+    /// the two were resolved from, which is the only place overriding happens.
+    ///
+    /// Only contract and interface members carry an implicit receiver, so free
+    /// and library functions never override anything, even when they share a
+    /// signature: two of them attached to the same type by different `using`
+    /// directives are competing candidates, not an override pair.
+    ///
+    /// Carrying a receiver is the whole test: the two do *not* have to be
+    /// declared in contracts that derive from one another. A resolution only
+    /// ever gathers members from a single contract's linearisation, and yields
+    /// them most-derived first, so a later candidate sharing a signature is
+    /// shadowed by an earlier one whether it was declared in a base or in a
+    /// sibling of one. `super.f()` in a contract whose two bases both declare
+    /// `f` relies on that, and requiring a derives-from relationship would
+    /// report it as ambiguous.
+    pub(crate) fn function_type_overrides_in_hierarchy(
+        &self,
+        ftype: &FunctionType,
+        other: &FunctionType,
+    ) -> bool {
+        ftype.implicit_receiver_type.is_some()
+            && other.implicit_receiver_type.is_some()
+            && self.function_type_overrides(ftype, other)
+    }
+
     // Returns true if a function type overrides another
     pub(crate) fn function_type_overrides(
         &self,


### PR DESCRIPTION
Stacked on top of #2053 

- `filter_overriden_definitions` collapsed any two functions sharing a signature, including unrelated free or library functions attached to one type by different `using` directives. Overriding only happens within a contract hierarchy, so compare the functions' implicit receivers: the new `function_type_overrides_in_hierarchy` requires both to be contract or interface members, the overriding one declared in the same contract as the overridden one or in one deriving from it.
- A function type with `Public` visibility no longer converts to `External`. A public function reached through `this` or a contract reference is already externalised at the point of access, so a value still carrying `Public` is a plain reference denoting the internal function.
