### PR TITLE
[v2] feat(parser): Parallelize parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,12 +99,14 @@ You can also use `nextest` directly for faster iteration on Rust tests:
 
 ## Parallelism (v2)
 
-`CompilationUnit::create()` parses source files in parallel over `rayon`'s global thread pool; IR
-building and semantic analysis are still sequential. One invariant holds it together: **output must
-not depend on the thread count.** Files are lowered to IR in `FileId` order, and that is what makes
-node ids stable — so the parse phase has to hand them back in that order, which is why it collects
-from an _indexed_ parallel iterator. `slang_solidity/src/tests/thread_safety.rs` guards this, both
-across pool sizes and across concurrent builds.
+`CompilationUnit::create()` parses source files in parallel over `rayon`'s ambient thread pool
+(the caller's installed pool, or the global one otherwise); IR building and semantic analysis are
+still sequential. `Concurrency::Inline` in the `Configuration` pins the whole compilation to the
+calling thread instead. One invariant holds it together: **output must not depend on the
+concurrency choice.** Files are lowered to IR in `FileId` order, and that is what makes node ids
+stable — so the parse phase has to hand them back in that order, which is why it collects from an
+_indexed_ parallel iterator. `slang_solidity/src/tests/thread_safety.rs` guards this, both across
+pool sizes and across concurrent builds.
 
 ## Code Generation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,15 @@ You can also use `nextest` directly for faster iteration on Rust tests:
 ./bin/cargo nextest run [FILTERS]         # Run tests that match specific filters (test names or file patterns)
 ```
 
+## Parallelism (v2)
+
+`CompilationUnit::create()` parses source files in parallel over `rayon`'s global thread pool; IR
+building and semantic analysis are still sequential. One invariant holds it together: **output must
+not depend on the thread count.** Files are lowered to IR in `FileId` order, and that is what makes
+node ids stable — so the parse phase has to hand them back in that order, which is why it collects
+from an _indexed_ parallel iterator. `slang_solidity/src/tests/thread_safety.rs` guards this, both
+across pool sizes and across concurrent builds.
+
 ## Code Generation
 
 Many source files are auto-generated, and are either under a `/generated/` directory, or have `*.generated.*` in their name.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4085,6 +4085,7 @@ version = "1.3.8"
 dependencies = [
  "num-bigint",
  "num-rational",
+ "rayon",
  "ruint",
  "serde_json",
  "slang_solidity_v2_ast",
@@ -4476,6 +4477,7 @@ dependencies = [
  "gungraun",
  "infra_utils",
  "paste",
+ "rayon",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/ir/Cargo.toml
@@ -18,6 +18,10 @@ license = "MIT"
 keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
+[features]
+default = []
+__private_testing_utils = []
+
 [dependencies]
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -577,8 +577,12 @@ impl slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::AdditiveExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
@@ -588,8 +592,12 @@ pub slang_solidity_v2_ir::ir::ArgumentsDeclaration::NamedArguments(slang_solidit
 pub slang_solidity_v2_ir::ir::ArgumentsDeclaration::PositionalArguments(slang_solidity_v2_ir::ir::PositionalArguments)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::clone(&self) -> slang_solidity_v2_ir::ir::ArgumentsDeclaration
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
+pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::eq(&self, &slang_solidity_v2_ir::ir::ArgumentsDeclaration) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArgumentsDeclaration
@@ -611,8 +619,12 @@ impl slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::AssignmentExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
@@ -648,8 +660,12 @@ pub slang_solidity_v2_ir::ir::ContractMember::UserDefinedValueTypeDefinition(sla
 pub slang_solidity_v2_ir::ir::ContractMember::UsingDirective(slang_solidity_v2_ir::ir::UsingDirective)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::clone(&self) -> slang_solidity_v2_ir::ir::ContractMember
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContractMember
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContractMember
+pub fn slang_solidity_v2_ir::ir::ContractMember::eq(&self, &slang_solidity_v2_ir::ir::ContractMember) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContractMember
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractMember
@@ -665,8 +681,12 @@ pub slang_solidity_v2_ir::ir::ElementaryType::UfixedKeyword(slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ElementaryType::UintKeyword(slang_solidity_v2_ir::ir::UintKeyword)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::clone(&self) -> slang_solidity_v2_ir::ir::ElementaryType
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ElementaryType
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ElementaryType
+pub fn slang_solidity_v2_ir::ir::ElementaryType::eq(&self, &slang_solidity_v2_ir::ir::ElementaryType) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ElementaryType
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ElementaryType
@@ -678,8 +698,12 @@ impl slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::EqualityExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::EqualityExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionOperator
@@ -740,8 +764,12 @@ pub slang_solidity_v2_ir::ir::Expression::TupleExpression(slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::Expression::TypeExpression(slang_solidity_v2_ir::ir::TypeExpression)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::clone(&self) -> slang_solidity_v2_ir::ir::Expression
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::Expression
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Expression
+pub fn slang_solidity_v2_ir::ir::Expression::eq(&self, &slang_solidity_v2_ir::ir::Expression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Expression
@@ -751,8 +779,12 @@ pub slang_solidity_v2_ir::ir::ForStatementCondition::ExpressionStatement(slang_s
 pub slang_solidity_v2_ir::ir::ForStatementCondition::Semicolon(slang_solidity_v2_ir::ir::Semicolon)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementCondition
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementCondition
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementCondition
+pub fn slang_solidity_v2_ir::ir::ForStatementCondition::eq(&self, &slang_solidity_v2_ir::ir::ForStatementCondition) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementCondition
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementCondition
@@ -763,8 +795,12 @@ pub slang_solidity_v2_ir::ir::ForStatementInitialization::Semicolon(slang_solidi
 pub slang_solidity_v2_ir::ir::ForStatementInitialization::VariableDeclarationStatement(slang_solidity_v2_ir::ir::VariableDeclarationStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementInitialization
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementInitialization
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementInitialization
+pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::eq(&self, &slang_solidity_v2_ir::ir::ForStatementInitialization) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementInitialization
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementInitialization
@@ -835,8 +871,12 @@ pub slang_solidity_v2_ir::ir::ImportClause::ImportDeconstruction(slang_solidity_
 pub slang_solidity_v2_ir::ir::ImportClause::PathImport(slang_solidity_v2_ir::ir::PathImport)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::clone(&self) -> slang_solidity_v2_ir::ir::ImportClause
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportClause
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportClause
+pub fn slang_solidity_v2_ir::ir::ImportClause::eq(&self, &slang_solidity_v2_ir::ir::ImportClause) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportClause
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportClause
@@ -850,8 +890,12 @@ impl slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::InequalityExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::InequalityExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionOperator
@@ -864,8 +908,12 @@ impl slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
@@ -1065,8 +1113,12 @@ impl slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::clone(&self) -> slang_solidity_v2_ir::ir::NumberUnit
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::NumberUnit
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NumberUnit
+pub fn slang_solidity_v2_ir::ir::NumberUnit::eq(&self, &slang_solidity_v2_ir::ir::NumberUnit) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NumberUnit
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NumberUnit
@@ -1078,8 +1130,12 @@ impl slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PostfixExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::PostfixExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionOperator
@@ -1090,8 +1146,12 @@ pub slang_solidity_v2_ir::ir::Pragma::ExperimentalPragma(slang_solidity_v2_ir::i
 pub slang_solidity_v2_ir::ir::Pragma::VersionPragma(slang_solidity_v2_ir::ir::VersionPragma)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::clone(&self) -> slang_solidity_v2_ir::ir::Pragma
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::Pragma
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Pragma
+pub fn slang_solidity_v2_ir::ir::Pragma::eq(&self, &slang_solidity_v2_ir::ir::Pragma) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Pragma
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Pragma
@@ -1107,8 +1167,12 @@ impl slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PrefixExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::PrefixExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionOperator
@@ -1121,8 +1185,12 @@ impl slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::ShiftExpressionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::ShiftExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionOperator
@@ -1143,8 +1211,12 @@ pub slang_solidity_v2_ir::ir::SourceUnitMember::UserDefinedValueTypeDefinition(s
 pub slang_solidity_v2_ir::ir::SourceUnitMember::UsingDirective(slang_solidity_v2_ir::ir::UsingDirective)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::clone(&self) -> slang_solidity_v2_ir::ir::SourceUnitMember
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::SourceUnitMember
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SourceUnitMember
+pub fn slang_solidity_v2_ir::ir::SourceUnitMember::eq(&self, &slang_solidity_v2_ir::ir::SourceUnitMember) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SourceUnitMember
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitMember
@@ -1206,8 +1278,12 @@ pub slang_solidity_v2_ir::ir::Statement::VariableDeclarationStatement(slang_soli
 pub slang_solidity_v2_ir::ir::Statement::WhileStatement(slang_solidity_v2_ir::ir::WhileStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::clone(&self) -> slang_solidity_v2_ir::ir::Statement
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::Statement
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Statement
+pub fn slang_solidity_v2_ir::ir::Statement::eq(&self, &slang_solidity_v2_ir::ir::Statement) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Statement
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Statement
@@ -1220,8 +1296,12 @@ impl slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::clone(&self) -> slang_solidity_v2_ir::ir::StorageLocation
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StorageLocation
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StorageLocation
+pub fn slang_solidity_v2_ir::ir::StorageLocation::eq(&self, &slang_solidity_v2_ir::ir::StorageLocation) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StorageLocation
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StorageLocation
@@ -1232,8 +1312,12 @@ pub slang_solidity_v2_ir::ir::StringExpression::StringLiterals(slang_solidity_v2
 pub slang_solidity_v2_ir::ir::StringExpression::UnicodeStringLiterals(slang_solidity_v2_ir::ir::UnicodeStringLiterals)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::clone(&self) -> slang_solidity_v2_ir::ir::StringExpression
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StringExpression
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StringExpression
+pub fn slang_solidity_v2_ir::ir::StringExpression::eq(&self, &slang_solidity_v2_ir::ir::StringExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StringExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StringExpression
@@ -1246,8 +1330,12 @@ pub slang_solidity_v2_ir::ir::TypeName::IdentifierPath(slang_solidity_v2_ir::ir:
 pub slang_solidity_v2_ir::ir::TypeName::MappingType(slang_solidity_v2_ir::ir::MappingType)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::clone(&self) -> slang_solidity_v2_ir::ir::TypeName
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::TypeName
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TypeName
+pub fn slang_solidity_v2_ir::ir::TypeName::eq(&self, &slang_solidity_v2_ir::ir::TypeName) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeName
@@ -1257,8 +1345,12 @@ pub slang_solidity_v2_ir::ir::UsingClause::IdentifierPath(slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::UsingClause::UsingDeconstruction(slang_solidity_v2_ir::ir::UsingDeconstruction)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::clone(&self) -> slang_solidity_v2_ir::ir::UsingClause
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingClause
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingClause
+pub fn slang_solidity_v2_ir::ir::UsingClause::eq(&self, &slang_solidity_v2_ir::ir::UsingClause) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingClause
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingClause
@@ -1283,8 +1375,12 @@ impl slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::clone(&self) -> slang_solidity_v2_ir::ir::UsingOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingOperator
+pub fn slang_solidity_v2_ir::ir::UsingOperator::eq(&self, &slang_solidity_v2_ir::ir::UsingOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingOperator
@@ -1294,8 +1390,12 @@ pub slang_solidity_v2_ir::ir::UsingTarget::Asterisk(slang_solidity_v2_ir::ir::As
 pub slang_solidity_v2_ir::ir::UsingTarget::TypeName(slang_solidity_v2_ir::ir::TypeName)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::clone(&self) -> slang_solidity_v2_ir::ir::UsingTarget
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingTarget
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingTarget
+pub fn slang_solidity_v2_ir::ir::UsingTarget::eq(&self, &slang_solidity_v2_ir::ir::UsingTarget) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingTarget
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingTarget
@@ -1305,8 +1405,12 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationTarget::MultiTypedDeclaration(s
 pub slang_solidity_v2_ir::ir::VariableDeclarationTarget::SingleTypedDeclaration(slang_solidity_v2_ir::ir::SingleTypedDeclaration)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::clone(&self) -> slang_solidity_v2_ir::ir::VariableDeclarationTarget
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationTarget) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationTarget
@@ -1316,8 +1420,12 @@ pub slang_solidity_v2_ir::ir::VersionExpression::VersionRange(slang_solidity_v2_
 pub slang_solidity_v2_ir::ir::VersionExpression::VersionTerm(slang_solidity_v2_ir::ir::VersionTerm)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::clone(&self) -> slang_solidity_v2_ir::ir::VersionExpression
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionExpression
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionExpression
+pub fn slang_solidity_v2_ir::ir::VersionExpression::eq(&self, &slang_solidity_v2_ir::ir::VersionExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionExpression
@@ -1327,8 +1435,12 @@ pub slang_solidity_v2_ir::ir::VersionLiteral::SimpleVersionLiteral(slang_solidit
 pub slang_solidity_v2_ir::ir::VersionLiteral::StringLiteral(slang_solidity_v2_ir::ir::StringLiteral)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::clone(&self) -> slang_solidity_v2_ir::ir::VersionLiteral
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionLiteral
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionLiteral
+pub fn slang_solidity_v2_ir::ir::VersionLiteral::eq(&self, &slang_solidity_v2_ir::ir::VersionLiteral) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionLiteral
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionLiteral
@@ -1345,8 +1457,12 @@ impl slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::clone(&self) -> slang_solidity_v2_ir::ir::VersionOperator
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionOperator
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionOperator
+pub fn slang_solidity_v2_ir::ir::VersionOperator::eq(&self, &slang_solidity_v2_ir::ir::VersionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionOperator
@@ -1357,8 +1473,12 @@ pub slang_solidity_v2_ir::ir::YulExpression::YulLiteral(slang_solidity_v2_ir::ir
 pub slang_solidity_v2_ir::ir::YulExpression::YulPath(slang_solidity_v2_ir::ir::YulPath)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::clone(&self) -> slang_solidity_v2_ir::ir::YulExpression
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulExpression
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulExpression
+pub fn slang_solidity_v2_ir::ir::YulExpression::eq(&self, &slang_solidity_v2_ir::ir::YulExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulExpression
@@ -1374,8 +1494,12 @@ impl slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::clone(&self) -> slang_solidity_v2_ir::ir::YulLiteral
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulLiteral
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulLiteral
+pub fn slang_solidity_v2_ir::ir::YulLiteral::eq(&self, &slang_solidity_v2_ir::ir::YulLiteral) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulLiteral
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLiteral
@@ -1394,8 +1518,12 @@ pub slang_solidity_v2_ir::ir::YulStatement::YulVariableAssignmentStatement(slang
 pub slang_solidity_v2_ir::ir::YulStatement::YulVariableDeclarationStatement(slang_solidity_v2_ir::ir::YulVariableDeclarationStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::clone(&self) -> slang_solidity_v2_ir::ir::YulStatement
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulStatement
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulStatement
+pub fn slang_solidity_v2_ir::ir::YulStatement::eq(&self, &slang_solidity_v2_ir::ir::YulStatement) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulStatement
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulStatement
@@ -1405,8 +1533,12 @@ pub slang_solidity_v2_ir::ir::AbicoderPragmaStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::AbicoderPragmaStruct::version: slang_solidity_v2_ir::ir::AbicoderVersion
 impl slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
+pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::AbicoderPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
@@ -1418,8 +1550,12 @@ pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AdditiveExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
@@ -1429,8 +1565,12 @@ pub slang_solidity_v2_ir::ir::AddressTypeStruct::is_payable: bool
 pub slang_solidity_v2_ir::ir::AddressTypeStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AddressTypeStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AddressTypeStruct
+pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::AddressTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AddressTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AddressTypeStruct
@@ -1475,8 +1615,12 @@ pub slang_solidity_v2_ir::ir::AndExpressionStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::AndExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AndExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AndExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AndExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AndExpressionStruct
@@ -1486,8 +1630,12 @@ pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::items: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ArrayExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayExpressionStruct
@@ -1498,8 +1646,12 @@ pub slang_solidity_v2_ir::ir::ArrayTypeNameStruct::operand: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ArrayTypeNameStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
+pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::eq(&self, &slang_solidity_v2_ir::ir::ArrayTypeNameStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
@@ -1510,8 +1662,12 @@ pub slang_solidity_v2_ir::ir::AssemblyStatementStruct::is_memory_safe: bool
 pub slang_solidity_v2_ir::ir::AssemblyStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
+pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::AssemblyStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssemblyStatementStruct
@@ -1523,8 +1679,12 @@ pub slang_solidity_v2_ir::ir::AssignmentExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::AssignmentExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
+pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AssignmentExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
@@ -1637,8 +1797,12 @@ pub slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
@@ -1649,8 +1813,12 @@ pub slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::range: core::ops::range
 pub slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
@@ -1661,8 +1829,12 @@ pub slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
+pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
@@ -1672,8 +1844,12 @@ pub slang_solidity_v2_ir::ir::BlockStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::BlockStruct::statements: slang_solidity_v2_ir::ir::Statements
 impl slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::BlockStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BlockStruct
+pub fn slang_solidity_v2_ir::ir::BlockStruct::eq(&self, &slang_solidity_v2_ir::ir::BlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BlockStruct
@@ -1699,8 +1875,12 @@ pub struct slang_solidity_v2_ir::ir::BreakStatementStruct
 pub slang_solidity_v2_ir::ir::BreakStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::BreakStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::BreakStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BreakStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BreakStatementStruct
@@ -1749,8 +1929,12 @@ pub slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::options: slang_solidi
 pub slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
+pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::CallOptionsExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
@@ -1796,8 +1980,12 @@ pub slang_solidity_v2_ir::ir::CatchClauseStruct::parameters: core::option::Optio
 pub slang_solidity_v2_ir::ir::CatchClauseStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::CatchClauseStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::CatchClauseStruct
+pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::eq(&self, &slang_solidity_v2_ir::ir::CatchClauseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CatchClauseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CatchClauseStruct
@@ -1809,8 +1997,12 @@ pub slang_solidity_v2_ir::ir::ConditionalExpressionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::ConditionalExpressionStruct::true_expression: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ConditionalExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
@@ -1823,8 +2015,12 @@ pub slang_solidity_v2_ir::ir::ConstantDefinitionStruct::value: core::option::Opt
 pub slang_solidity_v2_ir::ir::ConstantDefinitionStruct::visibility: core::option::Option<slang_solidity_v2_ir::ir::StateVariableVisibility>
 impl slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ConstantDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
@@ -1833,8 +2029,12 @@ pub struct slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub slang_solidity_v2_ir::ir::ContinueStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContinueStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ContinueStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContinueStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContinueStatementStruct
@@ -1848,8 +2048,12 @@ pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::storage_layout: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ContractDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractDefinitionStruct
@@ -1895,8 +2099,12 @@ pub slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::range: core::ops::r
 pub slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::unit: core::option::Option<slang_solidity_v2_ir::ir::NumberUnit>
 impl slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
@@ -1924,8 +2132,12 @@ pub slang_solidity_v2_ir::ir::DoWhileStatementStruct::condition: slang_solidity_
 pub slang_solidity_v2_ir::ir::DoWhileStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::DoWhileStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DoWhileStatementStruct
@@ -1936,8 +2148,12 @@ pub slang_solidity_v2_ir::ir::EmitStatementStruct::event: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::EmitStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::EmitStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EmitStatementStruct
+pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::EmitStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EmitStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EmitStatementStruct
@@ -1948,8 +2164,12 @@ pub slang_solidity_v2_ir::ir::EnumDefinitionStruct::name: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::EnumDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::EnumDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EnumDefinitionStruct
@@ -1995,8 +2215,12 @@ pub slang_solidity_v2_ir::ir::EqualityExpressionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::EqualityExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::EqualityExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionStruct
@@ -2007,8 +2231,12 @@ pub slang_solidity_v2_ir::ir::ErrorDefinitionStruct::parameters: slang_solidity_
 pub slang_solidity_v2_ir::ir::ErrorDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ErrorDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
@@ -2037,8 +2265,12 @@ pub slang_solidity_v2_ir::ir::EventDefinitionStruct::parameters: slang_solidity_
 pub slang_solidity_v2_ir::ir::EventDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::EventDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EventDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::EventDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EventDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EventDefinitionStruct
@@ -2048,8 +2280,12 @@ pub slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::feature: slang_solidity_
 pub slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
+pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::ExperimentalPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
@@ -2060,8 +2296,12 @@ pub slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::range: core::ops::
 pub slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ExponentiationExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
@@ -2071,8 +2311,12 @@ pub slang_solidity_v2_ir::ir::ExpressionStatementStruct::expression: slang_solid
 pub slang_solidity_v2_ir::ir::ExpressionStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
+pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ExpressionStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExpressionStatementStruct
@@ -2120,8 +2364,12 @@ pub slang_solidity_v2_ir::ir::ForStatementStruct::iterator: core::option::Option
 pub slang_solidity_v2_ir::ir::ForStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementStruct
+pub fn slang_solidity_v2_ir::ir::ForStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ForStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementStruct
@@ -2136,8 +2384,12 @@ pub slang_solidity_v2_ir::ir::FunctionAttributesStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::FunctionAttributesStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
+pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionAttributesStruct
@@ -2148,8 +2400,12 @@ pub slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::operand: slang_solid
 pub slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionCallExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
@@ -2167,8 +2423,12 @@ pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::id(&self) -> slang_so
 impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::is_externally_visible(&self) -> bool
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::signature_text_range(&self) -> core::ops::range::Range<usize>
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
@@ -2179,8 +2439,12 @@ pub slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::range: core::ops::ra
 pub slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
+pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
@@ -2192,8 +2456,12 @@ pub slang_solidity_v2_ir::ir::FunctionTypeStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::FunctionTypeStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::Parameters>
 impl slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionTypeStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionTypeStruct
+pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeStruct
@@ -2340,8 +2608,12 @@ pub slang_solidity_v2_ir::ir::HexNumberExpressionStruct::literal: slang_solidity
 pub slang_solidity_v2_ir::ir::HexNumberExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
+pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::HexNumberExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
@@ -2406,8 +2678,12 @@ pub slang_solidity_v2_ir::ir::IfStatementStruct::else_branch: core::option::Opti
 pub slang_solidity_v2_ir::ir::IfStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::IfStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::IfStatementStruct
+pub fn slang_solidity_v2_ir::ir::IfStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::IfStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IfStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IfStatementStruct
@@ -2418,8 +2694,12 @@ pub slang_solidity_v2_ir::ir::ImportDeconstructionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::ImportDeconstructionStruct::symbols: slang_solidity_v2_ir::ir::ImportDeconstructionSymbols
 impl slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::eq(&self, &slang_solidity_v2_ir::ir::ImportDeconstructionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
@@ -2430,8 +2710,12 @@ pub slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::name: slang_soli
 pub slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::eq(&self, &slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
@@ -2444,8 +2728,12 @@ pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::start: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::IndexAccessExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
@@ -2457,8 +2745,12 @@ pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
+pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::InequalityExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionStruct
@@ -2469,8 +2761,12 @@ pub slang_solidity_v2_ir::ir::InheritanceTypeStruct::range: core::ops::range::Ra
 pub slang_solidity_v2_ir::ir::InheritanceTypeStruct::type_name: slang_solidity_v2_ir::ir::IdentifierPath
 impl slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
+pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::InheritanceTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InheritanceTypeStruct
@@ -2500,8 +2796,12 @@ pub slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::name: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::InterfaceDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
@@ -2580,8 +2880,12 @@ pub slang_solidity_v2_ir::ir::LibraryDefinitionStruct::name: slang_solidity_v2_i
 pub slang_solidity_v2_ir::ir::LibraryDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::LibraryDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
@@ -2592,8 +2896,12 @@ pub slang_solidity_v2_ir::ir::MappingTypeStruct::range: core::ops::range::Range<
 pub slang_solidity_v2_ir::ir::MappingTypeStruct::value_type: slang_solidity_v2_ir::ir::Parameter
 impl slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MappingTypeStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MappingTypeStruct
+pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::MappingTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MappingTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MappingTypeStruct
@@ -2604,8 +2912,12 @@ pub slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::operand: slang_solid
 pub slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::MemberAccessExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
@@ -2701,8 +3013,12 @@ pub slang_solidity_v2_ir::ir::ModifierInvocationStruct::name: slang_solidity_v2_
 pub slang_solidity_v2_ir::ir::ModifierInvocationStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
+pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::eq(&self, &slang_solidity_v2_ir::ir::ModifierInvocationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ModifierInvocationStruct
@@ -2712,8 +3028,12 @@ pub slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::member: core::
 pub slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
@@ -2724,8 +3044,12 @@ pub slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::value: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
@@ -2737,8 +3061,12 @@ pub slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::range: core::ops::
 pub slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
@@ -2749,8 +3077,12 @@ pub slang_solidity_v2_ir::ir::NamedArgumentStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::NamedArgumentStruct::value: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::NamedArgumentStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NamedArgumentStruct
+pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::eq(&self, &slang_solidity_v2_ir::ir::NamedArgumentStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NamedArgumentStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NamedArgumentStruct
@@ -2760,8 +3092,12 @@ pub slang_solidity_v2_ir::ir::NewExpressionStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::NewExpressionStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::NewExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NewExpressionStruct
+pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::NewExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NewExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NewExpressionStruct
@@ -2789,8 +3125,12 @@ pub slang_solidity_v2_ir::ir::OrExpressionStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::OrExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::OrExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::OrExpressionStruct
+pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::OrExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::OrExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::OrExpressionStruct
@@ -2803,8 +3143,12 @@ pub slang_solidity_v2_ir::ir::ParameterStruct::storage_location: core::option::O
 pub slang_solidity_v2_ir::ir::ParameterStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ParameterStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ParameterStruct
+pub fn slang_solidity_v2_ir::ir::ParameterStruct::eq(&self, &slang_solidity_v2_ir::ir::ParameterStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ParameterStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ParameterStruct
@@ -2815,8 +3159,12 @@ pub slang_solidity_v2_ir::ir::PathImportStruct::path: slang_solidity_v2_ir::ir::
 pub slang_solidity_v2_ir::ir::PathImportStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PathImportStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PathImportStruct
+pub fn slang_solidity_v2_ir::ir::PathImportStruct::eq(&self, &slang_solidity_v2_ir::ir::PathImportStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PathImportStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PathImportStruct
@@ -2929,8 +3277,12 @@ pub slang_solidity_v2_ir::ir::PostfixExpressionStruct::operator: slang_solidity_
 pub slang_solidity_v2_ir::ir::PostfixExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::PostfixExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionStruct
@@ -2957,8 +3309,12 @@ pub slang_solidity_v2_ir::ir::PragmaDirectiveStruct::pragma: slang_solidity_v2_i
 pub slang_solidity_v2_ir::ir::PragmaDirectiveStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::eq(&self, &slang_solidity_v2_ir::ir::PragmaDirectiveStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
@@ -3071,8 +3427,12 @@ pub slang_solidity_v2_ir::ir::PrefixExpressionStruct::operator: slang_solidity_v
 pub slang_solidity_v2_ir::ir::PrefixExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
+pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::PrefixExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionStruct
@@ -3082,8 +3442,12 @@ pub slang_solidity_v2_ir::ir::ReturnStatementStruct::expression: core::option::O
 pub slang_solidity_v2_ir::ir::ReturnStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ReturnStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ReturnStatementStruct
+pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ReturnStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ReturnStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ReturnStatementStruct
@@ -3094,8 +3458,12 @@ pub slang_solidity_v2_ir::ir::RevertStatementStruct::error: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::RevertStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::RevertStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::RevertStatementStruct
+pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::RevertStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::RevertStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::RevertStatementStruct
@@ -3141,8 +3509,12 @@ pub slang_solidity_v2_ir::ir::ShiftExpressionStruct::range: core::ops::range::Ra
 pub slang_solidity_v2_ir::ir::ShiftExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
+pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ShiftExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionStruct
@@ -3153,8 +3525,12 @@ pub slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::range: core::ops::ra
 pub slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::value: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
@@ -3198,8 +3574,12 @@ pub slang_solidity_v2_ir::ir::SourceUnitStruct::members: slang_solidity_v2_ir::i
 pub slang_solidity_v2_ir::ir::SourceUnitStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::SourceUnitStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SourceUnitStruct
+pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::eq(&self, &slang_solidity_v2_ir::ir::SourceUnitStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SourceUnitStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitStruct
@@ -3211,8 +3591,12 @@ pub slang_solidity_v2_ir::ir::StateVariableAttributesStruct::range: core::ops::r
 pub slang_solidity_v2_ir::ir::StateVariableAttributesStruct::visibility: slang_solidity_v2_ir::ir::StateVariableVisibility
 impl slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
+pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::StateVariableAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
@@ -3225,8 +3609,12 @@ pub slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::type_name: slang_so
 pub slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::value: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::StateVariableDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
@@ -3289,8 +3677,12 @@ pub slang_solidity_v2_ir::ir::StructDefinitionStruct::name: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::StructDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StructDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StructDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::StructDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StructDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructDefinitionStruct
@@ -3301,8 +3693,12 @@ pub slang_solidity_v2_ir::ir::StructMemberStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::StructMemberStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::StructMemberStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StructMemberStruct
+pub fn slang_solidity_v2_ir::ir::StructMemberStruct::eq(&self, &slang_solidity_v2_ir::ir::StructMemberStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StructMemberStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructMemberStruct
@@ -3383,8 +3779,12 @@ pub slang_solidity_v2_ir::ir::TryStatementStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::TryStatementStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::Parameters>
 impl slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::TryStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TryStatementStruct
+pub fn slang_solidity_v2_ir::ir::TryStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::TryStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TryStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TryStatementStruct
@@ -3396,8 +3796,12 @@ impl slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::is_empty_tuple(&self) -> bool
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::TupleExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TupleExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::TupleExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TupleExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleExpressionStruct
@@ -3407,8 +3811,12 @@ pub slang_solidity_v2_ir::ir::TupleValueStruct::expression: core::option::Option
 pub slang_solidity_v2_ir::ir::TupleValueStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::TupleValueStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TupleValueStruct
+pub fn slang_solidity_v2_ir::ir::TupleValueStruct::eq(&self, &slang_solidity_v2_ir::ir::TupleValueStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TupleValueStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleValueStruct
@@ -3418,8 +3826,12 @@ pub slang_solidity_v2_ir::ir::TypeExpressionStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::TypeExpressionStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::TypeExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TypeExpressionStruct
+pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::TypeExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TypeExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeExpressionStruct
@@ -3465,8 +3877,12 @@ pub slang_solidity_v2_ir::ir::UncheckedBlockStruct::block: slang_solidity_v2_ir:
 pub slang_solidity_v2_ir::ir::UncheckedBlockStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
+pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::eq(&self, &slang_solidity_v2_ir::ir::UncheckedBlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UncheckedBlockStruct
@@ -3495,8 +3911,12 @@ pub slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::range: core:
 pub slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::value_type: slang_solidity_v2_ir::ir::ElementaryType
 impl slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
@@ -3506,8 +3926,12 @@ pub slang_solidity_v2_ir::ir::UsingDeconstructionStruct::range: core::ops::range
 pub slang_solidity_v2_ir::ir::UsingDeconstructionStruct::symbols: slang_solidity_v2_ir::ir::UsingDeconstructionSymbols
 impl slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDeconstructionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
@@ -3518,8 +3942,12 @@ pub slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::name: slang_solid
 pub slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
+pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
@@ -3531,8 +3959,12 @@ pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::target: slang_solidity_v2_ir::ir::UsingTarget
 impl slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
+pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDirectiveStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDirectiveStruct
@@ -3542,8 +3974,12 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::range: core::o
 pub slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::target: slang_solidity_v2_ir::ir::VariableDeclarationTarget
 impl slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
@@ -3555,8 +3991,12 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationStruct::storage_location: core:
 pub slang_solidity_v2_ir::ir::VariableDeclarationStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
+pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStruct
@@ -3566,8 +4006,12 @@ pub slang_solidity_v2_ir::ir::VersionPragmaStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::VersionPragmaStruct::sets: slang_solidity_v2_ir::ir::VersionExpressionSets
 impl slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionPragmaStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionPragmaStruct
+pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionPragmaStruct
@@ -3578,8 +4022,12 @@ pub slang_solidity_v2_ir::ir::VersionRangeStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::VersionRangeStruct::start: slang_solidity_v2_ir::ir::VersionLiteral
 impl slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionRangeStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionRangeStruct
+pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionRangeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionRangeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionRangeStruct
@@ -3608,8 +4056,12 @@ pub slang_solidity_v2_ir::ir::VersionTermStruct::operator: core::option::Option<
 pub slang_solidity_v2_ir::ir::VersionTermStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionTermStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionTermStruct
+pub fn slang_solidity_v2_ir::ir::VersionTermStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionTermStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionTermStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionTermStruct
@@ -3654,8 +4106,12 @@ pub slang_solidity_v2_ir::ir::WhileStatementStruct::condition: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::WhileStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::WhileStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::WhileStatementStruct
+pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::WhileStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::WhileStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WhileStatementStruct
@@ -3665,8 +4121,12 @@ pub slang_solidity_v2_ir::ir::YulBlockStruct::range: core::ops::range::Range<usi
 pub slang_solidity_v2_ir::ir::YulBlockStruct::statements: slang_solidity_v2_ir::ir::YulStatements
 impl slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulBlockStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulBlockStruct
+pub fn slang_solidity_v2_ir::ir::YulBlockStruct::eq(&self, &slang_solidity_v2_ir::ir::YulBlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulBlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBlockStruct
@@ -3675,8 +4135,12 @@ pub struct slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub slang_solidity_v2_ir::ir::YulBreakStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulBreakStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBreakStatementStruct
@@ -3685,8 +4149,12 @@ pub struct slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub slang_solidity_v2_ir::ir::YulContinueStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulContinueStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulContinueStatementStruct
@@ -3696,8 +4164,12 @@ pub slang_solidity_v2_ir::ir::YulDefaultCaseStruct::body: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::YulDefaultCaseStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::eq(&self, &slang_solidity_v2_ir::ir::YulDefaultCaseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
@@ -3710,8 +4182,12 @@ pub slang_solidity_v2_ir::ir::YulForStatementStruct::iterator: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::YulForStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulForStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulForStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulForStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulForStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulForStatementStruct
@@ -3722,8 +4198,12 @@ pub slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::operand: slang_so
 pub slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
@@ -3736,8 +4216,12 @@ pub slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::YulVariableNames>
 impl slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
+pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
@@ -3748,8 +4232,12 @@ pub slang_solidity_v2_ir::ir::YulIfStatementStruct::condition: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::YulIfStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulIfStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulIfStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulIfStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulIfStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulIfStatementStruct
@@ -3758,8 +4246,12 @@ pub struct slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub slang_solidity_v2_ir::ir::YulLeaveStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulLeaveStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
@@ -3771,8 +4263,12 @@ pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::value_cases: slang_solidity_v2_ir::ir::YulValueCases
 impl slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulSwitchStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
@@ -3783,8 +4279,12 @@ pub slang_solidity_v2_ir::ir::YulValueCaseStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::YulValueCaseStruct::value: slang_solidity_v2_ir::ir::YulLiteral
 impl slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulValueCaseStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulValueCaseStruct
+pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::eq(&self, &slang_solidity_v2_ir::ir::YulValueCaseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulValueCaseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulValueCaseStruct
@@ -3795,8 +4295,12 @@ pub slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::range: core:
 pub slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::variables: slang_solidity_v2_ir::ir::YulPaths
 impl slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
@@ -3807,8 +4311,12 @@ pub slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::value: core
 pub slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::variables: slang_solidity_v2_ir::ir::YulVariableNames
 impl slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
@@ -3818,8 +4326,12 @@ pub slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::expression: sla
 pub slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
+impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
+impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
+pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct

--- a/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/ir/generated/public_api.txt
@@ -577,12 +577,8 @@ impl slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AdditiveExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
-pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::AdditiveExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionOperator
@@ -592,12 +588,8 @@ pub slang_solidity_v2_ir::ir::ArgumentsDeclaration::NamedArguments(slang_solidit
 pub slang_solidity_v2_ir::ir::ArgumentsDeclaration::PositionalArguments(slang_solidity_v2_ir::ir::PositionalArguments)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::clone(&self) -> slang_solidity_v2_ir::ir::ArgumentsDeclaration
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
-pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::eq(&self, &slang_solidity_v2_ir::ir::ArgumentsDeclaration) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArgumentsDeclaration
 pub fn slang_solidity_v2_ir::ir::ArgumentsDeclaration::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArgumentsDeclaration
@@ -619,12 +611,8 @@ impl slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::AssignmentExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
-pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::AssignmentExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionOperator
@@ -660,12 +648,8 @@ pub slang_solidity_v2_ir::ir::ContractMember::UserDefinedValueTypeDefinition(sla
 pub slang_solidity_v2_ir::ir::ContractMember::UsingDirective(slang_solidity_v2_ir::ir::UsingDirective)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::clone(&self) -> slang_solidity_v2_ir::ir::ContractMember
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContractMember
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContractMember
-pub fn slang_solidity_v2_ir::ir::ContractMember::eq(&self, &slang_solidity_v2_ir::ir::ContractMember) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContractMember
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractMember
 pub fn slang_solidity_v2_ir::ir::ContractMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractMember
@@ -681,12 +665,8 @@ pub slang_solidity_v2_ir::ir::ElementaryType::UfixedKeyword(slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ElementaryType::UintKeyword(slang_solidity_v2_ir::ir::UintKeyword)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::clone(&self) -> slang_solidity_v2_ir::ir::ElementaryType
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ElementaryType
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ElementaryType
-pub fn slang_solidity_v2_ir::ir::ElementaryType::eq(&self, &slang_solidity_v2_ir::ir::ElementaryType) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ElementaryType
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ElementaryType
 pub fn slang_solidity_v2_ir::ir::ElementaryType::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ElementaryType
@@ -698,12 +678,8 @@ impl slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::EqualityExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
-pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::EqualityExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionOperator
@@ -764,12 +740,8 @@ pub slang_solidity_v2_ir::ir::Expression::TupleExpression(slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::Expression::TypeExpression(slang_solidity_v2_ir::ir::TypeExpression)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::clone(&self) -> slang_solidity_v2_ir::ir::Expression
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::Expression
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Expression
-pub fn slang_solidity_v2_ir::ir::Expression::eq(&self, &slang_solidity_v2_ir::ir::Expression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Expression
 pub fn slang_solidity_v2_ir::ir::Expression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Expression
@@ -779,12 +751,8 @@ pub slang_solidity_v2_ir::ir::ForStatementCondition::ExpressionStatement(slang_s
 pub slang_solidity_v2_ir::ir::ForStatementCondition::Semicolon(slang_solidity_v2_ir::ir::Semicolon)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementCondition
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementCondition
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementCondition
-pub fn slang_solidity_v2_ir::ir::ForStatementCondition::eq(&self, &slang_solidity_v2_ir::ir::ForStatementCondition) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementCondition
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementCondition
 pub fn slang_solidity_v2_ir::ir::ForStatementCondition::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementCondition
@@ -795,12 +763,8 @@ pub slang_solidity_v2_ir::ir::ForStatementInitialization::Semicolon(slang_solidi
 pub slang_solidity_v2_ir::ir::ForStatementInitialization::VariableDeclarationStatement(slang_solidity_v2_ir::ir::VariableDeclarationStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::clone(&self) -> slang_solidity_v2_ir::ir::ForStatementInitialization
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementInitialization
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementInitialization
-pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::eq(&self, &slang_solidity_v2_ir::ir::ForStatementInitialization) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementInitialization
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementInitialization
 pub fn slang_solidity_v2_ir::ir::ForStatementInitialization::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementInitialization
@@ -871,12 +835,8 @@ pub slang_solidity_v2_ir::ir::ImportClause::ImportDeconstruction(slang_solidity_
 pub slang_solidity_v2_ir::ir::ImportClause::PathImport(slang_solidity_v2_ir::ir::PathImport)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::clone(&self) -> slang_solidity_v2_ir::ir::ImportClause
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportClause
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportClause
-pub fn slang_solidity_v2_ir::ir::ImportClause::eq(&self, &slang_solidity_v2_ir::ir::ImportClause) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportClause
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportClause
 pub fn slang_solidity_v2_ir::ir::ImportClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportClause
@@ -890,12 +850,8 @@ impl slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::InequalityExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
-pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::InequalityExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionOperator
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionOperator
@@ -908,12 +864,8 @@ impl slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
-pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionOperator
@@ -1113,12 +1065,8 @@ impl slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::clone(&self) -> slang_solidity_v2_ir::ir::NumberUnit
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::NumberUnit
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NumberUnit
-pub fn slang_solidity_v2_ir::ir::NumberUnit::eq(&self, &slang_solidity_v2_ir::ir::NumberUnit) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NumberUnit
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NumberUnit
 pub fn slang_solidity_v2_ir::ir::NumberUnit::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NumberUnit
@@ -1130,12 +1078,8 @@ impl slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PostfixExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
-pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::PostfixExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionOperator
@@ -1146,12 +1090,8 @@ pub slang_solidity_v2_ir::ir::Pragma::ExperimentalPragma(slang_solidity_v2_ir::i
 pub slang_solidity_v2_ir::ir::Pragma::VersionPragma(slang_solidity_v2_ir::ir::VersionPragma)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::clone(&self) -> slang_solidity_v2_ir::ir::Pragma
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::Pragma
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Pragma
-pub fn slang_solidity_v2_ir::ir::Pragma::eq(&self, &slang_solidity_v2_ir::ir::Pragma) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Pragma
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Pragma
 pub fn slang_solidity_v2_ir::ir::Pragma::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Pragma
@@ -1167,12 +1107,8 @@ impl slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::PrefixExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
-pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::PrefixExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionOperator
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionOperator
@@ -1185,12 +1121,8 @@ impl slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::clone(&self) -> slang_solidity_v2_ir::ir::ShiftExpressionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
-pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::eq(&self, &slang_solidity_v2_ir::ir::ShiftExpressionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionOperator
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionOperator
@@ -1211,12 +1143,8 @@ pub slang_solidity_v2_ir::ir::SourceUnitMember::UserDefinedValueTypeDefinition(s
 pub slang_solidity_v2_ir::ir::SourceUnitMember::UsingDirective(slang_solidity_v2_ir::ir::UsingDirective)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::clone(&self) -> slang_solidity_v2_ir::ir::SourceUnitMember
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::SourceUnitMember
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SourceUnitMember
-pub fn slang_solidity_v2_ir::ir::SourceUnitMember::eq(&self, &slang_solidity_v2_ir::ir::SourceUnitMember) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SourceUnitMember
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitMember
 pub fn slang_solidity_v2_ir::ir::SourceUnitMember::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitMember
@@ -1278,12 +1206,8 @@ pub slang_solidity_v2_ir::ir::Statement::VariableDeclarationStatement(slang_soli
 pub slang_solidity_v2_ir::ir::Statement::WhileStatement(slang_solidity_v2_ir::ir::WhileStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::clone(&self) -> slang_solidity_v2_ir::ir::Statement
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::Statement
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::Statement
-pub fn slang_solidity_v2_ir::ir::Statement::eq(&self, &slang_solidity_v2_ir::ir::Statement) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::Statement
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::Statement
 pub fn slang_solidity_v2_ir::ir::Statement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::Statement
@@ -1296,12 +1220,8 @@ impl slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::clone(&self) -> slang_solidity_v2_ir::ir::StorageLocation
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StorageLocation
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StorageLocation
-pub fn slang_solidity_v2_ir::ir::StorageLocation::eq(&self, &slang_solidity_v2_ir::ir::StorageLocation) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StorageLocation
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StorageLocation
 pub fn slang_solidity_v2_ir::ir::StorageLocation::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StorageLocation
@@ -1312,12 +1232,8 @@ pub slang_solidity_v2_ir::ir::StringExpression::StringLiterals(slang_solidity_v2
 pub slang_solidity_v2_ir::ir::StringExpression::UnicodeStringLiterals(slang_solidity_v2_ir::ir::UnicodeStringLiterals)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::clone(&self) -> slang_solidity_v2_ir::ir::StringExpression
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StringExpression
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StringExpression
-pub fn slang_solidity_v2_ir::ir::StringExpression::eq(&self, &slang_solidity_v2_ir::ir::StringExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StringExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StringExpression
 pub fn slang_solidity_v2_ir::ir::StringExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StringExpression
@@ -1330,12 +1246,8 @@ pub slang_solidity_v2_ir::ir::TypeName::IdentifierPath(slang_solidity_v2_ir::ir:
 pub slang_solidity_v2_ir::ir::TypeName::MappingType(slang_solidity_v2_ir::ir::MappingType)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::clone(&self) -> slang_solidity_v2_ir::ir::TypeName
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::TypeName
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TypeName
-pub fn slang_solidity_v2_ir::ir::TypeName::eq(&self, &slang_solidity_v2_ir::ir::TypeName) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeName
 pub fn slang_solidity_v2_ir::ir::TypeName::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeName
@@ -1345,12 +1257,8 @@ pub slang_solidity_v2_ir::ir::UsingClause::IdentifierPath(slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::UsingClause::UsingDeconstruction(slang_solidity_v2_ir::ir::UsingDeconstruction)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::clone(&self) -> slang_solidity_v2_ir::ir::UsingClause
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingClause
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingClause
-pub fn slang_solidity_v2_ir::ir::UsingClause::eq(&self, &slang_solidity_v2_ir::ir::UsingClause) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingClause
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingClause
 pub fn slang_solidity_v2_ir::ir::UsingClause::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingClause
@@ -1375,12 +1283,8 @@ impl slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::clone(&self) -> slang_solidity_v2_ir::ir::UsingOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingOperator
-pub fn slang_solidity_v2_ir::ir::UsingOperator::eq(&self, &slang_solidity_v2_ir::ir::UsingOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingOperator
 pub fn slang_solidity_v2_ir::ir::UsingOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingOperator
@@ -1390,12 +1294,8 @@ pub slang_solidity_v2_ir::ir::UsingTarget::Asterisk(slang_solidity_v2_ir::ir::As
 pub slang_solidity_v2_ir::ir::UsingTarget::TypeName(slang_solidity_v2_ir::ir::TypeName)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::clone(&self) -> slang_solidity_v2_ir::ir::UsingTarget
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingTarget
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingTarget
-pub fn slang_solidity_v2_ir::ir::UsingTarget::eq(&self, &slang_solidity_v2_ir::ir::UsingTarget) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingTarget
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingTarget
 pub fn slang_solidity_v2_ir::ir::UsingTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingTarget
@@ -1405,12 +1305,8 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationTarget::MultiTypedDeclaration(s
 pub slang_solidity_v2_ir::ir::VariableDeclarationTarget::SingleTypedDeclaration(slang_solidity_v2_ir::ir::SingleTypedDeclaration)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::clone(&self) -> slang_solidity_v2_ir::ir::VariableDeclarationTarget
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
-pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationTarget) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationTarget
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationTarget::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationTarget
@@ -1420,12 +1316,8 @@ pub slang_solidity_v2_ir::ir::VersionExpression::VersionRange(slang_solidity_v2_
 pub slang_solidity_v2_ir::ir::VersionExpression::VersionTerm(slang_solidity_v2_ir::ir::VersionTerm)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::clone(&self) -> slang_solidity_v2_ir::ir::VersionExpression
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionExpression
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionExpression
-pub fn slang_solidity_v2_ir::ir::VersionExpression::eq(&self, &slang_solidity_v2_ir::ir::VersionExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionExpression
 pub fn slang_solidity_v2_ir::ir::VersionExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionExpression
@@ -1435,12 +1327,8 @@ pub slang_solidity_v2_ir::ir::VersionLiteral::SimpleVersionLiteral(slang_solidit
 pub slang_solidity_v2_ir::ir::VersionLiteral::StringLiteral(slang_solidity_v2_ir::ir::StringLiteral)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::clone(&self) -> slang_solidity_v2_ir::ir::VersionLiteral
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionLiteral
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionLiteral
-pub fn slang_solidity_v2_ir::ir::VersionLiteral::eq(&self, &slang_solidity_v2_ir::ir::VersionLiteral) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionLiteral
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionLiteral
 pub fn slang_solidity_v2_ir::ir::VersionLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionLiteral
@@ -1457,12 +1345,8 @@ impl slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::clone(&self) -> slang_solidity_v2_ir::ir::VersionOperator
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionOperator
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionOperator
-pub fn slang_solidity_v2_ir::ir::VersionOperator::eq(&self, &slang_solidity_v2_ir::ir::VersionOperator) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionOperator
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionOperator
 pub fn slang_solidity_v2_ir::ir::VersionOperator::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionOperator
@@ -1473,12 +1357,8 @@ pub slang_solidity_v2_ir::ir::YulExpression::YulLiteral(slang_solidity_v2_ir::ir
 pub slang_solidity_v2_ir::ir::YulExpression::YulPath(slang_solidity_v2_ir::ir::YulPath)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::clone(&self) -> slang_solidity_v2_ir::ir::YulExpression
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulExpression
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulExpression
-pub fn slang_solidity_v2_ir::ir::YulExpression::eq(&self, &slang_solidity_v2_ir::ir::YulExpression) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulExpression
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulExpression
 pub fn slang_solidity_v2_ir::ir::YulExpression::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulExpression
@@ -1494,12 +1374,8 @@ impl slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::unparse(&self) -> &str
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::clone(&self) -> slang_solidity_v2_ir::ir::YulLiteral
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulLiteral
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulLiteral
-pub fn slang_solidity_v2_ir::ir::YulLiteral::eq(&self, &slang_solidity_v2_ir::ir::YulLiteral) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulLiteral
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLiteral
 pub fn slang_solidity_v2_ir::ir::YulLiteral::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLiteral
@@ -1518,12 +1394,8 @@ pub slang_solidity_v2_ir::ir::YulStatement::YulVariableAssignmentStatement(slang
 pub slang_solidity_v2_ir::ir::YulStatement::YulVariableDeclarationStatement(slang_solidity_v2_ir::ir::YulVariableDeclarationStatement)
 impl core::clone::Clone for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::clone(&self) -> slang_solidity_v2_ir::ir::YulStatement
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulStatement
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulStatement
-pub fn slang_solidity_v2_ir::ir::YulStatement::eq(&self, &slang_solidity_v2_ir::ir::YulStatement) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulStatement
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulStatement
 pub fn slang_solidity_v2_ir::ir::YulStatement::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulStatement
@@ -1533,12 +1405,8 @@ pub slang_solidity_v2_ir::ir::AbicoderPragmaStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::AbicoderPragmaStruct::version: slang_solidity_v2_ir::ir::AbicoderVersion
 impl slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
-pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::AbicoderPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
 pub fn slang_solidity_v2_ir::ir::AbicoderPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AbicoderPragmaStruct
@@ -1550,12 +1418,8 @@ pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::AdditiveExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
-pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AdditiveExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AdditiveExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AdditiveExpressionStruct
@@ -1565,12 +1429,8 @@ pub slang_solidity_v2_ir::ir::AddressTypeStruct::is_payable: bool
 pub slang_solidity_v2_ir::ir::AddressTypeStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AddressTypeStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AddressTypeStruct
-pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::AddressTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AddressTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AddressTypeStruct
 pub fn slang_solidity_v2_ir::ir::AddressTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AddressTypeStruct
@@ -1615,12 +1475,8 @@ pub slang_solidity_v2_ir::ir::AndExpressionStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::AndExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AndExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AndExpressionStruct
-pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AndExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AndExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AndExpressionStruct
@@ -1630,12 +1486,8 @@ pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::items: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ArrayExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
-pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ArrayExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ArrayExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayExpressionStruct
@@ -1646,12 +1498,8 @@ pub slang_solidity_v2_ir::ir::ArrayTypeNameStruct::operand: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::ArrayTypeNameStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
-pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::eq(&self, &slang_solidity_v2_ir::ir::ArrayTypeNameStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
 pub fn slang_solidity_v2_ir::ir::ArrayTypeNameStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ArrayTypeNameStruct
@@ -1662,12 +1510,8 @@ pub slang_solidity_v2_ir::ir::AssemblyStatementStruct::is_memory_safe: bool
 pub slang_solidity_v2_ir::ir::AssemblyStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
-pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::AssemblyStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssemblyStatementStruct
 pub fn slang_solidity_v2_ir::ir::AssemblyStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssemblyStatementStruct
@@ -1679,12 +1523,8 @@ pub slang_solidity_v2_ir::ir::AssignmentExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::AssignmentExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
-pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::AssignmentExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
 pub fn slang_solidity_v2_ir::ir::AssignmentExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::AssignmentExpressionStruct
@@ -1797,12 +1637,8 @@ pub slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
-pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseAndExpressionStruct
@@ -1813,12 +1649,8 @@ pub slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::range: core::ops::range
 pub slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
-pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseOrExpressionStruct
@@ -1829,12 +1661,8 @@ pub slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
-pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
 pub fn slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BitwiseXorExpressionStruct
@@ -1844,12 +1672,8 @@ pub slang_solidity_v2_ir::ir::BlockStruct::range: core::ops::range::Range<usize>
 pub slang_solidity_v2_ir::ir::BlockStruct::statements: slang_solidity_v2_ir::ir::Statements
 impl slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::BlockStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BlockStruct
-pub fn slang_solidity_v2_ir::ir::BlockStruct::eq(&self, &slang_solidity_v2_ir::ir::BlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BlockStruct
 pub fn slang_solidity_v2_ir::ir::BlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BlockStruct
@@ -1875,12 +1699,8 @@ pub struct slang_solidity_v2_ir::ir::BreakStatementStruct
 pub slang_solidity_v2_ir::ir::BreakStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::BreakStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::BreakStatementStruct
-pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::BreakStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::BreakStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::BreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::BreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::BreakStatementStruct
@@ -1929,12 +1749,8 @@ pub slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::options: slang_solidi
 pub slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
-pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::CallOptionsExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
 pub fn slang_solidity_v2_ir::ir::CallOptionsExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CallOptionsExpressionStruct
@@ -1980,12 +1796,8 @@ pub slang_solidity_v2_ir::ir::CatchClauseStruct::parameters: core::option::Optio
 pub slang_solidity_v2_ir::ir::CatchClauseStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::CatchClauseStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::CatchClauseStruct
-pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::eq(&self, &slang_solidity_v2_ir::ir::CatchClauseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::CatchClauseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::CatchClauseStruct
 pub fn slang_solidity_v2_ir::ir::CatchClauseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::CatchClauseStruct
@@ -1997,12 +1809,8 @@ pub slang_solidity_v2_ir::ir::ConditionalExpressionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::ConditionalExpressionStruct::true_expression: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
-pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ConditionalExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ConditionalExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConditionalExpressionStruct
@@ -2015,12 +1823,8 @@ pub slang_solidity_v2_ir::ir::ConstantDefinitionStruct::value: core::option::Opt
 pub slang_solidity_v2_ir::ir::ConstantDefinitionStruct::visibility: core::option::Option<slang_solidity_v2_ir::ir::StateVariableVisibility>
 impl slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ConstantDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ConstantDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ConstantDefinitionStruct
@@ -2029,12 +1833,8 @@ pub struct slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub slang_solidity_v2_ir::ir::ContinueStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContinueStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContinueStatementStruct
-pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ContinueStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContinueStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::ContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContinueStatementStruct
@@ -2048,12 +1848,8 @@ pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::ContractDefinitionStruct::storage_layout: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ContractDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ContractDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ContractDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ContractDefinitionStruct
@@ -2099,12 +1895,8 @@ pub slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::range: core::ops::r
 pub slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::unit: core::option::Option<slang_solidity_v2_ir::ir::NumberUnit>
 impl slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
-pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DecimalNumberExpressionStruct
@@ -2132,12 +1924,8 @@ pub slang_solidity_v2_ir::ir::DoWhileStatementStruct::condition: slang_solidity_
 pub slang_solidity_v2_ir::ir::DoWhileStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
-pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::DoWhileStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::DoWhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::DoWhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::DoWhileStatementStruct
@@ -2148,12 +1936,8 @@ pub slang_solidity_v2_ir::ir::EmitStatementStruct::event: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::EmitStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::EmitStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EmitStatementStruct
-pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::EmitStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EmitStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EmitStatementStruct
 pub fn slang_solidity_v2_ir::ir::EmitStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EmitStatementStruct
@@ -2164,12 +1948,8 @@ pub slang_solidity_v2_ir::ir::EnumDefinitionStruct::name: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::EnumDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::EnumDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EnumDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EnumDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EnumDefinitionStruct
@@ -2215,12 +1995,8 @@ pub slang_solidity_v2_ir::ir::EqualityExpressionStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::EqualityExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
-pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::EqualityExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EqualityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::EqualityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EqualityExpressionStruct
@@ -2231,12 +2007,8 @@ pub slang_solidity_v2_ir::ir::ErrorDefinitionStruct::parameters: slang_solidity_
 pub slang_solidity_v2_ir::ir::ErrorDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::ErrorDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::ErrorDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ErrorDefinitionStruct
@@ -2265,12 +2037,8 @@ pub slang_solidity_v2_ir::ir::EventDefinitionStruct::parameters: slang_solidity_
 pub slang_solidity_v2_ir::ir::EventDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::EventDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::EventDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::EventDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::EventDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::EventDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::EventDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::EventDefinitionStruct
@@ -2280,12 +2048,8 @@ pub slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::feature: slang_solidity_
 pub slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
-pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::ExperimentalPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
 pub fn slang_solidity_v2_ir::ir::ExperimentalPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExperimentalPragmaStruct
@@ -2296,12 +2060,8 @@ pub slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::range: core::ops::
 pub slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
-pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ExponentiationExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ExponentiationExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExponentiationExpressionStruct
@@ -2311,12 +2071,8 @@ pub slang_solidity_v2_ir::ir::ExpressionStatementStruct::expression: slang_solid
 pub slang_solidity_v2_ir::ir::ExpressionStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
-pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ExpressionStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ExpressionStatementStruct
 pub fn slang_solidity_v2_ir::ir::ExpressionStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ExpressionStatementStruct
@@ -2364,12 +2120,8 @@ pub slang_solidity_v2_ir::ir::ForStatementStruct::iterator: core::option::Option
 pub slang_solidity_v2_ir::ir::ForStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ForStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ForStatementStruct
-pub fn slang_solidity_v2_ir::ir::ForStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ForStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ForStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ForStatementStruct
 pub fn slang_solidity_v2_ir::ir::ForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ForStatementStruct
@@ -2384,12 +2136,8 @@ pub slang_solidity_v2_ir::ir::FunctionAttributesStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::FunctionAttributesStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
-pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionAttributesStruct
@@ -2400,12 +2148,8 @@ pub slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::operand: slang_solid
 pub slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
-pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionCallExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionCallExpressionStruct
@@ -2423,12 +2167,8 @@ pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::id(&self) -> slang_so
 impl slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::is_externally_visible(&self) -> bool
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::signature_text_range(&self) -> core::ops::range::Range<usize>
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::FunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionDefinitionStruct
@@ -2439,12 +2179,8 @@ pub slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::range: core::ops::ra
 pub slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::visibility: slang_solidity_v2_ir::ir::FunctionVisibility
 impl slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
-pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeAttributesStruct
@@ -2456,12 +2192,8 @@ pub slang_solidity_v2_ir::ir::FunctionTypeStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::FunctionTypeStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::Parameters>
 impl slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::FunctionTypeStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::FunctionTypeStruct
-pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::FunctionTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::FunctionTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::FunctionTypeStruct
 pub fn slang_solidity_v2_ir::ir::FunctionTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::FunctionTypeStruct
@@ -2608,12 +2340,8 @@ pub slang_solidity_v2_ir::ir::HexNumberExpressionStruct::literal: slang_solidity
 pub slang_solidity_v2_ir::ir::HexNumberExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
-pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::HexNumberExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
 pub fn slang_solidity_v2_ir::ir::HexNumberExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::HexNumberExpressionStruct
@@ -2678,12 +2406,8 @@ pub slang_solidity_v2_ir::ir::IfStatementStruct::else_branch: core::option::Opti
 pub slang_solidity_v2_ir::ir::IfStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::IfStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::IfStatementStruct
-pub fn slang_solidity_v2_ir::ir::IfStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::IfStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IfStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IfStatementStruct
 pub fn slang_solidity_v2_ir::ir::IfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IfStatementStruct
@@ -2694,12 +2418,8 @@ pub slang_solidity_v2_ir::ir::ImportDeconstructionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::ImportDeconstructionStruct::symbols: slang_solidity_v2_ir::ir::ImportDeconstructionSymbols
 impl slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
-pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::eq(&self, &slang_solidity_v2_ir::ir::ImportDeconstructionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionStruct
@@ -2710,12 +2430,8 @@ pub slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::name: slang_soli
 pub slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
-pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::eq(&self, &slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ImportDeconstructionSymbolStruct
@@ -2728,12 +2444,8 @@ pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::start: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
-pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::IndexAccessExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::IndexAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::IndexAccessExpressionStruct
@@ -2745,12 +2457,8 @@ pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::range: core::ops::rang
 pub slang_solidity_v2_ir::ir::InequalityExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
-pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::InequalityExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InequalityExpressionStruct
 pub fn slang_solidity_v2_ir::ir::InequalityExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InequalityExpressionStruct
@@ -2761,12 +2469,8 @@ pub slang_solidity_v2_ir::ir::InheritanceTypeStruct::range: core::ops::range::Ra
 pub slang_solidity_v2_ir::ir::InheritanceTypeStruct::type_name: slang_solidity_v2_ir::ir::IdentifierPath
 impl slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
-pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::InheritanceTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InheritanceTypeStruct
 pub fn slang_solidity_v2_ir::ir::InheritanceTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InheritanceTypeStruct
@@ -2796,12 +2500,8 @@ pub slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::name: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::InterfaceDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::InterfaceDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::InterfaceDefinitionStruct
@@ -2880,12 +2580,8 @@ pub slang_solidity_v2_ir::ir::LibraryDefinitionStruct::name: slang_solidity_v2_i
 pub slang_solidity_v2_ir::ir::LibraryDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::LibraryDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::LibraryDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::LibraryDefinitionStruct
@@ -2896,12 +2592,8 @@ pub slang_solidity_v2_ir::ir::MappingTypeStruct::range: core::ops::range::Range<
 pub slang_solidity_v2_ir::ir::MappingTypeStruct::value_type: slang_solidity_v2_ir::ir::Parameter
 impl slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MappingTypeStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MappingTypeStruct
-pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::eq(&self, &slang_solidity_v2_ir::ir::MappingTypeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MappingTypeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MappingTypeStruct
 pub fn slang_solidity_v2_ir::ir::MappingTypeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MappingTypeStruct
@@ -2912,12 +2604,8 @@ pub slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::operand: slang_solid
 pub slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
-pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::MemberAccessExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MemberAccessExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MemberAccessExpressionStruct
@@ -3013,12 +2701,8 @@ pub slang_solidity_v2_ir::ir::ModifierInvocationStruct::name: slang_solidity_v2_
 pub slang_solidity_v2_ir::ir::ModifierInvocationStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
-pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::eq(&self, &slang_solidity_v2_ir::ir::ModifierInvocationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ModifierInvocationStruct
 pub fn slang_solidity_v2_ir::ir::ModifierInvocationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ModifierInvocationStruct
@@ -3028,12 +2712,8 @@ pub slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::member: core::
 pub slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
-pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationElementStruct
@@ -3044,12 +2724,8 @@ pub slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::value: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
-pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiTypedDeclarationStruct
@@ -3061,12 +2737,8 @@ pub slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::range: core::ops::
 pub slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
-pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::MultiplicativeExpressionStruct
@@ -3077,12 +2749,8 @@ pub slang_solidity_v2_ir::ir::NamedArgumentStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::NamedArgumentStruct::value: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::NamedArgumentStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NamedArgumentStruct
-pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::eq(&self, &slang_solidity_v2_ir::ir::NamedArgumentStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NamedArgumentStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NamedArgumentStruct
 pub fn slang_solidity_v2_ir::ir::NamedArgumentStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NamedArgumentStruct
@@ -3092,12 +2760,8 @@ pub slang_solidity_v2_ir::ir::NewExpressionStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::NewExpressionStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::NewExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::NewExpressionStruct
-pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::NewExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::NewExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::NewExpressionStruct
 pub fn slang_solidity_v2_ir::ir::NewExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::NewExpressionStruct
@@ -3125,12 +2789,8 @@ pub slang_solidity_v2_ir::ir::OrExpressionStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::OrExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::OrExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::OrExpressionStruct
-pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::OrExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::OrExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::OrExpressionStruct
 pub fn slang_solidity_v2_ir::ir::OrExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::OrExpressionStruct
@@ -3143,12 +2803,8 @@ pub slang_solidity_v2_ir::ir::ParameterStruct::storage_location: core::option::O
 pub slang_solidity_v2_ir::ir::ParameterStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ParameterStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ParameterStruct
-pub fn slang_solidity_v2_ir::ir::ParameterStruct::eq(&self, &slang_solidity_v2_ir::ir::ParameterStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ParameterStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ParameterStruct
 pub fn slang_solidity_v2_ir::ir::ParameterStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ParameterStruct
@@ -3159,12 +2815,8 @@ pub slang_solidity_v2_ir::ir::PathImportStruct::path: slang_solidity_v2_ir::ir::
 pub slang_solidity_v2_ir::ir::PathImportStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PathImportStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PathImportStruct
-pub fn slang_solidity_v2_ir::ir::PathImportStruct::eq(&self, &slang_solidity_v2_ir::ir::PathImportStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PathImportStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PathImportStruct
 pub fn slang_solidity_v2_ir::ir::PathImportStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PathImportStruct
@@ -3277,12 +2929,8 @@ pub slang_solidity_v2_ir::ir::PostfixExpressionStruct::operator: slang_solidity_
 pub slang_solidity_v2_ir::ir::PostfixExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
-pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::PostfixExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PostfixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PostfixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PostfixExpressionStruct
@@ -3309,12 +2957,8 @@ pub slang_solidity_v2_ir::ir::PragmaDirectiveStruct::pragma: slang_solidity_v2_i
 pub slang_solidity_v2_ir::ir::PragmaDirectiveStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
-pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::eq(&self, &slang_solidity_v2_ir::ir::PragmaDirectiveStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::PragmaDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PragmaDirectiveStruct
@@ -3427,12 +3071,8 @@ pub slang_solidity_v2_ir::ir::PrefixExpressionStruct::operator: slang_solidity_v
 pub slang_solidity_v2_ir::ir::PrefixExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
-pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::PrefixExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::PrefixExpressionStruct
 pub fn slang_solidity_v2_ir::ir::PrefixExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::PrefixExpressionStruct
@@ -3442,12 +3082,8 @@ pub slang_solidity_v2_ir::ir::ReturnStatementStruct::expression: core::option::O
 pub slang_solidity_v2_ir::ir::ReturnStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ReturnStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ReturnStatementStruct
-pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::ReturnStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ReturnStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ReturnStatementStruct
 pub fn slang_solidity_v2_ir::ir::ReturnStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ReturnStatementStruct
@@ -3458,12 +3094,8 @@ pub slang_solidity_v2_ir::ir::RevertStatementStruct::error: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::RevertStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::RevertStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::RevertStatementStruct
-pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::RevertStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::RevertStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::RevertStatementStruct
 pub fn slang_solidity_v2_ir::ir::RevertStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::RevertStatementStruct
@@ -3509,12 +3141,8 @@ pub slang_solidity_v2_ir::ir::ShiftExpressionStruct::range: core::ops::range::Ra
 pub slang_solidity_v2_ir::ir::ShiftExpressionStruct::right_operand: slang_solidity_v2_ir::ir::Expression
 impl slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
-pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::ShiftExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::ShiftExpressionStruct
 pub fn slang_solidity_v2_ir::ir::ShiftExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::ShiftExpressionStruct
@@ -3525,12 +3153,8 @@ pub slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::range: core::ops::ra
 pub slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::value: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
-pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SingleTypedDeclarationStruct
@@ -3574,12 +3198,8 @@ pub slang_solidity_v2_ir::ir::SourceUnitStruct::members: slang_solidity_v2_ir::i
 pub slang_solidity_v2_ir::ir::SourceUnitStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::SourceUnitStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::SourceUnitStruct
-pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::eq(&self, &slang_solidity_v2_ir::ir::SourceUnitStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::SourceUnitStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::SourceUnitStruct
 pub fn slang_solidity_v2_ir::ir::SourceUnitStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::SourceUnitStruct
@@ -3591,12 +3211,8 @@ pub slang_solidity_v2_ir::ir::StateVariableAttributesStruct::range: core::ops::r
 pub slang_solidity_v2_ir::ir::StateVariableAttributesStruct::visibility: slang_solidity_v2_ir::ir::StateVariableVisibility
 impl slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
-pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::eq(&self, &slang_solidity_v2_ir::ir::StateVariableAttributesStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableAttributesStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableAttributesStruct
@@ -3609,12 +3225,8 @@ pub slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::type_name: slang_so
 pub slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::value: core::option::Option<slang_solidity_v2_ir::ir::Expression>
 impl slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::StateVariableDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StateVariableDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StateVariableDefinitionStruct
@@ -3677,12 +3289,8 @@ pub slang_solidity_v2_ir::ir::StructDefinitionStruct::name: slang_solidity_v2_ir
 pub slang_solidity_v2_ir::ir::StructDefinitionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StructDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StructDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::StructDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StructDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::StructDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructDefinitionStruct
@@ -3693,12 +3301,8 @@ pub slang_solidity_v2_ir::ir::StructMemberStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::StructMemberStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::StructMemberStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::StructMemberStruct
-pub fn slang_solidity_v2_ir::ir::StructMemberStruct::eq(&self, &slang_solidity_v2_ir::ir::StructMemberStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::StructMemberStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::StructMemberStruct
 pub fn slang_solidity_v2_ir::ir::StructMemberStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::StructMemberStruct
@@ -3779,12 +3383,8 @@ pub slang_solidity_v2_ir::ir::TryStatementStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::TryStatementStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::Parameters>
 impl slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::TryStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TryStatementStruct
-pub fn slang_solidity_v2_ir::ir::TryStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::TryStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TryStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TryStatementStruct
 pub fn slang_solidity_v2_ir::ir::TryStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TryStatementStruct
@@ -3796,12 +3396,8 @@ impl slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
 impl slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::is_empty_tuple(&self) -> bool
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::TupleExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TupleExpressionStruct
-pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::TupleExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TupleExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TupleExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleExpressionStruct
@@ -3811,12 +3407,8 @@ pub slang_solidity_v2_ir::ir::TupleValueStruct::expression: core::option::Option
 pub slang_solidity_v2_ir::ir::TupleValueStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::TupleValueStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TupleValueStruct
-pub fn slang_solidity_v2_ir::ir::TupleValueStruct::eq(&self, &slang_solidity_v2_ir::ir::TupleValueStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TupleValueStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TupleValueStruct
 pub fn slang_solidity_v2_ir::ir::TupleValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TupleValueStruct
@@ -3826,12 +3418,8 @@ pub slang_solidity_v2_ir::ir::TypeExpressionStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::TypeExpressionStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::TypeExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::TypeExpressionStruct
-pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::TypeExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::TypeExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::TypeExpressionStruct
 pub fn slang_solidity_v2_ir::ir::TypeExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::TypeExpressionStruct
@@ -3877,12 +3465,8 @@ pub slang_solidity_v2_ir::ir::UncheckedBlockStruct::block: slang_solidity_v2_ir:
 pub slang_solidity_v2_ir::ir::UncheckedBlockStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
-pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::eq(&self, &slang_solidity_v2_ir::ir::UncheckedBlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UncheckedBlockStruct
 pub fn slang_solidity_v2_ir::ir::UncheckedBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UncheckedBlockStruct
@@ -3911,12 +3495,8 @@ pub slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::range: core:
 pub slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::value_type: slang_solidity_v2_ir::ir::ElementaryType
 impl slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UserDefinedValueTypeDefinitionStruct
@@ -3926,12 +3506,8 @@ pub slang_solidity_v2_ir::ir::UsingDeconstructionStruct::range: core::ops::range
 pub slang_solidity_v2_ir::ir::UsingDeconstructionStruct::symbols: slang_solidity_v2_ir::ir::UsingDeconstructionSymbols
 impl slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
-pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDeconstructionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionStruct
@@ -3942,12 +3518,8 @@ pub slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::name: slang_solid
 pub slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
-pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
 pub fn slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDeconstructionSymbolStruct
@@ -3959,12 +3531,8 @@ pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::range: core::ops::range::Ran
 pub slang_solidity_v2_ir::ir::UsingDirectiveStruct::target: slang_solidity_v2_ir::ir::UsingTarget
 impl slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
-pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::eq(&self, &slang_solidity_v2_ir::ir::UsingDirectiveStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::UsingDirectiveStruct
 pub fn slang_solidity_v2_ir::ir::UsingDirectiveStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::UsingDirectiveStruct
@@ -3974,12 +3542,8 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::range: core::o
 pub slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::target: slang_solidity_v2_ir::ir::VariableDeclarationTarget
 impl slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
-pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStatementStruct
@@ -3991,12 +3555,8 @@ pub slang_solidity_v2_ir::ir::VariableDeclarationStruct::storage_location: core:
 pub slang_solidity_v2_ir::ir::VariableDeclarationStruct::type_name: slang_solidity_v2_ir::ir::TypeName
 impl slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
-pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::eq(&self, &slang_solidity_v2_ir::ir::VariableDeclarationStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VariableDeclarationStruct
 pub fn slang_solidity_v2_ir::ir::VariableDeclarationStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VariableDeclarationStruct
@@ -4006,12 +3566,8 @@ pub slang_solidity_v2_ir::ir::VersionPragmaStruct::range: core::ops::range::Rang
 pub slang_solidity_v2_ir::ir::VersionPragmaStruct::sets: slang_solidity_v2_ir::ir::VersionExpressionSets
 impl slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionPragmaStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionPragmaStruct
-pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionPragmaStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionPragmaStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionPragmaStruct
 pub fn slang_solidity_v2_ir::ir::VersionPragmaStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionPragmaStruct
@@ -4022,12 +3578,8 @@ pub slang_solidity_v2_ir::ir::VersionRangeStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::VersionRangeStruct::start: slang_solidity_v2_ir::ir::VersionLiteral
 impl slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionRangeStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionRangeStruct
-pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionRangeStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionRangeStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionRangeStruct
 pub fn slang_solidity_v2_ir::ir::VersionRangeStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionRangeStruct
@@ -4056,12 +3608,8 @@ pub slang_solidity_v2_ir::ir::VersionTermStruct::operator: core::option::Option<
 pub slang_solidity_v2_ir::ir::VersionTermStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::VersionTermStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::VersionTermStruct
-pub fn slang_solidity_v2_ir::ir::VersionTermStruct::eq(&self, &slang_solidity_v2_ir::ir::VersionTermStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::VersionTermStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::VersionTermStruct
 pub fn slang_solidity_v2_ir::ir::VersionTermStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::VersionTermStruct
@@ -4106,12 +3654,8 @@ pub slang_solidity_v2_ir::ir::WhileStatementStruct::condition: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::WhileStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::WhileStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::WhileStatementStruct
-pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::WhileStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::WhileStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::WhileStatementStruct
 pub fn slang_solidity_v2_ir::ir::WhileStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::WhileStatementStruct
@@ -4121,12 +3665,8 @@ pub slang_solidity_v2_ir::ir::YulBlockStruct::range: core::ops::range::Range<usi
 pub slang_solidity_v2_ir::ir::YulBlockStruct::statements: slang_solidity_v2_ir::ir::YulStatements
 impl slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulBlockStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulBlockStruct
-pub fn slang_solidity_v2_ir::ir::YulBlockStruct::eq(&self, &slang_solidity_v2_ir::ir::YulBlockStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulBlockStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBlockStruct
 pub fn slang_solidity_v2_ir::ir::YulBlockStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBlockStruct
@@ -4135,12 +3675,8 @@ pub struct slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub slang_solidity_v2_ir::ir::YulBreakStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulBreakStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulBreakStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulBreakStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulBreakStatementStruct
@@ -4149,12 +3685,8 @@ pub struct slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub slang_solidity_v2_ir::ir::YulContinueStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulContinueStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulContinueStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulContinueStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulContinueStatementStruct
@@ -4164,12 +3696,8 @@ pub slang_solidity_v2_ir::ir::YulDefaultCaseStruct::body: slang_solidity_v2_ir::
 pub slang_solidity_v2_ir::ir::YulDefaultCaseStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
-pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::eq(&self, &slang_solidity_v2_ir::ir::YulDefaultCaseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulDefaultCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulDefaultCaseStruct
@@ -4182,12 +3710,8 @@ pub slang_solidity_v2_ir::ir::YulForStatementStruct::iterator: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::YulForStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulForStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulForStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulForStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulForStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulForStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulForStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulForStatementStruct
@@ -4198,12 +3722,8 @@ pub slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::operand: slang_so
 pub slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
-pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::eq(&self, &slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionCallExpressionStruct
@@ -4216,12 +3736,8 @@ pub slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::range: core::ops::ran
 pub slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::returns: core::option::Option<slang_solidity_v2_ir::ir::YulVariableNames>
 impl slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
-pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::eq(&self, &slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
 pub fn slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulFunctionDefinitionStruct
@@ -4232,12 +3748,8 @@ pub slang_solidity_v2_ir::ir::YulIfStatementStruct::condition: slang_solidity_v2
 pub slang_solidity_v2_ir::ir::YulIfStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulIfStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulIfStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulIfStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulIfStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulIfStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulIfStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulIfStatementStruct
@@ -4246,12 +3758,8 @@ pub struct slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub slang_solidity_v2_ir::ir::YulLeaveStatementStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulLeaveStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulLeaveStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulLeaveStatementStruct
@@ -4263,12 +3771,8 @@ pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::range: core::ops::range:
 pub slang_solidity_v2_ir::ir::YulSwitchStatementStruct::value_cases: slang_solidity_v2_ir::ir::YulValueCases
 impl slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulSwitchStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulSwitchStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulSwitchStatementStruct
@@ -4279,12 +3783,8 @@ pub slang_solidity_v2_ir::ir::YulValueCaseStruct::range: core::ops::range::Range
 pub slang_solidity_v2_ir::ir::YulValueCaseStruct::value: slang_solidity_v2_ir::ir::YulLiteral
 impl slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulValueCaseStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulValueCaseStruct
-pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::eq(&self, &slang_solidity_v2_ir::ir::YulValueCaseStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulValueCaseStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulValueCaseStruct
 pub fn slang_solidity_v2_ir::ir::YulValueCaseStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulValueCaseStruct
@@ -4295,12 +3795,8 @@ pub slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::range: core:
 pub slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::variables: slang_solidity_v2_ir::ir::YulPaths
 impl slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableAssignmentStatementStruct
@@ -4311,12 +3807,8 @@ pub slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::value: core
 pub slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::variables: slang_solidity_v2_ir::ir::YulVariableNames
 impl slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
-pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationStatementStruct
@@ -4326,12 +3818,8 @@ pub slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::expression: sla
 pub slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::range: core::ops::range::Range<usize>
 impl slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::id(&self) -> slang_solidity_v2_common::nodes::NodeId
-impl core::cmp::Eq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
-impl core::cmp::PartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
-pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::eq(&self, &slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct) -> bool
 impl core::fmt::Debug for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 impl slang_solidity_v2_ir::ir::NodeIdentity for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct
 pub fn slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct::node_id(&self) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl slang_solidity_v2_ir::ir::TextRange for slang_solidity_v2_ir::ir::YulVariableDeclarationValueStruct

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -15,7 +15,7 @@ pub use super::kinds::NodeKind;
 
 pub type AbicoderPragma = Arc<AbicoderPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AbicoderPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -30,7 +30,7 @@ impl AbicoderPragmaStruct {
 
 pub type AdditiveExpression = Arc<AdditiveExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AdditiveExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -47,7 +47,7 @@ impl AdditiveExpressionStruct {
 
 pub type AddressType = Arc<AddressTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AddressTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -62,7 +62,7 @@ impl AddressTypeStruct {
 
 pub type AndExpression = Arc<AndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AndExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -78,7 +78,7 @@ impl AndExpressionStruct {
 
 pub type ArrayExpression = Arc<ArrayExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ArrayExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -93,7 +93,7 @@ impl ArrayExpressionStruct {
 
 pub type ArrayTypeName = Arc<ArrayTypeNameStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ArrayTypeNameStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -109,7 +109,7 @@ impl ArrayTypeNameStruct {
 
 pub type AssemblyStatement = Arc<AssemblyStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AssemblyStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -125,7 +125,7 @@ impl AssemblyStatementStruct {
 
 pub type AssignmentExpression = Arc<AssignmentExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AssignmentExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -142,7 +142,7 @@ impl AssignmentExpressionStruct {
 
 pub type BitwiseAndExpression = Arc<BitwiseAndExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BitwiseAndExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -158,7 +158,7 @@ impl BitwiseAndExpressionStruct {
 
 pub type BitwiseOrExpression = Arc<BitwiseOrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BitwiseOrExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -174,7 +174,7 @@ impl BitwiseOrExpressionStruct {
 
 pub type BitwiseXorExpression = Arc<BitwiseXorExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BitwiseXorExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -190,7 +190,7 @@ impl BitwiseXorExpressionStruct {
 
 pub type Block = Arc<BlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -205,7 +205,7 @@ impl BlockStruct {
 
 pub type BreakStatement = Arc<BreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BreakStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -219,7 +219,7 @@ impl BreakStatementStruct {
 
 pub type CallOptionsExpression = Arc<CallOptionsExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CallOptionsExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -235,7 +235,7 @@ impl CallOptionsExpressionStruct {
 
 pub type CatchClause = Arc<CatchClauseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CatchClauseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -252,7 +252,7 @@ impl CatchClauseStruct {
 
 pub type ConditionalExpression = Arc<ConditionalExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ConditionalExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -269,7 +269,7 @@ impl ConditionalExpressionStruct {
 
 pub type ConstantDefinition = Arc<ConstantDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ConstantDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -287,7 +287,7 @@ impl ConstantDefinitionStruct {
 
 pub type ContinueStatement = Arc<ContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ContinueStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -301,7 +301,7 @@ impl ContinueStatementStruct {
 
 pub type ContractDefinition = Arc<ContractDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ContractDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -320,7 +320,7 @@ impl ContractDefinitionStruct {
 
 pub type DecimalNumberExpression = Arc<DecimalNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DecimalNumberExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -336,7 +336,7 @@ impl DecimalNumberExpressionStruct {
 
 pub type DoWhileStatement = Arc<DoWhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DoWhileStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -352,7 +352,7 @@ impl DoWhileStatementStruct {
 
 pub type EmitStatement = Arc<EmitStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EmitStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -368,7 +368,7 @@ impl EmitStatementStruct {
 
 pub type EnumDefinition = Arc<EnumDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EnumDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -384,7 +384,7 @@ impl EnumDefinitionStruct {
 
 pub type EqualityExpression = Arc<EqualityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EqualityExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -401,7 +401,7 @@ impl EqualityExpressionStruct {
 
 pub type ErrorDefinition = Arc<ErrorDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ErrorDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -417,7 +417,7 @@ impl ErrorDefinitionStruct {
 
 pub type EventDefinition = Arc<EventDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EventDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -434,7 +434,7 @@ impl EventDefinitionStruct {
 
 pub type ExperimentalPragma = Arc<ExperimentalPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ExperimentalPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -449,7 +449,7 @@ impl ExperimentalPragmaStruct {
 
 pub type ExponentiationExpression = Arc<ExponentiationExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ExponentiationExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -465,7 +465,7 @@ impl ExponentiationExpressionStruct {
 
 pub type ExpressionStatement = Arc<ExpressionStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ExpressionStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -480,7 +480,7 @@ impl ExpressionStatementStruct {
 
 pub type ForStatement = Arc<ForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ForStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -498,7 +498,7 @@ impl ForStatementStruct {
 
 pub type FunctionAttributes = Arc<FunctionAttributesStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FunctionAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -518,7 +518,7 @@ impl FunctionAttributesStruct {
 
 pub type FunctionCallExpression = Arc<FunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FunctionCallExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -534,7 +534,7 @@ impl FunctionCallExpressionStruct {
 
 pub type FunctionDefinition = Arc<FunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FunctionDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -554,7 +554,7 @@ impl FunctionDefinitionStruct {
 
 pub type FunctionType = Arc<FunctionTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FunctionTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -571,7 +571,7 @@ impl FunctionTypeStruct {
 
 pub type FunctionTypeAttributes = Arc<FunctionTypeAttributesStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FunctionTypeAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -587,7 +587,7 @@ impl FunctionTypeAttributesStruct {
 
 pub type HexNumberExpression = Arc<HexNumberExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct HexNumberExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -602,7 +602,7 @@ impl HexNumberExpressionStruct {
 
 pub type IfStatement = Arc<IfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct IfStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -619,7 +619,7 @@ impl IfStatementStruct {
 
 pub type ImportDeconstruction = Arc<ImportDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ImportDeconstructionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -635,7 +635,7 @@ impl ImportDeconstructionStruct {
 
 pub type ImportDeconstructionSymbol = Arc<ImportDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ImportDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -651,7 +651,7 @@ impl ImportDeconstructionSymbolStruct {
 
 pub type IndexAccessExpression = Arc<IndexAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct IndexAccessExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -669,7 +669,7 @@ impl IndexAccessExpressionStruct {
 
 pub type InequalityExpression = Arc<InequalityExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InequalityExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -686,7 +686,7 @@ impl InequalityExpressionStruct {
 
 pub type InheritanceType = Arc<InheritanceTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InheritanceTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -702,7 +702,7 @@ impl InheritanceTypeStruct {
 
 pub type InterfaceDefinition = Arc<InterfaceDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InterfaceDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -719,7 +719,7 @@ impl InterfaceDefinitionStruct {
 
 pub type LibraryDefinition = Arc<LibraryDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct LibraryDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -735,7 +735,7 @@ impl LibraryDefinitionStruct {
 
 pub type MappingType = Arc<MappingTypeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MappingTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -751,7 +751,7 @@ impl MappingTypeStruct {
 
 pub type MemberAccessExpression = Arc<MemberAccessExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MemberAccessExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -767,7 +767,7 @@ impl MemberAccessExpressionStruct {
 
 pub type ModifierInvocation = Arc<ModifierInvocationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ModifierInvocationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -783,7 +783,7 @@ impl ModifierInvocationStruct {
 
 pub type MultiTypedDeclaration = Arc<MultiTypedDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MultiTypedDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -799,7 +799,7 @@ impl MultiTypedDeclarationStruct {
 
 pub type MultiTypedDeclarationElement = Arc<MultiTypedDeclarationElementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MultiTypedDeclarationElementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -814,7 +814,7 @@ impl MultiTypedDeclarationElementStruct {
 
 pub type MultiplicativeExpression = Arc<MultiplicativeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MultiplicativeExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -831,7 +831,7 @@ impl MultiplicativeExpressionStruct {
 
 pub type NamedArgument = Arc<NamedArgumentStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct NamedArgumentStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -847,7 +847,7 @@ impl NamedArgumentStruct {
 
 pub type NewExpression = Arc<NewExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct NewExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -862,7 +862,7 @@ impl NewExpressionStruct {
 
 pub type OrExpression = Arc<OrExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct OrExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -878,7 +878,7 @@ impl OrExpressionStruct {
 
 pub type Parameter = Arc<ParameterStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ParameterStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -896,7 +896,7 @@ impl ParameterStruct {
 
 pub type PathImport = Arc<PathImportStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PathImportStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -912,7 +912,7 @@ impl PathImportStruct {
 
 pub type PostfixExpression = Arc<PostfixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PostfixExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -928,7 +928,7 @@ impl PostfixExpressionStruct {
 
 pub type PragmaDirective = Arc<PragmaDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PragmaDirectiveStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -943,7 +943,7 @@ impl PragmaDirectiveStruct {
 
 pub type PrefixExpression = Arc<PrefixExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PrefixExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -959,7 +959,7 @@ impl PrefixExpressionStruct {
 
 pub type ReturnStatement = Arc<ReturnStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ReturnStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -974,7 +974,7 @@ impl ReturnStatementStruct {
 
 pub type RevertStatement = Arc<RevertStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct RevertStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -990,7 +990,7 @@ impl RevertStatementStruct {
 
 pub type ShiftExpression = Arc<ShiftExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ShiftExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1007,7 +1007,7 @@ impl ShiftExpressionStruct {
 
 pub type SingleTypedDeclaration = Arc<SingleTypedDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SingleTypedDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1023,7 +1023,7 @@ impl SingleTypedDeclarationStruct {
 
 pub type SourceUnit = Arc<SourceUnitStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SourceUnitStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1038,7 +1038,7 @@ impl SourceUnitStruct {
 
 pub type StateVariableAttributes = Arc<StateVariableAttributesStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StateVariableAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1055,7 +1055,7 @@ impl StateVariableAttributesStruct {
 
 pub type StateVariableDefinition = Arc<StateVariableDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StateVariableDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1073,7 +1073,7 @@ impl StateVariableDefinitionStruct {
 
 pub type StructDefinition = Arc<StructDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StructDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1089,7 +1089,7 @@ impl StructDefinitionStruct {
 
 pub type StructMember = Arc<StructMemberStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StructMemberStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1105,7 +1105,7 @@ impl StructMemberStruct {
 
 pub type TryStatement = Arc<TryStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TryStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1123,7 +1123,7 @@ impl TryStatementStruct {
 
 pub type TupleExpression = Arc<TupleExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TupleExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1138,7 +1138,7 @@ impl TupleExpressionStruct {
 
 pub type TupleValue = Arc<TupleValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TupleValueStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1153,7 +1153,7 @@ impl TupleValueStruct {
 
 pub type TypeExpression = Arc<TypeExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TypeExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1168,7 +1168,7 @@ impl TypeExpressionStruct {
 
 pub type UncheckedBlock = Arc<UncheckedBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UncheckedBlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1183,7 +1183,7 @@ impl UncheckedBlockStruct {
 
 pub type UserDefinedValueTypeDefinition = Arc<UserDefinedValueTypeDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UserDefinedValueTypeDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1199,7 +1199,7 @@ impl UserDefinedValueTypeDefinitionStruct {
 
 pub type UsingDeconstruction = Arc<UsingDeconstructionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UsingDeconstructionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1214,7 +1214,7 @@ impl UsingDeconstructionStruct {
 
 pub type UsingDeconstructionSymbol = Arc<UsingDeconstructionSymbolStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UsingDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1230,7 +1230,7 @@ impl UsingDeconstructionSymbolStruct {
 
 pub type UsingDirective = Arc<UsingDirectiveStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UsingDirectiveStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1247,7 +1247,7 @@ impl UsingDirectiveStruct {
 
 pub type VariableDeclaration = Arc<VariableDeclarationStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VariableDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1264,7 +1264,7 @@ impl VariableDeclarationStruct {
 
 pub type VariableDeclarationStatement = Arc<VariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1279,7 +1279,7 @@ impl VariableDeclarationStatementStruct {
 
 pub type VersionPragma = Arc<VersionPragmaStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VersionPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1294,7 +1294,7 @@ impl VersionPragmaStruct {
 
 pub type VersionRange = Arc<VersionRangeStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VersionRangeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1310,7 +1310,7 @@ impl VersionRangeStruct {
 
 pub type VersionTerm = Arc<VersionTermStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VersionTermStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1326,7 +1326,7 @@ impl VersionTermStruct {
 
 pub type WhileStatement = Arc<WhileStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct WhileStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1342,7 +1342,7 @@ impl WhileStatementStruct {
 
 pub type YulBlock = Arc<YulBlockStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulBlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1357,7 +1357,7 @@ impl YulBlockStruct {
 
 pub type YulBreakStatement = Arc<YulBreakStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulBreakStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1371,7 +1371,7 @@ impl YulBreakStatementStruct {
 
 pub type YulContinueStatement = Arc<YulContinueStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulContinueStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1385,7 +1385,7 @@ impl YulContinueStatementStruct {
 
 pub type YulDefaultCase = Arc<YulDefaultCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulDefaultCaseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1400,7 +1400,7 @@ impl YulDefaultCaseStruct {
 
 pub type YulForStatement = Arc<YulForStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulForStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1418,7 +1418,7 @@ impl YulForStatementStruct {
 
 pub type YulFunctionCallExpression = Arc<YulFunctionCallExpressionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulFunctionCallExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1434,7 +1434,7 @@ impl YulFunctionCallExpressionStruct {
 
 pub type YulFunctionDefinition = Arc<YulFunctionDefinitionStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulFunctionDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1452,7 +1452,7 @@ impl YulFunctionDefinitionStruct {
 
 pub type YulIfStatement = Arc<YulIfStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulIfStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1468,7 +1468,7 @@ impl YulIfStatementStruct {
 
 pub type YulLeaveStatement = Arc<YulLeaveStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulLeaveStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1482,7 +1482,7 @@ impl YulLeaveStatementStruct {
 
 pub type YulSwitchStatement = Arc<YulSwitchStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulSwitchStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1499,7 +1499,7 @@ impl YulSwitchStatementStruct {
 
 pub type YulValueCase = Arc<YulValueCaseStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulValueCaseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1515,7 +1515,7 @@ impl YulValueCaseStruct {
 
 pub type YulVariableAssignmentStatement = Arc<YulVariableAssignmentStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulVariableAssignmentStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1531,7 +1531,7 @@ impl YulVariableAssignmentStatementStruct {
 
 pub type YulVariableDeclarationStatement = Arc<YulVariableDeclarationStatementStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulVariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1547,7 +1547,7 @@ impl YulVariableDeclarationStatementStruct {
 
 pub type YulVariableDeclarationValue = Arc<YulVariableDeclarationValueStruct>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct YulVariableDeclarationValueStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1570,7 +1570,7 @@ pub enum AbicoderVersion {
     V2,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AdditiveExpressionOperator {
     Minus(Minus),
     Plus(Plus),
@@ -1585,13 +1585,13 @@ impl AdditiveExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ArgumentsDeclaration {
     PositionalArguments(PositionalArguments),
     NamedArguments(NamedArguments),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AssignmentExpressionOperator {
     AmpersandEqual(AmpersandEqual),
     AsteriskEqual(AsteriskEqual),
@@ -1635,7 +1635,7 @@ pub enum CatchClauseKind {
     LowLevel,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ContractMember {
     UsingDirective(UsingDirective),
     FunctionDefinition(FunctionDefinition),
@@ -1648,7 +1648,7 @@ pub enum ContractMember {
     ConstantDefinition(ConstantDefinition),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ElementaryType {
     BoolKeyword(BoolKeyword),
     StringKeyword(StringKeyword),
@@ -1660,7 +1660,7 @@ pub enum ElementaryType {
     UfixedKeyword(UfixedKeyword),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EqualityExpressionOperator {
     BangEqual(BangEqual),
     EqualEqual(EqualEqual),
@@ -1683,7 +1683,7 @@ pub enum ExperimentalFeature {
     Unrecognized,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expression {
     AssignmentExpression(AssignmentExpression),
     ConditionalExpression(ConditionalExpression),
@@ -1720,13 +1720,13 @@ pub enum Expression {
     Identifier(Identifier),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ForStatementCondition {
     ExpressionStatement(ExpressionStatement),
     Semicolon(Semicolon),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ForStatementInitialization {
     VariableDeclarationStatement(VariableDeclarationStatement),
     ExpressionStatement(ExpressionStatement),
@@ -1758,13 +1758,13 @@ pub enum FunctionVisibility {
     External,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ImportClause {
     PathImport(PathImport),
     ImportDeconstruction(ImportDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum InequalityExpressionOperator {
     GreaterThan(GreaterThan),
     GreaterThanEqual(GreaterThanEqual),
@@ -1783,7 +1783,7 @@ impl InequalityExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MultiplicativeExpressionOperator {
     Asterisk(Asterisk),
     Percent(Percent),
@@ -1800,7 +1800,7 @@ impl MultiplicativeExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum NumberUnit {
     WeiKeyword(WeiKeyword),
     GweiKeyword(GweiKeyword),
@@ -1827,7 +1827,7 @@ impl NumberUnit {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PostfixExpressionOperator {
     MinusMinus(MinusMinus),
     PlusPlus(PlusPlus),
@@ -1842,14 +1842,14 @@ impl PostfixExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Pragma {
     VersionPragma(VersionPragma),
     AbicoderPragma(AbicoderPragma),
     ExperimentalPragma(ExperimentalPragma),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PrefixExpressionOperator {
     Bang(Bang),
     DeleteKeyword(DeleteKeyword),
@@ -1872,7 +1872,7 @@ impl PrefixExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ShiftExpressionOperator {
     GreaterThanGreaterThan(GreaterThanGreaterThan),
     GreaterThanGreaterThanGreaterThan(GreaterThanGreaterThanGreaterThan),
@@ -1889,7 +1889,7 @@ impl ShiftExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SourceUnitMember {
     PragmaDirective(PragmaDirective),
     ImportClause(ImportClause),
@@ -1921,7 +1921,7 @@ pub enum StateVariableVisibility {
     Internal,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Statement {
     IfStatement(IfStatement),
     ForStatement(ForStatement),
@@ -1940,7 +1940,7 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageLocation {
     MemoryKeyword(MemoryKeyword),
     StorageKeyword(StorageKeyword),
@@ -1957,14 +1957,14 @@ impl StorageLocation {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StringExpression {
     StringLiterals(StringLiterals),
     HexStringLiterals(HexStringLiterals),
     UnicodeStringLiterals(UnicodeStringLiterals),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TypeName {
     ArrayTypeName(ArrayTypeName),
     FunctionType(FunctionType),
@@ -1973,13 +1973,13 @@ pub enum TypeName {
     IdentifierPath(IdentifierPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UsingClause {
     IdentifierPath(IdentifierPath),
     UsingDeconstruction(UsingDeconstruction),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UsingOperator {
     Ampersand(Ampersand),
     Asterisk(Asterisk),
@@ -2020,31 +2020,31 @@ impl UsingOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UsingTarget {
     TypeName(TypeName),
     Asterisk(Asterisk),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VariableDeclarationTarget {
     SingleTypedDeclaration(SingleTypedDeclaration),
     MultiTypedDeclaration(MultiTypedDeclaration),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VersionExpression {
     VersionRange(VersionRange),
     VersionTerm(VersionTerm),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VersionLiteral {
     SimpleVersionLiteral(SimpleVersionLiteral),
     StringLiteral(StringLiteral),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VersionOperator {
     PragmaCaret(PragmaCaret),
     PragmaTilde(PragmaTilde),
@@ -2069,14 +2069,14 @@ impl VersionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum YulExpression {
     YulFunctionCallExpression(YulFunctionCallExpression),
     YulLiteral(YulLiteral),
     YulPath(YulPath),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum YulLiteral {
     TrueKeyword(TrueKeyword),
     FalseKeyword(FalseKeyword),
@@ -2099,7 +2099,7 @@ impl YulLiteral {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.generated.rs
@@ -15,7 +15,8 @@ pub use super::kinds::NodeKind;
 
 pub type AbicoderPragma = Arc<AbicoderPragmaStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AbicoderPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -30,7 +31,8 @@ impl AbicoderPragmaStruct {
 
 pub type AdditiveExpression = Arc<AdditiveExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AdditiveExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -47,7 +49,8 @@ impl AdditiveExpressionStruct {
 
 pub type AddressType = Arc<AddressTypeStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AddressTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -62,7 +65,8 @@ impl AddressTypeStruct {
 
 pub type AndExpression = Arc<AndExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AndExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -78,7 +82,8 @@ impl AndExpressionStruct {
 
 pub type ArrayExpression = Arc<ArrayExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ArrayExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -93,7 +98,8 @@ impl ArrayExpressionStruct {
 
 pub type ArrayTypeName = Arc<ArrayTypeNameStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ArrayTypeNameStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -109,7 +115,8 @@ impl ArrayTypeNameStruct {
 
 pub type AssemblyStatement = Arc<AssemblyStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AssemblyStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -125,7 +132,8 @@ impl AssemblyStatementStruct {
 
 pub type AssignmentExpression = Arc<AssignmentExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct AssignmentExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -142,7 +150,8 @@ impl AssignmentExpressionStruct {
 
 pub type BitwiseAndExpression = Arc<BitwiseAndExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct BitwiseAndExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -158,7 +167,8 @@ impl BitwiseAndExpressionStruct {
 
 pub type BitwiseOrExpression = Arc<BitwiseOrExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct BitwiseOrExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -174,7 +184,8 @@ impl BitwiseOrExpressionStruct {
 
 pub type BitwiseXorExpression = Arc<BitwiseXorExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct BitwiseXorExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -190,7 +201,8 @@ impl BitwiseXorExpressionStruct {
 
 pub type Block = Arc<BlockStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct BlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -205,7 +217,8 @@ impl BlockStruct {
 
 pub type BreakStatement = Arc<BreakStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct BreakStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -219,7 +232,8 @@ impl BreakStatementStruct {
 
 pub type CallOptionsExpression = Arc<CallOptionsExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct CallOptionsExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -235,7 +249,8 @@ impl CallOptionsExpressionStruct {
 
 pub type CatchClause = Arc<CatchClauseStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct CatchClauseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -252,7 +267,8 @@ impl CatchClauseStruct {
 
 pub type ConditionalExpression = Arc<ConditionalExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ConditionalExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -269,7 +285,8 @@ impl ConditionalExpressionStruct {
 
 pub type ConstantDefinition = Arc<ConstantDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ConstantDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -287,7 +304,8 @@ impl ConstantDefinitionStruct {
 
 pub type ContinueStatement = Arc<ContinueStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ContinueStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -301,7 +319,8 @@ impl ContinueStatementStruct {
 
 pub type ContractDefinition = Arc<ContractDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ContractDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -320,7 +339,8 @@ impl ContractDefinitionStruct {
 
 pub type DecimalNumberExpression = Arc<DecimalNumberExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct DecimalNumberExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -336,7 +356,8 @@ impl DecimalNumberExpressionStruct {
 
 pub type DoWhileStatement = Arc<DoWhileStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct DoWhileStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -352,7 +373,8 @@ impl DoWhileStatementStruct {
 
 pub type EmitStatement = Arc<EmitStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct EmitStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -368,7 +390,8 @@ impl EmitStatementStruct {
 
 pub type EnumDefinition = Arc<EnumDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct EnumDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -384,7 +407,8 @@ impl EnumDefinitionStruct {
 
 pub type EqualityExpression = Arc<EqualityExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct EqualityExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -401,7 +425,8 @@ impl EqualityExpressionStruct {
 
 pub type ErrorDefinition = Arc<ErrorDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ErrorDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -417,7 +442,8 @@ impl ErrorDefinitionStruct {
 
 pub type EventDefinition = Arc<EventDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct EventDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -434,7 +460,8 @@ impl EventDefinitionStruct {
 
 pub type ExperimentalPragma = Arc<ExperimentalPragmaStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ExperimentalPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -449,7 +476,8 @@ impl ExperimentalPragmaStruct {
 
 pub type ExponentiationExpression = Arc<ExponentiationExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ExponentiationExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -465,7 +493,8 @@ impl ExponentiationExpressionStruct {
 
 pub type ExpressionStatement = Arc<ExpressionStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ExpressionStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -480,7 +509,8 @@ impl ExpressionStatementStruct {
 
 pub type ForStatement = Arc<ForStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ForStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -498,7 +528,8 @@ impl ForStatementStruct {
 
 pub type FunctionAttributes = Arc<FunctionAttributesStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct FunctionAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -518,7 +549,8 @@ impl FunctionAttributesStruct {
 
 pub type FunctionCallExpression = Arc<FunctionCallExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct FunctionCallExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -534,7 +566,8 @@ impl FunctionCallExpressionStruct {
 
 pub type FunctionDefinition = Arc<FunctionDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct FunctionDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -554,7 +587,8 @@ impl FunctionDefinitionStruct {
 
 pub type FunctionType = Arc<FunctionTypeStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct FunctionTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -571,7 +605,8 @@ impl FunctionTypeStruct {
 
 pub type FunctionTypeAttributes = Arc<FunctionTypeAttributesStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct FunctionTypeAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -587,7 +622,8 @@ impl FunctionTypeAttributesStruct {
 
 pub type HexNumberExpression = Arc<HexNumberExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct HexNumberExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -602,7 +638,8 @@ impl HexNumberExpressionStruct {
 
 pub type IfStatement = Arc<IfStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct IfStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -619,7 +656,8 @@ impl IfStatementStruct {
 
 pub type ImportDeconstruction = Arc<ImportDeconstructionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ImportDeconstructionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -635,7 +673,8 @@ impl ImportDeconstructionStruct {
 
 pub type ImportDeconstructionSymbol = Arc<ImportDeconstructionSymbolStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ImportDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -651,7 +690,8 @@ impl ImportDeconstructionSymbolStruct {
 
 pub type IndexAccessExpression = Arc<IndexAccessExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct IndexAccessExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -669,7 +709,8 @@ impl IndexAccessExpressionStruct {
 
 pub type InequalityExpression = Arc<InequalityExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct InequalityExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -686,7 +727,8 @@ impl InequalityExpressionStruct {
 
 pub type InheritanceType = Arc<InheritanceTypeStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct InheritanceTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -702,7 +744,8 @@ impl InheritanceTypeStruct {
 
 pub type InterfaceDefinition = Arc<InterfaceDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct InterfaceDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -719,7 +762,8 @@ impl InterfaceDefinitionStruct {
 
 pub type LibraryDefinition = Arc<LibraryDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct LibraryDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -735,7 +779,8 @@ impl LibraryDefinitionStruct {
 
 pub type MappingType = Arc<MappingTypeStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct MappingTypeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -751,7 +796,8 @@ impl MappingTypeStruct {
 
 pub type MemberAccessExpression = Arc<MemberAccessExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct MemberAccessExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -767,7 +813,8 @@ impl MemberAccessExpressionStruct {
 
 pub type ModifierInvocation = Arc<ModifierInvocationStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ModifierInvocationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -783,7 +830,8 @@ impl ModifierInvocationStruct {
 
 pub type MultiTypedDeclaration = Arc<MultiTypedDeclarationStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct MultiTypedDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -799,7 +847,8 @@ impl MultiTypedDeclarationStruct {
 
 pub type MultiTypedDeclarationElement = Arc<MultiTypedDeclarationElementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct MultiTypedDeclarationElementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -814,7 +863,8 @@ impl MultiTypedDeclarationElementStruct {
 
 pub type MultiplicativeExpression = Arc<MultiplicativeExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct MultiplicativeExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -831,7 +881,8 @@ impl MultiplicativeExpressionStruct {
 
 pub type NamedArgument = Arc<NamedArgumentStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct NamedArgumentStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -847,7 +898,8 @@ impl NamedArgumentStruct {
 
 pub type NewExpression = Arc<NewExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct NewExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -862,7 +914,8 @@ impl NewExpressionStruct {
 
 pub type OrExpression = Arc<OrExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct OrExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -878,7 +931,8 @@ impl OrExpressionStruct {
 
 pub type Parameter = Arc<ParameterStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ParameterStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -896,7 +950,8 @@ impl ParameterStruct {
 
 pub type PathImport = Arc<PathImportStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct PathImportStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -912,7 +967,8 @@ impl PathImportStruct {
 
 pub type PostfixExpression = Arc<PostfixExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct PostfixExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -928,7 +984,8 @@ impl PostfixExpressionStruct {
 
 pub type PragmaDirective = Arc<PragmaDirectiveStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct PragmaDirectiveStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -943,7 +1000,8 @@ impl PragmaDirectiveStruct {
 
 pub type PrefixExpression = Arc<PrefixExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct PrefixExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -959,7 +1017,8 @@ impl PrefixExpressionStruct {
 
 pub type ReturnStatement = Arc<ReturnStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ReturnStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -974,7 +1033,8 @@ impl ReturnStatementStruct {
 
 pub type RevertStatement = Arc<RevertStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct RevertStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -990,7 +1050,8 @@ impl RevertStatementStruct {
 
 pub type ShiftExpression = Arc<ShiftExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct ShiftExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1007,7 +1068,8 @@ impl ShiftExpressionStruct {
 
 pub type SingleTypedDeclaration = Arc<SingleTypedDeclarationStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct SingleTypedDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1023,7 +1085,8 @@ impl SingleTypedDeclarationStruct {
 
 pub type SourceUnit = Arc<SourceUnitStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct SourceUnitStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1038,7 +1101,8 @@ impl SourceUnitStruct {
 
 pub type StateVariableAttributes = Arc<StateVariableAttributesStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct StateVariableAttributesStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1055,7 +1119,8 @@ impl StateVariableAttributesStruct {
 
 pub type StateVariableDefinition = Arc<StateVariableDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct StateVariableDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1073,7 +1138,8 @@ impl StateVariableDefinitionStruct {
 
 pub type StructDefinition = Arc<StructDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct StructDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1089,7 +1155,8 @@ impl StructDefinitionStruct {
 
 pub type StructMember = Arc<StructMemberStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct StructMemberStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1105,7 +1172,8 @@ impl StructMemberStruct {
 
 pub type TryStatement = Arc<TryStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct TryStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1123,7 +1191,8 @@ impl TryStatementStruct {
 
 pub type TupleExpression = Arc<TupleExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct TupleExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1138,7 +1207,8 @@ impl TupleExpressionStruct {
 
 pub type TupleValue = Arc<TupleValueStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct TupleValueStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1153,7 +1223,8 @@ impl TupleValueStruct {
 
 pub type TypeExpression = Arc<TypeExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct TypeExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1168,7 +1239,8 @@ impl TypeExpressionStruct {
 
 pub type UncheckedBlock = Arc<UncheckedBlockStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct UncheckedBlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1183,7 +1255,8 @@ impl UncheckedBlockStruct {
 
 pub type UserDefinedValueTypeDefinition = Arc<UserDefinedValueTypeDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct UserDefinedValueTypeDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1199,7 +1272,8 @@ impl UserDefinedValueTypeDefinitionStruct {
 
 pub type UsingDeconstruction = Arc<UsingDeconstructionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct UsingDeconstructionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1214,7 +1288,8 @@ impl UsingDeconstructionStruct {
 
 pub type UsingDeconstructionSymbol = Arc<UsingDeconstructionSymbolStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct UsingDeconstructionSymbolStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1230,7 +1305,8 @@ impl UsingDeconstructionSymbolStruct {
 
 pub type UsingDirective = Arc<UsingDirectiveStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct UsingDirectiveStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1247,7 +1323,8 @@ impl UsingDirectiveStruct {
 
 pub type VariableDeclaration = Arc<VariableDeclarationStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct VariableDeclarationStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1264,7 +1341,8 @@ impl VariableDeclarationStruct {
 
 pub type VariableDeclarationStatement = Arc<VariableDeclarationStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct VariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1279,7 +1357,8 @@ impl VariableDeclarationStatementStruct {
 
 pub type VersionPragma = Arc<VersionPragmaStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct VersionPragmaStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1294,7 +1373,8 @@ impl VersionPragmaStruct {
 
 pub type VersionRange = Arc<VersionRangeStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct VersionRangeStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1310,7 +1390,8 @@ impl VersionRangeStruct {
 
 pub type VersionTerm = Arc<VersionTermStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct VersionTermStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1326,7 +1407,8 @@ impl VersionTermStruct {
 
 pub type WhileStatement = Arc<WhileStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct WhileStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1342,7 +1424,8 @@ impl WhileStatementStruct {
 
 pub type YulBlock = Arc<YulBlockStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulBlockStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1357,7 +1440,8 @@ impl YulBlockStruct {
 
 pub type YulBreakStatement = Arc<YulBreakStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulBreakStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1371,7 +1455,8 @@ impl YulBreakStatementStruct {
 
 pub type YulContinueStatement = Arc<YulContinueStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulContinueStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1385,7 +1470,8 @@ impl YulContinueStatementStruct {
 
 pub type YulDefaultCase = Arc<YulDefaultCaseStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulDefaultCaseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1400,7 +1486,8 @@ impl YulDefaultCaseStruct {
 
 pub type YulForStatement = Arc<YulForStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulForStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1418,7 +1505,8 @@ impl YulForStatementStruct {
 
 pub type YulFunctionCallExpression = Arc<YulFunctionCallExpressionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulFunctionCallExpressionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1434,7 +1522,8 @@ impl YulFunctionCallExpressionStruct {
 
 pub type YulFunctionDefinition = Arc<YulFunctionDefinitionStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulFunctionDefinitionStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1452,7 +1541,8 @@ impl YulFunctionDefinitionStruct {
 
 pub type YulIfStatement = Arc<YulIfStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulIfStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1468,7 +1558,8 @@ impl YulIfStatementStruct {
 
 pub type YulLeaveStatement = Arc<YulLeaveStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulLeaveStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1482,7 +1573,8 @@ impl YulLeaveStatementStruct {
 
 pub type YulSwitchStatement = Arc<YulSwitchStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulSwitchStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1499,7 +1591,8 @@ impl YulSwitchStatementStruct {
 
 pub type YulValueCase = Arc<YulValueCaseStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulValueCaseStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1515,7 +1608,8 @@ impl YulValueCaseStruct {
 
 pub type YulVariableAssignmentStatement = Arc<YulVariableAssignmentStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulVariableAssignmentStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1531,7 +1625,8 @@ impl YulVariableAssignmentStatementStruct {
 
 pub type YulVariableDeclarationStatement = Arc<YulVariableDeclarationStatementStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulVariableDeclarationStatementStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1547,7 +1642,8 @@ impl YulVariableDeclarationStatementStruct {
 
 pub type YulVariableDeclarationValue = Arc<YulVariableDeclarationValueStruct>;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub struct YulVariableDeclarationValueStruct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -1570,7 +1666,8 @@ pub enum AbicoderVersion {
     V2,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum AdditiveExpressionOperator {
     Minus(Minus),
     Plus(Plus),
@@ -1585,13 +1682,15 @@ impl AdditiveExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ArgumentsDeclaration {
     PositionalArguments(PositionalArguments),
     NamedArguments(NamedArguments),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum AssignmentExpressionOperator {
     AmpersandEqual(AmpersandEqual),
     AsteriskEqual(AsteriskEqual),
@@ -1635,7 +1734,8 @@ pub enum CatchClauseKind {
     LowLevel,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ContractMember {
     UsingDirective(UsingDirective),
     FunctionDefinition(FunctionDefinition),
@@ -1648,7 +1748,8 @@ pub enum ContractMember {
     ConstantDefinition(ConstantDefinition),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ElementaryType {
     BoolKeyword(BoolKeyword),
     StringKeyword(StringKeyword),
@@ -1660,7 +1761,8 @@ pub enum ElementaryType {
     UfixedKeyword(UfixedKeyword),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum EqualityExpressionOperator {
     BangEqual(BangEqual),
     EqualEqual(EqualEqual),
@@ -1683,7 +1785,8 @@ pub enum ExperimentalFeature {
     Unrecognized,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum Expression {
     AssignmentExpression(AssignmentExpression),
     ConditionalExpression(ConditionalExpression),
@@ -1720,13 +1823,15 @@ pub enum Expression {
     Identifier(Identifier),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ForStatementCondition {
     ExpressionStatement(ExpressionStatement),
     Semicolon(Semicolon),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ForStatementInitialization {
     VariableDeclarationStatement(VariableDeclarationStatement),
     ExpressionStatement(ExpressionStatement),
@@ -1758,13 +1863,15 @@ pub enum FunctionVisibility {
     External,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ImportClause {
     PathImport(PathImport),
     ImportDeconstruction(ImportDeconstruction),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum InequalityExpressionOperator {
     GreaterThan(GreaterThan),
     GreaterThanEqual(GreaterThanEqual),
@@ -1783,7 +1890,8 @@ impl InequalityExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum MultiplicativeExpressionOperator {
     Asterisk(Asterisk),
     Percent(Percent),
@@ -1800,7 +1908,8 @@ impl MultiplicativeExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum NumberUnit {
     WeiKeyword(WeiKeyword),
     GweiKeyword(GweiKeyword),
@@ -1827,7 +1936,8 @@ impl NumberUnit {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum PostfixExpressionOperator {
     MinusMinus(MinusMinus),
     PlusPlus(PlusPlus),
@@ -1842,14 +1952,16 @@ impl PostfixExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum Pragma {
     VersionPragma(VersionPragma),
     AbicoderPragma(AbicoderPragma),
     ExperimentalPragma(ExperimentalPragma),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum PrefixExpressionOperator {
     Bang(Bang),
     DeleteKeyword(DeleteKeyword),
@@ -1872,7 +1984,8 @@ impl PrefixExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum ShiftExpressionOperator {
     GreaterThanGreaterThan(GreaterThanGreaterThan),
     GreaterThanGreaterThanGreaterThan(GreaterThanGreaterThanGreaterThan),
@@ -1889,7 +2002,8 @@ impl ShiftExpressionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum SourceUnitMember {
     PragmaDirective(PragmaDirective),
     ImportClause(ImportClause),
@@ -1921,7 +2035,8 @@ pub enum StateVariableVisibility {
     Internal,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum Statement {
     IfStatement(IfStatement),
     ForStatement(ForStatement),
@@ -1940,7 +2055,8 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum StorageLocation {
     MemoryKeyword(MemoryKeyword),
     StorageKeyword(StorageKeyword),
@@ -1957,14 +2073,16 @@ impl StorageLocation {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum StringExpression {
     StringLiterals(StringLiterals),
     HexStringLiterals(HexStringLiterals),
     UnicodeStringLiterals(UnicodeStringLiterals),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum TypeName {
     ArrayTypeName(ArrayTypeName),
     FunctionType(FunctionType),
@@ -1973,13 +2091,15 @@ pub enum TypeName {
     IdentifierPath(IdentifierPath),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum UsingClause {
     IdentifierPath(IdentifierPath),
     UsingDeconstruction(UsingDeconstruction),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum UsingOperator {
     Ampersand(Ampersand),
     Asterisk(Asterisk),
@@ -2020,31 +2140,36 @@ impl UsingOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum UsingTarget {
     TypeName(TypeName),
     Asterisk(Asterisk),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum VariableDeclarationTarget {
     SingleTypedDeclaration(SingleTypedDeclaration),
     MultiTypedDeclaration(MultiTypedDeclaration),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum VersionExpression {
     VersionRange(VersionRange),
     VersionTerm(VersionTerm),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum VersionLiteral {
     SimpleVersionLiteral(SimpleVersionLiteral),
     StringLiteral(StringLiteral),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum VersionOperator {
     PragmaCaret(PragmaCaret),
     PragmaTilde(PragmaTilde),
@@ -2069,14 +2194,16 @@ impl VersionOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum YulExpression {
     YulFunctionCallExpression(YulFunctionCallExpression),
     YulLiteral(YulLiteral),
     YulPath(YulPath),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum YulLiteral {
     TrueKeyword(TrueKeyword),
     FalseKeyword(FalseKeyword),
@@ -2099,7 +2226,8 @@ impl YulLiteral {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
 pub enum YulStatement {
     YulBlock(YulBlock),
     YulFunctionDefinition(YulFunctionDefinition),

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -16,7 +16,9 @@ pub use super::kinds::NodeKind;
 {% for parent_type, sequence in target.sequences %}
   pub type {{ parent_type }} = Arc<{{ parent_type }}Struct>;
 
-  #[derive(Debug, Eq, PartialEq)]
+  #[derive(Debug)]
+  {# IR nodes are deeply recursive, so we don't expose equality checks by default. #}
+  #[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
   pub struct {{ parent_type }}Struct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -62,7 +64,9 @@ pub use super::kinds::NodeKind;
   {% if all_external -%}
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
   {%- else -%}
-    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug)]
+    {# IR nodes are deeply recursive, so we don't expose equality checks by default. #}
+    #[cfg_attr(feature = "__private_testing_utils", derive(Eq, PartialEq))]
   {%- endif %}
   pub enum {{ parent_type }} {
     {% for variant in choice.variants -%}

--- a/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
+++ b/crates/solidity-v2/outputs/cargo/ir/src/ir/nodes.rs.jinja2
@@ -16,7 +16,7 @@ pub use super::kinds::NodeKind;
 {% for parent_type, sequence in target.sequences %}
   pub type {{ parent_type }} = Arc<{{ parent_type }}Struct>;
 
-  #[derive(Debug)]
+  #[derive(Debug, Eq, PartialEq)]
   pub struct {{ parent_type }}Struct {
     pub(crate) id: NodeId,
     pub range: Range<usize>,
@@ -62,7 +62,7 @@ pub use super::kinds::NodeKind;
   {% if all_external -%}
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
   {%- else -%}
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
   {%- endif %}
   pub enum {{ parent_type }} {
     {% for variant in choice.variants -%}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["utilities"]
 categories = ["compilers", "utilities"]
 
 [dependencies]
+rayon = { workspace = true }
 slang_solidity_v2_ast = { workspace = true }
 slang_solidity_v2_common = { workspace = true }
 slang_solidity_v2_cst = { workspace = true }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/Cargo.toml
@@ -32,6 +32,9 @@ num-bigint = { workspace = true }
 num-rational = { workspace = true }
 ruint = { workspace = true }
 serde_json = { workspace = true }
+slang_solidity_v2_ir = { workspace = true, features = [
+  "__private_testing_utils",
+] }
 
 [lints]
 workspace = true

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/compile.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/compile.rs
@@ -1,3 +1,4 @@
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use slang_solidity_v2_common::collections::{Set, SortedMap};
 use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::diagnostics::kinds::compilation::{
@@ -32,6 +33,17 @@ impl CompilationUnit {
     /// here, and every problem it runs into is reported as a diagnostic on the
     /// returned unit. Parse errors, unresolvable imports, and missing imported
     /// files are all collected this way — see [`CompilationUnit::diagnostics`].
+    ///
+    /// Parsing runs in parallel on [`rayon`]'s global thread pool. The result
+    /// does not depend on how large that pool is, so this is only ever a
+    /// question of speed; to bound it, call this inside
+    /// [`rayon::ThreadPool::install`] on a pool of your own.
+    // TODO(wasm): `rayon` falls back to the calling
+    // thread for its *implicit* global pool — which is why this already builds
+    // for `wasm32-wasip1`, but a pool built
+    // explicitly errors instead. Revisit this, and consider gating `rayon`
+    // behind a feature so the scheduler stays out of that build, if v2 gains a
+    // wasm interface.
     pub fn create<'s, S, R>(config: Configuration<S, R>) -> CompilationUnit
     where
         S: IntoIterator<Item = (FileId, &'s str)>,
@@ -95,28 +107,61 @@ struct ParsedFile<'s> {
     source_unit: cst::SourceUnit,
 }
 
-/// Parses every source file.
+/// Parses every source file, in parallel over [`rayon`]'s global thread pool.
+///
+/// The result must stay sorted by [`FileId`], since [`build_ir`] hands out node
+/// ids by walking it — hence the `Vec` and the *indexed* `unzip`, which fills
+/// the output by input position rather than by whoever finishes first.
+///
+/// TODO(v2): giving each file an independent node-id space would free this
+/// phase to schedule as it likes. It'll be necessary once IR building is parallelized.
 fn parse_files<'s>(
     sources: SortedMap<FileId, &'s str>,
     language_version: LanguageVersion,
     diagnostics: &mut DiagnosticCollection,
 ) -> Vec<ParsedFile<'s>> {
-    sources
-        .into_iter()
-        .map(|(file_id, contents)| {
-            let ParseOutput {
-                source_unit,
-                diagnostics: parse_diagnostics,
-            } = Parser::parse(&file_id, contents, language_version);
-            diagnostics.extend(parse_diagnostics);
+    let parse =
+        |(file_id, contents): (FileId, &'s str)| parse_file(file_id, contents, language_version);
 
-            ParsedFile {
-                file_id,
-                contents,
-                source_unit,
-            }
-        })
-        .collect()
+    // Using rayon's parallel iterator has some costs that are
+    // not worth it when a single file is being processed.
+    let (parsed_files, per_file_diagnostics): (Vec<_>, Vec<_>) = if sources.len() < 2 {
+        sources.into_iter().map(parse).unzip()
+    } else {
+        // Through a `Vec` because that is the only route rayon guarantees as an
+        // indexed parallel iterator, which is what fills `unzip`'s output by
+        // input position.
+        // See the TODO in this function, this requirement should go
+        // once order is relaxed.
+        Vec::from_iter(sources).into_par_iter().map(parse).unzip()
+    };
+
+    for parse_diagnostics in per_file_diagnostics {
+        diagnostics.extend(parse_diagnostics);
+    }
+
+    parsed_files
+}
+
+/// Parses one source file, returning its diagnostics rather than pushing them
+/// into a shared collection, so that it can run on any thread.
+fn parse_file(
+    file_id: FileId,
+    contents: &str,
+    language_version: LanguageVersion,
+) -> (ParsedFile<'_>, DiagnosticCollection) {
+    let ParseOutput {
+        source_unit,
+        diagnostics,
+    } = Parser::parse(&file_id, contents, language_version);
+
+    let parsed_file = ParsedFile {
+        file_id,
+        contents,
+        source_unit,
+    };
+
+    (parsed_file, diagnostics)
 }
 
 /// Lowers every parsed file into its IR representation, resolving the import

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/compilation/file.rs
@@ -64,4 +64,9 @@ impl FileStruct {
     pub fn ast(&self) -> ast::SourceUnit {
         ast::create_source_unit(&self.file.ir_root, &self.semantic)
     }
+
+    #[cfg(test)]
+    pub(crate) fn ir_root(&self) -> &ir::SourceUnit {
+        &self.file.ir_root
+    }
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
@@ -59,3 +59,11 @@ fn the_last_contents_given_for_a_file_id_win() {
         .collect();
     assert_eq!(contract_names, ["Fresh"]);
 }
+
+#[test]
+fn compiles_an_empty_source_list() {
+    let unit = compile([]);
+
+    assert!(unit.diagnostics().is_empty(), "{:#?}", unit.diagnostics());
+    assert_eq!(unit.files().count(), 0);
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
@@ -1,42 +1,5 @@
-use slang_solidity_v2_common::evm_targets::EvmTarget;
-
-use crate::compilation::{CompilationUnit, Configuration, FileId, ImportResolver};
+use super::support::{compile, contract};
 use crate::diagnostics::DiagnosticExtensions;
-use crate::diagnostics::kinds::compilation::UnresolvedImport;
-use crate::utils::LanguageVersion;
-
-/// Resolves every import path to a file of the same name.
-struct TestImportResolver;
-
-impl ImportResolver for TestImportResolver {
-    fn resolve_import(
-        &mut self,
-        _source_file_id: &FileId,
-        import_path: &str,
-    ) -> Result<FileId, UnresolvedImport> {
-        Ok(import_path.into())
-    }
-}
-
-fn compile<'s>(sources: impl IntoIterator<Item = (FileId, &'s str)>) -> CompilationUnit {
-    CompilationUnit::create(Configuration {
-        language_version: LanguageVersion::LATEST,
-        evm_target: EvmTarget::LATEST,
-        sources,
-        resolver: TestImportResolver,
-    })
-}
-
-fn contract(name: &str, imports: &[&str]) -> String {
-    use std::fmt::Write;
-
-    let imports = imports.iter().fold(String::new(), |mut text, path| {
-        writeln!(text, "import \"{path}\";").unwrap();
-        text
-    });
-
-    format!("pragma solidity ^0.8.0;\n{imports}\ncontract {name} {{}}\n")
-}
 
 #[test]
 fn compiles_every_source_it_is_given() {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/create.rs
@@ -1,11 +1,11 @@
-use super::support::{compile, contract};
+use super::support::{compile, file_with_empty_contract};
 use crate::diagnostics::DiagnosticExtensions;
 
 #[test]
 fn compiles_every_source_it_is_given() {
-    let main = contract("Main", &["lib.sol"]);
-    let lib = contract("Lib", &[]);
-    let extra = contract("Extra", &[]);
+    let main = file_with_empty_contract("Main", &["lib.sol"]);
+    let lib = file_with_empty_contract("Lib", &[]);
+    let extra = file_with_empty_contract("Extra", &[]);
     let unit = compile([
         ("main.sol".into(), main.as_str()),
         ("lib.sol".into(), lib.as_str()),
@@ -27,8 +27,8 @@ fn compiles_every_source_it_is_given() {
 
 #[test]
 fn the_last_contents_given_for_a_file_id_win() {
-    let stale = contract("Stale", &[]);
-    let fresh = contract("Fresh", &[]);
+    let stale = file_with_empty_contract("Stale", &[]);
+    let fresh = file_with_empty_contract("Fresh", &[]);
     let unit = compile([
         ("main.sol".into(), stale.as_str()),
         ("main.sol".into(), fresh.as_str()),

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/fixtures/mod.rs
@@ -1,11 +1,8 @@
 use std::sync::Arc;
 
-use slang_solidity_v2_common::evm_targets::EvmTarget;
-
 use crate::ast::{Definition, LibraryDefinition};
-use crate::compilation::{CompilationUnit, Configuration, FileId, ImportResolver};
-use crate::diagnostics::kinds::compilation::UnresolvedImport;
-use crate::utils::LanguageVersion;
+use crate::compilation::{CompilationUnit, FileId};
+use crate::tests::support;
 
 mod counter;
 
@@ -45,25 +42,8 @@ macro_rules! define_fixture {
     };
 }
 
-struct FixtureImportResolver;
-
-impl ImportResolver for FixtureImportResolver {
-    fn resolve_import(
-        &mut self,
-        _source_file_id: &FileId,
-        import_path: &str,
-    ) -> Result<FileId, UnresolvedImport> {
-        Ok(import_path.into())
-    }
-}
-
 pub(super) fn build_compilation_unit_from_fixture(files: &[FixtureFile]) -> Arc<CompilationUnit> {
-    let unit = CompilationUnit::create(Configuration {
-        language_version: LanguageVersion::LATEST,
-        evm_target: EvmTarget::LATEST,
-        sources: files.iter().map(|file| (file.id.clone(), file.contents)),
-        resolver: FixtureImportResolver,
-    });
+    let unit = support::compile(files.iter().map(|file| (file.id.clone(), file.contents)));
 
     assert!(
         unit.diagnostics().is_empty(),

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/mod.rs
@@ -3,5 +3,6 @@ mod ast;
 mod create;
 mod diagnostics;
 mod fixtures;
+mod support;
 mod thread_safety;
 mod unit;

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/support.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/support.rs
@@ -1,0 +1,43 @@
+//! Helpers shared by the sibling test modules.
+
+use slang_solidity_v2_common::evm_targets::EvmTarget;
+
+use crate::compilation::{CompilationUnit, Configuration, FileId, ImportResolver};
+use crate::diagnostics::kinds::compilation::UnresolvedImport;
+use crate::utils::LanguageVersion;
+
+/// Resolves every import path to a file of the same name.
+pub(super) struct TestImportResolver;
+
+impl ImportResolver for TestImportResolver {
+    fn resolve_import(
+        &mut self,
+        _source_file_id: &FileId,
+        import_path: &str,
+    ) -> Result<FileId, UnresolvedImport> {
+        Ok(import_path.into())
+    }
+}
+
+/// Compiles the given sources at the latest language version and EVM target,
+/// resolving imports with [`TestImportResolver`].
+pub(super) fn compile<'s>(sources: impl IntoIterator<Item = (FileId, &'s str)>) -> CompilationUnit {
+    CompilationUnit::create(Configuration {
+        language_version: LanguageVersion::LATEST,
+        evm_target: EvmTarget::LATEST,
+        sources,
+        resolver: TestImportResolver,
+    })
+}
+
+/// Renders a minimal contract of the given name that imports the given paths.
+pub(super) fn contract(name: &str, imports: &[&str]) -> String {
+    use std::fmt::Write;
+
+    let imports = imports.iter().fold(String::new(), |mut text, path| {
+        writeln!(text, "import \"{path}\";").unwrap();
+        text
+    });
+
+    format!("pragma solidity ^0.8.0;\n{imports}\ncontract {name} {{}}\n")
+}

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/support.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/support.rs
@@ -31,7 +31,7 @@ pub(super) fn compile<'s>(sources: impl IntoIterator<Item = (FileId, &'s str)>) 
 }
 
 /// Renders a minimal contract of the given name that imports the given paths.
-pub(super) fn contract(name: &str, imports: &[&str]) -> String {
+pub(super) fn file_with_empty_contract(name: &str, imports: &[&str]) -> String {
     use std::fmt::Write;
 
     let imports = imports.iter().fold(String::new(), |mut text, path| {

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -2,6 +2,8 @@ use std::hint::black_box;
 use std::sync::Arc;
 use std::thread;
 
+use slang_solidity_v2_ir::ir;
+
 use crate::ast::NodeId;
 use crate::compilation::{CompilationUnit, FileId};
 use crate::diagnostics::Diagnostic;
@@ -109,33 +111,57 @@ fn borrow_sources(sources: &[(FileId, String)]) -> impl Iterator<Item = (FileId,
         .map(|(file_id, contents)| (file_id.clone(), contents.as_str()))
 }
 
-/// Everything about a unit that a caller can observe.
+/// Everything a caller can observe about a unit: the diagnostics, the binder's
+/// definitions, and each file's full IR tree.
 struct Observable {
-    files: Vec<(String, NodeId)>,
+    files: Vec<(String, ir::SourceUnit)>,
     definitions: Vec<NodeId>,
     diagnostics: Vec<Diagnostic>,
 }
 
 impl Observable {
+    /// Every collection is sorted on the way in: the unit's accessors don't
+    /// promise an iteration order, so what gets compared is the contents,
+    /// never the order they happen to come out in today.
     fn from_compilation_unit(unit: &CompilationUnit) -> Self {
+        let mut files: Vec<(String, ir::SourceUnit)> = unit
+            .files()
+            .map(|file| (file.id().as_str().to_owned(), Arc::clone(file.ir_root())))
+            .collect();
+        files.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        let mut definitions: Vec<NodeId> = unit
+            .all_definitions()
+            .map(|definition| definition.node_id())
+            .collect();
+        definitions.sort_unstable();
+
         Self {
-            files: unit
-                .files()
-                .map(|file| (file.id().as_str().to_owned(), file.ast().node_id()))
-                .collect(),
-            definitions: unit
-                .all_definitions()
-                .map(|definition| definition.node_id())
-                .collect(),
-            // Via `iter()`, which sorts: compares the diagnostics, not their storage order.
+            files,
+            definitions,
+            // Via `iter()`, which sorts.
             diagnostics: unit.diagnostics().iter().cloned().collect(),
         }
     }
 
-    /// Compared field by field rather than as a whole, so a failure names which
-    /// part diverged instead of dumping the entire unit twice.
+    /// Compared field by field — and the IR file by file — rather than as a
+    /// whole, so a failure names which part diverged instead of dumping the
+    /// entire unit twice.
     fn assert_same(&self, expected: &Self, context: &str) {
-        assert_eq!(self.files, expected.files, "files diverged {context}");
+        let names = |observed: &Self| -> Vec<String> {
+            observed
+                .files
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect()
+        };
+        assert_eq!(names(self), names(expected), "files diverged {context}");
+        for ((name, ir_root), (_, expected_ir_root)) in self.files.iter().zip(&expected.files) {
+            assert_eq!(
+                ir_root, expected_ir_root,
+                "the IR of '{name}' diverged {context}"
+            );
+        }
         assert_eq!(
             self.definitions, expected.definitions,
             "definition node ids diverged {context}"
@@ -148,7 +174,7 @@ impl Observable {
 }
 
 /// Source files are parsed in parallel, so the size of the pool must not change
-/// what comes out — not the file order, not the node ids, not the diagnostics.
+/// what comes out.
 #[test]
 fn build_output_is_independent_of_the_thread_count() {
     let sources = mixed_sources();

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -2,6 +2,10 @@ use std::hint::black_box;
 use std::sync::Arc;
 use std::thread;
 
+use crate::ast::NodeId;
+use crate::compilation::{CompilationUnit, FileId};
+use crate::diagnostics::Diagnostic;
+use crate::tests::support::{compile, contract};
 use crate::tests::fixtures;
 
 #[test]
@@ -70,4 +74,159 @@ fn parallel_access_via_arc_consistent_with_serial_baseline() {
     for handle in handles {
         handle.join().expect("worker thread panicked");
     }
+}
+
+/// Enough files to spread over several threads, with broken and dangling ones
+/// mixed in so diagnostics take part in the comparisons.
+fn mixed_sources() -> Vec<(FileId, String)> {
+    (0..32)
+        .map(|index| {
+            let file_id: FileId = format!("file{index}.sol").into();
+            let contents = match index % 4 {
+                // Imports the next file, which exists.
+                0 => contract(&format!("C{index}"), &[&format!("file{}.sol", index + 1)]),
+                // Imports a file that is not part of the compilation.
+                1 => contract(&format!("C{index}"), &["absent.sol"]),
+                // Fails to parse, while also declaring an import.
+                2 => {
+                    format!("pragma solidity ^0.8.0;\nimport \"absent.sol\";\ncontract C{index} {{")
+                }
+                _ => contract(&format!("C{index}"), &[]),
+            };
+
+            (file_id, contents)
+        })
+        .collect()
+}
+
+/// Borrows the sources the way [`compile`] takes them.
+fn borrow_sources(sources: &[(FileId, String)]) -> impl Iterator<Item = (FileId, &str)> {
+    sources
+        .iter()
+        .map(|(file_id, contents)| (file_id.clone(), contents.as_str()))
+}
+
+/// Everything about a unit that a caller can observe.
+struct Observable {
+    files: Vec<(String, NodeId)>,
+    definitions: Vec<NodeId>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl Observable {
+    fn from_compilation_unit(unit: &CompilationUnit) -> Self {
+        Self {
+            files: unit
+                .files()
+                .map(|file| (file.id().as_str().to_owned(), file.ast().node_id()))
+                .collect(),
+            definitions: unit
+                .all_definitions()
+                .map(|definition| definition.node_id())
+                .collect(),
+            // Via `iter()`, which sorts: compares the diagnostics, not their storage order.
+            diagnostics: unit.diagnostics().iter().cloned().collect(),
+        }
+    }
+
+    /// Compared field by field rather than as a whole, so a failure names which
+    /// part diverged instead of dumping the entire unit twice.
+    fn assert_same(&self, expected: &Self, context: &str) {
+        assert_eq!(self.files, expected.files, "files diverged {context}");
+        assert_eq!(
+            self.definitions, expected.definitions,
+            "definition node ids diverged {context}"
+        );
+        assert_eq!(
+            self.diagnostics, expected.diagnostics,
+            "diagnostics diverged {context}"
+        );
+    }
+}
+
+/// Source files are parsed in parallel, so the size of the pool must not change
+/// what comes out — not the file order, not the node ids, not the diagnostics.
+#[test]
+fn build_output_is_independent_of_the_thread_count() {
+    let sources = mixed_sources();
+    let build = || compile(borrow_sources(&sources));
+
+    let baseline = pool_of(1).install(build);
+
+    // Guard against the comparisons below being vacuous. Half the corpus is
+    // built to produce diagnostics, so requiring every one of those files to be
+    // represented is what would catch a file's diagnostics going missing on the
+    // way out of the parallel phase — merely requiring *some* would not.
+    assert_eq!(baseline.files().count(), sources.len());
+    assert!(baseline.all_definitions().next().is_some());
+    let mut files_with_diagnostics: Vec<&str> = baseline
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.file_id().as_str())
+        .collect();
+    files_with_diagnostics.sort_unstable();
+    files_with_diagnostics.dedup();
+    assert_eq!(files_with_diagnostics.len(), sources.len() / 2);
+
+    // Those only show the thread count doesn't matter; they would hold just as
+    // well if every size agreed on a *wrong* order. So pin it absolutely too.
+    assert_root_node_ids_follow_file_order(&baseline);
+
+    let baseline = Observable::from_compilation_unit(&baseline);
+    for threads in [2, 4, 8, 16] {
+        let unit = Observable::from_compilation_unit(&pool_of(threads).install(build));
+        unit.assert_same(&baseline, &format!("on {threads} threads"));
+    }
+}
+
+/// Node ids are handed out one file at a time, walking the files in `FileId`
+/// order, which is the invariant a reordered parse breaks. Sorted here rather
+/// than leaning on `files()`, whose iteration order the API does not promise —
+/// were it ever to follow build order instead, this assertion would hold
+/// trivially and stop testing anything.
+fn assert_root_node_ids_follow_file_order(unit: &CompilationUnit) {
+    let mut roots: Vec<(FileId, NodeId)> = unit
+        .files()
+        .map(|file| (file.id().clone(), file.ast().node_id()))
+        .collect();
+    roots.sort_by(|left, right| left.0.cmp(&right.0));
+
+    for pair in roots.windows(2) {
+        let (previous_file_id, previous_node_id) = &pair[0];
+        let (file_id, node_id) = &pair[1];
+
+        assert!(
+            previous_node_id < node_id,
+            "'{previous_file_id}' has node id {previous_node_id:?}, \
+             but the later '{file_id}' has {node_id:?}"
+        );
+    }
+}
+
+/// The test above varies the pool *within* one build, so it cannot catch state
+/// shared more widely — a process-wide cache would stay consistent there and
+/// still corrupt two builds at once. So run several against the same pool.
+#[test]
+fn concurrent_builds_do_not_interfere() {
+    let sources = mixed_sources();
+    let baseline = Observable::from_compilation_unit(&compile(borrow_sources(&sources)));
+
+    thread::scope(|scope| {
+        for worker in 0..8 {
+            let sources = &sources;
+            let baseline = &baseline;
+
+            scope.spawn(move || {
+                let unit = Observable::from_compilation_unit(&compile(borrow_sources(sources)));
+                unit.assert_same(baseline, &format!("in worker {worker}"));
+            });
+        }
+    });
+}
+
+fn pool_of(threads: usize) -> rayon::ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .expect("thread pool builds")
 }

--- a/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
+++ b/crates/solidity-v2/outputs/cargo/slang_solidity/src/tests/thread_safety.rs
@@ -5,8 +5,8 @@ use std::thread;
 use crate::ast::NodeId;
 use crate::compilation::{CompilationUnit, FileId};
 use crate::diagnostics::Diagnostic;
-use crate::tests::support::{compile, contract};
 use crate::tests::fixtures;
+use crate::tests::support::{compile, file_with_empty_contract};
 
 #[test]
 fn parallel_access_via_arc_consistent_with_serial_baseline() {
@@ -84,14 +84,17 @@ fn mixed_sources() -> Vec<(FileId, String)> {
             let file_id: FileId = format!("file{index}.sol").into();
             let contents = match index % 4 {
                 // Imports the next file, which exists.
-                0 => contract(&format!("C{index}"), &[&format!("file{}.sol", index + 1)]),
+                0 => file_with_empty_contract(
+                    &format!("C{index}"),
+                    &[&format!("file{}.sol", index + 1)],
+                ),
                 // Imports a file that is not part of the compilation.
-                1 => contract(&format!("C{index}"), &["absent.sol"]),
+                1 => file_with_empty_contract(&format!("C{index}"), &["absent.sol"]),
                 // Fails to parse, while also declaring an import.
                 2 => {
                     format!("pragma solidity ^0.8.0;\nimport \"absent.sol\";\ncontract C{index} {{")
                 }
-                _ => contract(&format!("C{index}"), &[]),
+                _ => file_with_empty_contract(&format!("C{index}"), &[]),
             };
 
             (file_id, contents)
@@ -168,38 +171,10 @@ fn build_output_is_independent_of_the_thread_count() {
     files_with_diagnostics.dedup();
     assert_eq!(files_with_diagnostics.len(), sources.len() / 2);
 
-    // Those only show the thread count doesn't matter; they would hold just as
-    // well if every size agreed on a *wrong* order. So pin it absolutely too.
-    assert_root_node_ids_follow_file_order(&baseline);
-
     let baseline = Observable::from_compilation_unit(&baseline);
     for threads in [2, 4, 8, 16] {
         let unit = Observable::from_compilation_unit(&pool_of(threads).install(build));
         unit.assert_same(&baseline, &format!("on {threads} threads"));
-    }
-}
-
-/// Node ids are handed out one file at a time, walking the files in `FileId`
-/// order, which is the invariant a reordered parse breaks. Sorted here rather
-/// than leaning on `files()`, whose iteration order the API does not promise —
-/// were it ever to follow build order instead, this assertion would hold
-/// trivially and stop testing anything.
-fn assert_root_node_ids_follow_file_order(unit: &CompilationUnit) {
-    let mut roots: Vec<(FileId, NodeId)> = unit
-        .files()
-        .map(|file| (file.id().clone(), file.ast().node_id()))
-        .collect();
-    roots.sort_by(|left, right| left.0.cmp(&right.0));
-
-    for pair in roots.windows(2) {
-        let (previous_file_id, previous_node_id) = &pair[0];
-        let (file_id, node_id) = &pair[1];
-
-        assert!(
-            previous_node_id < node_id,
-            "'{previous_file_id}' has node id {previous_node_id:?}, \
-             but the later '{file_id}' has {node_id:?}"
-        );
     }
 }
 

--- a/crates/solidity/testing/perf/README.md
+++ b/crates/solidity/testing/perf/README.md
@@ -59,7 +59,12 @@ uses [`divan`](https://github.com/nvzqz/divan) to measure elapsed time while bui
 on its own. Alongside each timing it reports throughput (MB/s and files/s), so results stay
 comparable across [projects] of different sizes.
 
-Run it with:
+The suite also has a `thread_scaling` group, which runs one project on `rayon` pools of 1, 2, 4, 8,
+and 16 threads. The `1` row is the single-thread baseline the others should be read against, so this is
+where to check whether a newly parallel stage pays off — and whether more threads eventually start
+costing more than they save.
+
+Run them with:
 
 ```console
 ./scripts/bin/infra perf cargo slang-v2-wall-clock

--- a/crates/solidity/testing/perf/cargo/Cargo.toml
+++ b/crates/solidity/testing/perf/cargo/Cargo.toml
@@ -11,6 +11,7 @@ divan = { workspace = true }
 gungraun = { workspace = true }
 Inflector = { workspace = true }
 infra_utils = { workspace = true }
+rayon = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/comparison/main.rs
@@ -21,6 +21,7 @@ mod __dependencies_used_in_lib__ {
     use inflector as _;
     use infra_utils as _;
     use paste as _;
+    use rayon as _;
     use semver as _;
     use serde as _;
     use serde_json as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang/main.rs
@@ -23,6 +23,7 @@ mod __dependencies_used_in_lib__ {
     use inflector as _;
     use infra_utils as _;
     use paste as _;
+    use rayon as _;
     use semver as _;
     use serde as _;
     use serde_json as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2/main.rs
@@ -20,6 +20,7 @@ mod __dependencies_used_in_lib__ {
     use inflector as _;
     use infra_utils as _;
     use paste as _;
+    use rayon as _;
     use semver as _;
     use serde as _;
     use serde_json as _;

--- a/crates/solidity/testing/perf/cargo/benches/slang_v2_wall_clock/main.rs
+++ b/crates/solidity/testing/perf/cargo/benches/slang_v2_wall_clock/main.rs
@@ -75,6 +75,42 @@ fn parser(bencher: Bencher<'_, '_>, project_name: &str) {
         .bench(|| black_box(tests::slang_v2::parser::run(black_box(project))));
 }
 
+/// How the pipeline scales with the size of the thread pool it is given.
+///
+/// The benchmarks above take every core; these pin one project to pools of
+/// increasing size, so a stage that fails to scale — or that starts costing more
+/// than it saves — shows up instead of being averaged away.
+mod thread_scaling {
+    use divan::{Bencher, black_box};
+
+    use super::{MAX_TIME_SECS, with_throughput_counters};
+    use crate::tests;
+
+    /// One of the larger multi-file projects; a single-file one would have
+    /// nothing to spread.
+    // __SLANG_INFRA_PROJECT_LIST__ (keep in sync)
+    const PROJECT: &str = "uniswap";
+
+    /// `1` is the serial baseline the other rows should be read against.
+    const THREAD_COUNTS: [usize; 5] = [1, 2, 4, 8, 16];
+
+    /// Deliberately the same public entry point as the benchmark above, not a
+    /// stand-in: one that re-implements the pipeline can drift from it silently,
+    /// and then reports a speedup nobody gets.
+    #[divan::bench(args = THREAD_COUNTS, max_time = MAX_TIME_SECS)]
+    fn full_compilation(bencher: Bencher<'_, '_>, threads: usize) {
+        let project = tests::slang_v2::full_compilation::setup(PROJECT);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .expect("thread pool builds");
+
+        with_throughput_counters(bencher, project).bench(|| {
+            pool.install(|| black_box(tests::slang_v2::full_compilation::run(black_box(project))))
+        });
+    }
+}
+
 /// Reports bytes and files processed per second, so that results remain
 /// comparable across projects of very different sizes.
 fn with_throughput_counters<'a, 'b>(

--- a/crates/solidity/testing/perf/cargo/src/lib.rs
+++ b/crates/solidity/testing/perf/cargo/src/lib.rs
@@ -8,6 +8,7 @@ mod __dependencies_used_in_benches__ {
     use divan as _;
     use gungraun as _;
     use infra_utils as _;
+    use rayon as _;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This parallelizes the parsing using rayon.

It also introduces a new config axis for the compilation, `Concurrency`, it can either be `Inline` using the current thread, or the default `Ambient`, using rayon's ambient pool. Users can install their own pool and call `CompilationUnit::create` within it.

Also included: a small test refactor moving the compilation helpers shared by the slang_solidity_v2 test modules into tests/support, deduplicating the identical import resolvers in create and fixtures.

----
> Benchmarks run locally on my 8 cores container

On large projects like `uniswap` compilation goes from 14.9 ms  to 10.6 ms on average.
On single file projects like `one_step_leverage_f` there's no noticeable change in performance.