### PR TITLE
feat(diagnostics): Check and report expression not callable

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -2746,6 +2746,7 @@ pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnos
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthZero(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthZero)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::CannotCallViaContractTypeName(slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ConstantArithmeticError(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError)
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ExpressionNotCallable(slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionMutability(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::FallbackFunctionSignature(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::IncompatibleConstantOperator(slang_solidity_v2_common::diagnostics::kinds::type_system::IncompatibleConstantOperator)
@@ -2773,6 +2774,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_syst
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
@@ -2933,6 +2936,25 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable) -> bool
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable> for slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable) -> Self
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::mutability: alloc::string::String
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
@@ -3350,6 +3372,8 @@ impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_syst
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError) -> Self
+impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
 pub fn slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind::from(slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability) -> Self
 impl core::convert::From<slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionSignature> for slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind
@@ -3944,6 +3968,10 @@ impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solid
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
+impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::code(&self) -> &'static str
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::message(&self) -> alloc::string::String
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 impl slang_solidity_v2_common::diagnostics::DiagnosticExtensions for slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::code(&self) -> &'static str
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::FallbackFunctionMutability::message(&self) -> alloc::string::String

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/expression_not_callable.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/expression_not_callable.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use crate::diagnostics::extensions::DiagnosticExtensions;
+use crate::diagnostics::severity::DiagnosticSeverity;
+
+/// Diagnostic emitted when the callee of a call cannot be called: a value of a
+/// non-function type (eg. `1(2)`, or a mapping, which is indexed instead), a
+/// declaration that names no callable (eg. a modifier or an import alias), a
+/// built-in namespace such as `msg`, or `this`/`super`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExpressionNotCallable;
+
+impl DiagnosticExtensions for ExpressionNotCallable {
+    fn severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::Error
+    }
+
+    fn code(&self) -> &'static str {
+        "type-system/expression-not-callable"
+    }
+
+    fn message(&self) -> String {
+        "This expression is not callable.".to_owned()
+    }
+}

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
@@ -5,6 +5,7 @@ mod array_length_too_large;
 mod array_length_zero;
 mod cannot_call_via_contract_type_name;
 mod constant_arithmetic_error;
+mod expression_not_callable;
 mod fallback_function_mutability;
 mod fallback_function_signature;
 mod incompatible_constant_operator;
@@ -21,6 +22,7 @@ pub use array_length_too_large::ArrayLengthTooLarge;
 pub use array_length_zero::ArrayLengthZero;
 pub use cannot_call_via_contract_type_name::CannotCallViaContractTypeName;
 pub use constant_arithmetic_error::ConstantArithmeticError;
+pub use expression_not_callable::ExpressionNotCallable;
 pub use fallback_function_mutability::FallbackFunctionMutability;
 pub use fallback_function_signature::FallbackFunctionSignature;
 pub use incompatible_constant_operator::IncompatibleConstantOperator;
@@ -79,5 +81,7 @@ define_diagnostic_kind! {
         /// A function is called through a contract/interface type name (eg.
         /// `C.f()`) rather than through an instance.
         CannotCallViaContractTypeName(CannotCallViaContractTypeName),
+        /// The callee of a call is not callable.
+        ExpressionNotCallable(ExpressionNotCallable),
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -25,6 +25,7 @@ pub(crate) enum BuiltInCallError {
     Diagnostic(DiagnosticKind),
     /// The call is invalid, but no diagnostic is implemented for it yet. The
     /// `TODO(validation)` comment at each site tracks what is missing.
+    // TODO: remove when proper diagnostics are implemented
     NotReportedYet,
     /// A type the call depends on failed to resolve. That failure is reported
     /// where it happens, and the call has no result type only as a

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,3 +1,5 @@
+use slang_solidity_v2_common::diagnostics::kinds::DiagnosticKind;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotCallable;
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::binder::{Binder, Definition, Typing};
@@ -15,6 +17,20 @@ mod internal;
 pub(crate) use availability::is_built_in_available;
 pub(crate) use availability_specifiers::built_in_specifiers;
 pub use internal::InternalBuiltIn;
+
+/// Reason why a call to a built-in has no result type.
+#[derive(Debug)]
+pub(crate) enum BuiltInCallError {
+    /// The call is invalid, and this is the diagnostic to report for it.
+    Diagnostic(DiagnosticKind),
+    /// The call is invalid, but no diagnostic is implemented for it yet. The
+    /// `TODO(validation)` comment at each site tracks what is missing.
+    NotReportedYet,
+    /// A type the call depends on failed to resolve. That failure is reported
+    /// where it happens, and the call has no result type only as a
+    /// consequence, so reporting again here would just cascade.
+    UnresolvedDependency,
+}
 
 pub(crate) struct BuiltInsResolver<'a> {
     binder: &'a Binder,
@@ -471,100 +487,58 @@ impl<'a> BuiltInsResolver<'a> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
-    pub(crate) fn typing_of_function_call(
+    /// The result type of a call to `built_in`, or why it has none.
+    pub(crate) fn type_of_function_call(
         &mut self,
         built_in: &InternalBuiltIn,
         argument_typings: &[Typing],
-    ) -> Typing {
-        match built_in {
-            InternalBuiltIn::AbiDecode => {
-                if argument_typings.len() != 2 {
-                    return Typing::Unresolved;
-                }
-                let Typing::Resolved(type_id) = &argument_typings[1] else {
-                    return Typing::Unresolved;
-                };
-
-                // `abi.decode(data, (T))`: a single-element tuple collapses to the
-                // meta-type of `T`, which decodes to `T` itself.
-                if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
-                    return Typing::Resolved(decoded);
-                }
-
-                // `abi.decode(data, (T1, T2, ...))`: a tuple of meta-types decodes to
-                // the tuple of the types they denote. Note a *nested* tuple element is
-                // not a type name and does not decode (matching solc, which rejects
-                // eg. `abi.decode(data, (uint, (bool, bool)))`).
-                if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(*type_id) {
-                    let element_ids = types.clone();
-                    let mut decoded = Vec::with_capacity(element_ids.len());
-                    for element_id in element_ids {
-                        let Some(element) = self.type_denoted_by_meta_type(element_id) else {
-                            // TODO(validation) SDR[42]: report an error when a tuple
-                            // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
-                            return Typing::Unresolved;
-                        };
-                        decoded.push(element);
-                    }
-                    return Typing::Resolved(
-                        self.types
-                            .register_type(Type::Tuple(TupleType { types: decoded })),
-                    );
-                }
-
-                // TODO(validation) SDR[42]: report an error when the second argument
-                // is not a type or a tuple of types.
-                Typing::Unresolved
-            }
-            InternalBuiltIn::AbiEncode => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::AbiEncodeCall => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::AbiEncodePacked => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::AbiEncodeWithSelector => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::AbiEncodeWithSignature => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::Addmod => Typing::Resolved(self.types.uint256()),
-            InternalBuiltIn::AddressCall => Typing::Resolved(self.types.boolean_bytes_tuple()),
-            InternalBuiltIn::AddressCallcode => Typing::Resolved(self.types.boolean_bytes_tuple()),
-            InternalBuiltIn::AddressDelegatecall => {
-                Typing::Resolved(self.types.boolean_bytes_tuple())
-            }
-            InternalBuiltIn::AddressStaticcall => {
-                Typing::Resolved(self.types.boolean_bytes_tuple())
-            }
+    ) -> Result<TypeId, BuiltInCallError> {
+        let type_id = match built_in {
+            InternalBuiltIn::AbiDecode => self.type_of_abi_decode(argument_typings)?,
+            InternalBuiltIn::AbiEncode => self.types.bytes_memory(),
+            InternalBuiltIn::AbiEncodeCall => self.types.bytes_memory(),
+            InternalBuiltIn::AbiEncodePacked => self.types.bytes_memory(),
+            InternalBuiltIn::AbiEncodeWithSelector => self.types.bytes_memory(),
+            InternalBuiltIn::AbiEncodeWithSignature => self.types.bytes_memory(),
+            InternalBuiltIn::Addmod => self.types.uint256(),
+            InternalBuiltIn::AddressCall => self.types.boolean_bytes_tuple(),
+            InternalBuiltIn::AddressCallcode => self.types.boolean_bytes_tuple(),
+            InternalBuiltIn::AddressDelegatecall => self.types.boolean_bytes_tuple(),
+            InternalBuiltIn::AddressSend => self.types.boolean(),
+            InternalBuiltIn::AddressStaticcall => self.types.boolean_bytes_tuple(),
+            InternalBuiltIn::AddressTransfer => self.types.void(),
             InternalBuiltIn::ArrayPush(type_id) => {
                 if argument_typings.is_empty() {
-                    Typing::Resolved(*type_id)
+                    *type_id
                 } else {
-                    Typing::Resolved(self.types.void())
+                    self.types.void()
                 }
             }
-            InternalBuiltIn::ArrayPop => Typing::Resolved(self.types.void()),
-            InternalBuiltIn::Assert => Typing::Resolved(self.types.void()),
-            InternalBuiltIn::Blobhash => Typing::Resolved(self.types.bytes32()),
-            InternalBuiltIn::Blockhash => Typing::Resolved(self.types.bytes32()),
-            InternalBuiltIn::BytesConcat => Typing::Resolved(self.types.bytes_memory()),
-            InternalBuiltIn::Ecrecover => Typing::Resolved(self.types.address()),
-            InternalBuiltIn::Erc7201 => Typing::Resolved(self.types.uint256()),
-            InternalBuiltIn::Gasleft => Typing::Resolved(self.types.uint256()),
-            InternalBuiltIn::Keccak256 => Typing::Resolved(self.types.bytes32()),
-            InternalBuiltIn::Mulmod => Typing::Resolved(self.types.uint256()),
-            InternalBuiltIn::Require => Typing::Resolved(self.types.void()),
-            InternalBuiltIn::Revert => Typing::Resolved(self.types.void()),
-            InternalBuiltIn::Ripemd160 => Typing::Resolved(self.types.bytes20()),
-            InternalBuiltIn::Selfdestruct => Typing::Resolved(self.types.void()),
-            InternalBuiltIn::Sha256 => Typing::Resolved(self.types.bytes32()),
-            InternalBuiltIn::StringConcat => Typing::Resolved(self.types.string_memory()),
+            InternalBuiltIn::ArrayPop => self.types.void(),
+            InternalBuiltIn::Assert => self.types.void(),
+            InternalBuiltIn::Blobhash => self.types.bytes32(),
+            InternalBuiltIn::Blockhash => self.types.bytes32(),
+            InternalBuiltIn::BytesConcat => self.types.bytes_memory(),
+            InternalBuiltIn::Ecrecover => self.types.address(),
+            InternalBuiltIn::Erc7201 => self.types.uint256(),
+            InternalBuiltIn::Gasleft => self.types.uint256(),
+            InternalBuiltIn::Keccak256 => self.types.bytes32(),
+            InternalBuiltIn::Mulmod => self.types.uint256(),
+            InternalBuiltIn::Require => self.types.void(),
+            InternalBuiltIn::Revert => self.types.void(),
+            InternalBuiltIn::Ripemd160 => self.types.bytes20(),
+            InternalBuiltIn::Selfdestruct => self.types.void(),
+            InternalBuiltIn::Sha256 => self.types.bytes32(),
+            InternalBuiltIn::StringConcat => self.types.string_memory(),
             InternalBuiltIn::Unwrap(definition_id) => {
                 let Some(Definition::UserDefinedValueType(udvt)) =
                     self.binder.find_definition_by_id(*definition_id)
                 else {
                     unreachable!("definition bound to unwrap built-in is not a UDVT");
                 };
-                if let Some(target_type_id) = udvt.target_type_id {
-                    Typing::Resolved(target_type_id)
-                } else {
-                    Typing::Unresolved
-                }
+                // The UDVT's underlying type failed to resolve.
+                udvt.target_type_id
+                    .ok_or(BuiltInCallError::UnresolvedDependency)?
             }
             InternalBuiltIn::Wrap(definition_id) => {
                 let Some(Definition::UserDefinedValueType(_)) =
@@ -572,17 +546,64 @@ impl<'a> BuiltInsResolver<'a> {
                 else {
                     unreachable!("definition bound to wrap built-in is not a UDVT");
                 };
-                Typing::Resolved(self.types.register_type(Type::UserDefinedValue(
-                    UserDefinedValueType {
+                self.types
+                    .register_type(Type::UserDefinedValue(UserDefinedValueType {
                         definition_id: *definition_id,
-                    },
-                )))
+                    }))
             }
             _ => {
-                // other built-ins cannot be called
-                Typing::Unresolved
+                // Other built-ins are not functions: a namespace such as `abi`
+                // or `msg`, or a name for a type or a value. None of them can
+                // be called.
+                return Err(BuiltInCallError::Diagnostic(ExpressionNotCallable.into()));
             }
+        };
+        Ok(type_id)
+    }
+
+    fn type_of_abi_decode(
+        &mut self,
+        argument_typings: &[Typing],
+    ) -> Result<TypeId, BuiltInCallError> {
+        // TODO(validation): report an error when `abi.decode` is not given
+        // exactly two arguments.
+        if argument_typings.len() != 2 {
+            return Err(BuiltInCallError::NotReportedYet);
         }
+        // The second argument's own type failed to resolve.
+        let Typing::Resolved(type_id) = &argument_typings[1] else {
+            return Err(BuiltInCallError::UnresolvedDependency);
+        };
+
+        // `abi.decode(data, (T))`: a single-element tuple collapses to the
+        // meta-type of `T`, which decodes to `T` itself.
+        if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
+            return Ok(decoded);
+        }
+
+        // `abi.decode(data, (T1, T2, ...))`: a tuple of meta-types decodes to
+        // the tuple of the types they denote. Note a *nested* tuple element is
+        // not a type name and does not decode (matching solc, which rejects
+        // eg. `abi.decode(data, (uint, (bool, bool)))`).
+        if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(*type_id) {
+            let element_ids = types.clone();
+            let mut decoded = Vec::with_capacity(element_ids.len());
+            for element_id in element_ids {
+                let Some(element) = self.type_denoted_by_meta_type(element_id) else {
+                    // TODO(validation) SDR[42]: report an error when a tuple
+                    // element is not a type name (eg. `abi.decode(b, (uint, 5))`).
+                    return Err(BuiltInCallError::NotReportedYet);
+                };
+                decoded.push(element);
+            }
+            return Ok(self
+                .types
+                .register_type(Type::Tuple(TupleType { types: decoded })));
+        }
+
+        // TODO(validation) SDR[42]: report an error when the second argument
+        // is not a type or a tuple of types.
+        Err(BuiltInCallError::NotReportedYet)
     }
 
     /// Returns the value type a meta-type denotes: `type(T)` unwraps to `T`,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -2,7 +2,9 @@ use ruint::aliases::{U160, U256};
 use slang_solidity_v2_common::diagnostics::kinds::resolution::{
     AmbiguousReference, MemberNotFound, NoMatchingCallableDeclaration,
 };
-use slang_solidity_v2_common::diagnostics::kinds::type_system::CannotCallViaContractTypeName;
+use slang_solidity_v2_common::diagnostics::kinds::type_system::{
+    CannotCallViaContractTypeName, ExpressionNotCallable,
+};
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
 use slang_solidity_v2_ir::ir::NodeIdentity;
@@ -10,6 +12,7 @@ use slang_solidity_v2_ir::ir::NodeIdentity;
 use super::Pass;
 use super::disambiguation::OverloadMatch;
 use crate::binder::{Definition, Resolution, Typing};
+use crate::built_ins::BuiltInCallError;
 use crate::passes::common::node_location;
 use crate::types::{
     AddressType, ArraySliceType, ArrayType, ContractType, DataLocation, FixedSizeArrayType,
@@ -575,8 +578,14 @@ impl Pass<'_> {
         let argument_typings = self.collect_positional_argument_typings(arguments);
 
         match operand_typing {
-            Typing::Unresolved | Typing::This(_) | Typing::Super => {
-                // `this` and `super` are not callable
+            Typing::Unresolved => {
+                // The callee failed to resolve, which is already reported: it
+                // is only uncallable as a consequence.
+                Typing::Unresolved
+            }
+            Typing::This(_) | Typing::Super => {
+                // `this` and `super` name a contract instance, not a callable
+                self.report_operand_not_callable(node);
                 Typing::Unresolved
             }
             Typing::NewExpression(type_id) => {
@@ -590,9 +599,18 @@ impl Pass<'_> {
                     _ => Typing::Unresolved,
                 }
             }
-            Typing::BuiltIn(built_in) => self
-                .built_ins_resolver()
-                .typing_of_function_call(&built_in, &argument_typings),
+            Typing::BuiltIn(built_in) => {
+                match self
+                    .built_ins_resolver()
+                    .type_of_function_call(&built_in, &argument_typings)
+                {
+                    Ok(type_id) => Typing::Resolved(type_id),
+                    Err(error) => {
+                        self.report_built_in_call_error(node, error);
+                        Typing::Unresolved
+                    }
+                }
+            }
 
             Typing::Resolved(type_id) => self.typing_of_type_called_with_positional_arguments(
                 node,
@@ -648,7 +666,9 @@ impl Pass<'_> {
     /// Types a call whose operand is (or was disambiguated to) `type_id`: a
     /// function value is an actual call, a meta type is a cast (or a struct
     /// construction), and the user meta type of a function is a non-callable
-    /// declaration reached through a contract/interface type name.
+    /// declaration reached through a contract/interface type name. Anything
+    /// else, including a modifier and the alias of an imported file, is not
+    /// callable at all.
     fn typing_of_type_called_with_positional_arguments(
         &mut self,
         node: &ir::FunctionCallExpression,
@@ -656,7 +676,19 @@ impl Pass<'_> {
         argument_typings: &[Typing],
     ) -> Typing {
         match self.types.get_type_by_id(type_id) {
-            Type::Function(FunctionType { return_type, .. }) => Typing::Resolved(*return_type),
+            Type::Function(FunctionType {
+                definition_id,
+                return_type,
+                ..
+            }) => {
+                let (definition_id, return_type) = (*definition_id, *return_type);
+                if self.is_modifier_definition(definition_id) {
+                    self.report_operand_not_callable(node);
+                    Typing::Unresolved
+                } else {
+                    Typing::Resolved(return_type)
+                }
+            }
             Type::MetaType(MetaType {
                 type_id: target_type_id,
             }) => {
@@ -702,12 +734,41 @@ impl Pass<'_> {
                             .push(file_id, range, CannotCallViaContractTypeName);
                         Typing::Unresolved
                     }
+                    Some(Definition::Import(_)) => {
+                        // The alias of an imported file names a namespace, not
+                        // a callable.
+                        self.report_operand_not_callable(node);
+                        Typing::Unresolved
+                    }
+                    Some(Definition::Event(_)) => {
+                        // TODO: an event invocation has to be prefixed by
+                        // `emit`. The name *is* callable, so this is not a
+                        // callability error. OTOH we don't have a `Type`
+                        // variant for events to be able to type this yet. See
+                        // SDR[950].
+                        Typing::Unresolved
+                    }
+                    Some(Definition::Error(_)) => {
+                        // TODO: An error construction has no value type of its own,
+                        // except as an assertion parameter. Similar to the
+                        // event case, we don't have a `Type` variant to
+                        // represent the error yet.
+                        Typing::Unresolved
+                    }
+                    Some(Definition::UserDefinedValueType(_)) => {
+                        // TODO(validation): a UDVT is callable syntactically
+                        // but not castable by name, so this is a disallowed
+                        // conversion rather than a callability error.
+                        Typing::Unresolved
+                    }
 
                     _ => Typing::Unresolved,
                 }
             }
             _ => {
-                // TODO(validation) SDR[41]: the operand did not resolve to a function
+                // The operand is a value of some other type, which is not
+                // callable (eg. `1(2)`, or a mapping, which is indexed).
+                self.report_operand_not_callable(node);
                 Typing::Unresolved
             }
         }
@@ -736,8 +797,14 @@ impl Pass<'_> {
         let operand_typing = self.typing_of_callee_expression(&node.operand);
 
         let (typing, definition_id) = match operand_typing {
-            Typing::Unresolved | Typing::This(_) | Typing::Super => {
-                // `this` and `super` are not callable
+            Typing::Unresolved => {
+                // The callee failed to resolve, which is already reported: it
+                // is only uncallable as a consequence.
+                (Typing::Unresolved, None)
+            }
+            Typing::This(_) | Typing::Super => {
+                // `this` and `super` name a contract instance, not a callable
+                self.report_operand_not_callable(node);
                 (Typing::Unresolved, None)
             }
             Typing::Resolved(type_id) => {
@@ -791,7 +858,8 @@ impl Pass<'_> {
     /// and error constructions are callable this way; the user meta types of a
     /// function and of an event are non-callable declarations, reached through
     /// a contract/interface type name and outside an `emit` statement
-    /// respectively.
+    /// respectively. Anything else, including a modifier and the alias of an
+    /// imported file, is not callable at all.
     fn typing_of_type_called_with_named_arguments(
         &mut self,
         node: &ir::FunctionCallExpression,
@@ -802,7 +870,17 @@ impl Pass<'_> {
                 definition_id,
                 return_type,
                 ..
-            }) => (Typing::Resolved(*return_type), *definition_id),
+            }) => {
+                let (definition_id, return_type) = (*definition_id, *return_type);
+                if self.is_modifier_definition(definition_id) {
+                    self.report_operand_not_callable(node);
+                    // The definition is still returned so the argument names
+                    // resolve against the modifier's parameters.
+                    (Typing::Unresolved, definition_id)
+                } else {
+                    (Typing::Resolved(return_type), definition_id)
+                }
+            }
             Type::MetaType(_) => {
                 // This is a cast to the given type and is not valid with named arguments
                 (Typing::Unresolved, None)
@@ -822,17 +900,17 @@ impl Pass<'_> {
                         (Typing::Resolved(type_id), Some(definition_id))
                     }
                     Some(Definition::Error(_)) => {
-                        // An error construction has no value type of its own,
-                        // matching the positional form. Return the definition
-                        // so the argument names resolve against its parameters.
+                        // TODO: An error construction has no value type of its
+                        // own, matching the positional form. Return the
+                        // definition so the argument names resolve against its
+                        // parameters.
                         (Typing::Unresolved, Some(definition_id))
                     }
                     Some(Definition::Event(_)) => {
-                        // Likewise, an event invocation has no value type of
+                        // TODO: Likewise, an event invocation has no value type of
                         // its own; return the definition so the argument names
-                        // resolve against its parameters.
-                        // TODO(validation) SDR[950]: an event invocation has
-                        // to be prefixed by `emit`.
+                        // resolve against its parameters.  See SDR[950]: an
+                        // event invocation has to be prefixed by `emit`.
                         (Typing::Unresolved, Some(definition_id))
                     }
                     Some(Definition::Function(_)) => {
@@ -845,15 +923,50 @@ impl Pass<'_> {
                             .push(file_id, range, CannotCallViaContractTypeName);
                         (Typing::Unresolved, Some(definition_id))
                     }
-
-                    _ => (Typing::Unresolved, None),
+                    _ => {
+                        // Anything else is not callable through named arguments.
+                        self.report_operand_not_callable(node);
+                        (Typing::Unresolved, None)
+                    }
                 }
             }
             _ => {
-                // TODO(validation) SDR[41]: the operand did not resolve to a function
+                // The operand is a value of some other type, which is not
+                // callable (eg. `3({a: 1})`).
+                self.report_operand_not_callable(node);
                 (Typing::Unresolved, None)
             }
         }
+    }
+
+    /// Reports the callee of a call as not callable.
+    fn report_operand_not_callable(&mut self, node: &ir::FunctionCallExpression) {
+        let (file_id, range) = node_location(node, self.file_node_mapper);
+        self.diagnostics.push(file_id, range, ExpressionNotCallable);
+    }
+
+    /// Reports a built-in call that produced no result type, at the call site.
+    /// The failures that carry no diagnostic are silent by design: either the
+    /// check is not implemented yet, or what the call depends on already
+    /// reported its own failure.
+    fn report_built_in_call_error(
+        &mut self,
+        node: &ir::FunctionCallExpression,
+        error: BuiltInCallError,
+    ) {
+        match error {
+            BuiltInCallError::Diagnostic(kind) => self.push_diagnostic(node, kind),
+            BuiltInCallError::NotReportedYet | BuiltInCallError::UnresolvedDependency => {}
+        }
+    }
+
+    /// Whether `definition_id` is a modifier. A modifier has a function type so
+    /// that its invocation can be checked against its parameters, but it is not
+    /// callable from an expression.
+    fn is_modifier_definition(&self, definition_id: Option<NodeId>) -> bool {
+        definition_id
+            .and_then(|definition_id| self.binder.find_definition_by_id(definition_id))
+            .is_some_and(|definition| matches!(definition, Definition::Modifier(_)))
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -734,12 +734,6 @@ impl Pass<'_> {
                             .push(file_id, range, CannotCallViaContractTypeName);
                         Typing::Unresolved
                     }
-                    Some(Definition::Import(_)) => {
-                        // The alias of an imported file names a namespace, not
-                        // a callable.
-                        self.report_operand_not_callable(node);
-                        Typing::Unresolved
-                    }
                     Some(Definition::Event(_)) => {
                         // TODO: an event invocation has to be prefixed by
                         // `emit`. The name *is* callable, so this is not a
@@ -752,17 +746,26 @@ impl Pass<'_> {
                         // TODO: An error construction has no value type of its own,
                         // except as an assertion parameter. Similar to the
                         // event case, we don't have a `Type` variant to
-                        // represent the error yet.
+                        // represent the error yet. See SDR[1504]
                         Typing::Unresolved
                     }
                     Some(Definition::UserDefinedValueType(_)) => {
-                        // TODO(validation): a UDVT is callable syntactically
-                        // but not castable by name, so this is a disallowed
-                        // conversion rather than a callability error.
+                        // TODO(validation) SDR[1698]: a UDVT is callable
+                        // syntactically but not castable by name, so this is a
+                        // disallowed conversion rather than a callability
+                        // error.
                         Typing::Unresolved
                     }
-
-                    _ => Typing::Unresolved,
+                    Some(_) => {
+                        // Report any other definitions as expression not
+                        // callable. In practice only path imports can ever
+                        // reach here, but it's a safe default.
+                        self.report_operand_not_callable(node);
+                        Typing::Unresolved
+                    }
+                    None => {
+                        unreachable!("Invalid user meta type; not linking a definition");
+                    }
                 }
             }
             _ => {
@@ -923,10 +926,16 @@ impl Pass<'_> {
                             .push(file_id, range, CannotCallViaContractTypeName);
                         (Typing::Unresolved, Some(definition_id))
                     }
-                    _ => {
-                        // Anything else is not callable through named arguments.
+                    Some(_) => {
+                        // Report any other definitions as expression not
+                        // callable through named arguments. In practice only
+                        // path imports can ever reach here, but it's a safe
+                        // default.
                         self.report_operand_not_callable(node);
                         (Typing::Unresolved, None)
+                    }
+                    None => {
+                        unreachable!("Invalid user meta type; not linking a definition");
                     }
                 }
             }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -3600,6 +3600,50 @@ mod type_system {
         }
     }
 
+    mod expression_not_callable {
+        use super::*;
+
+        #[test]
+        fn built_in_object() -> Result<()> {
+            run("type_system/expression_not_callable", "built_in_object")
+        }
+
+        #[test]
+        fn enum_value() -> Result<()> {
+            run("type_system/expression_not_callable", "enum_value")
+        }
+
+        #[test]
+        fn import_alias() -> Result<()> {
+            run("type_system/expression_not_callable", "import_alias")
+        }
+
+        #[test]
+        fn integer_literal() -> Result<()> {
+            run("type_system/expression_not_callable", "integer_literal")
+        }
+
+        #[test]
+        fn mapping() -> Result<()> {
+            run("type_system/expression_not_callable", "mapping")
+        }
+
+        #[test]
+        fn modifier() -> Result<()> {
+            run("type_system/expression_not_callable", "modifier")
+        }
+
+        #[test]
+        fn named_arguments() -> Result<()> {
+            run("type_system/expression_not_callable", "named_arguments")
+        }
+
+        #[test]
+        fn this_expression() -> Result<()> {
+            run("type_system/expression_not_callable", "this_expression")
+        }
+    }
+
     #[test]
     fn fallback_function_mutability() -> Result<()> {
         run("type_system", "fallback_function_mutability")

--- a/crates/solidity-v2/testing/snapshots/binder_output/scoping/public_variable_and_inherited_function/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/scoping/public_variable_and_inherited_function/generated/0.8.0-success.txt
@@ -1,28 +1,26 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Definitions (10):
+Definitions (9):
 - Def: #1 ["A" @ input.sol:8:10] (contract)
 - Def: #2 ["x" @ input.sol:9:14] (function, type: function (uint256) returns uint256)
 - Def: #3 ["B" @ input.sol:14:10] (contract)
 - Def: #4 ["x" @ input.sol:15:20] (state var, type: uint256)
 - Def: #5 ["value" @ input.sol:17:14] (function, type: function () returns uint256)
-- Def: #6 ["callee" @ input.sol:21:14] (function, type: function () returns uint256)
-- Def: #7 ["qualified" @ input.sol:25:14] (function, type: function () returns uint256)
-- Def: #8 ["external_call" @ input.sol:29:14] (function, type: function () returns uint256)
-- Def: #9 ["assembly_use" @ input.sol:33:14] (function, type: function () returns void)
-- Def: #10 ["y" @ input.sol:35:17] (yul variable)
+- Def: #6 ["qualified" @ input.sol:21:14] (function, type: function () returns uint256)
+- Def: #7 ["external_call" @ input.sol:25:14] (function, type: function () returns uint256)
+- Def: #8 ["assembly_use" @ input.sol:29:14] (function, type: function () returns void)
+- Def: #9 ["y" @ input.sol:31:17] (yul variable)
 
 ------------------------------------------------------------------------
 
-References (8):
+References (7):
 - Ref: ["A" @ input.sol:14:15] -> #1
 - Ref: ["x" @ input.sol:18:16] -> #4
-- Ref: ["x" @ input.sol:22:16] -> #4
-- Ref: ["A" @ input.sol:26:16] -> #1
-- Ref: ["x" @ input.sol:26:18] -> #2
-- Ref: ["x" @ input.sol:30:21] -> #2
-- Ref: ["x" @ input.sol:35:22] -> #4
-- Ref: ["slot" @ input.sol:35:24] -> built-in
+- Ref: ["A" @ input.sol:22:16] -> #1
+- Ref: ["x" @ input.sol:22:18] -> #2
+- Ref: ["x" @ input.sol:26:21] -> #2
+- Ref: ["x" @ input.sol:31:22] -> #4
+- Ref: ["slot" @ input.sol:31:24] -> built-in
 
 ------------------------------------------------------------------------
 
@@ -56,36 +54,29 @@ Bindings:
     │                ┬  
     │                ╰── ref: 4
     │ 
- 21 │     function callee() internal view returns (uint256) {
-    │              ───┬──  
-    │                 ╰──── name: 6
- 22 │         return x(1);
-    │                ┬  
-    │                ╰── ref: 4
-    │ 
- 25 │     function qualified() internal pure returns (uint256) {
+ 21 │     function qualified() internal pure returns (uint256) {
     │              ────┬────  
-    │                  ╰────── name: 7
- 26 │         return A.x(1);
+    │                  ╰────── name: 6
+ 22 │         return A.x(1);
     │                ┬ ┬  
     │                ╰──── ref: 1
     │                  │  
     │                  ╰── ref: 2
     │ 
- 29 │     function external_call() external view returns (uint256) {
+ 25 │     function external_call() external view returns (uint256) {
     │              ──────┬──────  
-    │                    ╰──────── name: 8
- 30 │         return this.x(1);
+    │                    ╰──────── name: 7
+ 26 │         return this.x(1);
     │                     ┬  
     │                     ╰── ref: 2
     │ 
- 33 │     function assembly_use() internal pure {
+ 29 │     function assembly_use() internal pure {
     │              ──────┬─────  
-    │                    ╰─────── name: 9
+    │                    ╰─────── name: 8
     │ 
- 35 │             let y := x.slot
+ 31 │             let y := x.slot
     │                 ┬    ┬ ──┬─  
-    │                 ╰──────────── name: 10
+    │                 ╰──────────── name: 9
     │                      │   │   
     │                      ╰─────── ref: 4
     │                          │   

--- a/crates/solidity-v2/testing/snapshots/binder_output/scoping/public_variable_and_inherited_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/scoping/public_variable_and_inherited_function/input.sol
@@ -18,10 +18,6 @@ contract B is A {
         return x;
     }
 
-    function callee() internal view returns (uint256) {
-        return x(1);
-    }
-
     function qualified() internal pure returns (uint256) {
         return A.x(1);
     }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:10:17]
+    │
+ 10 │     uint256 a = msg(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:10:17]
+    │
+ 10 │     uint256 a = msg(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:10:17]
+    │
+ 10 │     uint256 a = msg(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/built_in_object/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/magic_not_callable.sol
+// Calling a built-in object, which is only good for member access.
+
+contract C {
+    // TypeError 5704: This expression is not callable.
+    uint256 a = msg(1000);
+
+    // Selecting a member of the same object is fine.
+    uint256 b = msg.value;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:16:17]
+    │
+ 16 │     uint256 a = E.B(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:16:17]
+    │
+ 16 │     uint256 a = E.B(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:16:17]
+    │
+ 16 │     uint256 a = E.B(1000);
+    │                 ────┬────  
+    │                     ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/enum_value/input.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/enum_value_not_callable.sol
+// Calling an enum member, which is a value and not callable.
+
+enum E {
+    A,
+    B,
+    C
+}
+
+contract C {
+    // TypeError 5704: This expression is not callable.
+    uint256 a = E.B(1000);
+
+    // A cast through the enum type name itself is fine.
+    E b = E(1);
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[b.sol:12:17]
+    │
+ 12 │     uint256 a = A(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[b.sol:12:17]
+    │
+ 12 │     uint256 a = A(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[b.sol:12:17]
+    │
+ 12 │     uint256 a = A(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/import_alias/input.sol
@@ -1,0 +1,23 @@
+// --- path: a.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+uint256 constant k = 1;
+
+// --- path: b.sol
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/module_not_callable.sol
+// Calling an import alias, which names a source unit and not a callable.
+
+import "a.sol" as A;
+
+contract C {
+    // TypeError 5704: This expression is not callable.
+    uint256 a = A(1000);
+
+    // Selecting a member of the same alias is fine.
+    uint256 b = A.k;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:11:11]
+    │
+ 11 │         ((1(3)), 2);
+    │           ──┬─  
+    │             ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:11:11]
+    │
+ 11 │         ((1(3)), 2);
+    │           ──┬─  
+    │             ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:11:11]
+    │
+ 11 │         ((1(3)), 2);
+    │           ──┬─  
+    │             ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/integer_literal/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/int_not_callable.sol
+// Calling a number literal.
+
+contract C {
+    function f() public pure {
+        // TypeError 5704: This expression is not callable.
+        ((1(3)), 2);
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:12:17]
+    │
+ 12 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:12:17]
+    │
+ 12 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:12:17]
+    │
+ 12 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/mapping/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/mapping_not_callable.sol
+// Calling a mapping, which is indexed and not called.
+
+contract C {
+    mapping(uint256 => uint256) m;
+
+    // TypeError 5704: This expression is not callable.
+    uint256 a = m(1000);
+
+    // Indexing the same mapping is fine.
+    uint256 b = m[1000];
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:11:17]
+    │
+ 11 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:11:17]
+    │
+ 11 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:11:17]
+    │
+ 11 │     uint256 a = m(1000);
+    │                 ───┬───  
+    │                    ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/modifier/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/modifier_not_callable.sol
+// Calling a modifier from an expression, rather than attaching it to a
+// function.
+
+contract C {
+    // TypeError 5704: This expression is not callable.
+    uint256 a = m(1000);
+
+    modifier m(uint256) {
+        _;
+    }
+
+    // Attaching the modifier to a function is fine.
+    function f() public m(1) {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:16:9]
+    │
+ 16 │         3({a: 1, x: true});
+    │         ─────────┬────────  
+    │                  ╰────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:16:9]
+    │
+ 16 │         3({a: 1, x: true});
+    │         ─────────┬────────  
+    │                  ╰────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:16:9]
+    │
+ 16 │         3({a: 1, x: true});
+    │         ─────────┬────────  
+    │                  ╰────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/named_arguments/input.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/nameAndTypeResolution/462_callable_crash.sol
+// The same check applies to the named-argument call form.
+
+contract C {
+    struct S {
+        uint256 a;
+        bool x;
+    }
+
+    constructor() {
+        // TypeError 5704: This expression is not callable.
+        3({a: 1, x: true});
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-callable] Error: This expression is not callable.
+    ╭─[input.sol:11:13]
+    │
+ 11 │         try this() {} catch Error(string memory) {}
+    │             ───┬──  
+    │                ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: Type is not callable
+    ╭─[input.sol:11:13]
+    │
+ 11 │         try this() {} catch Error(string memory) {}
+    │             ───┬──  
+    │                ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/solc/0.8.20-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/generated/solc/0.8.20-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 5704] Error: This expression is not callable.
+    ╭─[input.sol:11:13]
+    │
+ 11 │         try this() {} catch Error(string memory) {}
+    │             ───┬──  
+    │                ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_callable/this_expression/input.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Recovered from solc:
+// test/libsolidity/syntaxTests/functionCalls/this_not_callable.sol
+// Calling `this`, which is a contract instance and not a callable.
+
+contract C {
+    function f() public {
+        // TypeError 5704: This expression is not callable.
+        try this() {} catch Error(string memory) {}
+    }
+
+    function g() public {
+        // Calling a function through `this` is fine.
+        this.f();
+    }
+}


### PR DESCRIPTION
Closes NomicFoundation/slang-diagnostics-research#41
Closes NomicFoundation/slang-diagnostics-research#1265
Closes NomicFoundation/slang-diagnostics-research#1266

This PR also refines and exposes some other missing diagnostics, not covered in this one to keep the size and scope small.
