### PR TITLE
[v2] fix(semantic): Unify module meta-types across aliases of one source unit

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -1,5 +1,6 @@
 use ruint::aliases::{U160, U256};
 use slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName;
+use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::NodeIdentity;
@@ -283,6 +284,25 @@ impl Pass<'_> {
             ),
             _ => false,
         }
+    }
+
+    /// Whether both types alias one imported source unit, which solc treats as
+    /// one module type (`ModuleType::operator==`).
+    pub(super) fn alias_same_source_unit(&self, left: TypeId, right: TypeId) -> bool {
+        self.aliased_source_unit(left)
+            .is_some_and(|file_id| self.aliased_source_unit(right) == Some(file_id))
+    }
+
+    fn aliased_source_unit(&self, type_id: TypeId) -> Option<&FileId> {
+        let Type::UserMetaType(UserMetaType { definition_id }) = self.types.get_type_by_id(type_id)
+        else {
+            return None;
+        };
+        let Some(Definition::Import(import)) = self.binder.find_definition_by_id(*definition_id)
+        else {
+            return None;
+        };
+        import.resolved_file_id.as_ref()
     }
 
     pub(super) fn typing_of_resolution_as_contract_member(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -1,6 +1,5 @@
 use ruint::aliases::{U160, U256};
 use slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName;
-use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::NodeIdentity;
@@ -288,21 +287,26 @@ impl Pass<'_> {
 
     /// Whether both types alias one imported source unit, which solc treats as
     /// one module type (`ModuleType::operator==`).
-    pub(super) fn alias_same_source_unit(&self, left: TypeId, right: TypeId) -> bool {
-        self.aliased_source_unit(left)
-            .is_some_and(|file_id| self.aliased_source_unit(right) == Some(file_id))
-    }
-
-    fn aliased_source_unit(&self, type_id: TypeId) -> Option<&FileId> {
-        let Type::UserMetaType(UserMetaType { definition_id }) = self.types.get_type_by_id(type_id)
-        else {
-            return None;
+    pub(super) fn import_module_types_resolve_to_same_file(
+        &self,
+        left: TypeId,
+        right: TypeId,
+    ) -> bool {
+        let import_module_type_resolved_file = |type_id: TypeId| {
+            let Type::UserMetaType(UserMetaType { definition_id }) =
+                self.types.get_type_by_id(type_id)
+            else {
+                return None;
+            };
+            let Some(Definition::Import(import)) =
+                self.binder.find_definition_by_id(*definition_id)
+            else {
+                return None;
+            };
+            import.resolved_file_id.as_ref()
         };
-        let Some(Definition::Import(import)) = self.binder.find_definition_by_id(*definition_id)
-        else {
-            return None;
-        };
-        import.resolved_file_id.as_ref()
+        import_module_type_resolved_file(left)
+            .is_some_and(|file_id| import_module_type_resolved_file(right) == Some(file_id))
     }
 
     pub(super) fn typing_of_resolution_as_contract_member(

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -209,7 +209,10 @@ impl Visitor for Pass<'_> {
                 let false_mobile = self.types.compute_mobile_type(false_type_id);
                 match (true_mobile, false_mobile) {
                     (Some(true_mobile), Some(false_mobile))
-                        if self.alias_same_source_unit(true_mobile, false_mobile) =>
+                        if self.import_module_types_resolve_to_same_file(
+                            true_mobile,
+                            false_mobile,
+                        ) =>
                     {
                         Some(true_mobile)
                     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -208,6 +208,11 @@ impl Visitor for Pass<'_> {
                 let true_mobile = self.types.compute_mobile_type(true_type_id);
                 let false_mobile = self.types.compute_mobile_type(false_type_id);
                 match (true_mobile, false_mobile) {
+                    (Some(true_mobile), Some(false_mobile))
+                        if self.alias_same_source_unit(true_mobile, false_mobile) =>
+                    {
+                        Some(true_mobile)
+                    }
                     (Some(true_mobile), Some(false_mobile)) => {
                         self.types.common_type(true_mobile, false_mobile)
                     }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -789,6 +789,12 @@ fn test_conditional_expression_unresolved_when_branches_incompatible() {
     // involving one is unresolved.
     let (type_, _) = try_type_of_expression("true ? 0.5 : 1");
     assert_eq!(type_, None);
+
+    // Two distinct user meta-types with no imported source unit behind
+    // them: enum name pairs stay unresolved.
+    let (type_, _) =
+        try_type_of_expression_in_context("enum E1 { A } enum E2 { B }", "true ? E1 : E2");
+    assert_eq!(type_, None);
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -887,6 +887,16 @@ mod imports {
     }
 
     #[test]
+    fn conditional_alias_import() -> Result<()> {
+        run("imports", "conditional_alias_import")
+    }
+
+    #[test]
+    fn conditional_alias_import_distinct_files() -> Result<()> {
+        run("imports", "conditional_alias_import_distinct_files")
+    }
+
+    #[test]
     fn deconstruction() -> Result<()> {
         run("imports", "deconstruction")
     }

--- a/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import/generated/0.8.0-success.txt
@@ -1,0 +1,52 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (4):
+- Def: #1 ["K" @ lib.sol:1:18] (constant, type: uint256)
+- Def: #2 ["A" @ main.sol:1:23] (import)
+- Def: #3 ["B" @ main.sol:2:23] (import)
+- Def: #4 ["pick" @ main.sol:4:10] (function, type: function () returns uint256)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["A" @ main.sol:5:20] -> #2
+- Ref: ["B" @ main.sol:5:24] -> #3
+- Ref: ["K" @ main.sol:5:27] -> #1
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[lib.sol:1:1]
+   │
+ 1 │ uint256 constant K = 1;
+   │                  ┬  
+   │                  ╰── name: 1
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import "./lib.sol" as A;
+   │                       ┬  
+   │                       ╰── name: 2
+ 2 │ import "./lib.sol" as B;
+   │                       ┬  
+   │                       ╰── name: 3
+   │ 
+ 4 │ function pick() pure returns (uint256) {
+   │          ──┬─  
+   │            ╰─── name: 4
+ 5 │     return (true ? A : B).K;
+   │                    ┬   ┬  ┬  
+   │                    ╰───────── ref: 2
+   │                        │  │  
+   │                        ╰───── ref: 3
+   │                           │  
+   │                           ╰── ref: 1
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import/input.sol
@@ -1,0 +1,10 @@
+// ---- path: main.sol
+import "./lib.sol" as A;
+import "./lib.sol" as B;
+
+function pick() pure returns (uint256) {
+    return (true ? A : B).K;
+}
+
+// ---- path: lib.sol
+uint256 constant K = 1;

--- a/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import_distinct_files/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import_distinct_files/generated/0.8.0-failure.txt
@@ -1,0 +1,63 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (5):
+- Def: #1 ["K" @ lib.sol:1:18] (constant, type: uint256)
+- Def: #2 ["K" @ lib2.sol:1:18] (constant, type: uint256)
+- Def: #3 ["A" @ main.sol:1:23] (import)
+- Def: #4 ["B" @ main.sol:2:24] (import)
+- Def: #5 ["pick" @ main.sol:4:10] (function, type: function () returns uint256)
+
+------------------------------------------------------------------------
+
+References (3):
+- Ref: ["A" @ main.sol:5:20] -> #3
+- Ref: ["B" @ main.sol:5:24] -> #4
+- Ref: ["K" @ main.sol:5:27] -> unresolved
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[lib.sol:1:1]
+   │
+ 1 │ uint256 constant K = 1;
+   │                  ┬  
+   │                  ╰── name: 1
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[lib2.sol:1:1]
+   │
+ 1 │ uint256 constant K = 2;
+   │                  ┬  
+   │                  ╰── name: 2
+───╯
+
+------------------------------------------------------------------------
+
+Bindings: 
+   ╭─[main.sol:1:1]
+   │
+ 1 │ import "./lib.sol" as A;
+   │                       ┬  
+   │                       ╰── name: 3
+ 2 │ import "./lib2.sol" as B;
+   │                        ┬  
+   │                        ╰── name: 4
+   │ 
+ 4 │ function pick() pure returns (uint256) {
+   │          ──┬─  
+   │            ╰─── name: 5
+ 5 │     return (true ? A : B).K;
+   │                    ┬   ┬  ┬  
+   │                    ╰───────── ref: 3
+   │                        │  │  
+   │                        ╰───── ref: 4
+   │                           │  
+   │                           ╰── unresolved
+───╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import_distinct_files/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/imports/conditional_alias_import_distinct_files/input.sol
@@ -1,0 +1,13 @@
+// ---- path: main.sol
+import "./lib.sol" as A;
+import "./lib2.sol" as B;
+
+function pick() pure returns (uint256) {
+    return (true ? A : B).K;
+}
+
+// ---- path: lib.sol
+uint256 constant K = 1;
+
+// ---- path: lib2.sol
+uint256 constant K = 2;


### PR DESCRIPTION
Two imports of one file bind two definitions, so `import "./m.sol" as A; import "./m.sol" as B;` typed `A` and `B` as distinct `UserMetaType`s and `(cond ? A : B).K` had no common type, leaving the member access through it unbound. solc treats both as one module type: `ModuleType::operator==` compares by source unit.

A conditional expression whose branches are module meta-types now types as that module when both aliases resolve to the same source unit, and stays unresolved when they resolve to different ones. A conditional is the only expression form where two module types can meet, so the rule lives with it rather than in type conversion — this replaces the earlier approach of adding a convertibility arm backed by a registry projection, which spread the rule across p3, the registry and `implicitly_convertible_to` to serve that single site.

Tests: binder snapshots for the unifying and the non-unifying case, plus a unit case pinning that meta-types with no imported source unit behind them never unify.
