### PR TITLE
[v2] feat(ast): Hash a library member's selector from the library signature

### DIFF
--- a/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ast/generated/public_api.txt
@@ -2003,7 +2003,9 @@ impl slang_solidity_v2_ast::ast::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_abi_entry(&self) -> core::option::Option<slang_solidity_v2_ast::abi::AbiEntry>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_canonical_signature(&self) -> core::option::Option<alloc::string::String>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_internal_signature(&self) -> core::option::Option<alloc::string::String>
+pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_library_signature(&self) -> core::option::Option<alloc::string::String>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_selector(&self) -> core::option::Option<u32>
+pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::compute_selector_signature(&self) -> core::option::Option<alloc::string::String>
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::is_externally_visible(&self) -> bool
 impl slang_solidity_v2_ast::ast::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ast::ast::FunctionDefinitionStruct::enclosing_definition(&self) -> core::option::Option<slang_solidity_v2_ast::ast::Definition>

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/function_definition.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/function_definition.rs
@@ -4,7 +4,7 @@ use crate::abi::{
     AbiConstructor, AbiEntry, AbiFallback, AbiFunction, AbiMutability, AbiReceive,
     selector_from_signature,
 };
-use crate::ast::{FunctionDefinitionStruct, FunctionVisibility};
+use crate::ast::{Definition, FunctionDefinitionStruct, FunctionVisibility};
 
 impl FunctionDefinitionStruct {
     pub fn is_externally_visible(&self) -> bool {
@@ -89,11 +89,30 @@ impl FunctionDefinitionStruct {
         Some(format!("{name}({parameters})"))
     }
 
+    /// Returns the signature for this function using library type names for
+    /// parameters: scope-qualified internal names, a trailing ` storage` on
+    /// storage references, and a user-defined value type unwrapped to its
+    /// underlying type — none of which the canonical form can spell.
+    pub fn compute_library_signature(&self) -> Option<String> {
+        let name = self.ir_node.name.as_ref()?.unparse();
+        let parameters = self.parameters().compute_library_signature()?;
+        Some(format!("{name}({parameters})"))
+    }
+
+    /// Returns the signature a selector is hashed from: the library form for a
+    /// library member, the canonical form otherwise.
+    pub fn compute_selector_signature(&self) -> Option<String> {
+        match self.enclosing_definition() {
+            Some(Definition::Library(_)) => self.compute_library_signature(),
+            _ => self.compute_canonical_signature(),
+        }
+    }
+
     pub fn compute_selector(&self) -> Option<u32> {
         if !self.is_externally_visible() {
             return None;
         }
-        self.compute_canonical_signature()
+        self.compute_selector_signature()
             .map(|sig| selector_from_signature(&sig))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
+++ b/crates/solidity-v2/outputs/cargo/ast/src/abi/node_extensions/parameters.rs
@@ -27,6 +27,28 @@ impl ParametersStruct {
         Some(result)
     }
 
+    pub(crate) fn compute_canonical_signature(&self) -> Option<String> {
+        self.join_parameter_names(|type_id| {
+            Some(type_as_abi_type(&self.semantic, type_id)?.to_string())
+        })
+    }
+
+    pub(crate) fn compute_internal_signature(&self) -> Option<String> {
+        self.join_parameter_names(|type_id| Some(self.semantic.type_internal_name(type_id)))
+    }
+
+    pub(crate) fn compute_library_signature(&self) -> Option<String> {
+        self.join_parameter_names(|type_id| self.semantic.type_library_name(type_id))
+    }
+
+    fn join_parameter_names(&self, type_name: impl Fn(TypeId) -> Option<String>) -> Option<String> {
+        let mut result = Vec::new();
+        for type_id in self.parameter_types_iter() {
+            result.push(type_name(type_id?)?);
+        }
+        Some(result.join(","))
+    }
+
     fn parameter_types_iter(&self) -> impl Iterator<Item = Option<TypeId>> + '_ {
         self.ir_nodes.iter().map(|parameter| {
             self.semantic
@@ -34,22 +56,5 @@ impl ParametersStruct {
                 .node_typing(parameter.id())
                 .as_type_id()
         })
-    }
-
-    pub(crate) fn compute_canonical_signature(&self) -> Option<String> {
-        let mut result = Vec::new();
-        for type_id in self.parameter_types_iter() {
-            let abi_type = type_as_abi_type(&self.semantic, type_id?)?;
-            result.push(abi_type.to_string());
-        }
-        Some(result.join(","))
-    }
-
-    pub(crate) fn compute_internal_signature(&self) -> Option<String> {
-        let mut result = Vec::new();
-        for type_id in self.parameter_types_iter() {
-            result.push(self.semantic.type_internal_name(type_id?));
-        }
-        Some(result.join(","))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -311,6 +311,7 @@ pub fn slang_solidity_v2_semantic::context::SemanticContext::resolve_reference_i
 pub fn slang_solidity_v2_semantic::context::SemanticContext::resolve_reference_identifier_to_immediate_definition_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::storage_size_of_type_id(&self, slang_solidity_v2_semantic::types::TypeId) -> core::option::Option<slang_solidity_v2_semantic::context::StorageSize>
 pub fn slang_solidity_v2_semantic::context::SemanticContext::type_internal_name(&self, slang_solidity_v2_semantic::types::TypeId) -> alloc::string::String
+pub fn slang_solidity_v2_semantic::context::SemanticContext::type_library_name(&self, slang_solidity_v2_semantic::types::TypeId) -> core::option::Option<alloc::string::String>
 pub struct slang_solidity_v2_semantic::context::StorageLayoutBuilder
 impl slang_solidity_v2_semantic::context::StorageLayoutBuilder
 pub fn slang_solidity_v2_semantic::context::StorageLayoutBuilder::allocate(&mut self, slang_solidity_v2_semantic::context::StorageSize) -> core::option::Option<slang_solidity_v2_semantic::context::StoragePosition>

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -267,14 +267,13 @@ impl SemanticContext {
             .find_definition_by_id(definition_id)
             .unwrap()
             .identifier()
-            .unparse()
-            .to_string();
+            .unparse();
         match self.binder.enclosing_definition_node_id(definition_id) {
             Some(enclosing) => format!(
                 "{scope}.{name}",
                 scope = self.definition_canonical_name(enclosing)
             ),
-            None => name,
+            None => name.to_string(),
         }
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/context/mod.rs
@@ -18,9 +18,10 @@ use crate::passes::{
     p5_resolve_references, p6_resolve_yul, p7_contract_properties, p8_code_analysis,
 };
 use crate::types::{
-    ArraySliceType, ArrayType, ByteArrayType, ContractType, EnumType, FixedPointNumberType,
-    FixedSizeArrayType, IntegerType, InterfaceType, LibraryType, MappingType, MetaType, StructType,
-    TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
+    ArraySliceType, ArrayType, ByteArrayType, ContractType, DataLocation, EnumType,
+    FixedPointNumberType, FixedSizeArrayType, IntegerType, InterfaceType, LibraryType, MappingType,
+    MetaType, StructType, TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType,
+    UserMetaType,
 };
 
 mod contract_data;
@@ -258,13 +259,23 @@ impl SemanticContext {
         reference.resolution.as_definition_id()
     }
 
+    /// Qualifies a nested definition with its enclosing scope, as solc's
+    /// `canonicalName` does: `L.S`, `C.E`.
     pub(crate) fn definition_canonical_name(&self, definition_id: NodeId) -> String {
-        self.binder
+        let name = self
+            .binder
             .find_definition_by_id(definition_id)
             .unwrap()
             .identifier()
             .unparse()
-            .to_string()
+            .to_string();
+        match self.binder.enclosing_definition_node_id(definition_id) {
+            Some(enclosing) => format!(
+                "{scope}.{name}",
+                scope = self.definition_canonical_name(enclosing)
+            ),
+            None => name,
+        }
     }
 
     pub fn type_internal_name(&self, type_id: TypeId) -> String {
@@ -340,6 +351,50 @@ impl SemanticContext {
         }
     }
 
+    pub fn type_library_name(&self, type_id: TypeId) -> Option<String> {
+        let mut name = self.type_library_element_name(type_id)?;
+        if self.types.get_type_by_id(type_id).data_location() == Some(DataLocation::Storage) {
+            name.push_str(" storage");
+        }
+        Some(name)
+    }
+
+    /// A user-defined value type is spelled as the type it wraps, under an
+    /// array as well as on its own. A mapping keeps the wrapper's name
+    /// (matching solc, which has no ABI spelling for one).
+    fn type_library_element_name(&self, type_id: TypeId) -> Option<String> {
+        let name = match self.types.get_type_by_id(type_id) {
+            Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
+                self.type_internal_name(self.user_defined_value_target_type_id(*definition_id)?)
+            }
+            Type::Array(ArrayType { element_type, .. }) => {
+                format!(
+                    "{element}[]",
+                    element = self.type_library_element_name(*element_type)?
+                )
+            }
+            Type::FixedSizeArray(FixedSizeArrayType {
+                element_type, size, ..
+            }) => {
+                format!(
+                    "{element}[{size}]",
+                    element = self.type_library_element_name(*element_type)?
+                )
+            }
+            _ => self.type_internal_name(type_id),
+        };
+        Some(name)
+    }
+
+    fn user_defined_value_target_type_id(&self, definition_id: NodeId) -> Option<TypeId> {
+        let Definition::UserDefinedValueType(user_defined_value) =
+            self.binder.find_definition_by_id(definition_id)?
+        else {
+            return None;
+        };
+        user_defined_value.target_type_id
+    }
+
     pub(crate) const ADDRESS_BYTE_SIZE: usize = 20;
     pub(crate) const SELECTOR_SIZE: usize = 4;
 
@@ -411,17 +466,11 @@ impl SemanticContext {
                 visited_structs.remove(definition_id);
                 Some(Slots(builder.slots_used()?))
             }
-            Type::UserDefinedValue(UserDefinedValueType { definition_id }) => {
-                let Definition::UserDefinedValueType(user_defined_value) =
-                    self.binder.find_definition_by_id(*definition_id)?
-                else {
-                    return None;
-                };
-                self.storage_size_of_type_id_impl(
-                    user_defined_value.target_type_id?,
+            Type::UserDefinedValue(UserDefinedValueType { definition_id }) => self
+                .storage_size_of_type_id_impl(
+                    self.user_defined_value_target_type_id(*definition_id)?,
                     visited_structs,
-                )
-            }
+                ),
 
             Type::ArraySlice(_)
             | Type::Library(_)

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing.rs
@@ -2045,7 +2045,7 @@ fn test_explicit_enum_cast() {
 #[test]
 fn test_meta_type_internal_names() {
     // Meta-types print in solc's `type(T)` notation: `type(uint256)` for an
-    // elementary type, `type(E)` for a named definition.
+    // elementary type, `type(C.E)` for a named definition.
     let mut id_generator = NodeIdGenerator::default();
     let source = r#"
         contract C {
@@ -2102,7 +2102,7 @@ fn test_meta_type_internal_names() {
         .node_typing(enum_node_id)
         .as_type_id()
         .expect("enum name is typed");
-    assert_eq!(context.type_internal_name(enum_meta_id), "type(E)");
+    assert_eq!(context.type_internal_name(enum_meta_id), "type(C.E)");
 }
 
 #[test]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/internal_signature.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/internal_signature.rs
@@ -165,3 +165,30 @@ fn test_library_signature_unwraps_a_user_defined_value_type_under_an_array() {
         Some("m(mapping(uint256 => L.U) storage)".to_string())
     );
 }
+
+define_fixture!(
+    AliasedLibraryType,
+    file: "main.sol", r#"
+import {L as M} from "library.sol";
+
+library U {
+    function f(M.S storage s) external view returns (uint256) { return s.a; }
+}
+"#,
+    file: "library.sol", r#"
+library L {
+    struct S { uint256 a; }
+}
+"#,
+);
+
+#[test]
+fn test_library_signature_names_an_aliased_type_at_its_declaration() {
+    let unit = AliasedLibraryType::build_compilation_unit();
+    let functions = fixtures::find_library(&unit, "U").functions();
+
+    assert_eq!(
+        functions[0].compute_library_signature(),
+        Some("f(L.S storage)".to_string())
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/internal_signature.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/internal_signature.rs
@@ -1,3 +1,6 @@
+use super::fixtures;
+use crate::define_fixture;
+
 #[test]
 fn test_compute_internal_signature() {
     let unit = super::FullAbi::build_compilation_unit();
@@ -69,5 +72,96 @@ fn test_compute_internal_signature() {
     assert_eq!(
         events[1].compute_internal_signature(),
         Some("Event(uint256,bytes32)".to_string())
+    );
+}
+
+define_fixture!(
+    NestedKeyGetter,
+    file: "main.sol", r#"
+contract C {
+    enum E { A }
+
+    mapping(E => uint256) public m;
+}
+"#,
+);
+
+#[test]
+fn test_getter_internal_signature_qualifies_a_nested_key() {
+    let unit = NestedKeyGetter::build_compilation_unit();
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract can be found");
+    let state_variables = contract.state_variables();
+
+    assert_eq!(
+        state_variables[0].compute_internal_signature(),
+        Some("m(C.E)".to_string())
+    );
+}
+
+#[test]
+fn test_compute_internal_signature_of_library_member() {
+    let unit = super::LibraryAbi::build_compilation_unit();
+    let functions = fixtures::find_library(&unit, "L").functions();
+
+    // A type declared in the library is named under its enclosing scope.
+    assert_eq!(
+        functions[0].compute_internal_signature(),
+        Some("f(L.S,uint256)".to_string())
+    );
+}
+
+#[test]
+fn test_compute_library_signature() {
+    let unit = super::LibraryAbi::build_compilation_unit();
+    let functions = fixtures::find_library(&unit, "L").functions();
+    let [struct_storage, array_storage, _, _, user_defined_value] = functions.as_slice() else {
+        panic!("expected the library to declare five functions");
+    };
+
+    // The library form spells the data location the internal form omits...
+    assert_eq!(
+        struct_storage.compute_library_signature(),
+        Some("f(L.S storage,uint256)".to_string())
+    );
+    assert_eq!(
+        array_storage.compute_library_signature(),
+        Some("g(uint256[] storage)".to_string())
+    );
+
+    // ... and unwraps a user-defined value type to its underlying type.
+    assert_eq!(
+        user_defined_value.compute_library_signature(),
+        Some("j(uint64)".to_string())
+    );
+    assert_eq!(
+        user_defined_value.compute_internal_signature(),
+        Some("j(L.U)".to_string())
+    );
+}
+
+#[test]
+fn test_library_signature_unwraps_a_user_defined_value_type_under_an_array() {
+    let unit = super::LibraryUdvtAbi::build_compilation_unit();
+    let functions = fixtures::find_library(&unit, "L").functions();
+    let [array, fixed_size_array, mapping] = functions.as_slice() else {
+        panic!("expected the library to declare three functions");
+    };
+
+    // An array spells its element as the wrapped type, while a mapping keeps
+    // the wrapper's name (matching solc, which has no ABI spelling for one).
+    assert_eq!(
+        array.compute_library_signature(),
+        Some("k(uint64[])".to_string())
+    );
+    assert_eq!(
+        fixed_size_array.compute_library_signature(),
+        Some("q(uint64[2])".to_string())
+    );
+    assert_eq!(
+        mapping.compute_library_signature(),
+        Some("m(mapping(uint256 => L.U) storage)".to_string())
     );
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/mod.rs
@@ -57,3 +57,32 @@ contract Test is ITest, Base {
 }
 "#,
 );
+
+define_fixture!(
+    LibraryAbi,
+    file: "main.sol", r#"
+library L {
+    struct S { mapping(uint => uint) m; }
+    type U is uint64;
+
+    function f(S storage s, uint x) external returns (uint) {}
+    function g(uint[] storage xs) public {}
+    function h(uint x) external pure returns (uint) {}
+    function i(uint x) internal pure returns (uint) {}
+    function j(U u) external pure {}
+}
+"#,
+);
+
+define_fixture!(
+    LibraryUdvtAbi,
+    file: "main.sol", r#"
+library L {
+    type U is uint64;
+
+    function k(U[] memory xs) external pure {}
+    function q(U[2] memory xs) external pure {}
+    function m(mapping(uint256 => U) storage x) external {}
+}
+"#,
+);

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/selectors.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/selectors.rs
@@ -70,3 +70,82 @@ fn test_selectors_for_functions_with_tuple_parameters() {
     // g()
     assert_eq!(functions[1].compute_selector(), Some(0xe217_9b8e_u32));
 }
+
+#[test]
+fn test_library_function_selectors() {
+    let unit = super::LibraryAbi::build_compilation_unit();
+
+    let functions = fixtures::find_library(&unit, "L").functions();
+    let [
+        struct_storage,
+        array_storage,
+        encodable,
+        internal,
+        user_defined_value,
+    ] = functions.as_slice()
+    else {
+        panic!("expected the library to declare five functions");
+    };
+
+    assert_eq!(struct_storage.compute_selector(), Some(0x1f5b_11f0_u32)); // f(L.S storage,uint256)
+    assert_eq!(array_storage.compute_selector(), Some(0xc6bf_d994_u32)); // g(uint256[] storage)
+    assert_eq!(encodable.compute_selector(), Some(0xcb97_492a_u32)); // h(uint256)
+    assert_eq!(internal.compute_selector(), None);
+    assert_eq!(user_defined_value.compute_selector(), Some(0xdb66_c1de_u32)); // j(uint64)
+}
+
+#[test]
+fn test_library_function_selector_signatures() {
+    let unit = super::LibraryAbi::build_compilation_unit();
+
+    let functions = fixtures::find_library(&unit, "L").functions();
+    let [
+        struct_storage,
+        array_storage,
+        encodable,
+        _,
+        user_defined_value,
+    ] = functions.as_slice()
+    else {
+        panic!("expected the library to declare five functions");
+    };
+
+    // The canonical form has no spelling for a storage reference to a struct
+    // holding a mapping, which is why the library form exists.
+    assert_eq!(
+        struct_storage.compute_selector_signature(),
+        Some("f(L.S storage,uint256)".to_string())
+    );
+    assert_eq!(struct_storage.compute_canonical_signature(), None);
+
+    assert_eq!(
+        array_storage.compute_selector_signature(),
+        Some("g(uint256[] storage)".to_string())
+    );
+
+    // An encodable library member still selects on the canonical form.
+    assert_eq!(
+        encodable.compute_selector_signature(),
+        Some("h(uint256)".to_string())
+    );
+    assert_eq!(
+        encodable.compute_canonical_signature(),
+        Some("h(uint256)".to_string())
+    );
+
+    assert_eq!(
+        user_defined_value.compute_selector_signature(),
+        Some("j(uint64)".to_string())
+    );
+
+    let unit = super::FullAbi::build_compilation_unit();
+    let test_contract = unit
+        .find_contract_by_name("Test")
+        .next()
+        .expect("Test contract can be found");
+    let functions = test_contract.linearised_functions();
+    assert_eq!(
+        functions[2].compute_selector_signature(),
+        Some("foo(uint256)".to_string())
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/storage_layout.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/abi/storage_layout.rs
@@ -323,3 +323,32 @@ fn test_oversized_base_slot_has_no_layout() {
         .expect("contract can be found");
     assert!(contract.compute_abi().is_none());
 }
+
+// A struct declared inside a contract is laid out under its scope-qualified
+// name, the same spelling a library selector hashes.
+define_fixture!(
+    NestedStructLayout,
+    file: "main.sol", r#"
+contract C {
+    struct Inner {
+        uint256 a;
+    }
+
+    Inner nested;
+}
+"#,
+);
+
+#[test]
+fn test_nested_struct_lays_out_under_its_qualified_name() {
+    let unit = NestedStructLayout::build_compilation_unit();
+    let contract = unit
+        .find_contract_by_name("C")
+        .next()
+        .expect("contract can be found");
+    let contract_abi = contract.compute_abi().expect("can compute ABI");
+    let layout = contract_abi.storage_layout();
+
+    assert_eq!(layout.len(), 1);
+    assert_layout_item_eq!(layout[0], "nested", uint!(0_U256), 0, "C.Inner");
+}


### PR DESCRIPTION
Stacked on #2064 — the tests here use `LibraryDefinitionStruct::functions()` and the shared `find_library` helper it adds. Review the second commit only; retarget to `main` once #2064 lands.

solc selects on a signature the canonical form cannot spell: internal type names qualified by their scope, a trailing ` storage` on a storage reference, and a user-defined value type unwrapped to its underlying type, as in `f(L.S storage,uint256)`. Slang hashed the canonical form, which is `None` for a struct holding a mapping, so those library members had no selector at all.

`SemanticContext::type_library_name` spells that form, `compute_library_signature` builds the signature from it on both `ParametersStruct` and `FunctionDefinitionStruct`, and `compute_selector_signature` chooses it for a library member and the canonical form otherwise. Qualifying a nested definition with its enclosing scope, which solc's `canonicalName` does, also reaches `type(C.E)` and a storage layout's `struct C.Inner`.

Tests: selectors and selector signatures for the five members of a library fixture — including `f(L.S storage,uint256)` whose canonical form is `None`, and `j(uint64)` for a UDVT parameter — the library signature form on its own, a nested-key getter (`m(C.E)`), and a nested struct's storage-layout label.
