### PR TITLE
[v2] refactor(tests): Import resolver is shared across v2 tests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -40,6 +40,7 @@
     "nonterminal",
     "nonterminals",
     "pipenv",
+    "remappings",
     "rustup",
     "sourcify",
     "struct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4585,6 +4585,7 @@ dependencies = [
  "ariadne",
  "semver 1.0.28",
  "slang_solidity",
+ "slang_solidity_v2",
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
  "slang_solidity_v2_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,9 +4571,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "slang_solidity_v2",
  "slang_solidity_v2_common",
- "solidity_testing_utils",
  "solidity_v2_testing_utils",
  "tempfile",
 ]

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/diagnostics/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/diagnostics/mod.rs
@@ -1,0 +1,3 @@
+//! Tests diagnostics cases that need extra support from the caller.
+
+mod unresolved_import;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/diagnostics/unresolved_import.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/diagnostics/unresolved_import.rs
@@ -1,6 +1,4 @@
-//! Tests what the compilation pipeline reports when the host declines to
-//! resolve an import — the `UnresolvedImport` path, which the snapshot
-//! harnesses never reach since they resolve the way `solc` does.
+//! Tests specifically for builder configurations that don't resolve every import
 
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 
@@ -10,12 +8,12 @@ use crate::diagnostics::{DiagnosticExtensions, DiagnosticSeverity};
 use crate::utils::LanguageVersion;
 
 /// Serves one file and declines every import out of it.
-struct DecliningHost {
+struct DecliningBuilderConfig {
     name: &'static str,
     contents: &'static str,
 }
 
-impl CompilationBuilderConfig for DecliningHost {
+impl CompilationBuilderConfig for DecliningBuilderConfig {
     fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         if file_id.as_str() == self.name {
             Ok(self.contents.to_owned())
@@ -41,7 +39,7 @@ fn compile(name: &'static str, contents: &'static str) -> CompilationUnit {
     let mut builder = CompilationBuilder::create(
         LanguageVersion::LATEST,
         EvmTarget::LATEST,
-        DecliningHost { name, contents },
+        DecliningBuilderConfig { name, contents },
     );
     builder.add_file(name.into());
 
@@ -64,7 +62,7 @@ fn declined_import_is_reported_as_unresolved() {
     assert_eq!("compilation/unresolved-import", diagnostic.code());
     assert_eq!(DiagnosticSeverity::Error, diagnostic.severity());
 
-    // The host's reason is carried through verbatim.
+    // The builder config's reason is carried through verbatim.
     assert_eq!(
         "no remapping covers '@scope/pkg/foo.sol'",
         diagnostic.message()

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/host_resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/host_resolution.rs
@@ -1,0 +1,103 @@
+//! Tests what the compilation pipeline reports when the host declines to
+//! resolve an import — the `UnresolvedImport` path, which the snapshot
+//! harnesses never reach since they resolve the way `solc` does.
+
+use slang_solidity_v2_common::evm_targets::EvmTarget;
+
+use crate::compilation::{CompilationBuilder, CompilationBuilderConfig, CompilationUnit, FileId};
+use crate::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
+use crate::diagnostics::{DiagnosticExtensions, DiagnosticSeverity};
+use crate::utils::LanguageVersion;
+
+/// Serves one file and declines every import out of it.
+struct DecliningHost {
+    name: &'static str,
+    contents: &'static str,
+}
+
+impl CompilationBuilderConfig for DecliningHost {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
+        if file_id.as_str() == self.name {
+            Ok(self.contents.to_owned())
+        } else {
+            Err(MissingFile {
+                reason: format!("no file '{file_id}'"),
+            })
+        }
+    }
+
+    fn resolve_import(
+        &mut self,
+        _source_file_id: &FileId,
+        import_path: &str,
+    ) -> Result<FileId, UnresolvedImport> {
+        Err(UnresolvedImport {
+            reason: format!("no remapping covers '{import_path}'"),
+        })
+    }
+}
+
+fn compile(name: &'static str, contents: &'static str) -> CompilationUnit {
+    let mut builder = CompilationBuilder::create(
+        LanguageVersion::LATEST,
+        EvmTarget::LATEST,
+        DecliningHost { name, contents },
+    );
+    builder.add_file(name.into());
+
+    builder.build()
+}
+
+#[test]
+fn declined_import_is_reported_as_unresolved() {
+    let contents = "import {Foo} from \"@scope/pkg/foo.sol\";\ncontract Main {}\n";
+    let unit = compile("main.sol", contents);
+
+    let diagnostics: Vec<_> = unit.diagnostics().iter().collect();
+    assert_eq!(
+        1,
+        diagnostics.len(),
+        "expected exactly the unresolved import, but found: {diagnostics:#?}"
+    );
+
+    let diagnostic = diagnostics[0];
+    assert_eq!("compilation/unresolved-import", diagnostic.code());
+    assert_eq!(DiagnosticSeverity::Error, diagnostic.severity());
+
+    // The host's reason is carried through verbatim.
+    assert_eq!(
+        "no remapping covers '@scope/pkg/foo.sol'",
+        diagnostic.message()
+    );
+
+    // Reported against the import, in the file that wrote it.
+    assert_eq!("main.sol", diagnostic.file_id().as_str());
+    assert_eq!(
+        "\"@scope/pkg/foo.sol\"",
+        &contents[diagnostic.text_range().clone()]
+    );
+}
+
+/// Every declined import is reported, not just the first.
+#[test]
+fn every_declined_import_is_reported() {
+    let unit = compile(
+        "main.sol",
+        "import \"a.sol\";\nimport \"b.sol\";\nimport {C} from \"c.sol\";\ncontract Main {}\n",
+    );
+
+    let messages: Vec<_> = unit
+        .diagnostics()
+        .iter()
+        .map(DiagnosticExtensions::message)
+        .collect();
+
+    assert_eq!(
+        vec![
+            "no remapping covers 'a.sol'",
+            "no remapping covers 'b.sol'",
+            "no remapping covers 'c.sol'",
+        ],
+        messages
+    );
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
@@ -1,6 +1,6 @@
 mod abi;
 mod ast;
+mod diagnostics;
 mod fixtures;
-mod host_resolution;
 mod thread_safety;
 mod unit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod abi;
 mod ast;
 mod fixtures;
+mod host_resolution;
 mod thread_safety;
 mod unit;

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/runner.rs
@@ -2,37 +2,14 @@ use anyhow::{Result, ensure};
 use infra_utils::cargo::CargoWorkspace;
 use infra_utils::codegen::CodegenFileSystem;
 use infra_utils::paths::PathExtensions;
-use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig, FileId};
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2_common::collections::SortedMap;
-use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
+use solidity_v2_testing_utils::compilation;
 
 use super::report::binder_report;
 use super::report_data::ReportData;
 use crate::snapshots::{self, SnapshotOutcome, SnapshotStatus, TestConfig, TestMatrix};
 use crate::utils::multi_part_file::split_multi_file;
-use crate::utils::path_resolver;
-
-struct CompilationConfig {
-    files: SortedMap<FileId, String>,
-}
-
-impl CompilationBuilderConfig for CompilationConfig {
-    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
-        self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
-            reason: "File not found".to_string(),
-        })
-    }
-
-    fn resolve_import(
-        &mut self,
-        source_file_id: &FileId,
-        import_path: &str,
-    ) -> Result<FileId, UnresolvedImport> {
-        path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
-            reason: "Unresolved import".to_string(),
-        })
-    }
-}
 
 pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
     let test_dir = CargoWorkspace::locate_source_crate("solidity_v2_testing_snapshots")?
@@ -70,20 +47,7 @@ pub(crate) fn run(group_name: &str, test_name: &str) -> Result<()> {
         &test_config,
         "generated",
         |version, target| {
-            let compilation_config = CompilationConfig {
-                files: files.clone(),
-            };
-            let mut builder = CompilationBuilder::create(version, target, compilation_config);
-
-            // While `builder.add_file()` recursively adds dependencies, so adding
-            // the root file would be enough, we don't want to depend on the
-            // ordering of the parts in `input.sol`. Calling `add_file()` on files
-            // already added is idempotent, so to be sure we add all parts.
-            for file in files.keys() {
-                builder.add_file(file.clone());
-            }
-
-            let compilation = builder.build();
+            let compilation = compilation::compile(&files, version, target);
             let report_data = ReportData::prepare(&compilation, &files);
 
             let status = if report_data.all_resolved() {

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -11,14 +11,14 @@ mod compilation {
         use super::*;
 
         #[test]
+        fn escapes_root() -> Result<()> {
+            run("compilation/missing_imported_file", "escapes_root")
+        }
+
+        #[test]
         fn simple() -> Result<()> {
             run("compilation/missing_imported_file", "simple")
         }
-    }
-
-    #[test]
-    fn unresolved_import() -> Result<()> {
-        run("compilation", "unresolved_import")
     }
 }
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/targets/slang.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
-use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig, FileId};
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2_common::collections::SortedMap;
-use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
 use slang_solidity_v2_common::diagnostics::{DiagnosticExtensions, DiagnosticSeverity};
 use slang_solidity_v2_common::evm_targets::EvmTarget;
 use slang_solidity_v2_common::versions::LanguageVersion;
+use solidity_v2_testing_utils::compilation;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use crate::diagnostics_output::targets::{TargetOutcome, TestTarget};
-use crate::utils::path_resolver;
 
 pub(crate) struct SlangTarget;
 
@@ -23,16 +22,7 @@ impl TestTarget for SlangTarget {
         version: LanguageVersion,
         evm_target: EvmTarget,
     ) -> Result<TargetOutcome> {
-        let config = TestConfig {
-            files: files.clone(),
-        };
-        let mut builder = CompilationBuilder::create(version, evm_target, config);
-
-        for file in files.keys() {
-            builder.add_file(file.clone());
-        }
-
-        let compilation = builder.build();
+        let compilation = compilation::compile(files, version, evm_target);
 
         let diagnostics: Vec<_> = compilation.diagnostics().iter().collect();
 
@@ -53,28 +43,6 @@ impl TestTarget for SlangTarget {
         Ok(TargetOutcome {
             diagnostics: rendered,
             compilation_succeeded,
-        })
-    }
-}
-
-struct TestConfig {
-    files: SortedMap<FileId, String>,
-}
-
-impl CompilationBuilderConfig for TestConfig {
-    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
-        self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
-            reason: "File not found.".to_string(),
-        })
-    }
-
-    fn resolve_import(
-        &mut self,
-        source_file_id: &FileId,
-        import_path: &str,
-    ) -> Result<FileId, UnresolvedImport> {
-        path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
-            reason: "Unresolved import.".to_string(),
         })
     }
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/utils/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/utils/mod.rs
@@ -1,2 +1,1 @@
 pub(crate) mod multi_part_file;
-pub(crate) mod path_resolver;

--- a/crates/solidity-v2/testing/snapshots/binder_output/yul/imported_undefined_symbol/generated/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/yul/imported_undefined_symbol/generated/0.8.0-failure.txt
@@ -8,7 +8,7 @@ Parse errors:
    │                      ──────┬──────  
    │                            ╰──────── Error occurred here.
 ───╯
-[compilation/missing-file] Error: File not found
+[compilation/missing-file] Error: File not found.
    ─[slots.sol:0:0]
 
 ------------------------------------------------------------------------

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/slang/0.8.0-failure.txt
@@ -1,11 +1,14 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 1
+Diagnostics: 2
 
-[compilation/unresolved-import] Error: Unresolved import.
-   ╭─[input.sol:5:8]
+[compilation/missing-imported-file] Error: Imported file is missing: oops.sol
+   ╭─[input.sol:6:8]
    │
- 5 │ import "../../oops.sol";
+ 6 │ import "../../oops.sol";
    │        ────────┬───────  
    │                ╰───────── Error occurred here.
 ───╯
+
+[compilation/missing-file] Error: File not found.
+   ─[oops.sol:0:0]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.0-failure.txt
@@ -2,10 +2,10 @@
 
 Diagnostics: 1
 
-[ParserError 6275] Error: Source "oops.sol" not found: File not found. Searched the following locations: "".
-   ╭─[input.sol:5:1]
+[ParserError 6275] Error: Source "oops.sol" not found: File outside of allowed directories.
+   ╭─[input.sol:6:1]
    │
- 5 │ import "../../oops.sol";
+ 6 │ import "../../oops.sol";
    │ ────────────┬───────────  
    │             ╰───────────── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.12-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.12-failure.txt
@@ -2,10 +2,10 @@
 
 Diagnostics: 1
 
-[ParserError 6275] Error: Source "oops.sol" not found: File outside of allowed directories.
-   ╭─[input.sol:5:1]
+[ParserError 6275] Error: Source "oops.sol" not found: File not found. Searched the following locations: "".
+   ╭─[input.sol:6:1]
    │
- 5 │ import "../../oops.sol";
+ 6 │ import "../../oops.sol";
    │ ────────────┬───────────  
    │             ╰───────────── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.8-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/generated/solc/0.8.8-failure.txt
@@ -3,9 +3,9 @@
 Diagnostics: 1
 
 [ParserError 6275] Error: Source "oops.sol" not found: File not found.
-   ╭─[input.sol:5:1]
+   ╭─[input.sol:6:1]
    │
- 5 │ import "../../oops.sol";
+ 6 │ import "../../oops.sol";
    │ ────────────┬───────────  
    │             ╰───────────── Error occurred here.
 ───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/missing_imported_file/escapes_root/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// `..` past the root is dropped, so this imports the source `oops.sol`, which
+// the test doesn't provide:
+import "../../oops.sol";
+
+contract Main {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/unresolved_import/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/compilation/unresolved_import/input.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity *;
-
-// Our test resolver only resolves files in the same directory:
-import "../../oops.sol";
-
-contract Main {}

--- a/crates/solidity-v2/testing/solc/Cargo.toml
+++ b/crates/solidity-v2/testing/solc/Cargo.toml
@@ -16,9 +16,7 @@ rayon = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slang_solidity_v2 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
-solidity_testing_utils = { workspace = true }
 solidity_v2_testing_utils = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/solidity-v2/testing/solc/README.md
+++ b/crates/solidity-v2/testing/solc/README.md
@@ -68,7 +68,9 @@ splitting them up would only cost `nextest` tens of thousands of processes.
 3. **Run** — each `(version, test)` pair compiles with the slang v2
    `CompilationBuilder` pinned to that language version and the resolved EVM
    target (the `EVMVersion` setting if present, else that version's default),
-   resolving imports with the shared `solidity_testing_utils` `ImportResolver`.
+   resolving imports with the shared `solidity_v2_testing_utils` `path_resolver`,
+   which follows the rules `solc` applies to a standard JSON input with no
+   remappings.
 
     A setting we can't honor — an EVM target name we don't know, or a constraint
     no supported target satisfies — fails the run rather than falling back to the

--- a/crates/solidity-v2/testing/solc/results.generated.json
+++ b/crates/solidity-v2/testing/solc/results.generated.json
@@ -57,8 +57,8 @@
   "0.8.5": {
     "commit": "a4f2e591fe55900f86ab72fad37d03af7dfa638e",
     "executed": 1194,
-    "passed": 1166,
-    "failed": 28,
+    "passed": 1167,
+    "failed": 27,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -73,7 +73,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -93,8 +92,8 @@
   "0.8.6": {
     "commit": "11564f7ec2d34f488e7f7946c1f19491a967370e",
     "executed": 1195,
-    "passed": 1167,
-    "failed": 28,
+    "passed": 1168,
+    "failed": 27,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -109,7 +108,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -129,8 +127,8 @@
   "0.8.7": {
     "commit": "e28d00a76daa0747f00ffe47cea17862bca55771",
     "executed": 1205,
-    "passed": 1177,
-    "failed": 28,
+    "passed": 1178,
+    "failed": 27,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -145,7 +143,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -165,8 +162,8 @@
   "0.8.8": {
     "commit": "dddeac2faf1e2d3527a85f8a308138d0b27af297",
     "executed": 1233,
-    "passed": 1203,
-    "failed": 30,
+    "passed": 1204,
+    "failed": 29,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -181,7 +178,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -203,8 +199,8 @@
   "0.8.9": {
     "commit": "e5eed63a3e83d698d8657309fd371248945a1cda",
     "executed": 1245,
-    "passed": 1214,
-    "failed": 31,
+    "passed": 1215,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -219,7 +215,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -242,8 +237,8 @@
   "0.8.10": {
     "commit": "fc4108302703fe8bb7cb2443c45a5c172c8e0f11",
     "executed": 1257,
-    "passed": 1226,
-    "failed": 31,
+    "passed": 1227,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -258,7 +253,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -281,8 +275,8 @@
   "0.8.11": {
     "commit": "d7f0394316b84421d897671df1173cf01c641160",
     "executed": 1292,
-    "passed": 1261,
-    "failed": 31,
+    "passed": 1262,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -297,7 +291,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -320,8 +313,8 @@
   "0.8.12": {
     "commit": "f00d7308415b5f1e66b7dca11ef0edb395c09ad4",
     "executed": 1313,
-    "passed": 1282,
-    "failed": 31,
+    "passed": 1283,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -336,7 +329,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -359,8 +351,8 @@
   "0.8.13": {
     "commit": "abaa5c0eb321aab4cd09617598696172378a4b83",
     "executed": 1331,
-    "passed": 1300,
-    "failed": 31,
+    "passed": 1301,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -375,7 +367,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -398,8 +389,8 @@
   "0.8.14": {
     "commit": "80d49f37028b13e162951b6b67b0a42f477ba93c",
     "executed": 1338,
-    "passed": 1307,
-    "failed": 31,
+    "passed": 1308,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -414,7 +405,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -437,8 +427,8 @@
   "0.8.15": {
     "commit": "e14f27147bd4ffc63e2bf46a68e0d271fad0ed79",
     "executed": 1344,
-    "passed": 1313,
-    "failed": 31,
+    "passed": 1314,
+    "failed": 30,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -453,7 +443,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -476,8 +465,8 @@
   "0.8.16": {
     "commit": "07a7930e73f57ce6ed1c6f0b8dd9aad99e5c3692",
     "executed": 1355,
-    "passed": 1322,
-    "failed": 33,
+    "passed": 1323,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -494,7 +483,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -517,8 +505,8 @@
   "0.8.17": {
     "commit": "8df45f5f8632da4817bc7ceb81497518f298d290",
     "executed": 1363,
-    "passed": 1330,
-    "failed": 33,
+    "passed": 1331,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -535,7 +523,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -558,8 +545,8 @@
   "0.8.18": {
     "commit": "87f61d960cceab32489350726a99c050e6f92c61",
     "executed": 1414,
-    "passed": 1381,
-    "failed": 33,
+    "passed": 1382,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -576,7 +563,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -599,8 +585,8 @@
   "0.8.19": {
     "commit": "7dd6d404815651b2341ecae220709a88aaed4038",
     "executed": 1445,
-    "passed": 1412,
-    "failed": 33,
+    "passed": 1413,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -617,7 +603,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -640,8 +625,8 @@
   "0.8.20": {
     "commit": "a1b79de64235f13e6b06e088fe6365c5a12d13d3",
     "executed": 1453,
-    "passed": 1420,
-    "failed": 33,
+    "passed": 1421,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -658,7 +643,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -681,8 +665,8 @@
   "0.8.21": {
     "commit": "d9974bed7134e043f7ccc593c0c19c67d2d45dc4",
     "executed": 1466,
-    "passed": 1433,
-    "failed": 33,
+    "passed": 1434,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -699,7 +683,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -722,8 +705,8 @@
   "0.8.22": {
     "commit": "4fc1097e8df32897ccee8985019610fa5a869212",
     "executed": 1476,
-    "passed": 1443,
-    "failed": 33,
+    "passed": 1444,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -740,7 +723,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -763,8 +745,8 @@
   "0.8.23": {
     "commit": "f704f362dbb2a0af54d1484eb50cdafbc7dc086d",
     "executed": 1476,
-    "passed": 1443,
-    "failed": 33,
+    "passed": 1444,
+    "failed": 32,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -781,7 +763,6 @@
       "cleanup/bool_conversion_v1.sol",
       "cleanup/cleanup_address_types_v1.sol",
       "cleanup/cleanup_bytes_types_v1.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -804,8 +785,8 @@
   "0.8.24": {
     "commit": "e11b9ed9f2c254bc894d844c0a64a0eb76bbb4fd",
     "executed": 1506,
-    "passed": 1471,
-    "failed": 35,
+    "passed": 1472,
+    "failed": 34,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -824,7 +805,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -847,8 +827,8 @@
   "0.8.25": {
     "commit": "b61c2a91b3a478bd53fb831b0e8811668bc0dd05",
     "executed": 1506,
-    "passed": 1471,
-    "failed": 35,
+    "passed": 1472,
+    "failed": 34,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -867,7 +847,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -890,8 +869,8 @@
   "0.8.26": {
     "commit": "8a97fa7a1db1ec509221ead6fea6802c684ee887",
     "executed": 1516,
-    "passed": 1481,
-    "failed": 35,
+    "passed": 1482,
+    "failed": 34,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -910,7 +889,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -933,8 +911,8 @@
   "0.8.27": {
     "commit": "40a35a097cb1e03550c7ce415f2b46ad81e882a6",
     "executed": 1522,
-    "passed": 1487,
-    "failed": 35,
+    "passed": 1488,
+    "failed": 34,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -953,7 +931,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -976,8 +953,8 @@
   "0.8.28": {
     "commit": "7893614a31fbeacd1966994e310ed4f760772658",
     "executed": 1545,
-    "passed": 1510,
-    "failed": 35,
+    "passed": 1511,
+    "failed": 34,
     "failures": [
       "abiEncoderV1/abi_encode_empty_string.sol",
       "abiEncoderV1/bool_out_of_bounds.sol",
@@ -996,7 +973,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1019,8 +995,8 @@
   "0.8.29": {
     "commit": "ab55807c0d9198fb126442188d40fcab292a2acb",
     "executed": 1587,
-    "passed": 1552,
-    "failed": 35,
+    "passed": 1553,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1039,7 +1015,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1062,8 +1037,8 @@
   "0.8.30": {
     "commit": "73712a01b2de56d9ad91e3b6936f85c90cb7de36",
     "executed": 1587,
-    "passed": 1552,
-    "failed": 35,
+    "passed": 1553,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1082,7 +1057,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1105,8 +1079,8 @@
   "0.8.31": {
     "commit": "fd3a22656ebe9c91a96ebd846ab7699b5f2e053c",
     "executed": 1589,
-    "passed": 1554,
-    "failed": 35,
+    "passed": 1555,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1125,7 +1099,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1148,8 +1121,8 @@
   "0.8.32": {
     "commit": "ebbd65e568ccc79cfaaa5814a7d2a92b70ddd3ae",
     "executed": 1608,
-    "passed": 1573,
-    "failed": 35,
+    "passed": 1574,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1168,7 +1141,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1191,8 +1163,8 @@
   "0.8.33": {
     "commit": "64118f21280f0196f491689f0fc93dc5bec20dc1",
     "executed": 1608,
-    "passed": 1573,
-    "failed": 35,
+    "passed": 1574,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1211,7 +1183,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1234,8 +1205,8 @@
   "0.8.34": {
     "commit": "80d5c5362b5d41697fd62ef36cf6abd8d5a68cc4",
     "executed": 1620,
-    "passed": 1585,
-    "failed": 35,
+    "passed": 1586,
+    "failed": 34,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1254,7 +1225,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
       "operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol",
@@ -1277,8 +1247,8 @@
   "0.8.35": {
     "commit": "47b9dedda00ef23974eca07c06c97cc1c80088b4",
     "executed": 1646,
-    "passed": 1610,
-    "failed": 36,
+    "passed": 1611,
+    "failed": 35,
     "failures": [
       "abiEncodeDecode/abi_encode_empty_string_v1.sol",
       "abiEncodeDecode/abi_encode_with_selector.sol",
@@ -1297,7 +1267,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "isoltestTesting/future_evm_version_smoke_test.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",
@@ -1321,8 +1290,8 @@
   "0.8.36": {
     "commit": "8a079791d9cca7a6c03fd6a8429b93aa3bddefed",
     "executed": 1643,
-    "passed": 1606,
-    "failed": 37,
+    "passed": 1607,
+    "failed": 36,
     "failures": [
       "abicoder/abi_encode_empty_string_v1.sol",
       "abicoder/abi_encode_memory_dynamic_array_and_calldata_bytes_v1.sol",
@@ -1342,7 +1311,6 @@
       "cleanup/cleanup_bytes_types_v1.sol",
       "experimental/stub.sol",
       "experimental/type_class.sol",
-      "externalSource/non_normalized_paths.sol",
       "isoltestTesting/future_evm_version_smoke_test.sol",
       "operators/shifts/shift_right_garbled_signed_v1.sol",
       "operators/shifts/shift_right_garbled_v1.sol",

--- a/crates/solidity-v2/testing/solc/src/runner.rs
+++ b/crates/solidity-v2/testing/solc/src/runner.rs
@@ -1,12 +1,10 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use slang_solidity_v2::compilation::{CompilationBuilder, CompilationBuilderConfig};
-use slang_solidity_v2_common::collections::OrderedMap;
-use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
+use slang_solidity_v2_common::collections::SortedMap;
 use slang_solidity_v2_common::files::FileId;
 use slang_solidity_v2_common::versions::LanguageVersion;
-use solidity_testing_utils::import_resolver::{ImportResolver, SourceMap};
+use solidity_v2_testing_utils::compilation;
 use solidity_v2_testing_utils::reporting::diagnostic;
 
 use crate::evm_target::{FUTURE_EVM_VERSION, ParsedTarget, default_evm_target, resolve_evm_target};
@@ -39,8 +37,12 @@ pub fn run_test(test_path: &Path, language_version: LanguageVersion) -> Result<O
 }
 
 fn run_test_case(test_case: &IsolTestCase, language_version: LanguageVersion) -> Result<Outcome> {
-    let files = &test_case.files;
-    let config = TestConfig::new(files);
+    // The test's sources, keyed the way the compilation refers to them.
+    let files: SortedMap<FileId, String> = test_case
+        .files
+        .iter()
+        .map(|(name, contents)| (FileId::from(name.as_str()), contents.clone()))
+        .collect();
 
     let resolved = resolve_evm_target(
         test_case.evm_version.as_deref(),
@@ -58,15 +60,7 @@ fn run_test_case(test_case: &IsolTestCase, language_version: LanguageVersion) ->
         }
     };
 
-    let mut builder = CompilationBuilder::create(language_version, evm_target, config);
-
-    // Add every source as a root, so files that aren't reachable via imports
-    // (e.g. sibling sources in a multi-source test) are still analyzed.
-    for file_id in files.keys() {
-        builder.add_file(FileId::from(file_id.as_str()));
-    }
-
-    let unit = builder.build();
+    let unit = compilation::compile(&files, language_version, evm_target);
     let diagnostics = unit.diagnostics();
 
     if diagnostics.is_empty() {
@@ -77,10 +71,7 @@ fn run_test_case(test_case: &IsolTestCase, language_version: LanguageVersion) ->
         .iter()
         .map(|diagnostic| {
             let file_id = diagnostic.file_id();
-            let source = files
-                .get(file_id.as_str())
-                .map(String::as_str)
-                .unwrap_or_default();
+            let source = files.get(file_id).map(String::as_str).unwrap_or_default();
             diagnostic::render(diagnostic, file_id.as_str(), source, false)
         })
         .collect();
@@ -88,60 +79,4 @@ fn run_test_case(test_case: &IsolTestCase, language_version: LanguageVersion) ->
     Ok(Outcome::Failed {
         diagnostics: rendered,
     })
-}
-
-/// Feeds the in-memory sources of an [`IsolTestCase`] to the `slang` compilation
-/// builder, resolving imports between them.
-///
-/// Import resolution reuses the shared [`ImportResolver`] (also used by the
-/// sourcify runner), with each source registered under its own name.
-struct TestConfig {
-    files: OrderedMap<String, String>,
-    resolver: ImportResolver,
-}
-
-impl TestConfig {
-    fn new(files: &OrderedMap<String, String>) -> Self {
-        let source_maps = files
-            .keys()
-            .map(|id| SourceMap {
-                // Our source names are already the "virtual" paths that imports
-                // refer to, so the id and virtual path are the same.
-                source_id: id.clone(),
-                virtual_path: id.clone(),
-            })
-            .collect();
-
-        Self {
-            files: files.clone(),
-            resolver: ImportResolver {
-                import_remaps: Vec::new(),
-                source_maps,
-            },
-        }
-    }
-}
-
-impl CompilationBuilderConfig for TestConfig {
-    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
-        self.files
-            .get(file_id.as_str())
-            .cloned()
-            .ok_or_else(|| MissingFile {
-                reason: format!("no source registered for '{file_id}'"),
-            })
-    }
-
-    fn resolve_import(
-        &mut self,
-        source_file_id: &FileId,
-        import_path: &str,
-    ) -> Result<FileId, UnresolvedImport> {
-        self.resolver
-            .resolve_import(source_file_id.as_str(), import_path)
-            .map(FileId::from)
-            .ok_or_else(|| UnresolvedImport {
-                reason: format!("could not resolve import '{import_path}'"),
-            })
-    }
 }

--- a/crates/solidity-v2/testing/utils/Cargo.toml
+++ b/crates/solidity-v2/testing/utils/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 ariadne = { workspace = true }
 semver = { workspace = true }
 slang_solidity = { workspace = true }
+slang_solidity_v2 = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }
 slang_solidity_v2_parser = { workspace = true }

--- a/crates/solidity-v2/testing/utils/src/compilation.rs
+++ b/crates/solidity-v2/testing/utils/src/compilation.rs
@@ -12,7 +12,7 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 use crate::path_resolver;
 
 /// Compiles `files` at the given language version and EVM target, resolving
-/// imports between them.
+/// imports between them the way `solc` does.
 ///
 /// Every source is added as a root, so a source that is not imported gets
 /// analyzed too.
@@ -54,8 +54,6 @@ impl CompilationBuilderConfig for InMemoryHost {
         source_file_id: &FileId,
         import_path: &str,
     ) -> Result<FileId, UnresolvedImport> {
-        path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
-            reason: "Unresolved import.".to_string(),
-        })
+        Ok(path_resolver::resolve_import(source_file_id, import_path))
     }
 }

--- a/crates/solidity-v2/testing/utils/src/compilation.rs
+++ b/crates/solidity-v2/testing/utils/src/compilation.rs
@@ -1,0 +1,61 @@
+//! Compiles a fixed set of in-memory sources, shared by the v2 test harnesses.
+
+use slang_solidity_v2::compilation::{
+    CompilationBuilder, CompilationBuilderConfig, CompilationUnit,
+};
+use slang_solidity_v2_common::collections::SortedMap;
+use slang_solidity_v2_common::diagnostics::kinds::compilation::{MissingFile, UnresolvedImport};
+use slang_solidity_v2_common::evm_targets::EvmTarget;
+use slang_solidity_v2_common::files::FileId;
+use slang_solidity_v2_common::versions::LanguageVersion;
+
+use crate::path_resolver;
+
+/// Compiles `files` at the given language version and EVM target, resolving
+/// imports between them.
+///
+/// Every source is added as a root, so a source that is not imported gets
+/// analyzed too.
+pub fn compile(
+    files: &SortedMap<FileId, String>,
+    version: LanguageVersion,
+    target: EvmTarget,
+) -> CompilationUnit {
+    let mut builder = CompilationBuilder::create(
+        version,
+        target,
+        InMemoryHost {
+            files: files.clone(),
+        },
+    );
+
+    for file_id in files.keys() {
+        builder.add_file(file_id.clone());
+    }
+
+    builder.build()
+}
+
+/// Serves the sources it was given; anything else is reported as a missing file
+/// rather than a harness error.
+struct InMemoryHost {
+    files: SortedMap<FileId, String>,
+}
+
+impl CompilationBuilderConfig for InMemoryHost {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
+        self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
+            reason: "File not found.".to_string(),
+        })
+    }
+
+    fn resolve_import(
+        &mut self,
+        source_file_id: &FileId,
+        import_path: &str,
+    ) -> Result<FileId, UnresolvedImport> {
+        path_resolver::resolve_import(source_file_id, import_path).ok_or_else(|| UnresolvedImport {
+            reason: "Unresolved import.".to_string(),
+        })
+    }
+}

--- a/crates/solidity-v2/testing/utils/src/compilation.rs
+++ b/crates/solidity-v2/testing/utils/src/compilation.rs
@@ -11,8 +11,7 @@ use slang_solidity_v2_common::versions::LanguageVersion;
 
 use crate::path_resolver;
 
-/// Compiles `files` at the given language version and EVM target, resolving
-/// imports between them the way `solc` does.
+/// Compiles `files` at the given language version and EVM target.
 ///
 /// Every source is added as a root, so a source that is not imported gets
 /// analyzed too.
@@ -24,7 +23,7 @@ pub fn compile(
     let mut builder = CompilationBuilder::create(
         version,
         target,
-        InMemoryHost {
+        InMemoryConfig {
             files: files.clone(),
         },
     );
@@ -38,11 +37,11 @@ pub fn compile(
 
 /// Serves the sources it was given; anything else is reported as a missing file
 /// rather than a harness error.
-struct InMemoryHost {
+struct InMemoryConfig {
     files: SortedMap<FileId, String>,
 }
 
-impl CompilationBuilderConfig for InMemoryHost {
+impl CompilationBuilderConfig for InMemoryConfig {
     fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         self.files.get(file_id).cloned().ok_or_else(|| MissingFile {
             reason: "File not found.".to_string(),

--- a/crates/solidity-v2/testing/utils/src/lib.rs
+++ b/crates/solidity-v2/testing/utils/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod compilation;
 pub mod cst_renderer;
+pub mod path_resolver;
 pub mod reporting;
 pub mod v1_comparison;

--- a/crates/solidity-v2/testing/utils/src/path_resolver.rs
+++ b/crates/solidity-v2/testing/utils/src/path_resolver.rs
@@ -1,14 +1,23 @@
-use slang_solidity_v2::compilation::FileId;
+//! Resolves imports between in-memory sources the way `solc` does for a
+//! standard JSON input with no remappings:
+//!
+//! - An import path starting with `.` or `..` is *relative*: joined onto the
+//!   importing source's name (minus its last segment) and normalized.
+//! - Anything else is *direct*: it names a source verbatim and is not
+//!   normalized, so a source named `C/../////D/d.sol` is importable.
 
-/// Resolve an import path relative to a source file.
+use slang_solidity_v2_common::files::FileId;
+
+/// Resolves `import_path` as written inside the source named `source_file_id`,
+/// yielding the name of the source it refers to.
 ///
-/// `import_path` is the unquoted import path as provided by the v2
-/// `CompilationBuilderConfig::resolve_import` callback.
-pub fn resolve_import(source_file_id: &FileId, import_path: &str) -> Option<FileId> {
+/// Always yields a name; whether the compilation has a source under that name
+/// is a separate question, reported as a missing file.
+pub fn resolve_import(source_file_id: &FileId, import_path: &str) -> FileId {
     if is_relative_path(import_path) {
-        normalize_path(import_path, get_parent_path(source_file_id.as_str())).map(FileId::from)
+        normalize_path(import_path, get_parent_path(source_file_id.as_str())).into()
     } else {
-        Some(import_path.into())
+        import_path.into()
     }
 }
 
@@ -16,37 +25,55 @@ fn is_relative_path(path: &str) -> bool {
     path.starts_with("./") || path.starts_with("../")
 }
 
+/// The directory part of `path`, including its trailing `/` (empty when `path`
+/// has no directory part).
 fn get_parent_path(path: &str) -> &str {
     let sep_index = path.rfind('/').map_or(0usize, |index| index + 1);
     &path[..sep_index]
 }
 
-fn normalize_path(path: &str, base_path: &str) -> Option<String> {
-    let mut normalized = base_path.to_string();
-    let mut path = path;
-    while let Some(index) = path.find('/') {
-        match &path[..=index] {
-            "/" | "./" => (),
-            "../" => {
-                if normalized.is_empty() {
-                    return None;
+/// Joins a relative `path` onto `base_path` and normalizes away `.` and `..`
+/// segments.
+///
+/// Source names are `/`-separated whatever the host, so this works on `str`
+/// rather than `std::path`, whose separators and prefixes vary by platform.
+///
+/// `..` past the root is dropped rather than rejected, as it is in `solc`:
+/// `../../../../x/h.sol` from `dir/contract.sol` resolves to `x/h.sol`, and a
+/// rooted base path loses its root the same way.
+fn normalize_path(path: &str, base_path: &str) -> String {
+    let mut rooted = base_path.starts_with('/');
+    let mut segments: Vec<&str> = base_path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if segments.pop().is_none() {
+                    rooted = false;
                 }
-                let last_sep = normalized[..normalized.len() - 1]
-                    .rfind('/')
-                    .unwrap_or(0usize);
-                normalized.drain(last_sep..);
             }
-            other => normalized.push_str(other),
+            segment => segments.push(segment),
         }
-        path = &path[index + 1..];
     }
-    normalized.push_str(path);
-    Some(normalized)
+
+    let root = if rooted { "/" } else { "" };
+
+    format!("{root}{}", segments.join("/"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn resolve(source: &str, import: &str) -> String {
+        resolve_import(&FileId::from(source), import)
+            .as_str()
+            .to_owned()
+    }
 
     #[test]
     fn test_get_parent_path() {
@@ -57,24 +84,129 @@ mod tests {
 
     #[test]
     fn test_normalize_path() {
-        assert_eq!("foo.sol", normalize_path("foo.sol", "").unwrap());
-        assert_eq!("bar/foo.sol", normalize_path("foo.sol", "bar/").unwrap());
-        assert_eq!("bar/foo.sol", normalize_path("./foo.sol", "bar/").unwrap());
-        assert_eq!("foo.sol", normalize_path("../foo.sol", "bar/").unwrap());
-        assert_eq!("foo.sol", normalize_path("./../foo.sol", "bar/").unwrap());
+        assert_eq!("foo.sol", normalize_path("foo.sol", ""));
+        assert_eq!("bar/foo.sol", normalize_path("foo.sol", "bar/"));
+        assert_eq!("bar/foo.sol", normalize_path("./foo.sol", "bar/"));
+        assert_eq!("foo.sol", normalize_path("../foo.sol", "bar/"));
+        assert_eq!("foo.sol", normalize_path("./../foo.sol", "bar/"));
+        assert_eq!("foo.sol", normalize_path("../../foo.sol", "bar/baz/"));
+        assert_eq!("foo.sol", normalize_path(".././../foo.sol", "bar/baz/"));
+        assert_eq!("baz/foo.sol", normalize_path("../baz/foo.sol", "bar/"));
+
+        // `..` with nothing left to walk up yields the name anyway.
+        assert_eq!("foo.sol", normalize_path("../foo.sol", ""));
+        assert_eq!("foo.sol", normalize_path("../../foo.sol", "bar/"));
+
+        // A rooted base path keeps its root until a `..` pops it.
+        assert_eq!("/bar/foo.sol", normalize_path("./foo.sol", "/bar/"));
+        assert_eq!("/foo.sol", normalize_path("../foo.sol", "/bar/"));
+        assert_eq!("foo.sol", normalize_path("../foo.sol", "/"));
+    }
+
+    #[test]
+    fn direct_imports_name_a_source_verbatim() {
+        // However non-normalized they look, these are source names, not paths.
+        assert_eq!("C/../////D/d.sol", resolve("main.sol", "C/../////D/d.sol"));
         assert_eq!(
-            "foo.sol",
-            normalize_path("../../foo.sol", "bar/baz/").unwrap()
+            "_nonNormalizedPaths//a.sol",
+            resolve("main.sol", "_nonNormalizedPaths//a.sol")
+        );
+        assert_eq!("/ExtSource.sol", resolve("main.sol", "/ExtSource.sol"));
+        assert_eq!("a", resolve("main.sol", "a"));
+        assert_eq!(
+            "sub_external.sol",
+            resolve("dir/deep/main.sol", "sub_external.sol")
+        );
+    }
+
+    #[test]
+    fn relative_imports_resolve_against_the_importing_source() {
+        assert_eq!("a.sol", resolve("main.sol", "./a.sol"));
+        assert_eq!("dir/a.sol", resolve("dir/main.sol", "./a.sol"));
+        assert_eq!("b.sol", resolve("dir/main.sol", "../b.sol"));
+
+        // Walking up from a nested directory keeps the path separated.
+        assert_eq!("pre/b.sol", resolve("pre/dir/main.sol", "../b.sol"));
+        assert_eq!("pre/x/b.sol", resolve("pre/dir/main.sol", "../x/b.sol"));
+        assert_eq!("a/b.sol", resolve("a/b/c/main.sol", "../../b.sol"));
+
+        // `.` and `..` mix freely within one path.
+        assert_eq!("b.sol", resolve("dir/main.sol", "./../b.sol"));
+        assert_eq!("a/b.sol", resolve("a/b/c/main.sol", ".././../b.sol"));
+    }
+
+    /// `..` above the root is dropped, so resolution still lands on a name.
+    #[test]
+    fn dot_dot_past_the_root_is_clamped() {
+        assert_eq!("oops.sol", resolve("input.sol", "../../oops.sol"));
+        assert_eq!("oops.sol", resolve("dir/input.sol", "../../oops.sol"));
+        assert_eq!("oops.sol", resolve("dir/input.sol", "../../../../oops.sol"));
+        assert_eq!(
+            "x/h.sol",
+            resolve("dir/contract.sol", "../../../../x/h.sol")
+        );
+    }
+
+    /// A rooted source name keeps its root; `..` past it drops the root, as in
+    /// `solc`.
+    #[test]
+    fn rooted_source_names_keep_their_root() {
+        assert_eq!("/dir/a.sol", resolve("/dir/main.sol", "./a.sol"));
+        assert_eq!("/dir/B/b.sol", resolve("/dir/main.sol", "./B/b.sol"));
+        assert_eq!("/b.sol", resolve("/dir/main.sol", "../b.sol"));
+        assert_eq!("/x.sol", resolve("/ExtSource.sol", "./x.sol"));
+
+        // One `..` is enough: `solc` walks up with `parent_path()`, whose parent
+        // of `/` is empty.
+        assert_eq!("x.sol", resolve("/a.sol", "../x.sol"));
+        assert_eq!("x.sol", resolve("/a.sol", "../../x.sol"));
+        assert_eq!("x.sol", resolve("/dir/sub/main.sol", "../../../x.sol"));
+    }
+
+    /// The cases `semanticTests/externalSource/relative_imports.sol` covers.
+    #[test]
+    fn resolves_the_relative_imports_semantic_test() {
+        let source = "_relativeImports/dir/contract.sol";
+
+        assert_eq!("_relativeImports/dir/a.sol", resolve(source, "./a.sol"));
+        assert_eq!("_relativeImports/dir/B/b.sol", resolve(source, "./B/b.sol"));
+        assert_eq!("_relativeImports/c.sol", resolve(source, "../c.sol"));
+        assert_eq!("_relativeImports/D/d.sol", resolve(source, "../D/d.sol"));
+        assert_eq!(
+            "_relativeImports/dir/G/g.sol",
+            resolve(source, "./E/../F/../G/./g.sol")
+        );
+
+        assert_eq!(
+            "_relativeImports/h.sol",
+            resolve(source, "../../../../_relativeImports/h.sol")
+        );
+
+        assert_eq!(
+            "_relativeImports/c.sol",
+            resolve("_relativeImports/dir/B/b.sol", "../../c.sol")
         );
         assert_eq!(
-            "foo.sol",
-            normalize_path(".././../foo.sol", "bar/baz/").unwrap()
+            "_relativeImports/dir/B/b.sol",
+            resolve("_relativeImports/dir/G/g.sol", "../B/b.sol")
+        );
+    }
+
+    /// Sources named `./a.sol` and `../b.sol` exist in
+    /// `semanticTests/externalSource/source_name_starting_with_dots.sol`; a
+    /// relative import spelled the same way resolves against the importing
+    /// source anyway.
+    #[test]
+    fn dot_prefixed_source_names_do_not_capture_relative_imports() {
+        let source = "_sourceNameStartingWithDots/dir/contract.sol";
+
+        assert_eq!(
+            "_sourceNameStartingWithDots/dir/a.sol",
+            resolve(source, "./a.sol")
         );
         assert_eq!(
-            "baz/foo.sol",
-            normalize_path("../baz/foo.sol", "bar/").unwrap()
+            "_sourceNameStartingWithDots/b.sol",
+            resolve(source, "../b.sol")
         );
-        assert!(normalize_path("../foo.sol", "").is_none());
-        assert!(normalize_path("../../foo.sol", "bar/").is_none());
     }
 }

--- a/crates/solidity-v2/testing/utils/src/path_resolver.rs
+++ b/crates/solidity-v2/testing/utils/src/path_resolver.rs
@@ -4,7 +4,7 @@ use slang_solidity_v2::compilation::FileId;
 ///
 /// `import_path` is the unquoted import path as provided by the v2
 /// `CompilationBuilderConfig::resolve_import` callback.
-pub(crate) fn resolve_import(source_file_id: &FileId, import_path: &str) -> Option<FileId> {
+pub fn resolve_import(source_file_id: &FileId, import_path: &str) -> Option<FileId> {
     if is_relative_path(import_path) {
         normalize_path(import_path, get_parent_path(source_file_id.as_str())).map(FileId::from)
     } else {


### PR DESCRIPTION
Merged all v2 test harnesses import resolvers into a new one, fixed some bugs and changed the rules to agree with solc.
The solc semantic test suite run uses the new resolver, fixing some of the remainings divergences.

Test-only: no shipped crate changes behavior.

### Commits

1. **`refactor(testing)`: share the v2 import resolver and compilation host across snapshot harnesses** —
   the binder and diagnostics harnesses stop carrying their own resolver and
   compilation config, behaviour is kept the same.
2. **`fix(testing)`: resolve v2 test imports the way solc resolves them** —
   fixes the parent-walk bug, and makes `..` past the root resolve to a missing
   file rather than an unresolvable import, as solc does. A snapshot test changed diagnostic, added a unit test to check `UnresolvedImport` diagnostics.
3. **`refactor(solc-comparison)`: resolve imports with the shared v2 resolver** —
   the solc harness drops v1's sourcify-oriented resolver, gaining
   `externalSource/non_normalized_paths.sol` at every version.